### PR TITLE
IDEA-114933 Search everywhere triggers if shift is pressed only once

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/actions/SearchEverywhereAction.java
+++ b/platform/lang-impl/src/com/intellij/ide/actions/SearchEverywhereAction.java
@@ -130,6 +130,8 @@ public class SearchEverywhereAction extends AnAction implements CustomComponentA
   private static AtomicBoolean ourReleased = new AtomicBoolean(false);
   private static AtomicBoolean ourOtherKeyWasPressed = new AtomicBoolean(false);
   private static AtomicLong ourLastTimePressed = new AtomicLong(0);
+  private static AtomicLong lastKeyPressTime = new AtomicLong(0);
+  private static AtomicLong lastKeyReleasedTime = new AtomicLong(0);
   private ArrayList<VirtualFile> myAlreadyAddedFiles = new ArrayList<VirtualFile>();
 
   static {
@@ -141,6 +143,26 @@ public class SearchEverywhereAction extends AnAction implements CustomComponentA
           final int keyCode = keyEvent.getKeyCode();
 
           if (keyCode == KeyEvent.VK_SHIFT) {
+            if (SystemInfo.isLinux) {
+              if (event.getID() == KeyEvent.KEY_PRESSED) {
+                lastKeyPressTime.set(((KeyEvent)event).getWhen());
+              }
+              if (event.getID() == KeyEvent.KEY_RELEASED) {
+                lastKeyReleasedTime.set(((KeyEvent)event).getWhen());
+              }
+
+              if (lastKeyPressTime.get() != 0 && lastKeyReleasedTime.get() != 0) {
+                if (lastKeyReleasedTime.get() == lastKeyPressTime.get()) {
+                  return false;
+                } else {
+                  lastKeyReleasedTime.set(0);
+                  lastKeyPressTime.set(0);
+                }
+              } else {
+                return false;
+              }
+            }
+
             if (ourOtherKeyWasPressed.get() && System.currentTimeMillis() - ourLastTimePressed.get() < 300) {
               ourPressed.set(false);
               ourReleased.set(false);


### PR DESCRIPTION
Fix Linux key autorepeat behavior.

This changes not fully fix the original problem but resolve triggering 
of SearchEverywhere action by pressing Shift only one time (not releasing). 

On my environment on most of cases I able to call SearchEverywhere action 
by pressing Shift two times, but in some case it's fail unfortunately. It 
seems it's related to logic which begins under 144 line of original 
SearchEverywhereAction.java.

In any case it will be great if such code will helps...

Best Regards,
Vladimir
