### PR TITLE
Guard against awt.HeadlessException during builds

### DIFF
--- a/platform/util/src/com/intellij/util/ui/UIUtil.java
+++ b/platform/util/src/com/intellij/util/ui/UIUtil.java
@@ -231,9 +231,9 @@ public class UIUtil {
             return ourRetina.get();
           }
         } else if (SystemInfo.isJavaVersionAtLeast("1.7.0_40") && SystemInfo.isOracleJvm) {
-            GraphicsEnvironment env = GraphicsEnvironment.getLocalGraphicsEnvironment();
-            final GraphicsDevice device = env.getDefaultScreenDevice();
             try {
+              GraphicsEnvironment env = GraphicsEnvironment.getLocalGraphicsEnvironment();
+              final GraphicsDevice device = env.getDefaultScreenDevice();
               Field field = device.getClass().getDeclaredField("scale");
               if (field != null) {
                 field.setAccessible(true);


### PR DESCRIPTION
This is the exact exception this commit addresses:

```
Caused by: java.awt.HeadlessException
    at sun.java2d.HeadlessGraphicsEnvironment.getDefaultScreenDevice(HeadlessGraphicsEnvironment.java:77)
    at com.intellij.util.ui.UIUtil.isRetina(UIUtil.java:235)
```
