### PR TITLE
Refactor method search classes for better reusability

### DIFF
--- a/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodTextOccurrenceProcessor.java
+++ b/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodTextOccurrenceProcessor.java
@@ -28,11 +28,11 @@ import java.util.Arrays;
 /**
  * @author peter
  */
-public final class MethodTextOccurrenceProcessor extends RequestResultProcessor {
+public class MethodTextOccurrenceProcessor extends RequestResultProcessor {
   private static final PsiReferenceService ourReferenceService = PsiReferenceService.getService();
   private final PsiMethod[] myMethods;
-  private final PsiClass myContainingClass;
-  private final boolean myStrictSignatureSearch;
+  protected final PsiClass myContainingClass;
+  protected final boolean myStrictSignatureSearch;
 
   public MethodTextOccurrenceProcessor(@NotNull final PsiClass aClass, final boolean strictSignatureSearch, final PsiMethod... methods) {
     super(strictSignatureSearch, Arrays.asList(methods));
@@ -42,7 +42,7 @@ public final class MethodTextOccurrenceProcessor extends RequestResultProcessor 
   }
 
   @Override
-  public boolean processTextOccurrence(@NotNull PsiElement element, int offsetInElement, @NotNull final Processor<PsiReference> consumer) {
+  public final boolean processTextOccurrence(@NotNull PsiElement element, int offsetInElement, @NotNull final Processor<PsiReference> consumer) {
     for (PsiReference ref : ourReferenceService.getReferences(element, new PsiReferenceService.Hints(myMethods[0], offsetInElement))) {
       if (ReferenceRange.containsOffsetInElement(ref, offsetInElement) && !processReference(consumer, ref)) {
         return false;
@@ -50,7 +50,6 @@ public final class MethodTextOccurrenceProcessor extends RequestResultProcessor 
     }
     return true;
   }
-
 
   private boolean processReference(Processor<PsiReference> consumer, PsiReference ref) {
     for (PsiMethod method : myMethods) {
@@ -64,30 +63,35 @@ public final class MethodTextOccurrenceProcessor extends RequestResultProcessor 
       if (ref.isReferenceTo(method)) {
         return consumer.process(ref);
       }
-      PsiElement refElement = ref.resolve();
 
-      if (refElement instanceof PsiMethod) {
-        PsiMethod refMethod = (PsiMethod)refElement;
-        PsiClass refMethodClass = refMethod.getContainingClass();
-        if (refMethodClass == null) continue;
+      return processInexactReference(ref, ref.resolve(), method, consumer);
+    }
 
-        if (!refMethod.hasModifierProperty(PsiModifier.STATIC)) {
-          PsiSubstitutor substitutor = TypeConversionUtil.getClassSubstitutor(myContainingClass, refMethodClass, PsiSubstitutor.EMPTY);
-          if (substitutor != null) {
-            MethodSignature superSignature = method.getSignature(substitutor);
-            MethodSignature refSignature = refMethod.getSignature(PsiSubstitutor.EMPTY);
+    return true;
+  }
 
-            if (MethodSignatureUtil.isSubsignature(superSignature, refSignature)) {
-              if (!consumer.process(ref)) return false;
-            }
-          }
-        }
+  protected boolean processInexactReference(PsiReference ref, PsiElement refElement, PsiMethod method, Processor<PsiReference> consumer) {
+    if (refElement instanceof PsiMethod) {
+      PsiMethod refMethod = (PsiMethod)refElement;
+      PsiClass refMethodClass = refMethod.getContainingClass();
+      if (refMethodClass == null) return true;
 
-        if (!myStrictSignatureSearch) {
-          PsiManager manager = method.getManager();
-          if (manager.areElementsEquivalent(refMethodClass, myContainingClass)) {
+      if (!refMethod.hasModifierProperty(PsiModifier.STATIC)) {
+        PsiSubstitutor substitutor = TypeConversionUtil.getClassSubstitutor(myContainingClass, refMethodClass, PsiSubstitutor.EMPTY);
+        if (substitutor != null) {
+          MethodSignature superSignature = method.getSignature(substitutor);
+          MethodSignature refSignature = refMethod.getSignature(PsiSubstitutor.EMPTY);
+
+          if (MethodSignatureUtil.isSubsignature(superSignature, refSignature)) {
             if (!consumer.process(ref)) return false;
           }
+        }
+      }
+
+      if (!myStrictSignatureSearch) {
+        PsiManager manager = method.getManager();
+        if (manager.areElementsEquivalent(refMethodClass, myContainingClass)) {
+          if (!consumer.process(ref)) return false;
         }
       }
     }

--- a/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodUsagesSearcher.java
+++ b/java/java-indexing-impl/src/com/intellij/psi/impl/search/MethodUsagesSearcher.java
@@ -84,11 +84,14 @@ public class MethodUsagesSearcher extends QueryExecutorBase<PsiReference, Method
 
         short searchContext = UsageSearchContext.IN_CODE | UsageSearchContext.IN_COMMENTS | UsageSearchContext.IN_FOREIGN_LANGUAGES;
         collector.searchWord(methodName[0], restrictedByAccessScope, searchContext, true,
-                             new MethodTextOccurrenceProcessor(aClass, strictSignatureSearch, methods));
+                             getTextOccurrenceProcessor(methods, aClass, strictSignatureSearch));
 
         SimpleAccessorReferenceSearcher.addPropertyAccessUsages(method, restrictedByAccessScope, collector);
       }
     });
   }
 
+  protected MethodTextOccurrenceProcessor getTextOccurrenceProcessor(PsiMethod[] methods, PsiClass aClass, boolean strictSignatureSearch) {
+    return new MethodTextOccurrenceProcessor(aClass, strictSignatureSearch, methods);
+  }
 }


### PR DESCRIPTION
This refactoring allows to change some aspects of method search behavior in subclasses, namely:
- provide specific text processor implementation
- replace default signature comparison tied to Java PSI
