### PR TITLE
Fixes path so that local modules get priority

### DIFF
--- a/python/src/com/jetbrains/python/console/RunPythonConsoleAction.java
+++ b/python/src/com/jetbrains/python/console/RunPythonConsoleAction.java
@@ -226,6 +226,6 @@ public class RunPythonConsoleAction extends AnAction implements DumbAware {
       }
     }));
 
-    return "sys.path.extend([" + path + "])";
+    return "sys.path = [" + path + "] + sys.path";
   }
 }


### PR DESCRIPTION
By using `sys.path.extend()` the local source and content directories are given lower priority than the global python site-path. This can be problematic if the module being developed is also installed in the site-path.
