### PR TITLE
IDEA-116247 Path does not exist with cyrillic chars at Git

### DIFF
--- a/plugins/git4idea/src/git4idea/GitUtil.java
+++ b/plugins/git4idea/src/git4idea/GitUtil.java
@@ -664,6 +664,7 @@ public class GitUtil {
               catch (UnsupportedEncodingException e1) {
                 throw new IllegalStateException("The file name encoding is unsuported: " + encoding);
               }
+              i--;
             }
             else {
               throw new VcsException("Unknown escape sequence '\\" + path.charAt(i) + "' in the path: " + path);

--- a/plugins/git4idea/tests/git4idea/tests/GitUtilsTest.java
+++ b/plugins/git4idea/tests/git4idea/tests/GitUtilsTest.java
@@ -28,4 +28,10 @@ public class GitUtilsTest {
     Assert.assertEquals("0000000000000000", GitUtil.formatLongRev(0));
     Assert.assertEquals("fffffffffffffffe", GitUtil.formatLongRev(-2));
   }
+
+  @Test
+  public void testUnescapePath() throws Exception {
+    Assert.assertEquals("Cyrillic folder", "папка/file.txt", GitUtil.unescapePath("\\320\\277\\320\\260\\320\\277\\320\\272\\320\\260/file.txt"));
+    Assert.assertEquals("Cyrillic folder and filename", "папка/документ", GitUtil.unescapePath("\\320\\277\\320\\260\\320\\277\\320\\272\\320\\260/\\320\\264\\320\\276\\320\\272\\321\\203\\320\\274\\320\\265\\320\\275\\321\\202"));
+  }
 }


### PR DESCRIPTION
Unescaping git path cuts char after escape sequence. Upper iteration loop iterates over string, when gets slash char inner loop starts iterate over string to collect bytes. After last iteration of inner loop pointer stayed at char next by escape sequence, but after next iteration of outer loop pointer moved to next char.

http://youtrack.jetbrains.com/issue/IDEA-116247
