### PR TITLE
unix launch script: ensure filenames with special characters survive the...

### DIFF
--- a/bin/scripts/unix/idea.sh
+++ b/bin/scripts/unix/idea.sh
@@ -166,9 +166,17 @@ LD_LIBRARY_PATH="$IDE_BIN_HOME:$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH
 
 # ---------------------------------------------------------------------
+# Escape args passed to this script so they'll survive the eval call.
+# ---------------------------------------------------------------------
+EXTRA_ARGS=""
+for ARG in "$@"; do
+  EXTRA_ARGS="$EXTRA_ARGS \"$ARG\""
+done
+
+# ---------------------------------------------------------------------
 # Run the IDE.
 # ---------------------------------------------------------------------
 while true ; do
-  eval "$JDK/bin/java" $ALL_JVM_ARGS -Djb.restart.code=88 $MAIN_CLASS_NAME "$@"
+  eval "$JDK/bin/java" $ALL_JVM_ARGS -Djb.restart.code=88 $MAIN_CLASS_NAME $EXTRA_ARGS
   test $? -ne 88 && break
 done


### PR DESCRIPTION
... 'eval' call.

Just using "$@" fails with names with spaces or parenthesises in them.
While the initial "$@" properly quotes all args passing to eval, the
submit which eval does of the result misses the quotes. Hence this.
At least I think that's what's happening. And with this change it works.
Tested against bash 4.3.011 on Arch Linux.
Test call:

```
idea --line 2 subscription\(1\).xml --line 2 a\ a --line 2 "b b"
```

Prior to the patch, with debug enabled by adding -x option to the
shebang (and without parenthesises, as the eval call fails with them):

```
++ [...]  com.intellij.idea.Main --line 2 subscriptions.xml --line 2 a a
--line 2 b b
```

With patch:

```
++ [...]  com.intellij.idea.Main --line 2 'subscriptions(1).xml' --line
2 'a a' --line 2 'b b'
```

As a side note: the _--line xx_ argument does not work for the parameter
with the parentesises in it, but for the two others. Removing the
parenthesises makes it work, so it's not the quoting but presumably the
code handling the _--line_ option.
