### PR TITLE
Guard against an idea.home with spaces

### DIFF
--- a/python/build.xml
+++ b/python/build.xml
@@ -17,7 +17,7 @@
     <attribute name="script" />
     <sequential>
       <java failonerror="true" jar="${project.home}/lib/ant/lib/ant-launcher.jar" fork="true">
-        <jvmarg line="-Xmx612m -XX:MaxPermSize=152m -Didea.build.number=${idea.build.number} -DideaPath=${idea.path}"/>
+        <jvmarg line="-Xmx612m -XX:MaxPermSize=152m -Didea.build.number=${idea.build.number} &quot;-DideaPath=${idea.path}&quot;"/>
 
         <arg line="&quot;-Dgant.script=@{script}&quot;"/>
         <arg line="&quot;-Dteamcity.build.tempDir=${tmp.dir}&quot;"/>


### PR DESCRIPTION
This came up on Mac OS X where the IJ directory
is called `IntelliJ IDEA CE EAP.app` but it could affect users on
Windows who install into `Program Files` or such.
