### PR TITLE
Fixed adding property to XML properties file

### DIFF
--- a/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/xml/XmlPropertiesFileImpl.java
+++ b/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/xml/XmlPropertiesFileImpl.java
@@ -127,6 +127,7 @@ public class XmlPropertiesFileImpl extends XmlPropertiesFile {
     XmlTag rootTag = myFile.getRootTag();
     XmlTag entry = rootTag.createChildTag("entry", "", value, false);
     entry.setAttribute("key", key);
+    rootTag.addSubTag(entry, false);
     return new XmlProperty(entry, this);
   }
 

--- a/plugins/properties/testSrc/com/intellij/lang/properties/xml/XmlPropertiesTest.java
+++ b/plugins/properties/testSrc/com/intellij/lang/properties/xml/XmlPropertiesTest.java
@@ -5,6 +5,7 @@ import com.intellij.lang.properties.PropertiesImplUtil;
 import com.intellij.lang.properties.PropertiesReferenceManager;
 import com.intellij.lang.properties.psi.PropertiesFile;
 import com.intellij.openapi.application.PluginPathManager;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.psi.PsiFile;
 import com.intellij.testFramework.PlatformTestCase;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
@@ -36,6 +37,22 @@ public class XmlPropertiesTest extends LightPlatformCodeInsightFixtureTestCase {
 
   public void testHighlighting() throws Exception {
     myFixture.testHighlighting("foo.xml");
+  }
+
+  public void testAddProperty() {
+    final PsiFile psiFile = myFixture.configureByFile("foo.xml");
+    final PropertiesFile propertiesFile = PropertiesImplUtil.getPropertiesFile(psiFile);
+    assertNotNull(propertiesFile);
+
+    WriteCommandAction.runWriteCommandAction(getProject(), new Runnable() {
+      public void run() {
+        propertiesFile.addProperty("kkk", "vvv");
+      }
+    });
+
+    final IProperty property = propertiesFile.findPropertyByKey("kkk");
+    assertNotNull(property);
+    assertEquals("vvv", property.getValue());
   }
 
   @Override


### PR DESCRIPTION
When adding new property to properties in XML format, the underlying file is never updated. New element is created, but not attached to root element of properties file. 

This functionality is used for example in [wicketforge plugin](https://code.google.com/p/wicketforge/source/browse/src/wicketforge/action/ExtractPropertiesAction.java).

Method was not covered by tests, so I added also a test for it. 
