### PR TITLE
Resource bundle filtering

### DIFF
--- a/platform/platform-resources-en/src/messages/IdeBundle.properties
+++ b/platform/platform-resources-en/src/messages/IdeBundle.properties
@@ -1151,3 +1151,5 @@ presentation.mode.fon.size=Font size\:
 update.available.group=Update Checker
 
 loading.editors=Loading files...
+
+action.propertiesview.filter.invalid=Show items with missing translations

--- a/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/editor/ResourceBundlePropertyStructureViewElement.java
+++ b/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/editor/ResourceBundlePropertyStructureViewElement.java
@@ -31,11 +31,11 @@ import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
+import com.intellij.ui.JBColor;
 import com.intellij.util.PlatformIcons;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.awt.*;
 
 public class ResourceBundlePropertyStructureViewElement implements StructureViewTreeElement, ResourceBundleEditorViewElement {
   private final ResourceBundle myResourceBundle;
@@ -46,7 +46,7 @@ public class ResourceBundlePropertyStructureViewElement implements StructureView
 
   static {
     TextAttributes textAttributes = EditorColorsManager.getInstance().getGlobalScheme().getAttributes(PropertiesHighlighter.PROPERTY_KEY).clone();
-    textAttributes.setForegroundColor(Color.red);
+    textAttributes.setForegroundColor(JBColor.RED);
     INCOMPLETE_PROPERTY_KEY = TextAttributesKey.createTextAttributesKey("INCOMPLETE_PROPERTY_KEY", textAttributes);
 
   }
@@ -101,7 +101,7 @@ public class ResourceBundlePropertyStructureViewElement implements StructureView
 
       @Override
       public TextAttributesKey getTextAttributesKey() {
-        boolean isComplete = PropertiesUtil.isPropertyComplete(myResourceBundle, myProperty.getName());
+        boolean isComplete = propertyComplete();
 
         if (isComplete) {
           return PropertiesHighlighter.PROPERTY_KEY;
@@ -109,6 +109,10 @@ public class ResourceBundlePropertyStructureViewElement implements StructureView
         return INCOMPLETE_PROPERTY_KEY;
       }
     };
+  }
+
+  public boolean propertyComplete() {
+    return PropertiesUtil.isPropertyComplete(myResourceBundle, myProperty.getName());
   }
 
   @Override

--- a/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/editor/ResourceBundleStructureViewModel.java
+++ b/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/editor/ResourceBundleStructureViewModel.java
@@ -24,6 +24,7 @@ import com.intellij.ide.util.treeView.smartTree.Grouper;
 import com.intellij.ide.util.treeView.smartTree.Sorter;
 import com.intellij.lang.properties.ResourceBundle;
 import com.intellij.lang.properties.structureView.GroupByWordPrefixes;
+import com.intellij.lang.properties.structureView.InvalidElementFilter;
 import com.intellij.lang.properties.structureView.PropertiesSeparatorManager;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public class ResourceBundleStructureViewModel implements PropertiesGroupingStruc
   private final ResourceBundle myResourceBundle;
   private final GroupByWordPrefixes myByWordPrefixesGrouper;
   private final StructureViewTreeElement myRoot;
+  private final InvalidElementFilter myInvalidElementFilter;
 
   public ResourceBundleStructureViewModel(ResourceBundle root) {
     myResourceBundle = root;
@@ -41,6 +43,7 @@ public class ResourceBundleStructureViewModel implements PropertiesGroupingStruc
       getSeparator(myResourceBundle);
     myByWordPrefixesGrouper = new GroupByWordPrefixes(separator);
     myRoot = new ResourceBundleFileStructureViewElement(myResourceBundle);
+    myInvalidElementFilter = new InvalidElementFilter();
   }
 
   public void setSeparator(String separator) {
@@ -69,7 +72,7 @@ public class ResourceBundleStructureViewModel implements PropertiesGroupingStruc
 
   @NotNull
   public Filter[] getFilters() {
-    return Filter.EMPTY_ARRAY;
+    return new Filter[]{ myInvalidElementFilter };
   }
 
   public Object getCurrentEditorElement() {

--- a/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/structureView/InvalidElementFilter.java
+++ b/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/structureView/InvalidElementFilter.java
@@ -1,0 +1,36 @@
+package com.intellij.lang.properties.structureView;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.util.treeView.smartTree.ActionPresentation;
+import com.intellij.ide.util.treeView.smartTree.ActionPresentationData;
+import com.intellij.ide.util.treeView.smartTree.Filter;
+import com.intellij.ide.util.treeView.smartTree.TreeElement;
+import com.intellij.lang.properties.editor.ResourceBundlePropertyStructureViewElement;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ *  Filter which only shows elements that are invalid.
+ */
+public class InvalidElementFilter implements Filter {
+  @Override
+  public boolean isVisible(TreeElement treeNode) {
+    return !((ResourceBundlePropertyStructureViewElement) treeNode).propertyComplete();
+  }
+
+  @Override
+  public boolean isReverted() {
+    return false;
+  }
+
+  @NotNull
+  @Override
+  public ActionPresentation getPresentation() {
+    return new ActionPresentationData("Invalid items", "Filter invalid items", AllIcons.Nodes.PpInvalid);
+  }
+
+  @NotNull
+  @Override
+  public String getName() {
+    return "Invalid icons";
+  }
+}

--- a/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/structureView/InvalidElementFilter.java
+++ b/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/structureView/InvalidElementFilter.java
@@ -32,6 +32,6 @@ public class InvalidElementFilter implements Filter {
   @NotNull
   @Override
   public String getName() {
-    return "Invalid icons";
+    return "Invalid elements";
   }
 }

--- a/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/structureView/InvalidElementFilter.java
+++ b/plugins/properties/properties-psi-impl/src/com/intellij/lang/properties/structureView/InvalidElementFilter.java
@@ -1,6 +1,7 @@
 package com.intellij.lang.properties.structureView;
 
 import com.intellij.icons.AllIcons;
+import com.intellij.ide.IdeBundle;
 import com.intellij.ide.util.treeView.smartTree.ActionPresentation;
 import com.intellij.ide.util.treeView.smartTree.ActionPresentationData;
 import com.intellij.ide.util.treeView.smartTree.Filter;
@@ -9,7 +10,7 @@ import com.intellij.lang.properties.editor.ResourceBundlePropertyStructureViewEl
 import org.jetbrains.annotations.NotNull;
 
 /**
- *  Filter which only shows elements that are invalid.
+ *  Filter which only shows elements in properties structure view that are invalid (have missing translations).
  */
 public class InvalidElementFilter implements Filter {
   @Override
@@ -25,7 +26,7 @@ public class InvalidElementFilter implements Filter {
   @NotNull
   @Override
   public ActionPresentation getPresentation() {
-    return new ActionPresentationData("Invalid items", "Filter invalid items", AllIcons.Nodes.PpInvalid);
+    return new ActionPresentationData(IdeBundle.message("action.propertiesview.filter.invalid"), null, AllIcons.Nodes.ErrorIntroduction);
   }
 
   @NotNull


### PR DESCRIPTION
This is a fix for http://youtrack.jetbrains.com/issue/IDEA-86919  and adds a filter for invalid elements to the built-in resource bundle editor.
