### PR TITLE
Fixed a warning, run maven build in maven 3.2.1

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenResumeAction.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenResumeAction.java
@@ -138,6 +138,8 @@ public class MavenResumeAction extends AnAction {
             }
             else if (textWithoutInfo.length() > 0) {
               myMavenProjectNames.add(textWithoutInfo);
+            } else if (!myMavenProjectNames.isEmpty()) {
+              myState = STATE_WAIT_FOR______;
             }
             break;
 


### PR DESCRIPTION
<code>
[2395879]   WARN - en.execution.MavenResumeAction - Build was success, but not all project was build. Project build order: [sub-module2, my module, Using the builder org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder with a thread count of 1], build index: 2 
java.lang.Exception
    at org.jetbrains.idea.maven.execution.MavenResumeAction.log(MavenResumeAction.java:271)
    at org.jetbrains.idea.maven.execution.MavenResumeAction.access$300(MavenResumeAction.java:50)
    at org.jetbrains.idea.maven.execution.MavenResumeAction$1.processTerminated(MavenResumeAction.java:94)
</code>
