### PR TITLE
IDEA-105361 - Subversion: Compare action doesn't work for revisions in History after path rename

### DIFF
--- a/plugins/svn4idea/src/org/jetbrains/idea/svn/SvnUtil.java
+++ b/plugins/svn4idea/src/org/jetbrains/idea/svn/SvnUtil.java
@@ -729,9 +729,9 @@ public class SvnUtil {
     SVNWCClient wcClient = vcs.createWCClient();
     try {
       if (isUrl) {
-        wcClient.doGetFileContents(SVNURL.parseURIEncoded(path), pegRevision, revision, true, buffer);
+        wcClient.doGetFileContents(SVNURL.parseURIEncoded(path), revision, revision, true, buffer);
       } else {
-        wcClient.doGetFileContents(new File(path), pegRevision, revision, true, buffer);
+        wcClient.doGetFileContents(new File(path), revision, revision, true, buffer);
       }
       ContentRevisionCache.checkContentsSize(path, buffer.size());
     } catch (FileTooBigRuntimeException e) {


### PR DESCRIPTION
Not sure if this is right, but I have been using it for some time and it seems to work ok.

http://youtrack.jetbrains.com/issue/IDEA-105361
