### PR TITLE
Possibility opening tasks in browser using Issue URL pattern for generic...

### DIFF
--- a/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/GenericRepositoryEditor.form
+++ b/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/GenericRepositoryEditor.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.intellij.tasks.generic.GenericRepositoryEditor">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="8">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="6" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="8">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -191,7 +191,7 @@
       <grid id="2e934" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -223,6 +223,43 @@
             </constraints>
             <properties>
               <text value="&amp;Reset to Defaults"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="59c97" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="2">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="c4958" class="com.intellij.ui.components.JBLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <labelFor value="8c293"/>
+              <text value="Task URL:"/>
+            </properties>
+          </component>
+          <component id="8c293" class="com.intellij.ui.EditorTextField" binding="myTaskURLText" custom-create="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                <preferred-size width="10" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="7fb03" class="com.intellij.ui.components.JBLabel" binding="myTaskURLTooltip">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <componentStyle value="SMALL"/>
+              <fontColor value="BRIGHTER"/>
+              <text value="tooltip"/>
             </properties>
           </component>
         </children>

--- a/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/GenericRepositoryEditor.java
+++ b/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/GenericRepositoryEditor.java
@@ -46,6 +46,8 @@ public class GenericRepositoryEditor<T extends GenericRepository> extends BaseRe
   private JRadioButton myJsonRadioButton;
   private JButton myManageTemplateVariablesButton;
   private JButton myResetToDefaultsButton;
+  private EditorTextField myTaskURLText;
+  private JBLabel myTaskURLTooltip;
 
   public GenericRepositoryEditor(final Project project,
                                  final T repository,
@@ -108,6 +110,7 @@ public class GenericRepositoryEditor<T extends GenericRepository> extends BaseRe
     installListener(myTasksListURLText.getDocument());
     installListener(myLoginURLText.getDocument());
     installListener(myTaskPatternText.getDocument());
+    installListener(myTaskURLText.getDocument());
 
     String useCompletionText = ". Use " +
                                KeymapUtil
@@ -119,6 +122,10 @@ public class GenericRepositoryEditor<T extends GenericRepository> extends BaseRe
                               QUERY_PLACEHOLDER + " (use for faster tasks search)" + useCompletionText + "</html>");
     myTaskPatternTooltip.setText(
       "<html>Task pattern should be a regexp with two matching groups: ({id}.+?) and ({summary}.+?)" + useCompletionText + "</html>");
+
+    myTaskURLTooltip.setText(
+      "<html>Task url should be a template with named placeholders from task pattern: {id}, {summary} or any other</html>"
+    );
 
     myTabbedPane.addTab("Additional", myPanel);
 
@@ -148,6 +155,7 @@ public class GenericRepositoryEditor<T extends GenericRepository> extends BaseRe
     myLoginURLText.setText(clone.getLoginURL());
     myTasksListURLText.setText(clone.getTasksListURL());
     myTaskPatternText.setText(clone.getTaskPattern());
+    myTaskURLText.setText(clone.getTaskURLPattern());
     myLoginMethodTypeComboBox.setSelectedItem(clone.getLoginMethodType());
     myTasksListMethodTypeComboBox.setSelectedItem(clone.getTasksListMethodType());
     switch (clone.getResponseType()) {
@@ -191,6 +199,7 @@ public class GenericRepositoryEditor<T extends GenericRepository> extends BaseRe
     myRepository.setLoginURL(myLoginURLText.getText());
     myRepository.setLoginMethodType((String)myLoginMethodTypeComboBox.getModel().getSelectedItem());
     myRepository.setTasksListMethodType((String)myTasksListMethodTypeComboBox.getModel().getSelectedItem());
+    myRepository.setTaskURLPattern(myTaskURLText.getText());
     myRepository.setResponseType(
       myXmlRadioButton.isSelected() ? ResponseType.XML : myJsonRadioButton.isSelected() ? ResponseType.JSON : ResponseType.HTML);
     super.apply();
@@ -205,11 +214,14 @@ public class GenericRepositoryEditor<T extends GenericRepository> extends BaseRe
     final ArrayList<String> completionList1 = ContainerUtil.newArrayList(SERVER_URL_PLACEHOLDER, QUERY_PLACEHOLDER, MAX_COUNT_PLACEHOLDER);
     myTasksListURLText = TextFieldWithAutoCompletion.create(myProject, completionList1, null, false, myRepository.getTasksListURL());
 
-    final Document document = EditorFactory.getInstance().createDocument(myRepository.getTaskPattern());
+    Document document = EditorFactory.getInstance().createDocument(myRepository.getTaskPattern());
     myTaskPatternText = new EditorTextField(document, myProject, myRepository.getResponseType().getFileType(), false, false);
     final ArrayList<String> completionList2 = ContainerUtil.newArrayList("({id}.+?)", "({summary}.+?)");
     TextFieldWithAutoCompletionContributor
       .installCompletion(document, myProject, new TextFieldWithAutoCompletion.StringsCompletionProvider(completionList2, null), true);
     myTaskPatternText.setFontInheritedFromLAF(false);
+
+    document = EditorFactory.getInstance().createDocument(myRepository.getTaskURLPattern());
+    myTaskURLText = new EditorTextField(document, myProject, myRepository.getResponseType().getFileType(), false, true);
   }
 }

--- a/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/GenericTask.java
+++ b/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/GenericTask.java
@@ -13,11 +13,13 @@ import java.util.Date;
 public class GenericTask extends Task {
   private final String myId;
   private final String myDescription;
+  private final String myIssueUrl;
   private TaskRepository myRepository;
 
-  public GenericTask(final String id, final String description, final TaskRepository repository) {
+  public GenericTask(final String id, final String description, String issueUrl, final TaskRepository repository) {
     myId = id;
     myDescription = description;
+    myIssueUrl = issueUrl;
     myRepository = repository;
   }
 
@@ -82,7 +84,7 @@ public class GenericTask extends Task {
   @Nullable
   @Override
   public String getIssueUrl() {
-    return null;
+    return myIssueUrl;
   }
 
   @Nullable

--- a/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/assembla/AssemblaRepository.java
+++ b/plugins/tasks/tasks-core/src/com/intellij/tasks/generic/assembla/AssemblaRepository.java
@@ -62,7 +62,12 @@ public class AssemblaRepository extends GenericRepository {
 
   @Override
   protected String getTaskPatternDefault() {
-    return "<ticket>.*?<number type=\"integer\">({id}.*?)</number>.*?<summary>({summary}.*?)</summary>.*?</ticket>";
+    return "<ticket>.*?<number type=\"integer\">({id}.*?)</number>.*?<space-id>({space}.*?)</space-id>.*?<summary>({summary}.*?)</summary>.*?</ticket>";
+  }
+
+  @Override
+  protected String getTaskURLPatternDefault() {
+    return "http://www.assembla.com/spaces/{space}/tickets/{id}";
   }
 
   @Override

--- a/plugins/tasks/tasks-tests/test/com/intellij/tasks/integration/AssemblaIntegrationTest.java
+++ b/plugins/tasks/tasks-tests/test/com/intellij/tasks/integration/AssemblaIntegrationTest.java
@@ -64,5 +64,6 @@ public class AssemblaIntegrationTest extends TaskManagerTestCase {
 
     assertEquals(1, tasks.length);
     assertEquals("\u041F\u0440\u0438\u0432\u0435\u0442", tasks[0].getSummary());
+    assertEquals("http://www.assembla.com/spaces/ab1WOCMQar4QGgacwqjQWU/tickets/1", tasks[0].getIssueUrl());
   }
 }


### PR DESCRIPTION
When using Task plugin configured with generic task server is no way to open current task in browser. Menu item is disabled because Idea doesn't know task url. Assembla doesn't include direct url to task in tickets.xml and if we want to make it we should to get some addition information like space id and tiket number. So, issue url template can help with it: substitute matched groups from ticket pattern and get link to issue.

![tt](https://f.cloud.github.com/assets/690543/1501191/a11f0288-4887-11e3-86a6-c2bc80a09b83.png)
