### PR TITLE
Awesome WM support for IntelliJ

### DIFF
--- a/bin/scripts/unix/idea.sh
+++ b/bin/scripts/unix/idea.sh
@@ -166,6 +166,18 @@ LD_LIBRARY_PATH="$IDE_BIN_HOME:$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH
 
 # ---------------------------------------------------------------------
+# Check if the wmname tool is installed (part of the suckless-tools
+# package on debian) using the hash command (adopted from 
+# http://stackoverflow.com/a/677212). If it is installed set the fake
+# window manager name to LG3D. This makes intellij usable for users
+# of the awesome window manager (otherwise you just get a plain grey
+# window which is pretty sad.
+# ---------------------------------------------------------------------
+if hash wmname 2>/dev/null; then
+        wmname LG3D
+fi
+
+# ---------------------------------------------------------------------
 # Run the IDE.
 # ---------------------------------------------------------------------
 while true ; do


### PR DESCRIPTION
Awesome WM has some issues with Java applications (https://awesome.naquadah.org/wiki/Problems_with_Java). When you start IntelliJ while using Awesome WM you just get a gray window. To fix this you basically have to fake the window manager name using the wmname tool.
The lines I added first test if the wmname tool is available and then use it to set the window manaer name to LG3D (which apparently is one that java likes).
It would be awesome if you could pull this one in. Feel free to remove the huge comment I put there to justify the 3 lines of code I added.
