### PR TITLE
Fix passing idea version when creating RunProfileState in

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/server/MavenServerManager.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/server/MavenServerManager.java
@@ -228,7 +228,7 @@ public class MavenServerManager extends RemoteObjectWrapper<MavenServer> impleme
           params.getVMParametersList().defineProperty(each.getKey(), each.getValue());
         }
 
-        params.getVMParametersList().addProperty("idea.version=", MavenUtil.getIdeaVersionToPassToMavenProcess());
+        params.getVMParametersList().addProperty("idea.version", MavenUtil.getIdeaVersionToPassToMavenProcess());
 
         boolean xmxSet = false;
 


### PR DESCRIPTION
```
MavenServerManager.

Noticed this running 'jps -v':
17987 RemoteMavenServer -Djava.awt.headless=true -Didea.version==13.1.2
-Xmx512m -Dfile.encoding=UTF-8
                                                               ^^
```

Not sure what this broke, but it doesn't seem right.
Feel free to do apply the fix manually, as I haven't signed the CLA yet. If merging is preferred let me know and I'll send in the CLA.
