### PR TITLE
Fixed flow for Ant build file validation

### DIFF
--- a/plugins/ant/src/com/intellij/lang/ant/config/impl/AntConfigurationImpl.java
+++ b/plugins/ant/src/com/intellij/lang/ant/config/impl/AntConfigurationImpl.java
@@ -534,10 +534,10 @@ public class AntConfigurationImpl extends AntConfigurationBase implements Persis
     if (!(xmlFile instanceof XmlFile)) {
       throw new AntNoFileException("the file is not an xml file", file);
     }
-    AntSupport.markFileAsAntFile(file, xmlFile.getProject(), true);
     if (!AntDomFileDescription.isAntFile(((XmlFile)xmlFile))) {
       throw new AntNoFileException("the file is not recognized as an ANT file", file);
     }
+    AntSupport.markFileAsAntFile(file, xmlFile.getProject(), true);
     final AntBuildFileImpl buildFile = new AntBuildFileImpl((XmlFile)xmlFile, this);
     synchronized (myBuildFiles) {
       myBuildFilesArray = null;

--- a/plugins/ant/tests/data/config/BuildFileWithoutDefaultTarget.xml
+++ b/plugins/ant/tests/data/config/BuildFileWithoutDefaultTarget.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2000-2014 JetBrains s.r.o.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project name="A">
+  <target name="B"/>
+</project>

--- a/plugins/ant/tests/data/config/BuildFileWithoutProjectName.xml
+++ b/plugins/ant/tests/data/config/BuildFileWithoutProjectName.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2000-2014 JetBrains s.r.o.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project default="B">
+  <target name="B"/>
+</project>

--- a/plugins/ant/tests/data/config/BuildFileWithoutProjectTag.xml
+++ b/plugins/ant/tests/data/config/BuildFileWithoutProjectTag.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright 2000-2014 JetBrains s.r.o.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<target name="A"/>

--- a/plugins/ant/tests/data/config/ValidBuildFile.xml
+++ b/plugins/ant/tests/data/config/ValidBuildFile.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2000-2014 JetBrains s.r.o.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project name="A" default="B">
+  <target name="B"/>
+</project>

--- a/plugins/ant/tests/src/com/intellij/lang/ant/config/AntConfigurationTest.java
+++ b/plugins/ant/tests/src/com/intellij/lang/ant/config/AntConfigurationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.lang.ant.config;
+
+import com.intellij.lang.ant.config.AntConfiguration;
+import com.intellij.lang.ant.config.AntNoFileException;
+import com.intellij.openapi.application.PluginPathManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.LightCodeInsightTestCase;
+import com.intellij.testFramework.LightIdeaTestCase;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by andrey.myatlyuk on 11/23/14.
+ */
+public class AntConfigurationTest extends LightCodeInsightTestCase {
+
+  private AntConfiguration configuration;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    configuration = AntConfiguration.getInstance(getProject());
+  }
+
+  @NotNull
+  @Override
+  protected String getTestDataPath() {
+    return PluginPathManager.getPluginHomePath("ant") + "/tests/data/config/";
+  }
+
+  public void testValidBuildFile() throws Exception {
+    VirtualFile buildFile = getVirtualFile(getTestName(false) + ".xml");
+
+    configuration.addBuildFile(buildFile);
+
+    assertEquals(1, configuration.getBuildFiles().length);
+  }
+
+  public void testBuildFileWithoutProjectTag() throws Exception {
+    VirtualFile buildFile = getVirtualFile(getTestName(false) + ".xml");
+
+    try {
+      configuration.addBuildFile(buildFile);
+      fail("addBuildFile should throw an exception when build file does not have project tag");
+    }
+    catch (AntNoFileException ignored) {}
+  }
+
+  public void testBuildFileWithoutProjectName() throws Exception {
+    VirtualFile buildFile = getVirtualFile(getTestName(false) + ".xml");
+
+    try {
+      configuration.addBuildFile(buildFile);
+      fail("addBuildFile should throw an exception when build file does not have project name");
+    }
+    catch (AntNoFileException ignored) {}
+  }
+
+  public void testBuildFileWithoutDefaultTarget() throws Exception {
+    VirtualFile buildFile = getVirtualFile(getTestName(false) + ".xml");
+
+    try {
+      configuration.addBuildFile(buildFile);
+      fail("addBuildFile should throw an exception when build file does not have default target");
+    }
+    catch (AntNoFileException ignored) {}
+  }
+
+}


### PR DESCRIPTION
Pull request to fix AntConfiguration flow when a build file is added.

Currently the build file is marked as Ant file prior to inner structure validation. 

```
AntSupport.markFileAsAntFile(file, xmlFile.getProject(), true);
```

It means that although the validation is performed, it does not throw an exception for build files without required attributes.

```
if (!AntDomFileDescription.isAntFile(((XmlFile)xmlFile))) {
  throw new AntNoFileException("the file is not recognized as an ANT file", file);
}
```

The flow just falls to less strict check and hence the invalid Ant build file is added. Due to the previous call of marking the file as Ant file, pretty much any XML file can be added as Ant file.

```
if (vFile != null && ForcedAntFileAttribute.isAntFile(vFile)) {
  return true;
}
```

I changed the order that marking the file as Ant file is happening after the inner structure validation.
