### PR TITLE
Solves IDEA-107376

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorWindow.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorWindow.java
@@ -503,9 +503,10 @@ public class EditorWindow {
   public void requestFocus(boolean forced) {
     if (myTabbedPane != null) {
       myTabbedPane.requestFocus(forced);
-    }else{
+    }
+    else {
       //No Tabs Issue (IDEA-107376)
-      IdeFocusManager.findInstanceByComponent(myPanel).requestFocus(myPanel,true);
+      IdeFocusManager.findInstanceByComponent(myPanel).requestFocus(myPanel,forced);
     }
   }
 


### PR DESCRIPTION
The problem was due `myTabbedPane` is always null when there are not tabs (Editor / Editor Tabs / Tab Appearance set to none) therefor never requesting focus. 

I added a else case to make use of `IdeFocusManager` so it will use the `findInstanceByComponent` with the current panel and then request the focus to the editor.

Issue reference http://youtrack.jetbrains.com/issue/IDEA-107376
