### PR TITLE
OverriderUsageInfo: Store overriding PsiMethod in a separate field (to prevent replacement by "navigation element")

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/MethodReturnTypeFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/MethodReturnTypeFix.java
@@ -256,7 +256,7 @@ public class MethodReturnTypeFix extends LocalQuickFixAndIntentionActionOnPsiEle
     @Override
     public void visit(final UsageInfo usage) {
       if (usage instanceof OverriderUsageInfo) {
-        myAffectedMethods.add(((OverriderUsageInfo) usage).getElement());
+        myAffectedMethods.add(((OverriderUsageInfo) usage).getOverridingMethod());
       }
     }
 
@@ -269,8 +269,7 @@ public class MethodReturnTypeFix extends LocalQuickFixAndIntentionActionOnPsiEle
       for (Iterator<UsageInfo> usageInfoIterator = covariantOverriderInfos.iterator(); usageInfoIterator.hasNext();) {
         final UsageInfo info = usageInfoIterator.next();
         if (info instanceof OverriderUsageInfo) {
-          final OverriderUsageInfo overrideUsage = (OverriderUsageInfo) info;
-          if (myAffectedMethods.contains(overrideUsage.getElement())) {
+          if (myAffectedMethods.contains(((OverriderUsageInfo) info).getOverridingMethod())) {
             usageInfoIterator.remove();
           }
         }

--- a/java/java-impl/src/com/intellij/refactoring/changeSignature/ChangeSignatureProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/changeSignature/ChangeSignatureProcessor.java
@@ -183,7 +183,7 @@ public class ChangeSignatureProcessor extends ChangeSignatureProcessorBase {
       for (UsageInfo usageInfo : usages) {
         if (usageInfo instanceof OverriderUsageInfo) {
           final OverriderUsageInfo info = (OverriderUsageInfo)usageInfo;
-          PsiMethod overrider = assertNotNull(info.getElement());
+          PsiMethod overrider = assertNotNull(info.getOverridingMethod());
           PsiMethod baseMethod = info.getBaseMethod();
           PsiSubstitutor substitutor = calculateSubstitutor(overrider, baseMethod);
           PsiType type;

--- a/java/java-impl/src/com/intellij/refactoring/changeSignature/JavaChangeSignatureUsageProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/changeSignature/JavaChangeSignatureUsageProcessor.java
@@ -98,7 +98,7 @@ public class JavaChangeSignatureUsageProcessor implements ChangeSignatureUsagePr
       }
       else if (usage instanceof OverriderUsageInfo) {
         OverriderUsageInfo info = (OverriderUsageInfo)usage;
-        final PsiMethod method = info.getElement();
+        final PsiMethod method = info.getOverridingMethod();
         final PsiMethod baseMethod = info.getBaseMethod();
         if (info.isOriginalOverrider()) {
           processPrimaryMethod((JavaChangeInfo)changeInfo, method, baseMethod, false);
@@ -925,7 +925,7 @@ public class JavaChangeSignatureUsageProcessor implements ChangeSignatureUsagePr
       for (UsageInfo usageInfo : usagesSet) {
         final PsiElement element = usageInfo.getElement();
         if (usageInfo instanceof OverriderUsageInfo) {
-          final PsiMethod method = (PsiMethod)element;
+          final PsiMethod method = ((OverriderUsageInfo)usageInfo).getOverridingMethod();
           final PsiMethod baseMethod = ((OverriderUsageInfo)usageInfo).getBaseMethod();
           final int delta = baseMethod.getParameterList().getParametersCount() - method.getParameterList().getParametersCount();
           if (delta > 0) {

--- a/java/java-impl/src/com/intellij/refactoring/changeSignature/OverriderUsageInfo.java
+++ b/java/java-impl/src/com/intellij/refactoring/changeSignature/OverriderUsageInfo.java
@@ -26,10 +26,12 @@ public class OverriderUsageInfo extends UsageInfo {
   private final boolean myToInsertArgs;
   private final boolean myToCatchExceptions;
   private final boolean myIsOriginalOverrider;
+  private final PsiMethod myOverridingMethod;
 
   public OverriderUsageInfo(final PsiMethod method, PsiMethod baseMethod, boolean  isOriginalOverrider,
                             boolean toInsertArgs, boolean toCatchExceptions) {
     super(method);
+    myOverridingMethod = method;
     myBaseMethod = baseMethod;
     myToInsertArgs = toInsertArgs;
     myToCatchExceptions = toCatchExceptions;
@@ -40,8 +42,8 @@ public class OverriderUsageInfo extends UsageInfo {
     return myBaseMethod;
   }
 
-  public PsiMethod getElement() {
-    return (PsiMethod)super.getElement();
+  public PsiMethod getOverridingMethod() {
+    return myOverridingMethod;
   }
 
   public boolean isOriginalOverrider() {

--- a/plugins/groovy/src/org/jetbrains/plugins/groovy/refactoring/changeSignature/GrChangeSignatureUsageProcessor.java
+++ b/plugins/groovy/src/org/jetbrains/plugins/groovy/refactoring/changeSignature/GrChangeSignatureUsageProcessor.java
@@ -412,7 +412,7 @@ public class GrChangeSignatureUsageProcessor implements ChangeSignatureUsageProc
 
     if (beforeMethodChange) {
       if (usageInfo instanceof OverriderUsageInfo) {
-        processPrimaryMethodInner(((JavaChangeInfo)changeInfo), (GrMethod)((OverriderUsageInfo)usageInfo).getElement(),
+        processPrimaryMethodInner(((JavaChangeInfo)changeInfo), (GrMethod)((OverriderUsageInfo)usageInfo).getOverridingMethod(),
                                   ((OverriderUsageInfo)usageInfo).getBaseMethod());
       }
     }


### PR DESCRIPTION
The goal is to allow interoperability between Change Signature refactorings in Java and Kotlin (or, in general, Java-compatible language which doesn't use Java PSI). 
When Java method is overriden by Kotlin function, Change Signature creates OverriderUsageInfo using light method which servers as PsiMethod wrapper for Kotlin function. However upon creation it gets replaced by its navigation element (i. e. Kotlin one) which is not a PsiMethod, and Java refactoring fails with type casting error.
So I suggest to keep overriding PsiMethod (which may be either real Java method, or wrapper of some sort) in a separate field and use it instead of getElement() (in most cases).
