### PR TITLE
Change visibility of JBTerminalSystemSettingsProvider from package to public

### DIFF
--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/JBTerminalSystemSettingsProvider.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/JBTerminalSystemSettingsProvider.java
@@ -48,12 +48,12 @@ import java.util.List;
 /**
  * @author traff
  */
-class JBTerminalSystemSettingsProvider extends DefaultTabbedSettingsProvider implements Disposable {
+public class JBTerminalSystemSettingsProvider extends DefaultTabbedSettingsProvider implements Disposable {
   private Set<TerminalSettingsListener> myListeners = Sets.newHashSet();
 
   private final MyColorSchemeDelegate myColorScheme;
 
-  JBTerminalSystemSettingsProvider() {
+  public JBTerminalSystemSettingsProvider() {
     myColorScheme = createBoundColorSchemeDelegate(null);
 
     UISettings.getInstance().addUISettingsListener(new UISettingsListener() {


### PR DESCRIPTION
I would like to embed a terminal windows in one of my plugins. But with JBTerminalSystemSettingsProvider that have package visibility (this is the only non public class of the terminal plugin) it's a pain to do reflection to create and use it.

Please could you include this fix in the next IDEA 13.1.x ?
PS: I already the Contributor Agreement some months ago
