### PR TITLE
Added the Close All Projects and Close Other Projects actions.

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/actions/CloseAllProjectsAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/CloseAllProjectsAction.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.ide.actions;
+
+import com.intellij.ide.RecentProjectsManagerBase;
+import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeFrame;
+import com.intellij.projectImport.ProjectAttachProcessor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Closes all project windows and restore the Welcome Frame.
+ *
+ * @author Bradley M Handy &lt;brad.handy@gmail.com&gt;
+ */
+public class CloseAllProjectsAction extends AnAction implements DumbAware {
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    Project currentProject = CommonDataKeys.PROJECT.getData(e.getDataContext());
+    assert currentProject != null;
+
+    ProjectManager manager = ProjectManager.getInstance();
+
+    for (Project project : manager.getOpenProjects()) {
+      if (currentProject == project) {
+        continue;
+      }
+
+      ProjectUtil.closeAndDispose(project);
+    }
+
+    // force the current project to be closed last.
+    ProjectUtil.closeAndDispose(currentProject);
+    RecentProjectsManagerBase.getInstance().updateLastProjectPath();
+    WelcomeFrame.showIfNoProjectOpened();
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent event) {
+    Presentation presentation = event.getPresentation();
+    Project project = event.getData(CommonDataKeys.PROJECT);
+    ProjectManager manager = ProjectManager.getInstance();
+
+    presentation.setEnabled(project != null && manager.getOpenProjects().length > 1);
+    if (ProjectAttachProcessor.canAttachToProject() && project != null && ModuleManager.getInstance(project).getModules().length > 1) {
+      presentation.setText("Close Projects in _All Windows");
+    }
+    else {
+      presentation.setText("Close _All Projects");
+    }
+  }
+
+}

--- a/platform/platform-impl/src/com/intellij/ide/actions/CloseOtherProjectsAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/CloseOtherProjectsAction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.ide.actions;
+
+import com.intellij.ide.RecentProjectsManagerBase;
+import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.projectImport.ProjectAttachProcessor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Closes all project windows except for the current project.
+ *
+ * @author Bradley M Handy &lt;brad.handy@gmail.com&gt;
+ */
+public class CloseOtherProjectsAction extends AnAction implements DumbAware {
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    Project currentProject = CommonDataKeys.PROJECT.getData(e.getDataContext());
+    assert currentProject != null;
+
+    ProjectManager manager = ProjectManager.getInstance();
+
+    for (Project project : manager.getOpenProjects()) {
+      if (currentProject == project) {
+        continue;
+      }
+      ProjectUtil.closeAndDispose(project);
+    }
+
+    RecentProjectsManagerBase.getInstance().updateLastProjectPath();
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent event) {
+    Presentation presentation = event.getPresentation();
+    Project project = event.getData(CommonDataKeys.PROJECT);
+    ProjectManager manager = ProjectManager.getInstance();
+
+    presentation.setEnabled(project != null && manager.getOpenProjects().length > 1);
+    if (ProjectAttachProcessor.canAttachToProject() && project != null && ModuleManager.getInstance(project).getModules().length > 1) {
+      presentation.setText("Close Projects in _Other Windows");
+    }
+    else {
+      presentation.setText("Close _Other Projects");
+    }
+  }
+
+}

--- a/platform/platform-resources/src/idea/PlatformActions.xml
+++ b/platform/platform-resources/src/idea/PlatformActions.xml
@@ -31,7 +31,7 @@
 
     <action id="NextEditorTab" class="com.intellij.openapi.fileEditor.impl.SelectNextEditorTabAction"/>
     <action id="PreviousEditorTab" class="com.intellij.openapi.fileEditor.impl.SelectPreviousEditorTabAction"/>
-    
+
     <action id="TextComponent.ClearAction" class="com.intellij.ui.ClearTextAction"/>
     <action id="Switcher" class="com.intellij.ide.actions.Switcher" text="Switcher"/>
     <action id="QuickDocCopy" class="com.intellij.codeInsight.documentation.actions.CopyQuickDocAction" use-shortcut-of="$Copy"/>
@@ -176,6 +176,8 @@
           <action id="OpenFile" class="com.intellij.ide.actions.OpenFileAction" icon="AllIcons.Actions.Menu_open"/>
           <group id="$LRU" class="com.intellij.ide.actions.RecentProjectsGroup" popup="true"/>
           <action id="CloseProject" class="com.intellij.ide.actions.CloseProjectAction"/>
+          <action id="CloseOtherProjects" class="com.intellij.ide.actions.CloseOtherProjectsAction"/>
+          <action id="CloseAllProject" class="com.intellij.ide.actions.CloseAllProjectsAction"/>
         </group>
         <separator/>
         <group id="FileMainSettingsGroup">
@@ -194,9 +196,9 @@
         <action id="SaveAll" class="com.intellij.ide.actions.SaveAllAction" icon="AllIcons.Actions.Menu_saveall"/>
         <action id="Synchronize" class="com.intellij.ide.actions.SynchronizeAction" icon="AllIcons.Actions.Refresh"/>
         <action id="InvalidateCaches" class="com.intellij.ide.actions.InvalidateCachesAction"/>
-        
+
         <action id="ChangeFileEncodingAction" class="com.intellij.openapi.vfs.encoding.ChangeFileEncodingAction"/>
-        
+
         <group id="ChangeLineSeparators" text="Line Separators" popup="true" class="com.intellij.ide.actions.NonTrivialActionGroup">
           <action id="ConvertToWindowsLineSeparators" class="com.intellij.codeStyle.ConvertToWindowsLineSeparatorsAction"/>
           <action id="ConvertToUnixLineSeparators" class="com.intellij.codeStyle.ConvertToUnixLineSeparatorsAction"/>


### PR DESCRIPTION
These actions close multiple projects at once.
- CloseOtherProjectsAction leaves the current project open while closing all of the others.
- CloseAllProjectsAction closes all of the open projects and displays the WelcomeFrame.

For the copyright comment, I didn't feel right putting my name in place of JetBrains s.r.o. since the "update" method's only changes were to add the usage of the ProjectManager and a change in verbiage for the presentation text.

I committed these to branch 139 because I figured these would be a nice addition to IntelliJ 14.x.  However, if I should have committed them to trunk, let me know and I'll do that as well.
