### PR TITLE
PY-11531 Update module_redeclarator.py

### DIFF
--- a/python/helpers/pycharm_generator_utils/module_redeclarator.py
+++ b/python/helpers/pycharm_generator_utils/module_redeclarator.py
@@ -87,7 +87,7 @@ class ModuleRedeclarator(object):
         self.ret_type_cache = {}
         self.used_imports = emptylistdict() # qual_mod_name -> [imported_names,..]: actually used imported names
 
-    def _initializeQApp(self):
+    def _initializeQApp4(self):
         try:  # QtGui should be imported _before_ QtCore package.
             # This is done for the QWidget references from QtCore (such as QSignalMapper). Known bug in PyQt 4.7+
             # Causes "TypeError: C++ type 'QWidget*' is not supported as a native Qt signal type"
@@ -103,9 +103,12 @@ class ModuleRedeclarator(object):
             return
         except ImportError:
             pass
+
+    def _initializeQApp5(self):
         try:
             from PyQt5.QtCore import QCoreApplication
             self.app = QCoreApplication([])
+            return
         except ImportError:
             pass
 
@@ -817,8 +820,10 @@ class ModuleRedeclarator(object):
         """
         action("redoing header of module %r %r", p_name, str(self.module))
 
-        if "pyqt" in p_name.lower():   # qt specific patch
-            self._initializeQApp()
+        if "pyqt4" in p_name.lower():   # qt4 specific patch
+            self._initializeQApp4()
+        elif "pyqt5" in p_name.lower():   # qt5 specific patch
+            self._initializeQApp5()
 
         self.redo_simple_header(p_name)
 


### PR DESCRIPTION
In my system I have both PyQt4 and PyQt5, they run using different sip versions so when trying to import PyQt4 it will crash raising a runtime error like:
RuntimeError: the sip module implements API v11.0 but the PyQt4.QtGui module req
uires API v9.1

This halts any generation of PyQt5 skeletons also which is bad.

Also, the code _initializeQApp will return if PyQt4 can be loaded and a QCoreApplication instance created and thus leaving out PyQt5 generation.

Breaking these up in two cases (qt4 and qt5) solves the partial issue of not generating qt5-skeletons but still qt4-skeletons isnt generated due to the sip-version problem.

After a reinstallation of PyQt4 built on a more recent version of sip everything works out now. Without this patch however I get the error: 
RuntimeError: the PyQt4.QtCore and PyQt5.QtCore modules both wrap the QObject class

when generating PyQt5 skeletons.
