### PR TITLE
Fix to #py-13969

### DIFF
--- a/python/src/com/jetbrains/python/psi/impl/PyClassImpl.java
+++ b/python/src/com/jetbrains/python/psi/impl/PyClassImpl.java
@@ -1174,7 +1174,10 @@ public class PyClassImpl extends PyBaseElementImpl<PyClassStub> implements PyCla
     final PyClassStub stub = getStub();
     final List<PyClassLikeType> result = new ArrayList<PyClassLikeType>();
     if (stub != null) {
-      final PsiElement parent = stub.getParentStub().getPsi();
+      PsiElement parent = stub.getParentStub().getPsi();
+      while (parent instanceof PyClass) {
+        parent = parent.getParent();
+      }
       if (parent instanceof PyFile) {
         final PyFile file = (PyFile)parent;
         for (QualifiedName name : stub.getSuperClasses()) {


### PR DESCRIPTION
This one took me hours and hours to debug :O

`getPsi()` is a class instead of a file if a class is nested, and we do not get a fully-qualified name, but we should since sub class definitions are not more "volatile" than class definitions.

This fix appears to work, but I'm not super-familiar with the codebase so please point out any problems.

I sincerely hope that this can be reviewed soon, a lot of my projects depend on it.
