### PR TITLE
Don't repeat exception message twice

### DIFF
--- a/platform/platform-impl/src/com/intellij/diagnostic/LogMessage.java
+++ b/platform/platform-impl/src/com/intellij/diagnostic/LogMessage.java
@@ -49,7 +49,7 @@ public class LogMessage extends AbstractMessage {
       myHeader = aEvent.getMessage();
     }
 
-    if (myThrowable != null && StringUtil.isNotEmpty(myThrowable.getMessage())) {
+    if (myThrowable != null && StringUtil.isNotEmpty(myThrowable.getMessage()) && !myHeader.startsWith(myThrowable.getMessage())) {
       if (!myHeader.equals(NO_MESSAGE)) {
         if (!myHeader.endsWith(": ") && !myHeader.endsWith(":")) {
           myHeader += ": ";


### PR DESCRIPTION
Don't repeat message in exception if it's already present in `IdeaLogginEvent.getMessage()`.

![image](https://cloud.githubusercontent.com/assets/908958/2695721/fb3ff6b4-c3d9-11e3-8fed-da2e62f5e011.png)
