### PR TITLE
Correctly interpret python __slots__ that are external references

### DIFF
--- a/python/src/com/jetbrains/python/psi/PyUtil.java
+++ b/python/src/com/jetbrains/python/psi/PyUtil.java
@@ -52,7 +52,6 @@ import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.PlatformIcons;
 import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
-import com.intellij.util.containers.HashSet;
 import com.jetbrains.NotNullPredicate;
 import com.jetbrains.python.PyBundle;
 import com.jetbrains.python.PyNames;
@@ -959,6 +958,17 @@ public class PyUtil {
   public static List<String> strListValue(PyExpression value) {
     while (value instanceof PyParenthesizedExpression) {
       value = ((PyParenthesizedExpression)value).getContainedExpression();
+    }
+    if (value instanceof PyReferenceExpression) {
+      PyReferenceExpression refExpr = (PyReferenceExpression)value;
+      PsiElement deref = refExpr.getReference().resolve();
+      if (deref instanceof PyTargetExpression) {
+        PyTargetExpression te = (PyTargetExpression)deref;
+        PyExpression assignedValue = te.findAssignedValue();
+        if (assignedValue instanceof PySequenceExpression) {
+          value = assignedValue;
+        }
+      }
     }
     if (value instanceof PySequenceExpression) {
       final PyExpression[] elements = ((PySequenceExpression)value).getElements();

--- a/python/src/com/jetbrains/python/psi/PyUtil.java
+++ b/python/src/com/jetbrains/python/psi/PyUtil.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.ui.MessageType;
@@ -959,7 +960,10 @@ public class PyUtil {
     while (value instanceof PyParenthesizedExpression) {
       value = ((PyParenthesizedExpression)value).getContainedExpression();
     }
-    if (value instanceof PyReferenceExpression) {
+    // Don't allow the ``getReference()`` call before the actual full analysis
+    // engine is up and running, otherwise it will throw IndexNotReadyException
+    final boolean isDumb = null == value || DumbService.isDumb(value.getProject());
+    if ( !isDumb && value instanceof PyReferenceExpression) {
       PyReferenceExpression refExpr = (PyReferenceExpression)value;
       PsiElement deref = refExpr.getReference().resolve();
       if (deref instanceof PyTargetExpression) {

--- a/python/testData/inspections/PyUnresolvedReferencesInspection/slotsAsExternal.py
+++ b/python/testData/inspections/PyUnresolvedReferencesInspection/slotsAsExternal.py
@@ -1,0 +1,25 @@
+class A(object):
+    __slots__ = ['a', 'b']
+
+    def __init__(self):
+        self.a = None  # <- all ok here
+        self.b = None  # <- all ok here
+
+
+class B(A):
+    __slots__ = A.__slots__
+
+    def __init__(self):
+        super(B, self).__init__()
+        self.<warning descr="'B' object has no attribute 'c'">c</warning> = 'bug'
+
+
+EXTERNAL_SLOTS = ['a', 'b']
+
+
+class C(A):
+    __slots__ = EXTERNAL_SLOTS
+
+    def __init__(self):
+        super(C, self).__init__()
+        self.<warning descr="'C' object has no attribute 'c'">c</warning> = 'bug'

--- a/python/testSrc/com/jetbrains/python/inspections/PyUnresolvedReferencesInspectionTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/PyUnresolvedReferencesInspectionTest.java
@@ -52,6 +52,10 @@ public class PyUnresolvedReferencesInspectionTest extends PyInspectionTestCase {
     doTest();
   }
 
+  public void testSlotsAsExternal() {
+    doTest();
+  }
+
   public void testImportExceptImportError() {
     doTest();
   }


### PR DESCRIPTION
The commit message for `8a038fa` is the whole story, but the short version is that PyCharm should flag attribute references that it can prove are incorrect.

This is pretty much the opposite of [PY-10158](http://youtrack.jetbrains.com/issue/PY-10158) :-)

BTW, I ran the PyCharm test suite and there were two failures before I touched it:

```
java.lang.NegativeArraySizeException
    at com.intellij.testFramework.PlatformTestUtil.tryGcSoftlyReachableObjects(PlatformTestUtil.java:784)
    at com.jetbrains.python.PyDeprecationTest.testFileStub(PyDeprecationTest.java:78)

java.lang.NegativeArraySizeException
    at com.intellij.testFramework.PlatformTestUtil.tryGcSoftlyReachableObjects(PlatformTestUtil.java:784)
    at com.jetbrains.python.PyDeprecationTest.testFunctionStub(PyDeprecationTest.java:49)
```
