### PR TITLE
Add an option to only show trailing whitespace characters.

### DIFF
--- a/platform/editor-ui-api/src/com/intellij/openapi/editor/EditorSettings.java
+++ b/platform/editor-ui-api/src/com/intellij/openapi/editor/EditorSettings.java
@@ -24,6 +24,9 @@ public interface EditorSettings {
   boolean isWhitespacesShown();
   void setWhitespacesShown(boolean val);
 
+  boolean isOnlyTrailingWhitespacesShown();
+  void setOnlyTrailingWhitespacesShown(boolean val);
+
   int getRightMargin(Project project);
   void setRightMargin(int myRightMargin);
 

--- a/platform/lang-impl/src/com/intellij/application/options/editor/EditorAppearanceConfigurable.form
+++ b/platform/lang-impl/src/com/intellij/application/options/editor/EditorAppearanceConfigurable.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="11" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="0">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="519" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -36,14 +36,6 @@
         </constraints>
         <properties>
           <text resource-bundle="messages/ApplicationBundle" key="checkbox.show.line.numbers"/>
-        </properties>
-      </component>
-      <component id="2ee6" class="javax.swing.JCheckBox" binding="myCbShowWhitespaces">
-        <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="messages/ApplicationBundle" key="checkbox.show.whitespaces"/>
         </properties>
       </component>
       <component id="d097a" class="javax.swing.JCheckBox" binding="myShowVerticalIndentGuidesCheckBox" default-binding="true">
@@ -112,6 +104,34 @@
             </constraints>
             <properties>
               <text value="500"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="821a8" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="2ee6" class="javax.swing.JCheckBox" binding="myCbShowWhitespaces">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="messages/ApplicationBundle" key="checkbox.show.whitespaces"/>
+            </properties>
+          </component>
+          <component id="a5008" class="javax.swing.JCheckBox" binding="myShowOnlyTrailingWhitespacesCheckBox" default-binding="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <selected value="false"/>
+              <text resource-bundle="messages/ApplicationBundle" key="checkbox.show.only_trailing_whitespaces"/>
             </properties>
           </component>
         </children>

--- a/platform/lang-impl/src/com/intellij/application/options/editor/EditorAppearanceConfigurable.java
+++ b/platform/lang-impl/src/com/intellij/application/options/editor/EditorAppearanceConfigurable.java
@@ -60,6 +60,7 @@ public class EditorAppearanceConfigurable extends CompositeConfigurable<UnnamedC
   private JCheckBox myAntialiasingInEditorCheckBox;
   private JCheckBox myCbShowIconsInGutter;
   private JCheckBox myShowVerticalIndentGuidesCheckBox;
+  private JCheckBox myShowOnlyTrailingWhitespacesCheckBox;
 
   public EditorAppearanceConfigurable() {
     myCbBlinkCaret.addActionListener(
@@ -73,9 +74,17 @@ public class EditorAppearanceConfigurable extends CompositeConfigurable<UnnamedC
     if (!OptionsApplicabilityFilter.isApplicable(OptionId.ICONS_IN_GUTTER)) {
       myCbShowIconsInGutter.setVisible(false);
     }
+    myCbShowWhitespaces.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        if (!myCbShowWhitespaces.isSelected()) {
+          myShowOnlyTrailingWhitespacesCheckBox.setSelected(false);
+        }
+        myShowOnlyTrailingWhitespacesCheckBox.setEnabled(myCbShowWhitespaces.isSelected());
+      }
+    }
+    );
   }
-
-
 
   @Override
   public void reset() {
@@ -89,6 +98,8 @@ public class EditorAppearanceConfigurable extends CompositeConfigurable<UnnamedC
     myCbShowLineNumbers.setSelected(editorSettings.isLineNumbersShown());
     myCbBlockCursor.setSelected(editorSettings.isBlockCursor());
     myCbShowWhitespaces.setSelected(editorSettings.isWhitespacesShown());
+    myShowOnlyTrailingWhitespacesCheckBox.setSelected(editorSettings.isOnlyTrailingWhitespacesShown());
+    myShowOnlyTrailingWhitespacesCheckBox.setEnabled(editorSettings.isWhitespacesShown());
     myShowVerticalIndentGuidesCheckBox.setSelected(editorSettings.isIndentGuidesShown());
     myAntialiasingInEditorCheckBox.setSelected(UISettings.getInstance().ANTIALIASING_IN_EDITOR);
     myCbShowIconsInGutter.setSelected(DaemonCodeAnalyzerSettings.getInstance().SHOW_SMALL_ICONS_IN_GUTTER);
@@ -110,6 +121,7 @@ public class EditorAppearanceConfigurable extends CompositeConfigurable<UnnamedC
     editorSettings.setRightMarginShown(myCbRightMargin.isSelected());
     editorSettings.setLineNumbersShown(myCbShowLineNumbers.isSelected());
     editorSettings.setWhitespacesShown(myCbShowWhitespaces.isSelected());
+    editorSettings.setOnlyTrailingWhitespacesShown(myShowOnlyTrailingWhitespacesCheckBox.isSelected());
     editorSettings.setIndentGuidesShown(myShowVerticalIndentGuidesCheckBox.isSelected());
 
     EditorOptionsPanel.reinitAllEditors();
@@ -142,6 +154,7 @@ public class EditorAppearanceConfigurable extends CompositeConfigurable<UnnamedC
 
     isModified |= isModified(myCbShowLineNumbers, editorSettings.isLineNumbersShown());
     isModified |= isModified(myCbShowWhitespaces, editorSettings.isWhitespacesShown());
+    isModified |= isModified(myShowOnlyTrailingWhitespacesCheckBox, editorSettings.isOnlyTrailingWhitespacesShown());
     isModified |= isModified(myShowVerticalIndentGuidesCheckBox, editorSettings.isIndentGuidesShown());
     isModified |= isModified(myCbShowMethodSeparators, DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS);
     isModified |= isModified(myCbShowIconsInGutter, DaemonCodeAnalyzerSettings.getInstance().SHOW_SMALL_ICONS_IN_GUTTER);

--- a/platform/platform-impl/src/com/intellij/openapi/editor/actions/ToggleShowOnlyTrailingWhitespacesAction.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/actions/ToggleShowOnlyTrailingWhitespacesAction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.openapi.editor.actions;
+
+import com.intellij.openapi.editor.Editor;
+
+public class ToggleShowOnlyTrailingWhitespacesAction extends EditorToggleDecorationAction {
+  @Override
+  protected void setOption(Editor editor, boolean state) {
+    editor.getSettings().setOnlyTrailingWhitespacesShown(state);
+  }
+
+  @Override
+  protected boolean getOption(Editor editor) {
+    return editor.getSettings().isOnlyTrailingWhitespacesShown();
+  }
+}

--- a/platform/platform-impl/src/com/intellij/openapi/editor/ex/EditorSettingsExternalizable.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/ex/EditorSettingsExternalizable.java
@@ -61,6 +61,7 @@ public class EditorSettingsExternalizable implements NamedJDOMExternalizable, Ex
 
     public boolean IS_BLOCK_CURSOR = false;
     public boolean IS_WHITESPACES_SHOWN = false;
+    public boolean IS_ONLY_TRAILING_WHITESPACES_SHOWN = false;
     public boolean IS_ALL_SOFTWRAPS_SHOWN = false;
     public boolean IS_INDENT_GUIDES_SHOWN = true;
     public boolean IS_ANIMATED_SCROLLING = true;
@@ -443,6 +444,14 @@ public class EditorSettingsExternalizable implements NamedJDOMExternalizable, Ex
 
   public void setWhitespacesShown(boolean val) {
     myOptions.IS_WHITESPACES_SHOWN = val;
+  }
+
+  public boolean isOnlyTrailingWhitespacesShown() {
+    return myOptions.IS_ONLY_TRAILING_WHITESPACES_SHOWN;
+  }
+
+  public void setOnlyTrailingWhitespacesShown(boolean val) {
+    myOptions.IS_ONLY_TRAILING_WHITESPACES_SHOWN = val;
   }
 
   public boolean isAllSoftWrapsShown() {

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
@@ -3231,7 +3231,7 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
       x = drawTablessString(text, start, i, g, x, y, fontType, fontColor, clip);
 
       int x1 = EditorUtil.nextTabStop(x, this);
-      drawTabPlacer(g, y, x, x1);
+      drawTabPlacer(g, text, i, y, x, x1);
       x = x1;
       start = i + 1;
     }
@@ -3349,8 +3349,8 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
     return endX;
   }
 
-  private void drawTabPlacer(Graphics g, int y, int start, int stop) {
-    if (mySettings.isWhitespacesShown()) {
+  private void drawTabPlacer(Graphics g, CharSequence data, int index, int y, int start, int stop) {
+    if (mySettings.isWhitespacesShown() && (!mySettings.isOnlyTrailingWhitespacesShown() || isTrailingWhitespace(index, data))) {
       myTabPainter.paint(g, y, start, stop);
     }
   }
@@ -3406,6 +3406,19 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
 
   private static final char IDEOGRAPHIC_SPACE = '\u3000'; // http://www.marathon-studios.com/unicode/U3000/Ideographic_Space
 
+  private boolean isTrailingWhitespace(int charIndex, CharSequence data) {
+    for (int i = charIndex; i < data.length(); i++) {
+      if (!Character.isWhitespace(data.charAt(i))) {
+        return false;
+      }
+
+      if (data.charAt(i) == '\n') {
+        break;
+      }
+    }
+    return true;
+  }
+
   private void drawChars(@NotNull Graphics g, CharSequence data, int start, int end, int x, int y) {
     g.drawString(data.subSequence(start, end).toString(), x, y);
 
@@ -3418,9 +3431,10 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
         final char c = data.charAt(i);
         final int charWidth = isOracleRetina ? GraphicsUtil.charWidth(c, g.getFont()) : metrics.charWidth(c);
 
-        if (c == ' ') {
+        if (c == ' ' && (!mySettings.isOnlyTrailingWhitespacesShown() || isTrailingWhitespace(i, data))) {
           g.fillRect(x + (charWidth >> 1), y, 1, 1);
-        } else if (c == IDEOGRAPHIC_SPACE) {
+        }
+        else if (c == IDEOGRAPHIC_SPACE && (!mySettings.isOnlyTrailingWhitespacesShown() || isTrailingWhitespace(i, data))) {
           final int charHeight = getCharHeight();
           g.drawRect(x + 2, y - charHeight, charWidth - 4, charHeight);
         }

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/SettingsImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/SettingsImpl.java
@@ -69,6 +69,7 @@ public class SettingsImpl implements EditorSettings {
   private Boolean myIsSmartHome                           = null;
   private Boolean myIsBlockCursor                         = null;
   private Boolean myIsWhitespacesShown                    = null;
+  private Boolean myIsOnlyTrailingWhitespacesShown        = null;
   private Boolean myIndentGuidesShown                     = null;
   private Boolean myIsAnimatedScrolling                   = null;
   private Boolean myIsAdditionalPageAtBottom              = null;
@@ -119,6 +120,18 @@ public class SettingsImpl implements EditorSettings {
   @Override
   public void setWhitespacesShown(boolean val) {
     myIsWhitespacesShown = Boolean.valueOf(val);
+  }
+
+  @Override
+  public boolean isOnlyTrailingWhitespacesShown() {
+    return myIsOnlyTrailingWhitespacesShown != null
+           ? myIsOnlyTrailingWhitespacesShown.booleanValue()
+           : EditorSettingsExternalizable.getInstance().isOnlyTrailingWhitespacesShown();
+  }
+
+  @Override
+  public void setOnlyTrailingWhitespacesShown(boolean val) {
+    myIsOnlyTrailingWhitespacesShown = Boolean.valueOf(val);
   }
 
   @Override

--- a/platform/platform-resources-en/src/messages/ApplicationBundle.properties
+++ b/platform/platform-resources-en/src/messages/ApplicationBundle.properties
@@ -654,3 +654,5 @@ wrapping.after.annotations=After last field annotation
 reformat.changed.text.file.too.big.notification.groupId=Reformat changed text
 reformat.changed.text.file.too.big.notification.title=Couldn't calculate changed ranges
 reformat.changed.text.file.too.big.notification.text=file {0} is too big or there are too many changes
+
+checkbox.show.only_trailing_whitespaces=Show only trailing whitespaces

--- a/platform/platform-resources/src/idea/PlatformActions.xml
+++ b/platform/platform-resources/src/idea/PlatformActions.xml
@@ -304,6 +304,7 @@
 
         <group id="EditorToggleActions" popup="true">
           <action id="EditorToggleShowWhitespaces" class="com.intellij.openapi.editor.actions.ToggleShowWhitespacesAction"/>
+          <action id="EditorToggleShowOnlyTrailingWhitespaces" class="com.intellij.openapi.editor.actions.ToggleShowOnlyTrailingWhitespacesAction"/>
           <action id="EditorToggleShowLineNumbers" class="com.intellij.openapi.editor.actions.ToggleShowLineNumbersAction"/>
           <action id="EditorToggleShowIndentLines" class="com.intellij.openapi.editor.actions.ToggleShowIndentLinesAction"/>
           <action id="EditorToggleUseSoftWraps" class="com.intellij.openapi.editor.actions.ToggleUseSoftWrapsMenuAction" icon="AllIcons.Actions.ToggleSoftWrap"/>


### PR DESCRIPTION
This change adds an option to the editor settings dialog to show only trailing whitespace.

Trailing whitespace is defined as a tab, ' ' or ideographic space character that is not followed by a Character.isWhitespace character before the next new line or the end of the buffer.

The isTrailingWhitespace function is inefficient if the file contains extremely long lines.
