### PR TITLE
IDEA-97356 Link "Specify Master Password" dialog to the Help topic

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/passwordSafe/HelpID.java
+++ b/platform/platform-impl/src/com/intellij/ide/passwordSafe/HelpID.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2012 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.ide.passwordSafe;
+
+
+import org.jetbrains.annotations.NonNls;
+
+/**
+ * User: Matthew Aynalem
+ * Date: 12/19/12
+ * Time: 2:09 PM
+ */
+public interface HelpID {
+  @NonNls String RESET_PASSWORD = "reference_ide_settings_master_password_reset";
+  @NonNls String CHANGE_PASSWORD = "reference_settings_password_safe_master_password";
+}

--- a/platform/platform-impl/src/com/intellij/ide/passwordSafe/impl/providers/masterKey/ChangeMasterKeyDialog.java
+++ b/platform/platform-impl/src/com/intellij/ide/passwordSafe/impl/providers/masterKey/ChangeMasterKeyDialog.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.ide.passwordSafe.impl.providers.masterKey;
 
+import com.intellij.ide.passwordSafe.HelpID;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.util.Processor;
@@ -79,6 +80,14 @@ public class ChangeMasterKeyDialog extends DialogWrapper {
     });
     setErrorText(error);
     init();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected String getHelpId() {
+    return HelpID.CHANGE_PASSWORD;
   }
 
   /**

--- a/platform/platform-impl/src/com/intellij/ide/passwordSafe/impl/providers/masterKey/ResetPasswordDialog.java
+++ b/platform/platform-impl/src/com/intellij/ide/passwordSafe/impl/providers/masterKey/ResetPasswordDialog.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.ide.passwordSafe.impl.providers.masterKey;
 
+import com.intellij.ide.passwordSafe.HelpID;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.util.Processor;
@@ -92,6 +93,14 @@ public class ResetPasswordDialog extends DialogWrapper {
   @Override
   protected JComponent createCenterPanel() {
     return myPanel;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected String getHelpId() {
+    return HelpID.RESET_PASSWORD;
   }
 
   /**


### PR DESCRIPTION
Fix for http://youtrack.jetbrains.com/issue/IDEA-97356. added help links to both ChangeMasterKeyDialog and ResetPasswordDialog. both are directly accessible via Passwords settings or as described in the original issue
