### PR TITLE
Implement extension support for MethodTextOccurrenceProcessor

### DIFF
--- a/java/java-indexing-impl/src/com/intellij/psi/impl/search/JavaMethodTextOccurrenceProcessorDelegate.java
+++ b/java/java-indexing-impl/src/com/intellij/psi/impl/search/JavaMethodTextOccurrenceProcessorDelegate.java
@@ -1,0 +1,46 @@
+package com.intellij.psi.impl.search;
+
+import com.intellij.psi.*;
+import com.intellij.psi.util.MethodSignature;
+import com.intellij.psi.util.MethodSignatureUtil;
+import com.intellij.psi.util.TypeConversionUtil;
+import com.intellij.util.Processor;
+
+public class JavaMethodTextOccurrenceProcessorDelegate implements MethodTextOccurrenceProcessorDelegate {
+  @Override
+  public boolean processReference(PsiReference ref,
+                                  PsiElement refElement,
+                                  PsiMethod method,
+                                  MethodTextOccurrenceProcessor processor,
+                                  Processor<PsiReference> consumer) {
+    if (refElement instanceof PsiMethod) {
+      PsiClass containingClass = processor.getContainingClass();
+
+      PsiMethod refMethod = (PsiMethod)refElement;
+      PsiClass refMethodClass = refMethod.getContainingClass();
+      if (refMethodClass == null) return true;
+
+      if (!refMethod.hasModifierProperty(PsiModifier.STATIC)) {
+        PsiSubstitutor substitutor =
+          TypeConversionUtil.getClassSubstitutor(containingClass, refMethodClass, PsiSubstitutor.EMPTY);
+        if (substitutor != null) {
+          MethodSignature superSignature = method.getSignature(substitutor);
+          MethodSignature refSignature = refMethod.getSignature(PsiSubstitutor.EMPTY);
+
+          if (MethodSignatureUtil.isSubsignature(superSignature, refSignature)) {
+            if (!consumer.process(ref)) return false;
+          }
+        }
+      }
+
+      if (!processor.isStrictSignatureSearch()) {
+        PsiManager manager = method.getManager();
+        if (manager.areElementsEquivalent(refMethodClass, containingClass)) {
+          if (!consumer.process(ref)) return false;
+        }
+      }
+    }
+
+    return true;
+  }
+}

--- a/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodTextOccurrenceProcessor.java
+++ b/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodTextOccurrenceProcessor.java
@@ -17,9 +17,6 @@ package com.intellij.psi.impl.search;
 
 import com.intellij.psi.*;
 import com.intellij.psi.search.RequestResultProcessor;
-import com.intellij.psi.util.MethodSignature;
-import com.intellij.psi.util.MethodSignatureUtil;
-import com.intellij.psi.util.TypeConversionUtil;
 import com.intellij.util.Processor;
 import org.jetbrains.annotations.NotNull;
 
@@ -51,6 +48,13 @@ public final class MethodTextOccurrenceProcessor extends RequestResultProcessor 
     return true;
   }
 
+  public PsiClass getContainingClass() {
+    return myContainingClass;
+  }
+
+  public boolean isStrictSignatureSearch() {
+    return myStrictSignatureSearch;
+  }
 
   private boolean processReference(Processor<PsiReference> consumer, PsiReference ref) {
     for (PsiMethod method : myMethods) {
@@ -66,29 +70,8 @@ public final class MethodTextOccurrenceProcessor extends RequestResultProcessor 
       }
       PsiElement refElement = ref.resolve();
 
-      if (refElement instanceof PsiMethod) {
-        PsiMethod refMethod = (PsiMethod)refElement;
-        PsiClass refMethodClass = refMethod.getContainingClass();
-        if (refMethodClass == null) continue;
-
-        if (!refMethod.hasModifierProperty(PsiModifier.STATIC)) {
-          PsiSubstitutor substitutor = TypeConversionUtil.getClassSubstitutor(myContainingClass, refMethodClass, PsiSubstitutor.EMPTY);
-          if (substitutor != null) {
-            MethodSignature superSignature = method.getSignature(substitutor);
-            MethodSignature refSignature = refMethod.getSignature(PsiSubstitutor.EMPTY);
-
-            if (MethodSignatureUtil.isSubsignature(superSignature, refSignature)) {
-              if (!consumer.process(ref)) return false;
-            }
-          }
-        }
-
-        if (!myStrictSignatureSearch) {
-          PsiManager manager = method.getManager();
-          if (manager.areElementsEquivalent(refMethodClass, myContainingClass)) {
-            if (!consumer.process(ref)) return false;
-          }
-        }
+      for (MethodTextOccurrenceProcessorDelegate delegate : MethodTextOccurrenceProcessorDelegate.EP_NAME.getExtensions()) {
+        if (!delegate.processReference(ref, refElement, method, this, consumer)) return false;
       }
     }
 

--- a/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodTextOccurrenceProcessorDelegate.java
+++ b/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodTextOccurrenceProcessorDelegate.java
@@ -1,0 +1,20 @@
+package com.intellij.psi.impl.search;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiReference;
+import com.intellij.util.Processor;
+
+public interface MethodTextOccurrenceProcessorDelegate {
+  ExtensionPointName<MethodTextOccurrenceProcessorDelegate> EP_NAME =
+    ExtensionPointName.create("com.intellij.methodTextOccurrenceProcessorDelegate");
+
+  boolean processReference(
+    PsiReference ref,
+    PsiElement refElement,
+    PsiMethod method,
+    MethodTextOccurrenceProcessor processor,
+    Processor<PsiReference> consumer
+  );
+}

--- a/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
+++ b/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
@@ -789,6 +789,8 @@
                     interface="com.intellij.codeInsight.daemon.impl.analysis.DefaultHighlightingSettingProvider"/>
 
     <extensionPoint name="sdkResolveScopeProvider" interface="com.intellij.psi.SdkResolveScopeProvider"/>
+
+    <extensionPoint name="methodTextOccurrenceProcessorDelegate" interface="com.intellij.psi.impl.search.MethodTextOccurrenceProcessorDelegate"/>
   </extensionPoints>
 </idea-plugin>
 

--- a/resources/src/META-INF/IdeaPlugin.xml
+++ b/resources/src/META-INF/IdeaPlugin.xml
@@ -1468,6 +1468,9 @@
                      implementationClass="org.jetbrains.generate.tostring.inspection.FieldNotUsedInToStringInspection"/>
 
     <codeInsight.unresolvedReferenceQuickFixProvider implementation="com.intellij.jarFinder.FindJarQuickFixProvider"/>
+
+
+    <methodTextOccurrenceProcessorDelegate implementation="com.intellij.psi.impl.search.JavaMethodTextOccurrenceProcessorDelegate" />
   </extensions>
 
   <actions>


### PR DESCRIPTION
This pull request delegates signature comparison performed by MethodTextOccurrenceProcessor to its extensions. Therefore deciding whether particular reference satisfies search criteria can be extended to support comparison with non-Java PSI elements.

The main goal is to allow Kotlin plugin to reuse most of the existing Java method search infrastructure.
