### PR TITLE
Filter out non-physical classes in DefaultClassNavigationContributor

### DIFF
--- a/java/java-impl/src/com/intellij/ide/util/gotoByName/DefaultClassNavigationContributor.java
+++ b/java/java-impl/src/com/intellij/ide/util/gotoByName/DefaultClassNavigationContributor.java
@@ -90,7 +90,7 @@ public class DefaultClassNavigationContributor implements ChooseByNameContributo
       final boolean isAnnotation = parameters.getLocalPatternName().startsWith("@");
       @Override
       public boolean process(PsiClass aClass) {
-        if (aClass.getContainingFile().getVirtualFile() == null) return true;
+        if (aClass.getContainingFile().getVirtualFile() == null || !aClass.isPhysical()) return true;
         if (isAnnotation && !aClass.isAnnotationType()) return true;
         return processor.process(aClass);
       }


### PR DESCRIPTION
For example, in scala plugin we have fake companion classes. They are paired with real ones and have same containing file, but they are non-physical.
