### PR TITLE
IDEA-57875: Add Missing property quick fix

### DIFF
--- a/plugins/ant/src/META-INF/plugin.xml
+++ b/plugins/ant/src/META-INF/plugin.xml
@@ -41,6 +41,9 @@
     <localInspection language="XML" shortName="AntMissingPropertiesFileInspection" bundle="messages.AntBundle" key="ant.missing.properties.file.inspection"
                      groupKey="ant.inspections.display.name" enabledByDefault="true" level="ERROR"
                      implementationClass="com.intellij.lang.ant.validation.AntMissingPropertiesFileInspection"/>
+    <localInspection language="XML" shortName="AntMissingPropertyInspection" bundle="messages.AntBundle" key="ant.missing.property.inspection"
+                     groupKey="ant.inspections.display.name" enabledByDefault="true" level="ERROR"
+                     implementationClass="com.intellij.lang.ant.validation.AntMissingPropertyInspection"/>
     <localInspection language="XML" shortName="AntResolveInspection" displayName="Ant references resolve problems" bundle="messages.AntBundle"
                      groupKey="ant.inspections.display.name"
                      enabledByDefault="true" level="ERROR" implementationClass="com.intellij.lang.ant.dom.AntResolveInspection"/>

--- a/plugins/ant/src/com/intellij/lang/ant/quickfix/AntCreatePropertyFix.java
+++ b/plugins/ant/src/com/intellij/lang/ant/quickfix/AntCreatePropertyFix.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.lang.ant.quickfix;
+
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.lang.ant.AntBundle;
+import com.intellij.lang.properties.psi.PropertiesFile;
+import com.intellij.openapi.project.Project;
+import com.intellij.pom.Navigatable;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileSystemItem;
+import com.intellij.psi.xml.XmlFile;
+import com.intellij.psi.xml.XmlTag;
+import com.intellij.util.StringBuilderSpinAllocator;
+import com.intellij.util.xml.DomElement;
+import com.intellij.util.xml.DomUtil;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Make use of com.intellij.lang.ant.psi.impl.AntFileImpl
+ */
+public class AntCreatePropertyFix implements LocalQuickFix {
+  @NonNls public static final String PROPERTY = "property";
+  @NonNls public static final String NAME_ATTR = "name";
+  @NonNls public static final String VALUE_ATTR = "value";
+  private final String canonicalText;
+  private final PsiFileSystemItem propFile;
+
+  public AntCreatePropertyFix(String canonicalText, PsiFileSystemItem propertiesFile) {
+    this.canonicalText = canonicalText;
+    this.propFile = propertiesFile;
+  }
+
+  @NotNull
+  public String getName() {
+    StringBuilder builder = StringBuilderSpinAllocator.alloc();
+    try {
+      builder.append(getFamilyName());
+      builder.append(" '");
+      builder.append(canonicalText);
+      builder.append("'");
+      if (propFile != null) {
+        builder.append(' ');
+        builder.append(AntBundle.message("text.in.the.file", propFile.getName()));
+      }
+      return builder.toString();
+    }
+    finally {
+      StringBuilderSpinAllocator.dispose(builder);
+    }
+  }
+
+  @NotNull
+  public String getFamilyName() {
+    final String i18nName = AntBundle.message("ant.intention.create.property.family.name");
+    return (i18nName == null) ? "Create property" : i18nName;
+  }
+
+  public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
+    final PsiElement psiElement = descriptor.getPsiElement();
+    final PsiFile containingFile = psiElement.getContainingFile();
+
+    DomElement domElement = DomUtil.getDomElement(descriptor.getPsiElement());
+    Navigatable result;
+
+    if (propFile != null) {
+      PropertiesFile propertiesFile = (PropertiesFile)propFile;
+      result = propertiesFile.addProperty(canonicalText, "");
+    }
+    else {
+      final XmlFile xmlFile = (XmlFile)containingFile;
+      XmlTag rootTag = xmlFile.getRootTag();
+      XmlTag propTag = rootTag.createChildTag(PROPERTY, rootTag.getNamespace(), null, false);
+      propTag.setAttribute(NAME_ATTR, canonicalText);
+      propTag.setAttribute(VALUE_ATTR, "");
+      DomElement anchor = domElement.getParent();
+      if (anchor == null) {
+        result = (Navigatable)rootTag.add(propTag);
+      }
+      else {
+        result = (Navigatable)anchor.getXmlTag().getParent().addBefore(propTag, anchor.getXmlElement());
+      }
+    }
+    if (result != null) {
+      result.navigate(true);
+    }
+  }
+}

--- a/plugins/ant/src/com/intellij/lang/ant/validation/AntMissingPropertyInspection.java
+++ b/plugins/ant/src/com/intellij/lang/ant/validation/AntMissingPropertyInspection.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.lang.ant.validation;
+
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.lang.ant.AntBundle;
+import com.intellij.lang.ant.AntSupport;
+import com.intellij.lang.ant.dom.*;
+import com.intellij.lang.ant.quickfix.AntCreatePropertyFix;
+import com.intellij.lang.properties.psi.PropertiesFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileSystemItem;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.xml.XmlElement;
+import com.intellij.util.xml.DomElement;
+import com.intellij.util.xml.DomUtil;
+import com.intellij.util.xml.GenericDomValue;
+import com.intellij.util.xml.highlighting.DomElementAnnotationHolder;
+import com.intellij.util.xml.highlighting.DomHighlightingHelper;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class AntMissingPropertyInspection extends AntInspection {
+
+  @NonNls private static final String SHORT_NAME = "AntMissingPropertyInspection";
+
+  @Nls
+  @NotNull
+  public String getDisplayName() {
+    return AntBundle.message("ant.missing.property.inspection");
+  }
+
+  @NonNls
+  @NotNull
+  public String getShortName() {
+    return SHORT_NAME;
+  }
+
+  protected void checkDomElement(DomElement element, DomElementAnnotationHolder holder, DomHighlightingHelper helper) {
+    if (element instanceof GenericDomValue) {
+      final XmlElement xmlElement = DomUtil.getValueElement(((GenericDomValue)element));
+      if (xmlElement != null) {
+
+        for (final PsiReference ref : xmlElement.getReferences()) {
+          if (!(ref instanceof AntDomReference)) {
+            continue;
+          }
+          final AntDomReference antDomRef = (AntDomReference)ref;
+          if (antDomRef.shouldBeSkippedByAnnotator()) {
+            continue;
+          }
+
+          if (antDomRef instanceof AntDomPropertyReference && ref.resolve() == null) {
+            PsiFile containingFile = xmlElement.getContainingFile();
+            AntDomProject antDomProject = AntSupport.getAntDomProject(containingFile);
+            List<PsiFileSystemItem> propertyFiles = getPropertyFiles(antDomProject);
+
+
+            List<LocalQuickFix> quickFixList = new ArrayList<LocalQuickFix>();
+            String canonicalText = ((AntDomPropertyReference)antDomRef).getValue();
+            quickFixList.add(new AntCreatePropertyFix(canonicalText, null));
+            for (PsiFileSystemItem propertyFile : propertyFiles) {
+              quickFixList.add(new AntCreatePropertyFix(canonicalText, propertyFile));
+            }
+            LocalQuickFix[] fixes = quickFixList.toArray((new LocalQuickFix[quickFixList.size()]));
+            holder.createProblem(element, ProblemHighlightType.LIKE_UNKNOWN_SYMBOL, canonicalText, ref.getRangeInElement(), fixes);
+          }
+        }
+      }
+    }
+  }
+
+  @NotNull
+  private static List<PsiFileSystemItem> getPropertyFiles(AntDomProject antDomProject) {
+    List<PsiFileSystemItem> files = new ArrayList<PsiFileSystemItem>();
+    for (Iterator<AntDomElement> iterator = antDomProject.getAntChildrenIterator(); iterator.hasNext(); ) {
+      AntDomElement child = iterator.next();
+      if (child instanceof AntDomProperty) {
+        final AntDomProperty property = (AntDomProperty)child;
+        final String fileName = property.getFile().getStringValue();
+        if (fileName != null) {
+          final PsiFileSystemItem file = property.getFile().getValue();
+          files.add(file);
+        }
+      }
+    }
+    return files;
+  }
+}
+

--- a/resources-en/src/messages/AntBundle.properties
+++ b/resources-en/src/messages/AntBundle.properties
@@ -180,6 +180,7 @@ ant.inspections.display.name=Ant inspections
 ant.duplicate.targets.inspection=Duplicate targets
 ant.duplicate.imported.targets.inspection=Duplicate targets in imported files
 ant.missing.properties.file.inspection=Missing properties file
+ant.missing.property.inspection=Missing property
 register.ant.build.progress=Registering Ant build file ''{0}''...
 loading.ant.config.progress=Loading Ant configuration...
 intention.configure.highlighting.family.name=Configure highlighting


### PR DESCRIPTION
http://youtrack.jetbrains.com/issue/IDEA-57875
IDEA-57875 No quick fix to create property from a usage of unknown property in Ant

This brings back the features that were available in v9. 
It should create a property as an xml tag in the current file or as a property if a build.properties exists.
If multiple build properties exist you get multiple intentions pop up as well as the option to just include it in the current file.
