### PR TITLE
[hg] Per the TODO on HgWorkingCopyRevisionsCommand::parents(), that meth...

### DIFF
--- a/plugins/hg4idea/src/org/zmlx/hg4idea/command/HgWorkingCopyRevisionsCommand.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/command/HgWorkingCopyRevisionsCommand.java
@@ -48,13 +48,13 @@ public class HgWorkingCopyRevisionsCommand {
   /**
    * Current repository revision(s).
    * @param repo repository to work on.
-   * @return List of parent's revision numbers.
-   * @see #parents(com.intellij.openapi.vfs.VirtualFile, com.intellij.openapi.vfs.VirtualFile, org.zmlx.hg4idea.HgRevisionNumber)
-   * TODO: return Pair
+   * @return One or two (in case of a merge commit) parents of the given revision. Or even zero in case of a fresh repository.
+   *         So one should check pair elements for null.
+   * @see #parents(com.intellij.openapi.vfs.VirtualFile, com.intellij.openapi.vcs.FilePath, org.zmlx.hg4idea.HgRevisionNumber)
    */
   @NotNull
-  public List<HgRevisionNumber> parents(@NotNull VirtualFile repo) {
-    return getRevisions(repo, "parents", null, null, true);
+  public Pair<HgRevisionNumber, HgRevisionNumber> parents(@NotNull VirtualFile repo) {
+    return parents(repo, (FilePath)null, null);
   }
 
   /**
@@ -108,13 +108,13 @@ public class HgWorkingCopyRevisionsCommand {
 
   @Nullable
   public HgRevisionNumber firstParent(@NotNull VirtualFile repo) {
-    List<HgRevisionNumber> parents = parents(repo);
-    if (parents.isEmpty()) {
+    Pair<HgRevisionNumber, HgRevisionNumber> parents = parents(repo);
+    if (null == parents.first) {
       //this is possible when we have a freshly initialized mercurial repository
       return HgRevisionNumber.NULL_REVISION_NUMBER;
     }
     else {
-      return parents.get(0);
+      return parents.first;
     }
   }
 

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/provider/commit/HgCheckinEnvironment.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/provider/commit/HgCheckinEnvironment.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vcs.CheckinProjectPanel;
 import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vcs.VcsException;
@@ -130,13 +131,13 @@ public class HgCheckinEnvironment implements CheckinEnvironment {
   }
 
   private boolean isMergeCommit(VirtualFile repo) {
-    return new HgWorkingCopyRevisionsCommand(myProject).parents(repo).size() > 1;
+    return new HgWorkingCopyRevisionsCommand(myProject).parents(repo).second != null;
   }
 
   private Set<HgFile> getChangedFilesNotInCommit(VirtualFile repo, Set<HgFile> selectedFiles) {
-    List<HgRevisionNumber> parents = new HgWorkingCopyRevisionsCommand(myProject).parents(repo);
+    Pair<HgRevisionNumber, HgRevisionNumber> parents = new HgWorkingCopyRevisionsCommand(myProject).parents(repo);
 
-    HgStatusCommand statusCommand = new HgStatusCommand.Builder(true).unknown(false).ignored(false).baseRevision(parents.get(0)).build(myProject);
+    HgStatusCommand statusCommand = new HgStatusCommand.Builder(true).unknown(false).ignored(false).baseRevision(parents.first).build(myProject);
     Set<HgChange> allChangedFilesInRepo = statusCommand.execute(repo);
 
     Set<HgFile> filesNotIncluded = new HashSet<HgFile>();

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/provider/update/HgRegularUpdater.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/provider/update/HgRegularUpdater.java
@@ -15,6 +15,7 @@ package org.zmlx.hg4idea.provider.update;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.update.FileGroup;
@@ -97,8 +98,8 @@ public class HgRegularUpdater implements HgUpdater {
 
     if (shouldUpdate()) {
 
-      List<HgRevisionNumber> parentsBeforeUpdate = new HgWorkingCopyRevisionsCommand(project).parents(repository);
-      if (parentsBeforeUpdate.size() > 1) {
+      Pair<HgRevisionNumber, HgRevisionNumber> parentsBeforeUpdate = new HgWorkingCopyRevisionsCommand(project).parents(repository);
+      if (null != parentsBeforeUpdate.second) {
         throw new VcsException(HgVcsMessages.message("hg4idea.update.error.uncommittedMerge", repository.getPath()));
       }
 

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/status/HgCurrentBranchStatus.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/status/HgCurrentBranchStatus.java
@@ -12,13 +12,13 @@
 // limitations under the License.
 package org.zmlx.hg4idea.status;
 
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.zmlx.hg4idea.HgRevisionNumber;
 import org.zmlx.hg4idea.HgVcsMessages;
 
-import java.util.List;
 
 public class HgCurrentBranchStatus {
 
@@ -29,16 +29,16 @@ public class HgCurrentBranchStatus {
   public HgCurrentBranchStatus() {
   }
 
-  public void updateFor(@Nullable String branch, @NotNull List<HgRevisionNumber> parents) {
+  public void updateFor(@Nullable String branch, @NotNull Pair<HgRevisionNumber, HgRevisionNumber> parents) {
     StringBuilder parentsBuffer = new StringBuilder();
-    for (HgRevisionNumber parent : parents) {
-      String rev = parent.getRevision();
-      parentsBuffer.append(rev).append(", ");
+    if (null != parents.first) {
+      parentsBuffer.append(parents.first).append(", ");
+
+      if ( null != parents.second) {
+        parentsBuffer.append(parents.second);
+      }
     }
-    int length = parentsBuffer.length();
-    if (length > 2) {
-      parentsBuffer.delete(length - 2, length);
-    }
+
     String parent = parentsBuffer.toString();
     String statusText =
       !StringUtil.isEmptyOrSpaces(branch) ? HgVcsMessages.message("hg4idea.status.currentSituationText", branch, parent) : "";

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/status/ui/HgCurrentBranchStatusUpdater.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/status/ui/HgCurrentBranchStatusUpdater.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.ui.UIUtil;
@@ -30,8 +31,6 @@ import org.zmlx.hg4idea.command.HgTagBranchCommand;
 import org.zmlx.hg4idea.command.HgWorkingCopyRevisionsCommand;
 import org.zmlx.hg4idea.status.HgCurrentBranchStatus;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class HgCurrentBranchStatusUpdater implements HgUpdater {
@@ -67,7 +66,7 @@ public class HgCurrentBranchStatusUpdater implements HgUpdater {
     });
 
     if (textEditor.get() == null) {
-      handleUpdate(project, null, Collections.<HgRevisionNumber>emptyList());
+      handleUpdate(project, null, Pair.<HgRevisionNumber, HgRevisionNumber>create(null, null));
     }
     else {
       if (project.isDisposed()) {
@@ -83,7 +82,7 @@ public class HgCurrentBranchStatusUpdater implements HgUpdater {
           public void run() {
             HgTagBranchCommand hgTagBranchCommand = new HgTagBranchCommand(project, repo);
             final String branch = hgTagBranchCommand.getCurrentBranch();
-            final List<HgRevisionNumber> parents = new HgWorkingCopyRevisionsCommand(project).parents(repo);
+            final Pair<HgRevisionNumber, HgRevisionNumber> parents = new HgWorkingCopyRevisionsCommand(project).parents(repo);
             ApplicationManager.getApplication().invokeLater(new Runnable() {
               @Override
               public void run() {
@@ -97,7 +96,7 @@ public class HgCurrentBranchStatusUpdater implements HgUpdater {
   }
 
 
-  private void handleUpdate(Project project, @Nullable String branch, List<HgRevisionNumber> parents) {
+  private void handleUpdate(Project project, @Nullable String branch, Pair<HgRevisionNumber, HgRevisionNumber> parents) {
 
     currentBranchStatus.updateFor(branch, parents);
 

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/util/HgUtil.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/util/HgUtil.java
@@ -316,7 +316,7 @@ public abstract class HgUtil {
    * @return True if merge operation is in progress, false if there is no merge operation.
    */
   public static boolean isMergeInProgress(@NotNull Project project, VirtualFile repository) {
-    return new HgWorkingCopyRevisionsCommand(project).parents(repository).size() > 1;
+    return new HgWorkingCopyRevisionsCommand(project).parents(repository).second != null;
   }
   /**
    * Groups the given files by their Mercurial repositories and returns the map of relative paths to files for each repository.


### PR DESCRIPTION
...od now returns a Pair, matching all the other versions of the parents() method.

I had a really hard time getting the org.zmlx.hg4idea.test.HgUpdateTest#updateShouldMergeButNotCommitWithConflicts to work. I added a bunch of comments explaining what each step of the test does and what the resulting history is supposed to be like. I did not make any attempt at getting the other tests in this class to work.
