### PR TITLE
Fix infinite loop in MavenProjectsTree.findRootProject when there is more than one level of aggregate POMs

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsTree.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsTree.java
@@ -1069,7 +1069,7 @@ public class MavenProjectsTree {
     try {
       MavenProject rootProject = project;
       while (true) {
-        MavenProject aggregator = myModuleToAggregatorMapping.get(project);
+        MavenProject aggregator = myModuleToAggregatorMapping.get(rootProject);
         if (aggregator == null) {
           return rootProject;
         }


### PR DESCRIPTION
Fix with it's unittest.

Please could you include this fix in the next IDEA 13.1.x ?
PS: I already the Contributor Agreement some months ago
