### PR TITLE
PY-10020 Darcula: Python External Documentation Settings panel have not "blue"-dracula styled elements

### DIFF
--- a/python/src/com/jetbrains/python/documentation/PythonDocumentationConfigurable.java
+++ b/python/src/com/jetbrains/python/documentation/PythonDocumentationConfigurable.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.AddEditRemovePanel;
 import com.intellij.ui.ColoredTableCellRenderer;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.Nls;
@@ -110,7 +111,7 @@ public class PythonDocumentationConfigurable implements SearchableConfigurable, 
               closeBrace = text.length();
             else
               closeBrace++;
-            append(text.substring(openBrace, closeBrace), new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, Color.blue.darker()));
+            append(text.substring(openBrace, closeBrace), new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, JBColor.BLUE.darker()));
             pos = closeBrace;
           }
         }


### PR DESCRIPTION
Very small fix to support Darcula theme in the Python External 
Documentation Settings panel.
Issue with color in a highlighted strings.
