### PR TITLE
Expose a commit's branch in a few different places:

### DIFF
--- a/platform/platform-resources-en/src/messages/VcsBundle.properties
+++ b/platform/platform-resources-en/src/messages/VcsBundle.properties
@@ -465,6 +465,7 @@ outdated.version.pretty.date.text=Outdated version. Modified by {0} {1}: {2}
 outdated.version.text.deleted=Outdated version. Deleted by {0} {1}: {2}
 current.version.text={4}<br/><br/>Current version is {3}.<br/>Modified by {0}<br/>{1}<br/>{2}
 committed.changes.filter.title=Filter by
+committed.changes.group.title=Group by
 changelist.details.committed.format=Committed by {0} {1}
 incoming.changes.indicator.tooltip={0} incoming changelists available
 column.name.type=Type

--- a/platform/vcs-api/src/com/intellij/openapi/vcs/versionBrowser/CommittedChangeList.java
+++ b/platform/vcs-api/src/com/intellij/openapi/vcs/versionBrowser/CommittedChangeList.java
@@ -19,6 +19,7 @@ package com.intellij.openapi.vcs.versionBrowser;
 import com.intellij.openapi.vcs.AbstractVcs;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.ChangeList;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Date;
@@ -30,6 +31,15 @@ public interface CommittedChangeList extends ChangeList {
   String getCommitterName();
   Date getCommitDate();
   long getNumber();
+
+  /**
+   * Returns the branch on which this changelist occurred. This method may return null if
+   * the changelist did not occur on a branch or if branching is not supported.
+   *
+   * @return the branch of this changelist, or null if not applicable.
+   */
+  @Nullable
+  String getBranch();
 
   /**
    * Returns the VCS by which the changelist was generated. This method must return a not null

--- a/platform/vcs-api/src/com/intellij/openapi/vcs/versionBrowser/CommittedChangeListImpl.java
+++ b/platform/vcs-api/src/com/intellij/openapi/vcs/versionBrowser/CommittedChangeListImpl.java
@@ -60,6 +60,11 @@ public class CommittedChangeListImpl implements CommittedChangeList {
     return myNumber;
   }
 
+  @Override
+  public String getBranch() {
+    return null;
+  }
+
   public AbstractVcs getVcs() {
     return null;
   }

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/CommittedChangeListRenderer.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/CommittedChangeListRenderer.java
@@ -92,6 +92,7 @@ public class CommittedChangeListRenderer extends ColoredTreeCellRenderer {
     String date = ", " + getDateOfChangeList(changeList.getCommitDate());
     final FontMetrics fontMetrics = tree.getFontMetrics(tree.getFont());
     final FontMetrics boldMetrics = tree.getFontMetrics(tree.getFont().deriveFont(Font.BOLD));
+    final FontMetrics italicMetrics = tree.getFontMetrics(tree.getFont().deriveFont(Font.ITALIC));
     if (myDateWidth <= 0 || (fontMetrics.getFont().getSize() != myFontSize)) {
       myDateWidth = Math.max(fontMetrics.stringWidth(", Yesterday 00:00 PM "), fontMetrics.stringWidth(", 00/00/00 00:00 PM "));
       myDateWidth = Math.max(myDateWidth, fontMetrics.stringWidth(getDateOfChangeList(new Date(2000, 11, 31))));
@@ -133,6 +134,15 @@ public class CommittedChangeListRenderer extends ColoredTreeCellRenderer {
       }
     }
 
+    int branchWidth = 0;
+    String branch = changeList.getBranch();
+    if ( null != branch ) {
+      branch += " ";
+      branchWidth = italicMetrics.stringWidth(branch);
+      descWidth += branchWidth;
+      append(branch, SimpleTextAttributes.GRAY_ITALIC_ATTRIBUTES);
+    }
+
     if (description.isEmpty() && !truncated) {
       append(VcsBundle.message("committed.changes.empty.comment"), SimpleTextAttributes.GRAYED_ATTRIBUTES);
       appendFixedTextFragmentWidth(descMaxWidth);
@@ -147,7 +157,7 @@ public class CommittedChangeListRenderer extends ColoredTreeCellRenderer {
     else {
       final String moreMarker = VcsBundle.message("changes.browser.details.marker");
       int moreWidth = fontMetrics.stringWidth(moreMarker);
-      int remainingWidth = descMaxWidth - moreWidth - numberWidth;
+      int remainingWidth = descMaxWidth - moreWidth - numberWidth - branchWidth;
       description = truncateDescription(description, fontMetrics, remainingWidth);
       myRenderer.appendTextWithLinks(description);
       if (!StringUtil.isEmpty(description)) {

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/CommittedChangesTreeBrowser.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/CommittedChangesTreeBrowser.java
@@ -1,4 +1,3 @@
-
 package com.intellij.openapi.vcs.changes.committed;
 
 import com.intellij.ide.CopyProvider;
@@ -345,7 +344,7 @@ public class CommittedChangesTreeBrowser extends JPanel implements TypeSafeDataP
     toolbarGroup.add(leadGroup);
     toolbarGroup.addSeparator();
     toolbarGroup.add(new SelectFilteringAction(project, this));
-    toolbarGroup.add(new SelectGroupingAction(this));
+    toolbarGroup.add(new SelectGroupingAction(project, this));
     final ExpandAllAction expandAllAction = new ExpandAllAction(myChangesTree);
     final CollapseAllAction collapseAllAction = new CollapseAllAction(myChangesTree);
     expandAllAction.registerCustomShortcutSet(

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/SelectGroupingAction.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/SelectGroupingAction.java
@@ -15,16 +15,23 @@
  */
 package com.intellij.openapi.vcs.changes.committed;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.*;
+import com.intellij.openapi.vcs.versionBrowser.CommittedChangeList;
+
 import javax.swing.*;
+import java.util.Comparator;
 
 /**
  * @author yole
  */
 public class SelectGroupingAction extends LabeledComboBoxAction {
+  private final Project myProject;
   private final CommittedChangesTreeBrowser myBrowser;
 
-  public SelectGroupingAction(final CommittedChangesTreeBrowser browser) {
-    super("Group by");
+  public SelectGroupingAction(Project project, final CommittedChangesTreeBrowser browser) {
+    super(VcsBundle.message("committed.changes.group.title"));
+    myProject = project;
     myBrowser = browser;
     getComboBox().setPrototypeDisplayValue("Date+");
   }
@@ -34,6 +41,59 @@ public class SelectGroupingAction extends LabeledComboBoxAction {
   }
 
   protected ComboBoxModel createModel() {
-    return new DefaultComboBoxModel(new Object[] { new DateChangeListGroupingStrategy(), ChangeListGroupingStrategy.USER });
+    DefaultComboBoxModel model =
+      new DefaultComboBoxModel(new Object[]{new DateChangeListGroupingStrategy(), ChangeListGroupingStrategy.USER});
+    final AbstractVcs[] vcss = ProjectLevelVcsManager.getInstance(myProject).getAllActiveVcss();
+    for(AbstractVcs vcs: vcss) {
+      final CommittedChangesProvider provider = vcs.getCommittedChangesProvider();
+      if (provider != null) {
+        for(ChangeListColumn column: provider.getColumns()) {
+          if (ChangeListColumn.isCustom(column) && null != column.getComparator()) {
+            model.addElement(new CustomChangeListColumnGroupingStrategy(column));
+          }
+        }
+      }
+    }
+    return model;
+  }
+
+
+  private static class CustomChangeListColumnGroupingStrategy
+    implements ChangeListGroupingStrategy {
+
+    private final ChangeListColumn<CommittedChangeList> myColumn;
+
+    private CustomChangeListColumnGroupingStrategy(ChangeListColumn column) {
+      // The column is coming from a call to CommittedChangesProvider::getColumns(), which is typed as
+      //  simply "ChangeListColumn[]" without any additional type info. Inspecting the implementations
+      //  of that method shows that all the ChangeListColumn's that are returned are actually
+      //  ChangeListColumn<? extends CommittedChangeList>. Hence this cast, while ugly, is currently OK.
+      //noinspection unchecked
+      myColumn = (ChangeListColumn<CommittedChangeList>)column;
+    }
+
+    @Override
+    public void beforeStart() {
+    }
+
+    @Override
+    public boolean changedSinceApply() {
+      return false;
+    }
+
+    @Override
+    public String getGroupName(CommittedChangeList changeList) {
+      return changeList.getBranch();
+    }
+
+    @Override
+    public Comparator<CommittedChangeList> getComparator() {
+      return myColumn.getComparator();
+    }
+
+    @Override
+    public String toString() {
+      return myColumn.getTitle();
+    }
   }
 }

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/provider/HgCachingCommittedChangesProvider.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/provider/HgCachingCommittedChangesProvider.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.*;
@@ -371,7 +372,14 @@ public class HgCachingCommittedChangesProvider implements CachingCommittedChange
                                      localRevision.getAuthor(), localRevision.getRevisionDate(), changes);
   }
 
-  private final ChangeListColumn<HgCommittedChangeList> BRANCH_COLUMN = new ChangeListColumn<HgCommittedChangeList>() {
+  private static final Comparator<HgCommittedChangeList> BRANCH_COLUMN_COMPARATOR = new Comparator<HgCommittedChangeList>() {
+    @Override
+    public int compare(HgCommittedChangeList o1, HgCommittedChangeList o2) {
+      return Comparing.compare(o1.getBranch(), o2.getBranch());
+    }
+  };
+
+  private static final ChangeListColumn<HgCommittedChangeList> BRANCH_COLUMN = new ChangeListColumn<HgCommittedChangeList>() {
     public String getTitle() {
       return HgVcsMessages.message("hg4idea.changelist.column.branch");
     }
@@ -379,6 +387,12 @@ public class HgCachingCommittedChangesProvider implements CachingCommittedChange
     public Object getValue(final HgCommittedChangeList changeList) {
       final String branch = changeList.getBranch();
       return branch.isEmpty() ? "default" : branch;
+    }
+
+    @Nullable
+    @Override
+    public Comparator<HgCommittedChangeList> getComparator() {
+      return BRANCH_COLUMN_COMPARATOR;
     }
   };
 

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/provider/HgCommittedChangeList.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/provider/HgCommittedChangeList.java
@@ -1,5 +1,6 @@
 package org.zmlx.hg4idea.provider;
 
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.AbstractVcs;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
@@ -24,7 +25,7 @@ public class HgCommittedChangeList extends CommittedChangeListImpl implements Vc
     super(revision.asString() + ": " + comment, comment, committerName, revision.getRevisionAsLong(), commitDate, changes);
     myVcs = vcs;
     myRevision = revision;
-    myBranch = branch;
+    myBranch = StringUtil.isEmpty(branch) ? "default" : branch;
   }
 
   @NotNull

--- a/plugins/svn4idea/src/org/jetbrains/idea/svn/history/SvnChangeList.java
+++ b/plugins/svn4idea/src/org/jetbrains/idea/svn/history/SvnChangeList.java
@@ -582,6 +582,11 @@ public class SvnChangeList implements CommittedChangeList {
     return myRevision;
   }
 
+  @Override
+  public String getBranch() {
+    return null;
+  }
+
   public AbstractVcs getVcs() {
     return myVcs;
   }


### PR DESCRIPTION
- Added getBranch() to the CommittedChangeList, allowing easy determination of which branch the changelist happened on. May return null if not applicable. Check the branch of the changelist when rendering the changes; if non-empty, make the branch visible to the user. Very helpful when looking at all changes.
- When custom ChangeListColumns are added to the Repository table, and that column has a comparator, it will be added as an option for grouping. In particular, for Mercurial you can now view the Repository tab grouped by Branch.
