### PR TITLE
Show language name instead of internal id to user

### DIFF
--- a/platform/lang-impl/src/com/intellij/refactoring/inline/GenericInlineHandler.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/inline/GenericInlineHandler.java
@@ -184,7 +184,7 @@ public class GenericInlineHandler {
       }
     }
     else {
-      conflicts.putValue(referenceElement, "Cannot inline reference from " + language.getID());
+      conflicts.putValue(referenceElement, "Cannot inline reference from " + language.getDisplayName());
     }
   }
 


### PR DESCRIPTION
I haven't found "Cannot inline reference from ..." in test data but didn't run tests too.
