### PR TITLE
fileContentIndexingVoter extension point

### DIFF
--- a/platform/indexing-api/src/com/intellij/util/indexing/FileBasedIndex.java
+++ b/platform/indexing-api/src/com/intellij/util/indexing/FileBasedIndex.java
@@ -40,6 +40,12 @@ import java.util.Set;
  * Author: dmitrylomov
  */
 public abstract class FileBasedIndex implements BaseComponent {
+  public abstract boolean isFileContentIndexable(@NotNull VirtualFile file);
+
+  public abstract void registerFileContentIndexingVoter(@NotNull FileContentIndexingVoter voter);
+
+  public abstract void removeFileContentIndexingVoter(@NotNull FileContentIndexingVoter voter);
+
   public abstract void iterateIndexableFiles(@NotNull ContentIterator processor, @NotNull Project project, ProgressIndicator indicator);
 
   public abstract void registerIndexableSet(@NotNull IndexableFileSet set, @Nullable Project project);

--- a/platform/indexing-api/src/com/intellij/util/indexing/FileContentIndexingVoter.java
+++ b/platform/indexing-api/src/com/intellij/util/indexing/FileContentIndexingVoter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.util.indexing;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author <a href="mailto:stanley.shyiko@gmail.com">Stanley Shyiko</a>
+ */
+public interface FileContentIndexingVoter {
+  ExtensionPointName<FileContentIndexingVoter> EP_NAME = ExtensionPointName.create("com.intellij.fileContentIndexingVoter");
+
+  boolean isIndexable(@NotNull VirtualFile file);
+}

--- a/platform/lang-impl/src/com/intellij/util/indexing/FileBasedIndexProjectHandler.java
+++ b/platform/lang-impl/src/com/intellij/util/indexing/FileBasedIndexProjectHandler.java
@@ -25,6 +25,7 @@ import com.intellij.ide.startup.StartupManagerEx;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.AbstractProjectComponent;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.*;
@@ -87,6 +88,11 @@ public class FileBasedIndexProjectHandler extends AbstractProjectComponent imple
             }
           });
 
+          final FileContentIndexingVoter[] extensions = Extensions.getExtensions(FileContentIndexingVoter.EP_NAME, project);
+          for (FileContentIndexingVoter voter : extensions) {
+            myIndex.registerFileContentIndexingVoter(voter);
+          }
+
           myIndex.registerIndexableSet(FileBasedIndexProjectHandler.this, project);
           projectManager.addProjectManagerListener(project, new ProjectManagerAdapter() {
             private boolean removed = false;
@@ -95,6 +101,10 @@ public class FileBasedIndexProjectHandler extends AbstractProjectComponent imple
               if (!removed) {
                 removed = true;
                 myIndex.removeIndexableSet(FileBasedIndexProjectHandler.this);
+
+                for (FileContentIndexingVoter voter : extensions) {
+                  myIndex.removeFileContentIndexingVoter(voter);
+                }
               }
             }
           });

--- a/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
+++ b/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
@@ -338,6 +338,8 @@
 
     <!-- File-Based Index-->
     <extensionPoint name="fileBasedIndex" interface="com.intellij.util.indexing.FileBasedIndexExtension"/>
+    <extensionPoint name="fileContentIndexingVoter" interface="com.intellij.util.indexing.FileContentIndexingVoter"
+                    area="IDEA_PROJECT"/>
     <extensionPoint name="stubIndex" interface="com.intellij.psi.stubs.StubIndexExtension"/>
     <extensionPoint name="indexedRootsProvider" interface="com.intellij.util.indexing.IndexedRootsProvider"/>
     <extensionPoint name="include.provider" interface="com.intellij.psi.impl.include.FileIncludeProvider"/>


### PR DESCRIPTION
A proposal for introducing fileContentIndexingVoter extension point which would allow to control file content indexing, effectively providing a way for overcoming issues described in [IDEA-23537](http://youtrack.jetbrains.com/issue/IDEA-23537) (has 8 linked issues, including IDEA, WI and WEB spaces), [IDEA-96277](http://youtrack.jetbrains.com/issue/IDEA-96277) and so on. 

I've assembled a small plugin [shyiko/ijignore](https://github.com/shyiko/ijignore) to demonstrate how it can be used. Once .ijignore is in place, opening a project (sandbox home was forcefully rm -rf'ed, so no cheating) with

```
src/
    ... (few classes)
ext-4.2.1.883/ (374.5 MB / 14,782 items)
    ...
ideaIC-133.193/ (686.9 MB / 76,952 items) 
    ...
.ijignore
```

where .ijignore looked like

```
ext-4.2.1.883/
ideaIC-133.193/
```

was almost instantaneous (in comparison to "without .ijignore"). Tested on 2 year old Macbook Pro (with SSD).

Same extension point could be used (for example):
- to add "Ignore" to the list of source actions (in addition to "Exclude", if you (ever) see it fit). 
- for implementing custom indexing suppression strategies (e.g. by file extension, "marker files")

This would be really helpful for projects with frequent filesystem changes, significantly reducing time spent on "Indexing..." where it's not really needed.

Please let me know if you have any concerns regarding the pull request's content. I'm willing to make any changes you deem appropriate.

Thank you.
