### PR TITLE
Gradle dependency import should honor file name

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
@@ -652,6 +652,8 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
           if (matcher.matches()) {
             final String classifier = matcher.group(1);
             libraryName += (":" + classifier);
+          } else {
+            libraryName += (":" + libraryFileName);
           }
         }
       }


### PR DESCRIPTION
When importing dependencies from Gradle Intellij identifies them by 'groupId:artifactId:version[:classifier]'. While being sufficient for conventional layouts, it still may fail with custom Ivy repositories. Consider the following example:

``` groovy
apply plugin: 'java'
repositories {
    ivy {
        ivyPattern 'http://teamcity.jetbrains.com/guestAuth/repository/download/[module]/[revision]/teamcity-ivy.xml'
        artifactPattern 'http://teamcity.jetbrains.com/guestAuth/repository/download/[module]/[revision]/[artifact](.[ext])'
    }
}

dependencies {
    compile ( 'org:bt345:lastSuccessful' ){
        artifact {
            name = 'kotlin-compiler-0.9.712'
            type = 'zip'
        }
    }
    compile ( 'org:bt345:lastSuccessful' ){
        artifact {
            name = 'kotlin-compiler-for-maven'
            type = 'jar'
        }
    }
} 
```

Upon import Intellij creates only one of these deps, ignoring the second one as a duplicate. Proposed fix addresses the problem by appending a filename for dependencies which does not follow Maven naming convention.
