### PR TITLE
BaseAnalysisAction now respects ignored directores.

### DIFF
--- a/platform/lang-impl/src/com/intellij/analysis/BaseAnalysisAction.java
+++ b/platform/lang-impl/src/com/intellij/analysis/BaseAnalysisAction.java
@@ -181,7 +181,7 @@ public abstract class BaseAnalysisAction extends AnAction {
             files.add(vFile);
             vFile = ((VirtualFileWindow)vFile).getDelegate();
           }
-          collectFilesUnder(vFile, files);
+          collectFilesUnder(vFile, fileIndex, files);
         }
       }
       return new AnalysisScope(project, files);
@@ -208,15 +208,19 @@ public abstract class BaseAnalysisAction extends AnAction {
     return null;
   }
 
-  private static void collectFilesUnder(@NotNull VirtualFile vFile, @NotNull final Set<VirtualFile> files) {
+  private static void collectFilesUnder(@NotNull VirtualFile vFile,
+                                        @NotNull final ProjectFileIndex fileIndex,
+                                        @NotNull final Set<VirtualFile> files) {
     VfsUtilCore.visitChildrenRecursively(vFile, new VirtualFileVisitor() {
       @Override
-      public boolean visitFile(@NotNull VirtualFile file) {
-        if (!file.isDirectory()) {
+      public Result visitFileEx(@NotNull VirtualFile file) {
+        boolean ignored = fileIndex.isIgnored(file);
+        if (!ignored && !file.isDirectory()) {
           files.add(file);
         }
-        return true;
+        return ignored ? SKIP_CHILDREN : CONTINUE;
       }
     });
   }
+
 }


### PR DESCRIPTION
When traversing the files looking for candidates BaseAnaysisAction
would blindly traverse all directories and all files below any
directory contained in the project, disregarding subdirectories that
have been marked as excluded. For projects that contain large
subdirectories mapped to network devices or joined, caching file
systems, this is prohibitively expensive; sometimes appearing to
hang IDEA on such things as right-clicking in the project view.

With this change BaseAnalysisAction will no longer traverse the
content of directories that have been excluded from the project.
