### PR TITLE
option BROWSEWORDATCARET removed

### DIFF
--- a/colorSchemes/src/colorSchemes/Darcula.xml
+++ b/colorSchemes/src/colorSchemes/Darcula.xml
@@ -111,12 +111,6 @@
         <option name="BACKGROUND" value="3a2323" />
       </value>
     </option>
-    <option name="BROWSEWORDATCARET">
-      <value>
-        <option name="EFFECT_COLOR" value="526da5" />
-        <option name="ERROR_STRIPE_COLOR" value="273955" />
-      </value>
-    </option>
     <option name="Bad character">
       <value>
         <option name="FOREGROUND" value="ff0000" />


### PR DESCRIPTION
Latest BrowseWordAtCaret fully supports darcula scheme, so this key is not longer needed. https://code.google.com/p/browsewordatcaret/issues/detail?id=16
