### PR TITLE
IDEA-71391 Adds --rename-manifest-package to AndroidFacetConfiguration

### DIFF
--- a/plugins/android/common/src/org/jetbrains/android/compiler/tools/AndroidApt.java
+++ b/plugins/android/common/src/org/jetbrains/android/compiler/tools/AndroidApt.java
@@ -146,8 +146,7 @@ public final class AndroidApt {
                                                                          @NotNull String[] extraPackages,
                                                                          @Nullable String customPackage,
                                                                          boolean nonConstantIds,
-                                                                         @Nullable String proguardCfgOutputFileOsPath)
-    throws IOException {
+                                                                         @Nullable String proguardCfgOutputFileOsPath) throws IOException {
     final List<String> args = new ArrayList<String>();
 
     args.add(target.getPath(IAndroidTarget.AAPT));
@@ -234,6 +233,7 @@ public final class AndroidApt {
                                                                                @NotNull String[] osAssetDirPaths,
                                                                                @NotNull String outputPath,
                                                                                @Nullable String configFilter,
+                                                                               @NotNull String renamedManifest,
                                                                                boolean debugMode,
                                                                                int versionCode,
                                                                                FileFilter assetsFilter) throws IOException {
@@ -289,6 +289,11 @@ public final class AndroidApt {
     if (configFilter != null) {
       args.add("-c");
       args.add(configFilter);
+    }
+
+    if (renamedManifest.length() > 0) {
+      args.add("--rename-manifest-package");
+      args.add(renamedManifest);
     }
 
     args.add("-M");

--- a/plugins/android/jps-plugin/src/org/jetbrains/jps/android/AndroidPackagingBuilder.java
+++ b/plugins/android/jps-plugin/src/org/jetbrains/jps/android/AndroidPackagingBuilder.java
@@ -547,13 +547,13 @@ public class AndroidPackagingBuilder extends TargetBuilder<BuildRootDescriptor, 
       final IgnoredFileIndex ignoredFileIndex = context.getProjectDescriptor().getIgnoredFileIndex();
 
       final Map<AndroidCompilerMessageKind, List<String>> messages = AndroidApt
-        .packageResources(target, -1, manifestFile.getPath(), resourceDirPaths, assetsDirPaths, outputPath, null,
-                          !releasePackage, 0, new FileFilter() {
-          @Override
-          public boolean accept(File pathname) {
-            return !ignoredFileIndex.isIgnored(PathUtilRt.getFileName(pathname.getPath()));
-          }
-        });
+        .packageResources(target, -1, manifestFile.getPath(), resourceDirPaths, assetsDirPaths, outputPath, null, null, !releasePackage, 0,
+                          new FileFilter() {
+                            @Override
+                            public boolean accept(File pathname) {
+                              return !ignoredFileIndex.isIgnored(PathUtilRt.getFileName(pathname.getPath()));
+                            }
+                          });
 
       AndroidJpsUtil.addMessages(context, messages, BUILDER_NAME, moduleName);
       return messages.get(AndroidCompilerMessageKind.ERROR).size() == 0;

--- a/plugins/android/resources/messages/AndroidBundle.properties
+++ b/plugins/android/resources/messages/AndroidBundle.properties
@@ -378,6 +378,7 @@ android.export.unsigned.package.action.text=Export Unsigned Application Package
 android.inspections.element.not.allowed.name=Android XML element is not allowed
 android.facet.settings.run.proguard=Run ProGuard
 android.facet.settings.proguard.cfg.label=Config file:
+android.facet.settings.rename.package.label=Rename package name:
 android.lint.inspections.always.show.action=Usage of showAsAction\=always
 android.lint.inspections.button.order=Buttons order
 android.lint.inspections.back.button=Back button

--- a/plugins/android/src/org/jetbrains/android/compiler/AndroidAptCompiler.java
+++ b/plugins/android/src/org/jetbrains/android/compiler/AndroidAptCompiler.java
@@ -184,10 +184,12 @@ public class AndroidAptCompiler implements SourceGeneratingCompiler {
     final VirtualFile myManifestFile;
     final String[] myResourcesPaths;
     final IAndroidTarget myAndroidTarget;
-    
+
     final String myPackage;
     final String[] myLibraryPackages;
     final boolean myNonConstantFields;
+
+    final String myRenamedManifest;
 
     final int myPlatformToolsRevision;
     private final MyValidityState myValidityState;
@@ -201,6 +203,7 @@ public class AndroidAptCompiler implements SourceGeneratingCompiler {
                               @NotNull String aPackage,
                               @NotNull String[] libPackages,
                               boolean nonConstantFields,
+                              @NotNull String renamedManifest,
                               @Nullable String proguardCfgOutputFileOsPath) {
       myModule = module;
       myManifestFile = manifestFile;
@@ -209,6 +212,7 @@ public class AndroidAptCompiler implements SourceGeneratingCompiler {
       myPackage = aPackage;
       myLibraryPackages = libPackages;
       myNonConstantFields = nonConstantFields;
+      myRenamedManifest = renamedManifest;
       myPlatformToolsRevision = platformToolsRevision;
       myProguardCfgOutputFileOsPath = proguardCfgOutputFileOsPath;
       myValidityState = new MyValidityState(myModule, Collections.<String>emptySet(), myPlatformToolsRevision, myNonConstantFields,
@@ -314,6 +318,8 @@ public class AndroidAptCompiler implements SourceGeneratingCompiler {
           }
           final boolean generateNonFinalFields = facet.getConfiguration().LIBRARY_PROJECT || circularDepLibWithSamePackage != null;
 
+          final String renamedManifest = facet.getConfiguration().RENAMED_MANIFEST;
+
           final VirtualFile outputDirForDex = AndroidDexCompiler.getOutputDirectoryForDex(module);
           final String proguardCfgOutputFileOsPath =
             AndroidCompileUtil.getProguardConfigFilePathIfShouldRun(facet, myContext) != null
@@ -321,7 +327,7 @@ public class AndroidAptCompiler implements SourceGeneratingCompiler {
             : null;
 
           items.add(new AptGenerationItem(module, manifestFile, resPaths, target, platformToolsRevision, packageName, libPackages,
-                                          generateNonFinalFields, proguardCfgOutputFileOsPath));
+                                          generateNonFinalFields, renamedManifest, proguardCfgOutputFileOsPath));
         }
       }
       return items.toArray(new GenerationItem[items.size()]);

--- a/plugins/android/src/org/jetbrains/android/compiler/AndroidResourcesPackagingCompiler.java
+++ b/plugins/android/src/org/jetbrains/android/compiler/AndroidResourcesPackagingCompiler.java
@@ -90,7 +90,8 @@ public class AndroidResourcesPackagingCompiler implements ClassPostProcessingCom
             }
 
             items.add(new MyItem(module, target, platformToolsRevision, manifestFile, resourcesDirPaths, assetDirPaths, outputPath,
-                                 configuration.GENERATE_UNSIGNED_APK, AndroidCompileUtil.isReleaseBuild(context)));
+                                 configuration.RENAMED_MANIFEST, configuration.GENERATE_UNSIGNED_APK,
+                                 AndroidCompileUtil.isReleaseBuild(context)));
             //items.add(new MyItem(module, target, manifestFile, resourcesDirPaths, assetsDirPath, outputPath + RELEASE_SUFFIX, true));
           }
         }
@@ -186,7 +187,7 @@ public class AndroidResourcesPackagingCompiler implements ClassPostProcessingCom
                                     preprocessedManifestFile.getPath(),
                                     item.myResourceDirPaths,
                                     item.myAssetsDirPaths,
-                                    outputPath, null, !releasePackage, 0, new FileFilter() {
+                                    outputPath, null, item.myRenamedManifest, !releasePackage, 0, new FileFilter() {
           @Override
           public boolean accept(File file) {
             final VirtualFile vFile = LocalFileSystem.getInstance().findFileByIoFile(file);
@@ -293,6 +294,7 @@ public class AndroidResourcesPackagingCompiler implements ClassPostProcessingCom
     final String[] myResourceDirPaths;
     final String[] myAssetsDirPaths;
     final String myOutputPath;
+    final String myRenamedManifest;
 
     private final boolean myFileExists;
     private final boolean myGenerateUnsignedApk;
@@ -306,6 +308,7 @@ public class AndroidResourcesPackagingCompiler implements ClassPostProcessingCom
                    String[] resourceDirPaths,
                    String[] assetsDirPath,
                    String outputPath,
+                   String renamedManifest,
                    boolean generateUnsignedApk,
                    boolean releaseBuild) {
       myModule = module;
@@ -316,6 +319,7 @@ public class AndroidResourcesPackagingCompiler implements ClassPostProcessingCom
       myAssetsDirPaths = assetsDirPath;
       myOutputPath = outputPath;
       myFileExists = new File(outputPath).exists();
+      myRenamedManifest = renamedManifest;
       myGenerateUnsignedApk = generateUnsignedApk;
       myReleaseBuild = releaseBuild;
     }

--- a/plugins/android/src/org/jetbrains/android/facet/AndroidFacetConfiguration.java
+++ b/plugins/android/src/org/jetbrains/android/facet/AndroidFacetConfiguration.java
@@ -74,6 +74,8 @@ public class AndroidFacetConfiguration implements FacetConfiguration {
 
   public boolean LIBRARY_PROJECT = false;
 
+  public String RENAMED_MANIFEST = "";
+
   public boolean RUN_PROCESS_RESOURCES_MAVEN_TASK = true;
 
   public boolean GENERATE_UNSIGNED_APK = false;

--- a/plugins/android/src/org/jetbrains/android/facet/AndroidFacetEditorTab.form
+++ b/plugins/android/src/org/jetbrains/android/facet/AndroidFacetEditorTab.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="myContentPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="512" height="669"/>
+      <xy x="20" y="20" width="512" height="696"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -115,7 +115,7 @@
               </vspacer>
             </children>
           </grid>
-          <grid id="84519" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="84519" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="4" right="0"/>
             <constraints>
               <tabbedpane title="Compiler"/>
@@ -168,7 +168,7 @@
               </grid>
               <vspacer id="e716a">
                 <constraints>
-                  <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="9" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
               <grid id="c2a96" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -340,6 +340,16 @@
                   </component>
                 </children>
               </grid>
+              <component id="74842" class="com.intellij.openapi.ui.LabeledComponent" binding="myRenamedManifestComponent">
+                <constraints>
+                  <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <componentClass value="com.intellij.ui.EditorTextField"/>
+                  <labelLocation value="West"/>
+                  <text resource-bundle="messages/AndroidBundle" key="android.facet.settings.rename.package.label"/>
+                </properties>
+              </component>
             </children>
           </grid>
         </children>

--- a/plugins/android/src/org/jetbrains/android/facet/AndroidFacetEditorTab.java
+++ b/plugins/android/src/org/jetbrains/android/facet/AndroidFacetEditorTab.java
@@ -26,6 +26,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.ui.LabeledComponent;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.io.FileUtil;
@@ -33,6 +34,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.ComboboxWithBrowseButton;
+import com.intellij.ui.EditorTextField;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ArrayUtil;
@@ -99,6 +101,7 @@ public class AndroidFacetEditorTab extends FacetEditorTab {
   private TextFieldWithBrowseButton myProguardConfigFileTextField;
   private JCheckBox myIncludeSystemProguardFileCheckBox;
   private JBCheckBox myIncludeAssetsFromLibraries;
+  private LabeledComponent<EditorTextField> myRenamedManifestComponent;
 
   public AndroidFacetEditorTab(FacetEditorContext context, AndroidFacetConfiguration androidFacetConfiguration) {
     final Project project = context.getProject();
@@ -322,6 +325,9 @@ public class AndroidFacetEditorTab extends FacetEditorTab {
     if (myConfiguration.isIncludeAssetsFromLibraries() != myIncludeAssetsFromLibraries.isSelected()) {
       return true;
     }
+    if (!getRenamedManifestPackage().equals(myConfiguration.RENAMED_MANIFEST)) {
+      return true;
+    }
 
     if (checkRelativePath(myConfiguration.PROGUARD_CFG_PATH, myProguardConfigFileTextField.getText())) {
       return true;
@@ -340,6 +346,13 @@ public class AndroidFacetEditorTab extends FacetEditorTab {
   private String getSelectedCustomKeystorePath() {
     final String path = myCustomDebugKeystoreField.getText().trim();
     return path.length() > 0 ? VfsUtil.pathToUrl(FileUtil.toSystemIndependentName(path)) : "";
+  }
+
+  @NotNull
+  private String getRenamedManifestPackage() {
+    EditorTextField textField = myRenamedManifestComponent.getComponent();
+    final String renamedManifest = textField.getText().trim();
+    return renamedManifest.length() > 0 ? renamedManifest : "";
   }
 
   @NotNull
@@ -442,6 +455,8 @@ public class AndroidFacetEditorTab extends FacetEditorTab {
 
     myConfiguration.setIncludeAssetsFromLibraries(myIncludeAssetsFromLibraries.isSelected());
 
+    myConfiguration.RENAMED_MANIFEST = getRenamedManifestPackage();
+
     String absProguardPath = myProguardConfigFileTextField.getText().trim();
     if (absProguardPath.length() == 0) {
       if (myRunProguardCheckBox.isSelected()) {
@@ -533,6 +548,8 @@ public class AndroidFacetEditorTab extends FacetEditorTab {
     myNativeLibsFolder.setText(libsAbsPath != null ? libsAbsPath : "");
 
     myCustomDebugKeystoreField.setText(FileUtil.toSystemDependentName(VfsUtil.urlToPath(configuration.CUSTOM_DEBUG_KEYSTORE_PATH)));
+
+    myRenamedManifestComponent.getComponent().setText(configuration.RENAMED_MANIFEST);
 
     String proguardCfgRelPath = configuration.PROGUARD_CFG_PATH;
     String proguardCfgAbsPath = proguardCfgRelPath.length() > 0 ? toAbsolutePath(proguardCfgRelPath) : "";

--- a/plugins/android/src/org/jetbrains/android/run/AndroidRunConfiguration.java
+++ b/plugins/android/src/org/jetbrains/android/run/AndroidRunConfiguration.java
@@ -181,6 +181,7 @@ public class AndroidRunConfiguration extends AndroidRunConfigurationBase impleme
         activityToLaunch = JavaExecutionUtil.getRuntimeQualifiedName(activityClass);
       }
     }
+
     return new MyApplicationLauncher(activityToLaunch);
   }
 
@@ -231,7 +232,9 @@ public class AndroidRunConfiguration extends AndroidRunConfigurationBase impleme
       String activityName = myActivityName;
       if (activityName == null) return true;
       activityName = activityName.replace("$", "\\$");
-      final String activityPath = state.getPackageName() + '/' + activityName;
+      final String renamedManifest = state.getFacet().getConfiguration().RENAMED_MANIFEST;
+      final String finalPackage = renamedManifest.length() > 0 ? renamedManifest : state.getPackageName();
+      final String activityPath = finalPackage + '/' + activityName;
       ProcessHandler processHandler = state.getProcessHandler();
       if (state.isStopped()) return false;
       processHandler.notifyTextAvailable("Launching application: " + activityPath + ".\n", STDOUT);


### PR DESCRIPTION
This allows to compile the same app with a different package name. Useful for when you want to deploy both production or dev builds.

I added the code and input field into the AndroidFacetEditorTab.form instead of the AndroidRunConfigurationEditor.form because this applies to the compiling/packaging of the APK. If this is incorrect I can change it.

Also edited the launcher to take into consideration if the package has been renamed before launching the app.
