### PR TITLE
Remove plugin references that are not part of CE

### DIFF
--- a/python/src/META-INF/python-core.xml
+++ b/python/src/META-INF/python-core.xml
@@ -115,7 +115,10 @@
 
     <runConfigurationProducer implementation="com.jetbrains.python.testing.unittest.PythonUnitTestConfigurationProducer"/>
     <testSrcLocator implementation="com.jetbrains.python.testing.PythonUnitTestTestIdUrlProvider"/>
+    <!--
+    Not present in Community Edition
     <testSrcLocator implementation="com.jetbrains.django.testRunner.DjangoTestTestIdUrlProvider"/>
+    -->
     <testSrcLocator implementation="com.jetbrains.python.testing.nosetest.PythonNoseTestUrlProvider"/>
 
     <runConfigurationProducer implementation="com.jetbrains.python.testing.pytest.PyTestConfigurationProducer"/>
@@ -132,7 +135,10 @@
     <highlightUsagesHandlerFactory implementation="com.jetbrains.python.codeInsight.highlighting.PyHighlightExitPointsHandlerFactory"/>
 
     <joinLinesHandler implementation="com.jetbrains.python.editor.PyJoinLinesHandler"/>
+    <!--
+    Not present in Community Edition
     <duplicates.profile implementation="com.jetbrains.python.duplocator.PyDuplicatesProfile"/>
+    -->
 
     <intentionAction>
       <className>com.jetbrains.python.codeInsight.intentions.PyConvertMethodToPropertyIntention</className>


### PR DESCRIPTION
The Django one causes the following kaboom after running `unittest.TestCase` based test suites in community edition:

```
java.lang.ClassNotFoundException: com.jetbrains.django.testRunner.DjangoTestTestIdUrlProvider: java.lang.ClassNotFoundException: com.jetbrains.django.testRunner.DjangoTestTestIdUrlProvider
com.intellij.openapi.extensions.impl.PicoPluginExtensionInitializationException: java.lang.ClassNotFoundException: com.jetbrains.django.testRunner.DjangoTestTestIdUrlProvider
    at com.intellij.openapi.extensions.impl.ExtensionComponentAdapter.getComponentInstance(ExtensionComponentAdapter.java:99)
    at com.intellij.openapi.extensions.impl.ExtensionComponentAdapter.getExtension(ExtensionComponentAdapter.java:122)
    at com.intellij.openapi.extensions.impl.ExtensionPointImpl.processAdapters(ExtensionPointImpl.java:244)
    at com.intellij.openapi.extensions.impl.ExtensionPointImpl.getExtensions(ExtensionPointImpl.java:194)
    at com.intellij.openapi.extensions.Extensions.getExtensions(Extensions.java:111)
    at com.intellij.openapi.extensions.Extensions.getExtensions(Extensions.java:98)
    at com.intellij.execution.testframework.sm.CompositeTestLocationProvider.getLocation(CompositeTestLocationProvider.java:50)
    at com.intellij.execution.testframework.sm.runner.SMTestProxy.getLocation(SMTestProxy.java:261)
```

The `duplicates.profile` just turns red but thankfully has not yet caused any exceptions
