### PR TITLE
Add extension point for postprocessing of usages in the course of Move refactoring

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/MoveClassToInnerProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/MoveClassToInnerProcessor.java
@@ -167,6 +167,8 @@ public class MoveClassToInnerProcessor extends BaseRefactoringProcessor {
           element.delete();
         }
       }
+
+      CommonMoveUtil.postprocessUsages(usages);
     }
     catch (IncorrectOperationException e) {
       LOG.error(e);

--- a/java/java-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/MoveClassesOrPackagesProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/MoveClassesOrPackagesProcessor.java
@@ -48,7 +48,6 @@ import com.intellij.refactoring.util.classRefs.ClassReferenceScanner;
 import com.intellij.usageView.UsageInfo;
 import com.intellij.usageView.UsageViewDescriptor;
 import com.intellij.usageView.UsageViewUtil;
-import com.intellij.util.ArrayUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.Processor;
 import com.intellij.util.VisibilityUtil;
@@ -542,6 +541,8 @@ public class MoveClassesOrPackagesProcessor extends BaseRefactoringProcessor {
           MoveClassesOrPackagesUtil.finishMoveClass((PsiClass)element);
         }
       }
+
+      CommonMoveUtil.postprocessUsages(usages);
 
       myNonCodeUsages = CommonMoveUtil.retargetUsages(usages, oldToNewElementsMapping);
     }

--- a/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerProcessor.java
@@ -35,6 +35,7 @@ import com.intellij.refactoring.BaseRefactoringProcessor;
 import com.intellij.refactoring.RefactoringBundle;
 import com.intellij.refactoring.listeners.RefactoringElementListener;
 import com.intellij.refactoring.move.MoveCallback;
+import com.intellij.refactoring.move.moveClassesOrPackages.CommonMoveUtil;
 import com.intellij.refactoring.move.moveClassesOrPackages.MoveClassesOrPackagesUtil;
 import com.intellij.refactoring.rename.RenameUtil;
 import com.intellij.refactoring.util.*;
@@ -273,6 +274,8 @@ public class MoveInnerProcessor extends BaseRefactoringProcessor {
       else {
         ChangeContextUtil.decodeContextInfo(newClass, null, null);
       }
+
+      CommonMoveUtil.postprocessUsages(usages);
 
       PsiFile targetFile = newClass.getContainingFile();
       OpenFileDescriptor descriptor = new OpenFileDescriptor(myProject, targetFile.getVirtualFile(), newClass.getTextOffset());

--- a/java/java-impl/src/com/intellij/refactoring/move/moveInstanceMethod/MoveInstanceMethodProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveInstanceMethod/MoveInstanceMethodProcessor.java
@@ -31,6 +31,7 @@ import com.intellij.psi.util.PsiUtil;
 import com.intellij.refactoring.BaseRefactoringProcessor;
 import com.intellij.refactoring.RefactoringBundle;
 import com.intellij.refactoring.move.MoveInstanceMembersUtil;
+import com.intellij.refactoring.move.moveClassesOrPackages.CommonMoveUtil;
 import com.intellij.refactoring.util.*;
 import com.intellij.usageView.UsageInfo;
 import com.intellij.usageView.UsageViewDescriptor;
@@ -247,6 +248,8 @@ public class MoveInstanceMethodProcessor extends BaseRefactoringProcessor{
         reference.bindToElement(method);
       }
       VisibilityUtil.fixVisibility(UsageViewUtil.toElements(usages), method, myNewVisibility);
+
+      CommonMoveUtil.postprocessUsages(usages);
     }
     catch (IncorrectOperationException e) {
       LOG.error(e);

--- a/java/java-impl/src/com/intellij/refactoring/move/moveMembers/MoveMembersProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveMembers/MoveMembersProcessor.java
@@ -30,6 +30,7 @@ import com.intellij.refactoring.listeners.RefactoringElementListener;
 import com.intellij.refactoring.move.MoveCallback;
 import com.intellij.refactoring.move.MoveHandler;
 import com.intellij.refactoring.move.MoveMemberViewDescriptor;
+import com.intellij.refactoring.move.moveClassesOrPackages.CommonMoveUtil;
 import com.intellij.refactoring.util.CommonRefactoringUtil;
 import com.intellij.refactoring.util.MoveRenameUsageInfo;
 import com.intellij.refactoring.util.RefactoringConflictsUtil;
@@ -226,6 +227,8 @@ public class MoveMembersProcessor extends BaseRefactoringProcessor {
       // qualifier info must be decoded after members are moved
       final MoveMemberHandler handler = MoveMemberHandler.EP_NAME.forLanguage(myTargetClass.getLanguage());
       if (handler != null) handler.decodeContextInfo(myTargetClass);
+
+      CommonMoveUtil.postprocessUsages(usages);
 
       myMembersToMove.clear();
       if (myMoveCallback != null) {

--- a/platform/lang-impl/src/com/intellij/refactoring/move/MoveUsagesPostprocessor.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/move/MoveUsagesPostprocessor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.refactoring.move;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.usageView.UsageInfo;
+
+public interface MoveUsagesPostprocessor {
+  ExtensionPointName<MoveUsagesPostprocessor> EP_NAME = ExtensionPointName.create("com.intellij.refactoring.moveUsagesPostprocessor");
+
+  void postprocessUsages(UsageInfo[] usages);
+}

--- a/platform/lang-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/CommonMoveUtil.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/CommonMoveUtil.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.util.ProperTextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
+import com.intellij.refactoring.move.MoveUsagesPostprocessor;
 import com.intellij.refactoring.util.MoveRenameUsageInfo;
 import com.intellij.refactoring.util.NonCodeUsageInfo;
 import com.intellij.usageView.UsageInfo;
@@ -61,5 +62,11 @@ public class CommonMoveUtil {
       }
     }
     return nonCodeUsages.toArray(new NonCodeUsageInfo[nonCodeUsages.size()]);
+  }
+
+  public static void postprocessUsages(UsageInfo[] usages) {
+    for (MoveUsagesPostprocessor postprocessor : MoveUsagesPostprocessor.EP_NAME.getExtensions()) {
+      postprocessor.postprocessUsages(usages);
+    }
   }
 }

--- a/platform/lang-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/MoveDirectoryWithClassesProcessor.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/move/moveClassesOrPackages/MoveDirectoryWithClassesProcessor.java
@@ -197,6 +197,8 @@ public class MoveDirectoryWithClassesProcessor extends BaseRefactoringProcessor 
       for (PsiDirectory directory : myDirectories) {
         directory.delete();
       }
+
+      CommonMoveUtil.postprocessUsages(usages);
     }
     catch (IncorrectOperationException e) {
       myNonCodeUsages = new NonCodeUsageInfo[0];

--- a/platform/lang-impl/src/com/intellij/refactoring/move/moveFilesOrDirectories/MoveFilesOrDirectoriesProcessor.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/move/moveFilesOrDirectories/MoveFilesOrDirectoriesProcessor.java
@@ -33,6 +33,7 @@ import com.intellij.refactoring.listeners.RefactoringElementListener;
 import com.intellij.refactoring.listeners.RefactoringEventData;
 import com.intellij.refactoring.move.FileReferenceContextUtil;
 import com.intellij.refactoring.move.MoveCallback;
+import com.intellij.refactoring.move.moveClassesOrPackages.CommonMoveUtil;
 import com.intellij.refactoring.rename.RenameUtil;
 import com.intellij.refactoring.util.CommonRefactoringUtil;
 import com.intellij.refactoring.util.NonCodeUsageInfo;
@@ -188,6 +189,8 @@ public class MoveFilesOrDirectoriesProcessor extends BaseRefactoringProcessor {
       }
 
       retargetUsages(usages, oldToNewMap);
+
+      CommonMoveUtil.postprocessUsages(usages);
 
       // Perform CVS "add", "remove" commands on moved files.
 

--- a/resources/src/META-INF/IdeaPlugin.xml
+++ b/resources/src/META-INF/IdeaPlugin.xml
@@ -203,6 +203,8 @@
       <with attribute="implementationClass" implements="com.intellij.refactoring.move.moveMembers.MoveMemberHandler"/>
     </extensionPoint>
 
+    <extensionPoint name="refactoring.moveUsagesPostprocessor" interface="com.intellij.refactoring.move.MoveUsagesPostprocessor"/>
+
     <extensionPoint name="testGenerator"
                     beanClass="com.intellij.lang.LanguageExtensionPoint">
       <with attribute="implementationClass" implements="com.intellij.testIntegration.createTest.TestGenerator"/>


### PR DESCRIPTION
In Kotlin rebinding of PsiReference may require file analysis which can lead to poor performance when many usages are located in the same file. This extension point would allow to postpone reference update until the end of refactoring and avoid unnecessary analysis.
