### PR TITLE
BasicStepMethodFilter.getMethodName() extracted to the separate interface

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/engine/BasicStepMethodFilter.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/BasicStepMethodFilter.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
  * @author Eugene Zhuravlev
  *         Date: 10/26/13
  */
-public class BasicStepMethodFilter implements MethodFilter {
+public class BasicStepMethodFilter implements NamedMethodFilter {
   @NotNull
   protected final JVMName myDeclaringClassName;
   @NotNull

--- a/java/debugger/impl/src/com/intellij/debugger/engine/DebugProcessEvents.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/DebugProcessEvents.java
@@ -393,8 +393,8 @@ public class DebugProcessEvents extends DebugProcessImpl {
       getSuspendManager().voteSuspend(suspendContext);
       if (hint != null) {
         final MethodFilter methodFilter = hint.getMethodFilter();
-        if (methodFilter instanceof BasicStepMethodFilter && !hint.wasStepTargetMethodMatched()) {
-          final String message = "Method <b>" + ((BasicStepMethodFilter)methodFilter).getMethodName() + "()</b> has not been called";
+        if (methodFilter instanceof NamedMethodFilter && !hint.wasStepTargetMethodMatched()) {
+          final String message = "Method <b>" + ((NamedMethodFilter)methodFilter).getMethodName() + "()</b> has not been called";
           XDebugSessionImpl.NOTIFICATION_GROUP.createNotification(message, MessageType.INFO).notify(project);
         }
       }

--- a/java/debugger/impl/src/com/intellij/debugger/engine/NamedMethodFilter.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/NamedMethodFilter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.debugger.engine;
+
+/**
+ * Nikolay.Tropin
+ * 2014-06-10
+ */
+public interface NamedMethodFilter extends MethodFilter {
+  String getMethodName();
+}


### PR DESCRIPTION
For scala plugin: BasicStepMethodFilter is not suitable for local functions in scala
