### PR TITLE
[Decompiler] Don't include redundant casts even when castAlways is true.

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -874,7 +874,7 @@ public class ExprProcessor implements CodeConstants {
 
     boolean cast =
       !leftType.isSuperset(rightType) && (rightType.equals(VarType.VARTYPE_OBJECT) || leftType.type != CodeConstants.TYPE_OBJECT);
-    cast |= castAlways;
+    cast |= castAlways && !leftType.equals(rightType);
 
     if (!cast && castNull && rightType.type == CodeConstants.TYPE_NULL) {
       // check for a nameless anonymous class


### PR DESCRIPTION
In the previous fernflower binaries, this was the case, however inexplicably this code has been absent in the source since day one. Adding this check prevents instances of duplicate casts such as `((String) ((String) "test"))` or `(Type) objectOfType` in method calls, which is completely redundant.

@trespasserw as mentioned previously I currently maintain a forked fernflower based on modified bytecode from the last obfuscated released. I figure I'd start pull requesting the useful stuff upstream, so here is a start!
