### PR TITLE
IDEA-74131 Maven interpolation error: Failed to interpolate field

### DIFF
--- a/plugins/maven/maven2-server-impl/src/org/jetbrains/idea/maven/server/embedder/CustomModelInterpolator.java
+++ b/plugins/maven/maven2-server-impl/src/org/jetbrains/idea/maven/server/embedder/CustomModelInterpolator.java
@@ -32,22 +32,22 @@ public class CustomModelInterpolator extends StringSearchModelInterpolator {
   }
 
   @Override
-  protected synchronized void interpolateObject(Object obj,
-                                                Model model,
-                                                File projectDir,
-                                                ProjectBuilderConfiguration config,
-                                                boolean debugEnabled) throws ModelInterpolationException {
-    try {
-      super.interpolateObject(obj, model, projectDir, config, debugEnabled);
-    }
-    catch (NullPointerException e) {
-      // npe may be thrown from here:
-      //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.isQualifiedForInterpolation(StringSearchModelInterpolator.java:344)
-      //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.traverseObjectWithParents(StringSearchModelInterpolator.java:172)
-      //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.traverseObjectWithParents(StringSearchModelInterpolator.java:328)
-      //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.run(StringSearchModelInterpolator.java:135)
-      //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.run(StringSearchModelInterpolator.java:102)
-      throw new ModelInterpolationException("Cannot interpolate", e);
+  protected void interpolateObject(Object obj, Model model, File projectDir, ProjectBuilderConfiguration config, boolean debugEnabled)
+    throws ModelInterpolationException {
+    // IDEA-74131 avoid concurrent access to the static cache in StringSearchModelInterpolator
+    synchronized (CustomModelInterpolator.class) {
+      try {
+        super.interpolateObject(obj, model, projectDir, config, debugEnabled);
+      }
+      catch (NullPointerException e) {
+        // npe may be thrown from here:
+        //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.isQualifiedForInterpolation(StringSearchModelInterpolator.java:344)
+        //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.traverseObjectWithParents(StringSearchModelInterpolator.java:172)
+        //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.traverseObjectWithParents(StringSearchModelInterpolator.java:328)
+        //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.run(StringSearchModelInterpolator.java:135)
+        //at org.apache.maven.project.interpolation.StringSearchModelInterpolator$InterpolateObjectAction.run(StringSearchModelInterpolator.java:102)
+        throw new ModelInterpolationException("Cannot interpolate", e);
+      }
     }
   }
 }


### PR DESCRIPTION
The synchronized keyword on the method interpolateObject was not enough because the cache in StringSearchModelInterpolator is static, so we need to protect concurrent access whatever the instance of CustomModelInterpolator. Here I simply use the CustomModelInterpolator class as synchronization object.
I never see the error again since I applied this fix.
