### PR TITLE
PY-9356 Clean .pyc should include $py.class files if jython interpreter is used

### DIFF
--- a/python/src/META-INF/python-core.xml
+++ b/python/src/META-INF/python-core.xml
@@ -653,7 +653,7 @@
       <add-to-group group-id="ProjectViewPopupMenuRunGroup" anchor="first"/>
     </action>
 
-    <action id="CleanPyc" class="com.jetbrains.python.actions.CleanPycAction" text="Clean .pyc"
+    <action id="CleanPyc" class="com.jetbrains.python.actions.CleanPycAction" text="Clean python compiled files"
             description="Delete compiled bytecode files in selected directory and its subdirectories">
       <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="ProjectViewPopupMenuRefactoringGroup"/>
     </action>

--- a/python/src/com/jetbrains/python/actions/CleanPycAction.java
+++ b/python/src/com/jetbrains/python/actions/CleanPycAction.java
@@ -47,7 +47,8 @@ public class CleanPycAction extends AnAction {
       public boolean process(File file) {
         if (file.getParentFile().getName().equals(PyNames.PYCACHE) ||
             FileUtilRt.extensionEquals(file.getName(), "pyc") ||
-            FileUtilRt.extensionEquals(file.getName(), "pyo")) {
+            FileUtilRt.extensionEquals(file.getName(), "pyo") ||
+            FileUtilRt.extensionEquals(file.getName(), "$py.class")) {
           pycFiles.add(file);
         }
         return true;


### PR DESCRIPTION
PY-9356 Clean .pyc should include $py.class files if jython interpreter is 
used. Also display label was renamed to have more logical meaning for 
Jython and Python at one time.
