### PR TITLE
Run ant headless so no dock icon will appear

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -17,6 +17,7 @@
     <sequential>
       <java failonerror="true" jar="${project.home}/lib/ant/lib/ant-launcher.jar" fork="true">
         <jvmarg line="-Xmx612m -XX:MaxPermSize=152m"/>
+        <!-- prevent ant from appearing in the OSX Dock -->
         <jvmarg line="-Djava.awt.headless=true"/>
 
         <arg line="&quot;-Dgant.script=@{script}&quot;"/>

--- a/build/scripts/utils.gant
+++ b/build/scripts/utils.gant
@@ -756,6 +756,7 @@ binding.setVariable("buildWinLauncher", { String ch, String inputPath, String ou
   }
 
   ant.java(classname: "com.pme.launcher.LauncherGeneratorMain", fork: "true") {
+    // prevent ant from appearing in the OSX Dock
     jvmarg(line: "-Djava.awt.headless=true")
     arg(value: inputPath)
     arg(value: appInfo)

--- a/python/build.xml
+++ b/python/build.xml
@@ -19,6 +19,7 @@
       <java failonerror="true" jar="${project.home}/lib/ant/lib/ant-launcher.jar" fork="true">
         <jvmarg line="-Xmx612m -XX:MaxPermSize=152m -Didea.build.number=${idea.build.number} &quot;-DideaPath=${idea.path}&quot;"/>
 
+        <!-- prevent ant from appearing in the OSX Dock -->
         <jvmarg line="-Djava.awt.headless=true"/>
         <arg line="&quot;-Dgant.script=@{script}&quot;"/>
         <arg line="&quot;-Dteamcity.build.tempDir=${tmp.dir}&quot;"/>


### PR DESCRIPTION
It not only appears in the dock, but _because_ it appears in the dock it
steals focus from whatever you are doing at the time.

Specifying `java.awt.headless=true` as a JVM arg stops this annoying behavior.

q.v. https://discussions.apple.com/message/6052815#6052815

I tested this on Windows to ensure that it still functions as designed, and it worked for me.
