### PR TITLE
IDEA-103973 Gradle wrapper detection is more generic

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/GradleInstallationManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/GradleInstallationManager.java
@@ -175,8 +175,8 @@ public class GradleInstallationManager {
       return null;
     }
 
-    String version = GradleUtil.getWrapperVersion(linkedProjectPath);
-    if (version == null) {
+    String distribution = GradleUtil.getWrapperDistribution(linkedProjectPath);
+    if (distribution == null) {
       return null;
     }
     File gradleSystemDir = new File(System.getProperty("user.home"), ".gradle");
@@ -189,7 +189,7 @@ public class GradleInstallationManager {
       return null;
     }
 
-    File targetDistributionHome = new File(gradleWrapperDistributionsHome, String.format("gradle-%s-bin", version));
+    File targetDistributionHome = new File(gradleWrapperDistributionsHome, distribution);
     if (!targetDistributionHome.isDirectory()) {
       return null;
     }
@@ -200,9 +200,14 @@ public class GradleInstallationManager {
       return null;
     }
 
-    File result = new File(files[0], String.format("gradle-%s", version));
-    if (result.isDirectory()) {
-      return result;
+    File[] distFiles = files[0].listFiles();
+    if (distFiles == null || distFiles.length != 1) {
+      // There should exist only the gradle directory in the distribution directory
+      return null;
+    }
+
+    if (distFiles[0].isDirectory()) {
+      return distFiles[0];
     }
     else {
       return null;


### PR DESCRIPTION
Changed gradle wrapper home directory discovery to act the same way that the gradle wrapper does rather than using a pattern of `gradle-*-bin.zip`.  This fixes http://youtrack.jetbrains.com/issue/IDEA-103973 and http://youtrack.jetbrains.com/issue/IDEA-106491.

I modeled the wrapper resolution code after the gradle wrapper project directly, see: https://github.com/gradle/gradle/blob/master/subprojects/wrapper/src/main/java/org/gradle/wrapper/PathAssembler.java
