### PR TITLE
Add extension point for preprocessing of inner class usages

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerClassJavaUsagesHandler.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerClassJavaUsagesHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.refactoring.move.moveInner;
+
+import com.intellij.psi.*;
+import com.intellij.refactoring.util.RefactoringChangeUtil;
+import com.intellij.usageView.UsageInfo;
+import org.jetbrains.annotations.NotNull;
+
+public class MoveInnerClassJavaUsagesHandler implements MoveInnerClassUsagesHandler {
+  @Override
+  public void correctInnerClassUsage(@NotNull UsageInfo usage, @NotNull PsiClass outerClass) {
+    PsiElement refElement = usage.getElement();
+    if (refElement == null) return;
+
+    PsiManager manager = refElement.getManager();
+
+    PsiElement refParent = refElement.getParent();
+    if (refParent instanceof PsiNewExpression || refParent instanceof PsiAnonymousClass) {
+      PsiNewExpression newExpr = refParent instanceof PsiNewExpression
+                                 ? (PsiNewExpression)refParent
+                                 : (PsiNewExpression)refParent.getParent();
+
+      PsiExpressionList argList = newExpr.getArgumentList();
+
+      if (argList != null) { // can happen in incomplete code
+        if (newExpr.getQualifier() == null) {
+          PsiThisExpression thisExpr;
+          PsiClass parentClass = RefactoringChangeUtil.getThisClass(newExpr);
+          if (outerClass.equals(parentClass)) {
+            thisExpr = RefactoringChangeUtil.createThisExpression(manager, null);
+          }
+          else {
+            thisExpr = RefactoringChangeUtil.createThisExpression(manager, outerClass);
+          }
+          argList.addAfter(thisExpr, null);
+        }
+        else {
+          argList.addAfter(newExpr.getQualifier(), null);
+          newExpr.getQualifier().delete();
+        }
+      }
+    }
+  }
+}

--- a/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerClassUsagesHandler.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerClassUsagesHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.refactoring.move.moveInner;
+
+import com.intellij.lang.LanguageExtension;
+import com.intellij.psi.PsiClass;
+import com.intellij.usageView.UsageInfo;
+import org.jetbrains.annotations.NotNull;
+
+public interface MoveInnerClassUsagesHandler {
+  LanguageExtension<MoveInnerClassUsagesHandler> EP_NAME =
+    new LanguageExtension<MoveInnerClassUsagesHandler>("com.intellij.refactoring.moveInnerClassUsagesHandler");
+
+  void correctInnerClassUsage(@NotNull UsageInfo usage, @NotNull PsiClass outerClass);
+}

--- a/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/move/moveInner/MoveInnerProcessor.java
@@ -214,35 +214,11 @@ public class MoveInnerProcessor extends BaseRefactoringProcessor {
 
       // correct references in usages
       for (UsageInfo usage : usages) {
-        if (usage.isNonCodeUsage) continue;
-        PsiElement refElement = usage.getElement();
-        if (myParameterNameOuterClass != null) { // should pass outer as parameter
-          PsiElement refParent = refElement.getParent();
-          if (refParent instanceof PsiNewExpression || refParent instanceof PsiAnonymousClass) {
-            PsiNewExpression newExpr = refParent instanceof PsiNewExpression
-                                       ? (PsiNewExpression)refParent
-                                       : (PsiNewExpression)refParent.getParent();
+        if (usage.isNonCodeUsage || myParameterNameOuterClass == null) continue; // should pass outer as parameter
 
-            PsiExpressionList argList = newExpr.getArgumentList();
-
-            if (argList != null) { // can happen in incomplete code
-              if (newExpr.getQualifier() == null) {
-                PsiThisExpression thisExpr;
-                PsiClass parentClass = RefactoringChangeUtil.getThisClass(newExpr);
-                if (myOuterClass.equals(parentClass)) {
-                  thisExpr = RefactoringChangeUtil.createThisExpression(manager, null);
-                }
-                else {
-                  thisExpr = RefactoringChangeUtil.createThisExpression(manager, myOuterClass);
-                }
-                argList.addAfter(thisExpr, null);
-              }
-              else {
-                argList.addAfter(newExpr.getQualifier(), null);
-                newExpr.getQualifier().delete();
-              }
-            }
-          }
+        MoveInnerClassUsagesHandler usagesHandler = MoveInnerClassUsagesHandler.EP_NAME.forLanguage(usage.getElement().getLanguage());
+        if (usagesHandler != null) {
+          usagesHandler.correctInnerClassUsage(usage, myOuterClass);
         }
       }
 

--- a/resources/src/META-INF/IdeaPlugin.xml
+++ b/resources/src/META-INF/IdeaPlugin.xml
@@ -188,6 +188,10 @@
       <with attribute="implementationClass" implements="com.intellij.refactoring.move.moveInner.MoveInnerHandler"/>
     </extensionPoint>
 
+    <extensionPoint name="refactoring.moveInnerClassUsagesHandler" beanClass="com.intellij.lang.LanguageExtensionPoint">
+      <with attribute="implementationClass" implements="com.intellij.refactoring.move.moveInner.MoveInnerClassUsagesHandler"/>
+    </extensionPoint>
+
     <extensionPoint name="refactoring.moveClassToInnerHandler"
                     interface="com.intellij.refactoring.move.moveClassesOrPackages.MoveClassToInnerHandler"/>
 
@@ -1201,6 +1205,7 @@
     <refactoring.moveClassToInnerHandler implementation="com.intellij.refactoring.move.moveClassesOrPackages.JavaMoveClassToInnerHandler" id="java"/>
     <refactoring.moveMemberHandler language="JAVA" implementationClass="com.intellij.refactoring.move.moveMembers.MoveJavaMemberHandler" id="java"/>
     <refactoring.moveInnerHandler language="JAVA" implementationClass="com.intellij.refactoring.move.moveInner.MoveJavaInnerHandler" id="java"/>
+    <refactoring.moveInnerClassUsagesHandler language="JAVA" implementationClass="com.intellij.refactoring.move.moveInner.MoveInnerClassJavaUsagesHandler" id="java"/>
 
     <refactoring.safeDeleteProcessor implementation="com.intellij.refactoring.safeDelete.JavaSafeDeleteProcessor" id="javaProcessor"/>
     <refactoring.safeDelete.JavaSafeDeleteDelegate implementationClass="com.intellij.refactoring.safeDelete.JavaSafeDeleteDelegateImpl" language="JAVA"/>


### PR DESCRIPTION
Add usages processor (with corresponding extension point) which is invoked when inner class is moved to top level. The goal is to provide other languages with a way to modify constructor invocations (e.g. in Kotlin `A().B()` should become `B(A())`).
