### PR TITLE
IDEA-120753: Allow tool window weight to be configurable in the .idea.properties

### DIFF
--- a/bin/idea.properties
+++ b/bin/idea.properties
@@ -100,3 +100,9 @@ sun.java2d.pmoffscreen=false
 # in Show Diff or when calculating Digest Diff
 #---------------------------------------------------------------------
 #idea.max.vcs.loaded.size.kb=20480
+
+#---------------------------------------------------------------------
+# Set this property to configure the default weight used when creating
+# toolwindows that are not already configured in window-manager.xml.
+#---------------------------------------------------------------------
+#idea.toolwindow.defaultWeight=0.33

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/WindowInfoImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/WindowInfoImpl.java
@@ -42,6 +42,9 @@ public final class WindowInfoImpl implements Cloneable,JDOMExternalizable, Windo
   static final float DEFAULT_WEIGHT= 0.33f;
   static final float DEFAULT_SIDE_WEIGHT = 0.5f;
 
+  private final String TOOLWINDOW_WEIGHT_PROPERTY = "idea.toolwindow.defaultWeight";
+
+
   private boolean myActive;
   @NotNull
   private ToolWindowAnchor myAnchor;
@@ -96,7 +99,7 @@ public final class WindowInfoImpl implements Cloneable,JDOMExternalizable, Windo
     myId = id;
     setType(ToolWindowType.DOCKED);
     myVisible = false;
-    myWeight = DEFAULT_WEIGHT;
+    myWeight = getToolWindowWeight();
     mySideWeight = DEFAULT_SIDE_WEIGHT;
     myOrder = -1;
     mySplitMode = false;
@@ -192,12 +195,36 @@ public final class WindowInfoImpl implements Cloneable,JDOMExternalizable, Windo
   }
 
   /**
-   * @return internal weight of tool window. "weigth" means how much of internal desktop
+   * @return internal weight of tool window. "weight" means how much of internal desktop
    * area the tool window is occupied. The weight has sense if the tool window is docked or
    * sliding.
    */
   float getWeight(){
     return myWeight;
+  }
+
+  /**
+   * Pulls in the weight property listed in idea.properties. If it isn't a
+   * valid number that can be parsed into a float, the original, default
+   * weight is returned.
+   *
+   * @return The user-set weight value, or the default weight if the user-set
+   *         value is invalid.
+   */
+  private float getToolWindowWeight() {
+    final String toolWindowWeightProp = System.getProperty(TOOLWINDOW_WEIGHT_PROPERTY);
+
+    if (toolWindowWeightProp == null) {
+      return DEFAULT_WEIGHT;
+    }
+
+    try {
+      return Float.parseFloat(toolWindowWeightProp);
+    }
+    // if value is invalid, return the original default value
+    catch (NumberFormatException e) {
+      return DEFAULT_WEIGHT;
+    }
   }
 
   float getSideWeight() {

--- a/plugins/ui-designer/src/com/intellij/uiDesigner/propertyInspector/UIDesignerToolWindowManager.java
+++ b/plugins/ui-designer/src/com/intellij/uiDesigner/propertyInspector/UIDesignerToolWindowManager.java
@@ -69,6 +69,10 @@ public class UIDesignerToolWindowManager implements ProjectComponent {
   private boolean myToolWindowDisposed = false;
   private final List<TreeSelectionListener> myPendingListeners = ContainerUtil.createLockFreeCopyOnWriteList();
 
+  private final String TOOLWINDOW_WEIGHT_PROPERTY = "idea.toolwindow.defaultWeight";
+  private final float DEFAULT_WEIGHT = 0.33f;
+
+
   public UIDesignerToolWindowManager(final Project project, final FileEditorManager fileEditorManager) {
     myProject = project;
     myFileEditorManager = fileEditorManager;
@@ -90,8 +94,32 @@ public class UIDesignerToolWindowManager implements ProjectComponent {
     }
   }
 
+  /**
+   * Pulls in the weight property listed in idea.properties. If it isn't a
+   * valid number that can be parsed into a float, the original, default
+   * weight is returned.
+   *
+   * @return The user-set weight value, or the default weight if the user-set
+   *         value is invalid.
+   */
+  private float getToolWindowWeight() {
+    final String toolWindowWeightProp = System.getProperty(TOOLWINDOW_WEIGHT_PROPERTY);
+
+    if (toolWindowWeightProp == null) {
+      return DEFAULT_WEIGHT;
+    }
+
+    try {
+      return Float.parseFloat(toolWindowWeightProp);
+    }
+    // if value is invalid, return the original default value
+    catch (NumberFormatException e) {
+      return DEFAULT_WEIGHT;
+    }
+  }
+
   private void initToolWindow() {
-    myToolWindowPanel = new MyToolWindowPanel();
+    myToolWindowPanel = new MyToolWindowPanel(getToolWindowWeight());
     myComponentTree = new ComponentTree(myProject);
     for (TreeSelectionListener listener : myPendingListeners) {
       myComponentTree.addTreeSelectionListener(listener);
@@ -249,8 +277,8 @@ public class UIDesignerToolWindowManager implements ProjectComponent {
   }
 
   private class MyToolWindowPanel extends Splitter implements DataProvider {
-    MyToolWindowPanel() {
-      super(true, 0.33f);
+    MyToolWindowPanel(float weight) {
+      super(true, weight);
     }
 
     @Nullable


### PR DESCRIPTION
Before the toolwindow weight was hardcoded to 0.33f. Now it can be configured in the .idea.properties by uncommenting line 108. This new weight is used whenever a new project is created and a toolwindow NOT configured in window-manager.xml is created (ie: 'Maven Projects').
