### PR TITLE
Adds the ability for secondary toolbar buttons to be right aligned.

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/navigationToolbar/NavBarRootPaneExtension.java
+++ b/platform/lang-impl/src/com/intellij/ide/navigationToolbar/NavBarRootPaneExtension.java
@@ -27,8 +27,10 @@ import com.intellij.ide.ui.customization.CustomActionsSchema;
 import com.intellij.ide.ui.customization.CustomisedActionGroup;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction;
+import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.wm.IdeRootPaneNorthExtension;
 import com.intellij.openapi.wm.impl.IdeFrameImpl;
 import com.intellij.ui.ScrollPaneFactory;
@@ -135,6 +137,9 @@ public class NavBarRootPaneExtension extends IdeRootPaneNorthExtension {
       if (toolbarRunGroup instanceof ActionGroup) {
         final boolean needGap = isNeedGap(toolbarRunGroup);
         final ActionToolbar actionToolbar = manager.createActionToolbar(ActionPlaces.NAVIGATION_BAR_TOOLBAR, (ActionGroup)toolbarRunGroup, true);
+        if (Registry.get("actionSystem.rightAlignSecondaries").asBoolean() && actionToolbar instanceof ActionToolbarImpl) {
+          ((ActionToolbarImpl)actionToolbar).setRightAlignSecondaries(true);
+        }
         final JComponent component = actionToolbar.getComponent();
         component.setOpaque(false);
         myRunPanel = new JPanel(new BorderLayout()) {

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeRootPane.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeRootPane.java
@@ -25,12 +25,14 @@ import com.intellij.ide.ui.UISettingsListener;
 import com.intellij.ide.ui.customization.CustomActionsSchema;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx;
+import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.wm.*;
 import com.intellij.openapi.wm.ex.IdeFrameEx;
 import com.intellij.openapi.wm.impl.status.IdeStatusBarImpl;
@@ -212,6 +214,9 @@ public class IdeRootPane extends JRootPane implements UISettingsListener {
       group,
       true
     );
+    if (Registry.get("actionSystem.rightAlignSecondaries").asBoolean() && toolBar instanceof ActionToolbarImpl) {
+      ((ActionToolbarImpl)toolBar).setRightAlignSecondaries(true);
+    }
     toolBar.setLayoutPolicy(ActionToolbar.WRAP_LAYOUT_POLICY);
 
     DefaultActionGroup menuGroup = new DefaultActionGroup();

--- a/platform/util/resources/misc/registry.properties
+++ b/platform/util/resources/misc/registry.properties
@@ -40,6 +40,7 @@ actionSystem.win.suppressAlt.new=true
 actionSystem.mouseGesturesEnabled=true
 actionSystem.assertFocusAccessFromEdt=true
 actionSystem.enableAbbreviations=true
+actionSystem.rightAlignSecondaries=false
 
 ide.firstStartup=true
 ide.debugMode=false


### PR DESCRIPTION
This ability must be turned on via the 'Registry' to have any effect.  Otherwise, secondaries will continue
to function as they do now.  It also must be opted into for each toolbar as secondaries in other toolbars
use the cogwheel dropdown.
Right aligned secondaries are placed to the right of the search button.

This right aligning is required in Android Studio to right align our Google Login widget -- which is a
requirement for common look and feel with other applications that support login.
