### PR TITLE
Fix the asm jar version required by javac2 in ant build

### DIFF
--- a/java/compiler/impl/src/com/intellij/compiler/ant/BuildPropertiesImpl.java
+++ b/java/compiler/impl/src/com/intellij/compiler/ant/BuildPropertiesImpl.java
@@ -111,7 +111,7 @@ public class BuildPropertiesImpl extends BuildProperties {
         Path javac2 = new Path(PROPERTY_JAVAC2_CLASSPATH_ID);
         javac2.add(new PathElement(propertyRelativePath(PROPERTY_JAVAC2_HOME, "javac2.jar")));
         javac2.add(new PathElement(propertyRelativePath(PROPERTY_JAVAC2_HOME, "jdom.jar")));
-        javac2.add(new PathElement(propertyRelativePath(PROPERTY_JAVAC2_HOME, "asm4-all.jar")));
+        javac2.add(new PathElement(propertyRelativePath(PROPERTY_JAVAC2_HOME, "asm-all.jar")));
         javac2.add(new PathElement(propertyRelativePath(PROPERTY_JAVAC2_HOME, "jgoodies-forms.jar")));
         add(javac2);
         //noinspection HardCodedStringLiteral


### PR DESCRIPTION
When one asks IJ to create an Ant build for the project, and "Enable UI forms compilation" is checked on the dialog, the output build file incorrectly references `asm4-all.jar` which causes the exception below, whereas `asm-all.jar` builds the project correctly.

```
Caused by: java.lang.ClassNotFoundException: org.jetbrains.org.objectweb.asm.ClassVisitor
  at org.apache.tools.ant.AntClassLoader.findClassInComponents(AntClassLoader.java:1374)
  at org.apache.tools.ant.AntClassLoader.findClass(AntClassLoader.java:1323)
  at org.apache.tools.ant.AntClassLoader.loadClass(AntClassLoader.java:1076)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
  ... 20 more
```

This behavior is present in 2c694642 and in the latest 14 EAP (139.1.20).
