### PR TITLE
IDEA-98030 Encoding problem in comments in hg4idea plugin in IDEA

### DIFF
--- a/plugins/hg4idea/src/org/zmlx/hg4idea/command/HgLogCommand.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/command/HgLogCommand.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.zmlx.hg4idea.HgFile;
 import org.zmlx.hg4idea.execution.HgCommandExecutor;
 import org.zmlx.hg4idea.execution.HgCommandResult;
+import org.zmlx.hg4idea.util.HgEncodingUtil;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -75,6 +76,7 @@ public class HgLogCommand extends HgRevisionsCommand {
     if (logFile) {
       arguments.add(hgFile.getRelativePath());
     }
+    executor.setCharset(HgEncodingUtil.getDefaultCharset());
     return executor.executeInCurrentThread(repo, "log", arguments);
   }
 

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/util/HgEncodingUtil.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/util/HgEncodingUtil.java
@@ -9,32 +9,38 @@ import java.nio.charset.Charset;
  * @author Kirill Likhodedov
  */
 public class HgEncodingUtil {
-  
-  private static final String WINDOWS_DEFAULT_CHARSET = "cp1251";
-  private static final String UNIX_DEFAULT_CHARSET = "UTF-8";
+
+  private static final Charset DEFAULT_CHARSET;
+
+  static {
+    // next in line is HGENCODING in environment
+    String enc = System.getenv("HGENCODING");
+
+    // next is platform encoding as available in JDK
+    Charset cs = SystemInfo.isWindows ? Charset.defaultCharset() : Charset.forName("UTF-8");
+    try {
+      if (enc != null && enc.length() > 0 && Charset.isSupported(enc)) {
+        cs = Charset.forName(enc);
+      }
+    } catch (Exception e) {
+      cs = SystemInfo.isWindows ? Charset.defaultCharset() : Charset.forName("UTF-8");
+    } finally {
+      DEFAULT_CHARSET = cs;
+    }
+  }
 
   private HgEncodingUtil() {
   }
 
   /**
-   * Returns the default charset for Mercurial.
-   * It is cp1251 for Windows, and UTF-8 for Unix-like systems.
-   * The {@code HGENCODING} environment variable is not considered, because being set for IDEA it is inherited by the hg process
-   * spawned by IDEA.
-   * @return cp1251 for windows / UTF-8 for Unix-like systems.
+   * The default encoding which is used by the current environment.
+   * <b>Note</b>: Python's encoding isn't 1-1 with Charset.name() so do not store
+   * {@link java.nio.charset.Charset}.
+   *
+   * @return a valid encoding name, never null.
    */
   @NotNull
   public static Charset getDefaultCharset() {
-    return SystemInfo.isWindows ? getCharsetForNameOrDefault(WINDOWS_DEFAULT_CHARSET) : getCharsetForNameOrDefault(UNIX_DEFAULT_CHARSET);
-  }
-
-  @NotNull
-  private static Charset getCharsetForNameOrDefault(@NotNull String name) {
-    try {
-      return Charset.forName(name);
-    }
-    catch (Exception e) {
-      return Charset.defaultCharset();
-    }
+    return DEFAULT_CHARSET;
   }
 }


### PR DESCRIPTION
Fix for http://youtrack.jetbrains.com/issue/IDEA-98030
The default encoding for Windows may be changed depending on the locale.
For example, Japanese is cp932.
And, if the HGENCODING is set to overrides the system default.

Please reference the following for the code page of Windows.
http://msdn.microsoft.com/en-us/library/2x8et5ee.aspx
