### PR TITLE
IDEA-120753: Modified tool window weight to be configurable in the Intellij registry

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/WindowInfoImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/WindowInfoImpl.java
@@ -18,6 +18,11 @@ package com.intellij.openapi.wm.impl;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.JDOMExternalizable;
 import com.intellij.openapi.wm.*;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.openapi.wm.ToolWindowAnchor;
+import com.intellij.openapi.wm.ToolWindowContentUiType;
+import com.intellij.openapi.wm.ToolWindowType;
+import com.intellij.openapi.wm.WindowInfo;
 import org.jdom.Element;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -36,7 +41,8 @@ public final class WindowInfoImpl implements Cloneable,JDOMExternalizable, Windo
   /**
    * Default window weight.
    */
-  static final float DEFAULT_WEIGHT= 0.33f;
+  private static final String TOOLWINDOW_WEIGHT_PROPERTY = "idea.toolwindow.defaultWeight";
+  static final float DEFAULT_WEIGHT = Registry.floatValue(TOOLWINDOW_WEIGHT_PROPERTY);
   static final float DEFAULT_SIDE_WEIGHT = 0.5f;
 
   private boolean myActive;
@@ -189,7 +195,7 @@ public final class WindowInfoImpl implements Cloneable,JDOMExternalizable, Windo
   }
 
   /**
-   * @return internal weight of tool window. "weigth" means how much of internal desktop
+   * @return internal weight of tool window. "weight" means how much of internal desktop
    * area the tool window is occupied. The weight has sense if the tool window is docked or
    * sliding.
    */

--- a/platform/util/resources/misc/registry.properties
+++ b/platform/util/resources/misc/registry.properties
@@ -520,3 +520,6 @@ lcd.contrast.value.description=Set LCD text contrast value from 100 to 250
 
 removable.welcome.screen.projects=false
 removable.welcomesreen.projects.description=Allows removing recent projects from welcome screen with mouse
+
+idea.toolwindow.defaultWeight=0.33
+idea.designer.toolwindow.defaultWeight=0.33

--- a/platform/util/src/com/intellij/openapi/util/registry/Registry.java
+++ b/platform/util/src/com/intellij/openapi/util/registry/Registry.java
@@ -87,6 +87,10 @@ public class Registry  {
     return get(key).asString();
   }
 
+  public static float floatValue(@PropertyKey(resourceBundle = REGISTRY_BUNDLE) @NotNull String key) {
+    return get(key).asFloat();
+  }
+
   public static Color getColor(@PropertyKey(resourceBundle = REGISTRY_BUNDLE) @NotNull String key, Color defaultValue) throws MissingResourceException {
     return get(key).asColor(defaultValue);
   }

--- a/platform/util/src/com/intellij/openapi/util/registry/RegistryValue.java
+++ b/platform/util/src/com/intellij/openapi/util/registry/RegistryValue.java
@@ -40,6 +40,7 @@ public class RegistryValue {
   private String myStringCachedValue;
   private Integer myIntCachedValue;
   private Double myDoubleCachedValue;
+  private Float myFloatCachedValue;
   private Boolean myBooleanCachedValue;
 
   RegistryValue(@NotNull Registry registry, @NotNull String key) {
@@ -82,6 +83,14 @@ public class RegistryValue {
     }
 
     return myDoubleCachedValue.doubleValue();
+  }
+
+  public float asFloat() {
+    if (myFloatCachedValue == null) {
+      myFloatCachedValue = Float.valueOf(get(myKey, "0.0", true));
+    }
+
+    return myFloatCachedValue.floatValue();
   }
 
   public Color asColor(Color defaultValue) {

--- a/plugins/ui-designer/src/com/intellij/uiDesigner/propertyInspector/DesignerToolWindow.java
+++ b/plugins/ui-designer/src/com/intellij/uiDesigner/propertyInspector/DesignerToolWindow.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.actionSystem.DataProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.ScrollPaneFactory;
 import com.intellij.ui.SideBorder;
@@ -38,7 +39,7 @@ import java.awt.*;
  * @author Alexander Lobas
  */
 public class DesignerToolWindow implements LightToolWindowContent {
-  private final MyToolWindowPanel myToolWindowPanel = new MyToolWindowPanel();
+  private final MyToolWindowPanel myToolWindowPanel = new MyToolWindowPanel(Registry.floatValue("idea.designer.toolwindow.defaultWeight"));
   private ComponentTree myComponentTree;
   private ComponentTreeBuilder myComponentTreeBuilder;
   private PropertyInspector myPropertyInspector;
@@ -124,8 +125,8 @@ public class DesignerToolWindow implements LightToolWindowContent {
   }
 
   private class MyToolWindowPanel extends Splitter implements DataProvider {
-    MyToolWindowPanel() {
-      super(true, 0.33f);
+    MyToolWindowPanel(float weight) {
+      super(true, weight);
     }
 
     @Nullable


### PR DESCRIPTION
Made a new PR since I accidentally closed the other one and GitHub wouldn't let me reopen it. Now using the registry to store the UI designer and standard tool window weights. Since these values are floats, I added the necessary functions to handle floats in RegistryValue and Registry (others exist for double, int, string, etc.). By default, they are set to 0.33 as they were hardcoded.
