### PR TITLE
IDEA-88520 When applying dark color scheme and ColorIde plugin then settings tree is displayed incorrectly

### DIFF
--- a/platform/platform-api/src/com/intellij/ide/util/treeView/PresentableNodeDescriptor.java
+++ b/platform/platform-api/src/com/intellij/ide/util/treeView/PresentableNodeDescriptor.java
@@ -17,7 +17,6 @@ package com.intellij.ide.util.treeView;
 
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.openapi.project.Project;
-import com.intellij.ui.Gray;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
@@ -167,7 +166,7 @@ public abstract class PresentableNodeDescriptor<E> extends NodeDescriptor<E>  {
   }
 
   public Color getHighlightColor() {
-    return UIUtil.isUnderDarcula() ? UIUtil.getPanelBackground().brighter() : Gray._245;
+    return UIUtil.isUnderDarcula() ? UIUtil.getPanelBackground().brighter() : UIUtil.getTreeBackground().brighter();
   }
 
   public static class ColoredFragment {

--- a/platform/util/src/com/intellij/util/ui/UIUtil.java
+++ b/platform/util/src/com/intellij/util/ui/UIUtil.java
@@ -611,6 +611,10 @@ public class UIUtil {
     return UIManager.getColor("Panel.background");
   }
 
+  public static Color getTreeBackground() {
+    return UIManager.getColor("Tree.background");
+  }
+
   public static Color getTreeForeground() {
     return UIManager.getColor("Tree.foreground");
   }


### PR DESCRIPTION
Bug fix according to issue IDEA-88520. Instead of using hardcoded value for background compute it using tree background color.
