### PR TITLE
IDEA-35950  Generate ant build adds generated file to Ant Build window

### DIFF
--- a/java/compiler/impl/compiler-impl.iml
+++ b/java/compiler/impl/compiler-impl.iml
@@ -24,6 +24,7 @@
     <orderEntry type="module" module-name="java-impl" />
     <orderEntry type="module" module-name="jps-builders" />
     <orderEntry type="library" name="Netty" level="project" />
+    <orderEntry type="module" module-name="ant" />
     <orderEntry type="module" module-name="testFramework-java" scope="TEST" />
   </component>
   <component name="copyright">


### PR DESCRIPTION
http://youtrack.jetbrains.com/issue/IDEA-35950
IDEA-35950  Generate ant build dialog could have an option to add generated file to project build files list (in Ant Build window)

This does mean adding a dependency on the ant module.
