### PR TITLE
removed duplicate class IElementType.Predicate (use com.intellij.util.containers.Predicate)

### DIFF
--- a/platform/core-api/src/com/intellij/psi/tree/IElementType.java
+++ b/platform/core-api/src/com/intellij/psi/tree/IElementType.java
@@ -17,6 +17,7 @@ package com.intellij.psi.tree;
 
 import com.intellij.lang.Language;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.containers.Predicate;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,9 +43,9 @@ public class IElementType {
    *
    * @see #enumerate(Predicate)
    */
-  public static final Predicate TRUE = new Predicate() {
+  public static final Predicate<IElementType> TRUE = new Predicate<IElementType>() {
     @Override
-    public boolean matches(IElementType type) {
+    public boolean apply(IElementType type) {
       return true;
     }
   };
@@ -149,15 +150,6 @@ public class IElementType {
     }
   }
 
-  /**
-   * Predicate for matching element types.
-   *
-   * @see IElementType#enumerate(Predicate)
-   */
-  public interface Predicate {
-    boolean matches(IElementType type);
-  }
-
   static short getAllocatedTypesCount() {
     return ourCounter;
   }
@@ -177,7 +169,7 @@ public class IElementType {
 
     List<IElementType> matches = new ArrayList<IElementType>();
     for (IElementType value : copy) {
-      if (p.matches(value)) {
+      if (p.apply(value)) {
         matches.add(value);
       }
     }

--- a/platform/core-api/src/com/intellij/psi/tree/TokenSet.java
+++ b/platform/core-api/src/com/intellij/psi/tree/TokenSet.java
@@ -201,7 +201,7 @@ public class TokenSet {
     return andNot(this, t);
   }
 
-  /** @deprecated please use {@linkplain IElementType#enumerate(com.intellij.psi.tree.IElementType.Predicate)} (to remove in IDEA 13) */
+  /** @deprecated please use {@linkplain IElementType#enumerate(com.intellij.util.containers.Predicate)} (to remove in IDEA 13) */
   @SuppressWarnings("UnusedDeclaration")
   @NotNull
   public static TokenSet not(@NotNull TokenSet set) {

--- a/platform/indexing-api/src/com/intellij/psi/stubs/SerializationManager.java
+++ b/platform/indexing-api/src/com/intellij/psi/stubs/SerializationManager.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.IStubFileElementType;
+import com.intellij.util.containers.Predicate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,8 +48,8 @@ public abstract class SerializationManager {
       for (StubElementTypeHolderEP holderEP : Extensions.getExtensions(StubElementTypeHolderEP.EP_NAME)) {
         holderEP.initialize();
       }
-      final IElementType[] stubElementTypes = IElementType.enumerate(new IElementType.Predicate() {
-        public boolean matches(final IElementType type) {
+      final IElementType[] stubElementTypes = IElementType.enumerate(new Predicate<IElementType>() {
+        public boolean apply(final IElementType type) {
           return type instanceof StubSerializer;
         }
       });


### PR DESCRIPTION
сurrently util have dependency 'guava' - it have Predicate(analog), and util class Predicates, but it not exported to others modules
