### PR TITLE
Fix maven-surefire-plugin argList.

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcher.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcher.java
@@ -16,6 +16,7 @@
 package org.jetbrains.idea.maven.execution;
 
 import com.intellij.execution.JUnitPatcher;
+import com.intellij.execution.configurations.CommandLineTokenizer;
 import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.util.text.StringUtil;
@@ -85,7 +86,10 @@ public class MavenJUnitPatcher extends JUnitPatcher {
     if (argLine != null) {
       String value = argLine.getTextTrim();
       if (StringUtil.isNotEmpty(value)) {
-        javaParameters.getVMParametersList().add(value);
+        CommandLineTokenizer tokenizer = new CommandLineTokenizer(value);
+        while (tokenizer.hasMoreTokens()) {
+          javaParameters.getVMParametersList().add(tokenizer.nextToken());
+        }
       }
     }
   }

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcherTest.java
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcherTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.idea.maven.execution;
+
+import com.intellij.execution.configurations.JavaParameters;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.idea.maven.MavenImportingTestCase;
+
+import static java.util.Arrays.asList;
+
+public class MavenJUnitPatcherTest extends MavenImportingTestCase {
+  public void testArgList() throws Exception {
+    VirtualFile m1 = createModulePom("m1", "<groupId>test</groupId>" +
+                                           "<artifactId>m1</artifactId>" +
+                                           "<version>1</version>" +
+                                           "<dependencies>" +
+                                           "  <dependency>" +
+                                           "    <groupId>test</groupId>" +
+                                           "    <artifactId>m2</artifactId>" +
+                                           "    <version>1</version>" +
+                                           "  </dependency>" +
+                                           "</dependencies>" +
+                                           "<build><plugins>" +
+                                           "  <plugin>" +
+                                           "    <groupId>org.apache.maven.plugins</groupId>" +
+                                           "    <artifactId>maven-surefire-plugin</artifactId>" +
+                                           "    <version>2.16</version>" +
+                                           "    <configuration>" +
+                                           "      <argLine>-Xmx2048M -XX:MaxPermSize=512M \"-Dargs=can have spaces\"</argLine>" +
+                                           "    </configuration>" +
+                                           "  </plugin>" +
+                                           "</plugins></build>");
+
+    importProjects(m1);
+    Module module = getModule("m1");
+
+    MavenJUnitPatcher mavenJUnitPatcher = new MavenJUnitPatcher();
+    JavaParameters javaParameters = new JavaParameters();
+    mavenJUnitPatcher.patchJavaParameters(module, javaParameters);
+    assertEquals(asList("-Xmx2048M", "-XX:MaxPermSize=512M", "-Dargs=can have spaces"),
+                 javaParameters.getVMParametersList().getList());
+  }
+}


### PR DESCRIPTION
When maven-surefire-plugin's argList is given, it contains a bash-style
list of VM args, not just one.
