### PR TITLE
IDEA-87163: Make the remove-all-splits action always work

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/actions/UnsplitAllAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/UnsplitAllAction.java
@@ -30,10 +30,4 @@ public final class UnsplitAllAction extends SplitterActionBase {
     //VirtualFile file = fileEditorManager.getSelectedFiles()[0];
     fileEditorManager.unsplitAllWindow();
   }
-
-  @Override
-  protected boolean isActionEnabled(Project project) {
-    final FileEditorManagerEx fileEditorManager = FileEditorManagerEx.getInstanceEx(project);
-    return fileEditorManager.getWindowSplitCount() > 2;
-  }
 }


### PR DESCRIPTION
Currently, the UnsplitAll action is arbitrarily disabled when there are only two windows, which means that people who have this bound to a key find that it doesn't work in all the cases where a split is present. This patch removes that restriction.

I have submitted a contributor agreement and was notified today that it has been accepted.
