### PR TITLE
Give MavenImporters a chance to set user properties.

### DIFF
--- a/plugins/maven/maven-server-api/src/org/jetbrains/idea/maven/server/MavenServerEmbedder.java
+++ b/plugins/maven/maven-server-api/src/org/jetbrains/idea/maven/server/MavenServerEmbedder.java
@@ -24,13 +24,15 @@ import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Properties;
 
 public interface MavenServerEmbedder extends Remote {
   void customize(@Nullable MavenWorkspaceMap workspaceMap,
                  boolean failOnUnresolvedDependency,
                  @NotNull MavenServerConsole console,
                  @NotNull MavenServerProgressIndicator indicator,
-                 boolean alwaysUpdateSnapshots) throws RemoteException;
+                 boolean alwaysUpdateSnapshots,
+                 @Nullable Properties userProperties) throws RemoteException;
 
   @NotNull
   MavenServerExecutionResult resolveProject(@NotNull File file,

--- a/plugins/maven/maven2-server-impl/src/org/jetbrains/idea/maven/server/embedder/Maven2ServerEmbedderImpl.java
+++ b/plugins/maven/maven2-server-impl/src/org/jetbrains/idea/maven/server/embedder/Maven2ServerEmbedderImpl.java
@@ -587,13 +587,15 @@ public class Maven2ServerEmbedderImpl extends MavenRemoteObject implements Maven
                         boolean failOnUnresolvedDependency,
                         @NotNull MavenServerConsole console,
                         @NotNull MavenServerProgressIndicator indicator,
-                        boolean alwaysUpdateSnapshots) {
+                        boolean alwaysUpdateSnapshots,
+                        @Nullable Properties userProperties) {
     try {
       ((CustomArtifactFactory)getComponent(ArtifactFactory.class)).customize();
       ((CustomArtifactFactory)getComponent(ProjectArtifactFactory.class)).customize();
       ((CustomArtifactResolver)getComponent(ArtifactResolver.class)).customize(workspaceMap, failOnUnresolvedDependency);
       ((CustomRepositoryMetadataManager)getComponent(RepositoryMetadataManager.class)).customize(workspaceMap);
       ((CustomWagonManager)getComponent(WagonManager.class)).customize(failOnUnresolvedDependency);
+      myImpl.setUserProperties(userProperties);
 
       setConsoleAndIndicator(console, indicator);
     }

--- a/plugins/maven/maven2-server-impl/src/org/jetbrains/maven/embedder/MavenEmbedder.java
+++ b/plugins/maven/maven2-server-impl/src/org/jetbrains/maven/embedder/MavenEmbedder.java
@@ -58,6 +58,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
@@ -76,6 +77,7 @@ public class MavenEmbedder {
   private final Logger myLogger;
   private final MavenEmbedderSettings myEmbedderSettings;
   private final ArtifactRepository myLocalRepository;
+  private Properties myUserProperties = new Properties();
 
   private MavenEmbedder(@NotNull DefaultPlexusContainer container,
                         @NotNull Settings settings,
@@ -415,7 +417,7 @@ public class MavenEmbedder {
     MavenExecutionRequest result = new DefaultMavenExecutionRequest(myLocalRepository, mySettings, dispatcher, goals, file.getParent(),
                                                                     createProfileManager(activeProfiles, inactiveProfiles,
                                                                                          executionProperties), executionProperties,
-                                                                    new Properties(), true) {
+                                                                    myUserProperties, true) {
       private boolean myIsRecursive;
 
       @Override
@@ -591,6 +593,10 @@ public class MavenEmbedder {
   public static <T> void setImplementation(PlexusContainer container, Class<T> componentClass, Class<? extends T> implementationClass) {
     ComponentDescriptor d = container.getComponentDescriptor(componentClass.getName());
     d.setImplementation(implementationClass.getName());
+  }
+
+  public void setUserProperties(@Nullable Properties userProperties) {
+    myUserProperties = userProperties == null ? new Properties() : userProperties;
   }
 }
 

--- a/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3ServerEmbedderImpl.java
+++ b/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3ServerEmbedderImpl.java
@@ -113,6 +113,8 @@ public class Maven3ServerEmbedderImpl extends MavenRemoteObject implements Maven
 
   private boolean myAlwaysUpdateSnapshots;
 
+  @Nullable private Properties myUserProperties;
+
   public Maven3ServerEmbedderImpl(MavenServerSettings settings) throws RemoteException {
     File mavenHome = settings.getMavenHome();
     if (mavenHome != null) {
@@ -272,7 +274,8 @@ public class Maven3ServerEmbedderImpl extends MavenRemoteObject implements Maven
                         boolean failOnUnresolvedDependency,
                         @NotNull MavenServerConsole console,
                         @NotNull MavenServerProgressIndicator indicator,
-                        boolean alwaysUpdateSnapshots) throws RemoteException {
+                        boolean alwaysUpdateSnapshots,
+                        @Nullable Properties userProperties) throws RemoteException {
 
     try {
       ((CustomMaven3ArtifactFactory)getComponent(ArtifactFactory.class)).customize();
@@ -287,6 +290,8 @@ public class Maven3ServerEmbedderImpl extends MavenRemoteObject implements Maven
       myAlwaysUpdateSnapshots = alwaysUpdateSnapshots;
 
       setConsoleAndIndicator(console, new MavenServerProgressIndicatorWrapper(indicator));
+
+      myUserProperties = userProperties;
     }
     catch (Exception e) {
       throw rethrowException(e);
@@ -524,6 +529,7 @@ public class Maven3ServerEmbedderImpl extends MavenRemoteObject implements Maven
       getComponent(MavenExecutionRequestPopulator.class).populateDefaults(result);
 
       result.setSystemProperties(mySystemProperties);
+      result.setUserProperties(myUserProperties);
 
       result.setActiveProfiles(activeProfiles);
       result.setInactiveProfiles(inactiveProfiles);

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenImporter.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenImporter.java
@@ -199,4 +199,10 @@ public abstract class MavenImporter {
   protected String findGoalConfigValue(MavenProject p, String goal, String path) {
     return MavenJDOMUtil.findChildValueByPath(getGoalConfig(p, goal), path);
   }
+
+  /**
+   * Override this method if you'd like control over properties used by Maven, e.g. for pom interpolation.
+   */
+  public void customizeUserProperties(Project project, MavenProject mavenProject, Properties properties) {
+  }
 }

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsTree.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsTree.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 import org.jetbrains.idea.maven.dom.references.MavenFilteredPropertyPsiReferenceProvider;
+import org.jetbrains.idea.maven.importing.MavenImporter;
 import org.jetbrains.idea.maven.model.*;
 import org.jetbrains.idea.maven.server.MavenEmbedderWrapper;
 import org.jetbrains.idea.maven.server.NativeMavenProjectHolder;
@@ -1206,7 +1207,11 @@ public class MavenProjectsTree {
                       @NotNull ResolveContext context,
                       @NotNull MavenProgressIndicator process) throws MavenProcessCanceledException {
     MavenEmbedderWrapper embedder = embeddersManager.getEmbedder(MavenEmbeddersManager.FOR_DEPENDENCIES_RESOLVE);
-    embedder.customizeForResolve(getWorkspaceMap(), console, process, generalSettings.isAlwaysUpdateSnapshots());
+    Properties userProperties = new Properties();
+    for (MavenImporter mavenImporter : mavenProject.getSuitableImporters()) {
+      mavenImporter.customizeUserProperties(project, mavenProject, userProperties);
+    }
+    embedder.customizeForResolve(getWorkspaceMap(), console, process, generalSettings.isAlwaysUpdateSnapshots(), userProperties);
 
     try {
       process.checkCanceled();

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/server/MavenEmbedderWrapper.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/server/MavenEmbedderWrapper.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 public abstract class MavenEmbedderWrapper extends RemoteObjectWrapper<MavenServerEmbedder> {
   private Customization myCustomization;
@@ -49,7 +50,7 @@ public abstract class MavenEmbedderWrapper extends RemoteObjectWrapper<MavenServ
   }
 
   public void customizeForResolve(MavenConsole console, MavenProgressIndicator indicator) {
-    setCustomization(console, indicator, null, false, false);
+    setCustomization(console, indicator, null, false, false, null);
     perform(new Retriable<Object>() {
       @Override
       public Object execute() throws RemoteException {
@@ -60,7 +61,12 @@ public abstract class MavenEmbedderWrapper extends RemoteObjectWrapper<MavenServ
   }
 
   public void customizeForResolve(MavenWorkspaceMap workspaceMap, MavenConsole console, MavenProgressIndicator indicator, boolean alwaysUpdateSnapshot) {
-    setCustomization(console, indicator, workspaceMap, false, alwaysUpdateSnapshot);
+    customizeForResolve(workspaceMap, console, indicator, alwaysUpdateSnapshot, null);
+  }
+
+  public void customizeForResolve(MavenWorkspaceMap workspaceMap, MavenConsole console, MavenProgressIndicator indicator,
+                                  boolean alwaysUpdateSnapshot, @Nullable Properties userProperties) {
+    setCustomization(console, indicator, workspaceMap, false, alwaysUpdateSnapshot, userProperties);
     perform(new Retriable<Object>() {
       @Override
       public Object execute() throws RemoteException {
@@ -73,7 +79,7 @@ public abstract class MavenEmbedderWrapper extends RemoteObjectWrapper<MavenServ
   public void customizeForStrictResolve(MavenWorkspaceMap workspaceMap,
                                         MavenConsole console,
                                         MavenProgressIndicator indicator) {
-    setCustomization(console, indicator, workspaceMap, true, false);
+    setCustomization(console, indicator, workspaceMap, true, false, null);
     perform(new Retriable<Object>() {
       @Override
       public Object execute() throws RemoteException {
@@ -88,7 +94,8 @@ public abstract class MavenEmbedderWrapper extends RemoteObjectWrapper<MavenServ
                                    myCustomization.failOnUnresolvedDependency,
                                    myCustomization.console,
                                    myCustomization.indicator,
-                                   myCustomization.alwaysUpdateSnapshot);
+                                   myCustomization.alwaysUpdateSnapshot,
+                                   myCustomization.userProperties);
   }
 
   @NotNull
@@ -245,13 +252,15 @@ public abstract class MavenEmbedderWrapper extends RemoteObjectWrapper<MavenServ
                                              MavenProgressIndicator indicator,
                                              MavenWorkspaceMap workspaceMap,
                                              boolean failOnUnresolvedDependency,
-                                             boolean alwaysUpdateSnapshot) {
+                                             boolean alwaysUpdateSnapshot,
+                                             @Nullable Properties userProperties) {
     resetCustomization();
     myCustomization = new Customization(MavenServerManager.wrapAndExport(console),
                                         MavenServerManager.wrapAndExport(indicator),
                                         workspaceMap,
                                         failOnUnresolvedDependency,
-                                        alwaysUpdateSnapshot);
+                                        alwaysUpdateSnapshot,
+                                        userProperties);
   }
 
   private synchronized void resetCustomization() {
@@ -280,17 +289,20 @@ public abstract class MavenEmbedderWrapper extends RemoteObjectWrapper<MavenServ
     private final MavenWorkspaceMap workspaceMap;
     private final boolean failOnUnresolvedDependency;
     private final boolean alwaysUpdateSnapshot;
+    private final Properties userProperties;
 
     private Customization(MavenServerConsole console,
                           MavenServerProgressIndicator indicator,
                           MavenWorkspaceMap workspaceMap,
                           boolean failOnUnresolvedDependency,
-                          boolean alwaysUpdateSnapshot) {
+                          boolean alwaysUpdateSnapshot,
+                          @Nullable Properties userProperties) {
       this.console = console;
       this.indicator = indicator;
       this.workspaceMap = workspaceMap;
       this.failOnUnresolvedDependency = failOnUnresolvedDependency;
       this.alwaysUpdateSnapshot = alwaysUpdateSnapshot;
+      this.userProperties = userProperties;
     }
   }
 }

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/server/MavenServerManagerHelper.java
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/server/MavenServerManagerHelper.java
@@ -26,7 +26,7 @@ public class MavenServerManagerHelper {
     ApplicationImpl application = (ApplicationImpl)ApplicationManager.getApplication();
     MavenServerManager msm = MavenServerManager.getInstance(); // do this first, it won't work outside of unit test mode
 
-    msm.cleanup(); // in case we were previously connected to maven2
+    msm.shutdown(true); // in case we were previously connected to maven2
 
     boolean oldUnitTestMode = application.isUnitTestMode();
     application.setUnitTestMode(false);
@@ -40,6 +40,6 @@ public class MavenServerManagerHelper {
 
   public static void disconnectFromServer() {
     MavenServerManager msm = MavenServerManager.getInstance();
-    msm.cleanup();
+    msm.shutdown(true);
   }
 }


### PR DESCRIPTION
Subclasses of `MavenImporter` can override `customizeUserProperties()`.
Improved robustness of maven 2/maven 3 switching in `MiscImportingTest`.

Fixes [IDEA-123761 MavenImporters should be able to set properties for import](http://youtrack.jetbrains.com/issue/IDEA-123761)
