### PR TITLE
Fix a path unescaping.

### DIFF
--- a/plugins/git4idea/src/git4idea/GitUtil.java
+++ b/plugins/git4idea/src/git4idea/GitUtil.java
@@ -650,6 +650,8 @@ public class GitUtil {
                   b[n++] = (byte)code;
                 }
                 if (i + 1 >= l || path.charAt(i) != '\\' || !VcsFileUtil.isOctal(path.charAt(i + 1))) {
+                  //noinspection AssignmentToForLoopParameter
+                  i--;  // We need to backtrack one char, because the outer loop will move us forward again.
                   break;
                 }
                 //noinspection AssignmentToForLoopParameter
@@ -676,7 +678,7 @@ public class GitUtil {
     }
     return rc.toString();
   }
-  
+
   public static boolean justOneGitRepository(Project project) {
     if (project.isDisposed()) {
       return true;


### PR DESCRIPTION
The character following a octal string sequence was skipped.
Writing a test is a bit problematic due to 'hardcoded' call to
GitConfigUtil.getFileNameEncoding().
