### PR TITLE
New highlights

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightNamesUtil.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightNamesUtil.java
@@ -169,9 +169,9 @@ public class HighlightNamesUtil {
       return HighlightInfoType.LOCAL_VARIABLE;
     }
     if (var instanceof PsiField) {
-      return var.hasModifierProperty(PsiModifier.STATIC)
-             ? HighlightInfoType.STATIC_FIELD
-             : HighlightInfoType.INSTANCE_FIELD;
+      return var.hasModifierProperty(PsiModifier.STATIC) ? (var.hasModifierProperty(PsiModifier.FINAL)
+                                                            ? HighlightInfoType.STATIC_FINAL_FIELD
+                                                            : HighlightInfoType.STATIC_FIELD) : HighlightInfoType.INSTANCE_FIELD;
     }
     if (var instanceof PsiParameter) {
       return HighlightInfoType.PARAMETER;

--- a/java/java-impl/src/com/intellij/openapi/options/colors/pages/JavaColorSettingsPage.java
+++ b/java/java-impl/src/com/intellij/openapi/options/colors/pages/JavaColorSettingsPage.java
@@ -73,6 +73,7 @@ public class JavaColorSettingsPage implements ColorSettingsPage, InspectionColor
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.implicit.anonymous.parameter"), CodeInsightColors.IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES),
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.instance.field"), CodeInsightColors.INSTANCE_FIELD_ATTRIBUTES),
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.static.field"), CodeInsightColors.STATIC_FIELD_ATTRIBUTES),
+    new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.static.final.field"), CodeInsightColors.STATIC_FINAL_FIELD_ATTRIBUTES),
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.parameter"), CodeInsightColors.PARAMETER_ATTRIBUTES),
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.method.call"), CodeInsightColors.METHOD_CALL_ATTRIBUTES),
     new AttributesDescriptor(OptionsBundle.message("options.java.attribute.descriptor.method.declaration"), CodeInsightColors.METHOD_DECLARATION_ATTRIBUTES),
@@ -103,6 +104,7 @@ public class JavaColorSettingsPage implements ColorSettingsPage, InspectionColor
     ourTags.put("reassignedParameter", CodeInsightColors.REASSIGNED_PARAMETER_ATTRIBUTES);
     ourTags.put("implicitAnonymousParameter", CodeInsightColors.IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES);
     ourTags.put("static", CodeInsightColors.STATIC_FIELD_ATTRIBUTES);
+    ourTags.put("static_final", CodeInsightColors.STATIC_FINAL_FIELD_ATTRIBUTES);
     ourTags.put("deprecated", CodeInsightColors.DEPRECATED_ATTRIBUTES);
     ourTags.put("constructorCall", CodeInsightColors.CONSTRUCTOR_CALL_ATTRIBUTES);
     ourTags.put("constructorDeclaration", CodeInsightColors.CONSTRUCTOR_DECLARATION_ATTRIBUTES);
@@ -184,9 +186,9 @@ public class JavaColorSettingsPage implements ColorSettingsPage, InspectionColor
       "    <reassignedParameter>reassignedParam</reassignedParameter> = new int[2];\n" +
       "  }\n" +
       "}\n" +
-      "enum <enum>AnEnum</enum> { <static>CONST1</static>, <static>CONST2</static> }\n"+
+      "enum <enum>AnEnum</enum> { <static_final>CONST1</static_final>, <static_final>CONST2</static_final> }\n"+
       "interface <interface>AnInterface</interface> {\n" +
-      "  int <static>CONSTANT</static> = 2;\n" +
+      "  int <static_final>CONSTANT</static_final> = 2;\n" +
       "  void <methodDeclaration>method</methodDeclaration>();\n" +
       "}\n" +
       "abstract class <abstractClass>SomeAbstractClass</abstractClass> {\n" +

--- a/platform/core-api/src/com/intellij/openapi/editor/colors/CodeInsightColors.java
+++ b/platform/core-api/src/com/intellij/openapi/editor/colors/CodeInsightColors.java
@@ -37,6 +37,7 @@ public interface CodeInsightColors {
   TextAttributesKey IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES");
   TextAttributesKey INSTANCE_FIELD_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("INSTANCE_FIELD_ATTRIBUTES");
   TextAttributesKey STATIC_FIELD_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("STATIC_FIELD_ATTRIBUTES");
+  TextAttributesKey STATIC_FINAL_FIELD_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("STATIC_FINAL_FIELD_ATTRIBUTES");
   TextAttributesKey PARAMETER_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("PARAMETER_ATTRIBUTES");
   TextAttributesKey CLASS_NAME_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("CLASS_NAME_ATTRIBUTES");
   TextAttributesKey ANONYMOUS_CLASS_NAME_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("ANONYMOUS_CLASS_NAME_ATTRIBUTES");

--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/HighlightInfo.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/HighlightInfo.java
@@ -286,6 +286,7 @@ public class HighlightInfo implements Segment {
     if (type == HighlightInfoType.LOCAL_VARIABLE) return false;
     if (type == HighlightInfoType.INSTANCE_FIELD) return false;
     if (type == HighlightInfoType.STATIC_FIELD) return false;
+    if (type == HighlightInfoType.STATIC_FINAL_FIELD) return false;
     if (type == HighlightInfoType.PARAMETER) return false;
     if (type == HighlightInfoType.METHOD_CALL) return false;
     if (type == HighlightInfoType.METHOD_DECLARATION) return false;

--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/HighlightInfoType.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/HighlightInfoType.java
@@ -70,6 +70,7 @@ public interface HighlightInfoType {
   HighlightInfoType LOCAL_VARIABLE = new HighlightInfoTypeImpl(SYMBOL_TYPE_SEVERITY, CodeInsightColors.LOCAL_VARIABLE_ATTRIBUTES);
   HighlightInfoType INSTANCE_FIELD = new HighlightInfoTypeImpl(SYMBOL_TYPE_SEVERITY, CodeInsightColors.INSTANCE_FIELD_ATTRIBUTES);
   HighlightInfoType STATIC_FIELD = new HighlightInfoTypeImpl(SYMBOL_TYPE_SEVERITY, CodeInsightColors.STATIC_FIELD_ATTRIBUTES);
+  HighlightInfoType STATIC_FINAL_FIELD = new HighlightInfoTypeImpl(SYMBOL_TYPE_SEVERITY, CodeInsightColors.STATIC_FINAL_FIELD_ATTRIBUTES);
   HighlightInfoType PARAMETER = new HighlightInfoTypeImpl(SYMBOL_TYPE_SEVERITY, CodeInsightColors.PARAMETER_ATTRIBUTES);
   HighlightInfoType METHOD_CALL = new HighlightInfoTypeImpl(SYMBOL_TYPE_SEVERITY, CodeInsightColors.METHOD_CALL_ATTRIBUTES);
   HighlightInfoType METHOD_DECLARATION = new HighlightInfoTypeImpl(SYMBOL_TYPE_SEVERITY, CodeInsightColors.METHOD_DECLARATION_ATTRIBUTES);

--- a/platform/platform-resources-en/src/messages/OptionsBundle.properties
+++ b/platform/platform-resources-en/src/messages/OptionsBundle.properties
@@ -78,6 +78,7 @@ options.java.attribute.descriptor.reassigned.parameter=Reassigned parameter
 options.java.attribute.descriptor.implicit.anonymous.parameter=Implicit anonymous class parameter
 options.java.attribute.descriptor.instance.field=Instance field
 options.java.attribute.descriptor.static.field=Static field
+options.java.attribute.descriptor.static.final.field=Constant
 options.java.attribute.descriptor.parameter=Parameter
 options.java.attribute.descriptor.method.call=Method call
 options.java.attribute.descriptor.method.declaration=Method declaration

--- a/platform/platform-resources/src/DefaultColorSchemesManager.xml
+++ b/platform/platform-resources/src/DefaultColorSchemesManager.xml
@@ -762,6 +762,14 @@
           <option name="FOREGROUND" value="660e7a"/>
           <option name="BACKGROUND"/>
           <option name="EFFECT_COLOR"/>
+          <option name="FONT_TYPE" value="2"/>
+        </value>
+      </option>
+      <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+        <value>
+          <option name="FOREGROUND" value="660e7a"/>
+          <option name="BACKGROUND"/>
+          <option name="EFFECT_COLOR"/>
           <option name="FONT_TYPE" value="3"/>
         </value>
       </option>

--- a/resources/src/colorSchemes/Darcula.xml
+++ b/resources/src/colorSchemes/Darcula.xml
@@ -2251,6 +2251,16 @@
         <option name="ERROR_STRIPE_COLOR" />
       </value>
     </option>
+    <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d0d0ff" />
+        <option name="BACKGROUND" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ffffff" />
+        <option name="EFFECT_TYPE" value="1" />
+        <option name="ERROR_STRIPE_COLOR" />
+      </value>
+    </option>
     <option name="STATIC_METHOD_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" />


### PR DESCRIPTION
As a former Eclipse user, I really miss highlights for abstract and inherited method calls.
That's why I wrote some code to have it working.

Implementing abstract method calls hightlights was trivial, but inherited method calls was a little harder as **PsiMethod.getMethodReceiver()** isn't giving expected information.

Hope this helps.
