### PR TITLE
Joined two console CompositFilters into one

### DIFF
--- a/platform/lang-api/src/com/intellij/execution/filters/Filter.java
+++ b/platform/lang-api/src/com/intellij/execution/filters/Filter.java
@@ -59,6 +59,10 @@ public interface Filter {
       return myNextAction;
     }
 
+    public void setResultItems(List<ResultItem> resultItems) {
+      myResultItems = resultItems;
+    }
+
     public void setNextAction(NextAction nextAction) {
       myNextAction = nextAction;
     }

--- a/platform/platform-impl/src/com/intellij/execution/impl/EditorHyperlinkSupport.java
+++ b/platform/platform-impl/src/com/intellij/execution/impl/EditorHyperlinkSupport.java
@@ -224,7 +224,10 @@ public class EditorHyperlinkSupport {
     return getHyperlinkInfoByLineAndCol(pos.line, pos.column);
   }
 
-  public void highlightHyperlinks(final Filter customFilter, final Filter predefinedMessageFilter, final int line1, final int endLine) {
+  public void highlightHyperlinks(@NotNull final Filter filter1,
+                                  @Nullable final Filter filter2,
+                                  final int line1,
+                                  final int endLine) {
     final Document document = myEditor.getDocument();
 
     final int startLine = Math.max(0, line1);
@@ -235,9 +238,9 @@ public class EditorHyperlinkSupport {
         endOffset++; // add '\n'
       }
       final String text = getLineText(document, line, true);
-      Filter.Result result = customFilter.applyFilter(text, endOffset);
-      if (result == null) {
-        result = predefinedMessageFilter.applyFilter(text, endOffset);
+      Filter.Result result = filter1.applyFilter(text, endOffset);
+      if (result == null && filter2 != null) {
+        result = filter2.applyFilter(text, endOffset);
       }
       if (result != null) {
         for (Filter.ResultItem resultItem : result.getResultItems()) {

--- a/platform/platform-tests/testSrc/com/intellij/execution/filters/CompositeFilterTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/execution/filters/CompositeFilterTest.java
@@ -30,6 +30,7 @@ public class CompositeFilterTest {
   @Before
   public void setUp() throws Exception {
     myCompositeFilter = new CompositeFilter(new MockDumbService(null));
+    myCompositeFilter.setForceUseAllFilters(false);
   }
 
   @Test
@@ -54,6 +55,9 @@ public class CompositeFilterTest {
 
     myCompositeFilter.addFilter(returnResultFilter());
     notNullResultOfSize(applyFilter(), 3);
+    
+    myCompositeFilter.setForceUseAllFilters(true);  
+    notNullResultOfSize(applyFilter(), 4);
 
   }
 


### PR DESCRIPTION
CompositeFilter uses all filters by default and merges results (skips intersecting hyperlinks) - to hopefully remove a need to introduce a new interface for ordering of filters
