### PR TITLE
Add ipnb and the edu modules to repair PyC build

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -40,6 +40,7 @@
       <module fileurl="file://$PROJECT_DIR$/plugins/copyright/copyright.iml" filepath="$PROJECT_DIR$/plugins/copyright/copyright.iml" group="plugins" />
       <module fileurl="file://$PROJECT_DIR$/platform/core-api/core-api.iml" filepath="$PROJECT_DIR$/platform/core-api/core-api.iml" group="platform" />
       <module fileurl="file://$PROJECT_DIR$/platform/core-impl/core-impl.iml" filepath="$PROJECT_DIR$/platform/core-impl/core-impl.iml" group="platform" />
+      <module fileurl="file://$PROJECT_DIR$/python/edu/course-creator/course-creator.iml" filepath="$PROJECT_DIR$/python/edu/course-creator/course-creator.iml" group="python/educational" />
       <module fileurl="file://$PROJECT_DIR$/plugins/coverage/coverage.iml" filepath="$PROJECT_DIR$/plugins/coverage/coverage.iml" group="plugins/coverage" />
       <module fileurl="file://$PROJECT_DIR$/plugins/coverage-common/coverage-common.iml" filepath="$PROJECT_DIR$/plugins/coverage-common/coverage-common.iml" group="plugins/coverage" />
       <module fileurl="file://$PROJECT_DIR$/plugins/coverage/covergae_rt/coverage_rt.iml" filepath="$PROJECT_DIR$/plugins/coverage/covergae_rt/coverage_rt.iml" group="plugins/coverage" />
@@ -94,6 +95,7 @@
       <module fileurl="file://$PROJECT_DIR$/platform/indexing-impl/indexing-impl.iml" filepath="$PROJECT_DIR$/platform/indexing-impl/indexing-impl.iml" group="platform" />
       <module fileurl="file://$PROJECT_DIR$/java/compiler/instrumentation-util/instrumentation-util.iml" filepath="$PROJECT_DIR$/java/compiler/instrumentation-util/instrumentation-util.iml" group="java/compiler" />
       <module fileurl="file://$PROJECT_DIR$/plugins/IntelliLang/intellilang-jps-plugin/intellilang-jps-plugin.iml" filepath="$PROJECT_DIR$/plugins/IntelliLang/intellilang-jps-plugin/intellilang-jps-plugin.iml" group="jps" />
+      <module fileurl="file://$PROJECT_DIR$/python/ipnb/ipnb.iml" filepath="$PROJECT_DIR$/python/ipnb/ipnb.iml" group="python" />
       <module fileurl="file://$PROJECT_DIR$/java/java-analysis-api/java-analysis-api.iml" filepath="$PROJECT_DIR$/java/java-analysis-api/java-analysis-api.iml" group="java" />
       <module fileurl="file://$PROJECT_DIR$/java/java-analysis-impl/java-analysis-impl.iml" filepath="$PROJECT_DIR$/java/java-analysis-impl/java-analysis-impl.iml" group="java" />
       <module fileurl="file://$PROJECT_DIR$/plugins/java-decompiler/engine/java-decompiler-engine.iml" filepath="$PROJECT_DIR$/plugins/java-decompiler/engine/java-decompiler-engine.iml" group="plugins" />
@@ -133,6 +135,7 @@
       <module fileurl="file://$PROJECT_DIR$/platform/lang-api/lang-api.iml" filepath="$PROJECT_DIR$/platform/lang-api/lang-api.iml" group="platform" />
       <module fileurl="file://$PROJECT_DIR$/platform/lang-impl/lang-impl.iml" filepath="$PROJECT_DIR$/platform/lang-impl/lang-impl.iml" group="platform" />
       <module fileurl="file://$PROJECT_DIR$/android/tools-base/layoutlib-api/layoutlib-api.iml" filepath="$PROJECT_DIR$/android/tools-base/layoutlib-api/layoutlib-api.iml" group="android/sdktools" />
+      <module fileurl="file://$PROJECT_DIR$/python/edu/learn-python/learn-python.iml" filepath="$PROJECT_DIR$/python/edu/learn-python/learn-python.iml" group="python/educational" />
       <module fileurl="file://$PROJECT_DIR$/android/tools-base/lint/libs/lint-api/lint-api.iml" filepath="$PROJECT_DIR$/android/tools-base/lint/libs/lint-api/lint-api.iml" group="android/sdktools" />
       <module fileurl="file://$PROJECT_DIR$/android/tools-base/lint/libs/lint-checks/lint-checks.iml" filepath="$PROJECT_DIR$/android/tools-base/lint/libs/lint-checks/lint-checks.iml" group="android/sdktools" />
       <module fileurl="file://$PROJECT_DIR$/platform/lvcs-api/lvcs-api.iml" filepath="$PROJECT_DIR$/platform/lvcs-api/lvcs-api.iml" group="platform" />


### PR DESCRIPTION
If one opens the Module Settings in IJ, the `main_pycharm_ce` module is in error, as is the `main_pycharm_edu` module. This also impacts the command-line build of PyCharm using `ant` because after the build, the packaging step complains about a missing `ipnb` module and dies.

This fixes both of these problems.
