### PR TITLE
Fixes to CoreJavaFileManager

### DIFF
--- a/java/java-psi-impl/src/com/intellij/core/CoreJavaFileManager.java
+++ b/java/java-psi-impl/src/com/intellij/core/CoreJavaFileManager.java
@@ -144,15 +144,22 @@ public class CoreJavaFileManager implements JavaFileManager {
 
   @Nullable
   private static PsiClass findClassInPsiFile(@NotNull String classNameWithInnerClassesDotSeparated, @NotNull PsiClassOwner file) {
-    final PsiClass[] classes = file.getClasses();
-    if (classes.length != 1) {
-      return null;
+    for (PsiClass topLevelClass : file.getClasses()) {
+      PsiClass candidate = findClassByTopLevelClass(classNameWithInnerClassesDotSeparated, topLevelClass);
+      if (candidate != null) {
+        return candidate;
+      }
     }
-    PsiClass curClass = classes[0];
+    return null;
+  }
+
+  @Nullable
+  private static PsiClass findClassByTopLevelClass(@NotNull String classNameWithInnerClassesDotSeparated, @NotNull PsiClass topLevelClass) {
     Iterator<String> segments = StringUtil.split(classNameWithInnerClassesDotSeparated, ".").iterator();
-    if (!segments.hasNext() || !segments.next().equals(curClass.getName())) {
+    if (!segments.hasNext() || !segments.next().equals(topLevelClass.getName())) {
       return null;
     }
+    PsiClass curClass = topLevelClass;
     while (segments.hasNext()) {
       String innerClassName = segments.next();
       PsiClass innerClass = curClass.findInnerClassByName(innerClassName, false);

--- a/java/java-psi-impl/src/com/intellij/core/CoreJavaFileManager.java
+++ b/java/java-psi-impl/src/com/intellij/core/CoreJavaFileManager.java
@@ -84,7 +84,7 @@ public class CoreJavaFileManager implements JavaFileManager {
   @Override
   public PsiClass findClass(@NotNull String qName, @NotNull GlobalSearchScope scope) {
     for (VirtualFile root : roots()) {
-      final PsiClass psiClass = findClassInClasspathRoot(qName, root, myPsiManager);
+      final PsiClass psiClass = findClassInClasspathRoot(qName, root, myPsiManager, scope);
       if (psiClass != null) {
         return psiClass;
       }
@@ -93,7 +93,10 @@ public class CoreJavaFileManager implements JavaFileManager {
   }
 
   @Nullable
-  public static PsiClass findClassInClasspathRoot(String qName, VirtualFile root, PsiManager psiManager) {
+  public static PsiClass findClassInClasspathRoot(@NotNull String qName,
+                                                  @NotNull VirtualFile root,
+                                                  @NotNull PsiManager psiManager,
+                                                  @NotNull GlobalSearchScope scope) {
     String pathRest = qName;
     VirtualFile cur = root;
 
@@ -120,6 +123,9 @@ public class CoreJavaFileManager implements JavaFileManager {
     }
     if (!vFile.isValid()) {
       LOG.error("Invalid child of valid parent: " + vFile.getPath() + "; " + root.isValid() + " path=" + root.getPath());
+      return null;
+    }
+    if (!scope.contains(vFile)) {
       return null;
     }
 
@@ -176,7 +182,7 @@ public class CoreJavaFileManager implements JavaFileManager {
   public PsiClass[] findClasses(@NotNull String qName, @NotNull GlobalSearchScope scope) {
     List<PsiClass> result = new ArrayList<PsiClass>();
     for (VirtualFile file : roots()) {
-      final PsiClass psiClass = findClassInClasspathRoot(qName, file, myPsiManager);
+      final PsiClass psiClass = findClassInClasspathRoot(qName, file, myPsiManager, scope);
       if (psiClass != null) {
         result.add(psiClass);
       }

--- a/java/java-psi-impl/src/com/intellij/core/CoreJavaFileManager.java
+++ b/java/java-psi-impl/src/com/intellij/core/CoreJavaFileManager.java
@@ -160,8 +160,12 @@ public class CoreJavaFileManager implements JavaFileManager {
   }
 
   @Nullable
-  private static PsiClass findClassByTopLevelClass(@NotNull String classNameWithInnerClassesDotSeparated, @NotNull PsiClass topLevelClass) {
-    Iterator<String> segments = StringUtil.split(classNameWithInnerClassesDotSeparated, ".").iterator();
+  private static PsiClass findClassByTopLevelClass(@NotNull String className, @NotNull PsiClass topLevelClass) {
+    if (className.indexOf('.') < 0) {
+      return className.equals(topLevelClass.getName()) ? topLevelClass : null;
+    }
+
+    Iterator<String> segments = StringUtil.split(className, ".").iterator();
     if (!segments.hasNext() || !segments.next().equals(topLevelClass.getName())) {
       return null;
     }

--- a/java/java-tests/testSrc/com/intellij/psi/CoreJavaFileManagerTest.java
+++ b/java/java-tests/testSrc/com/intellij/psi/CoreJavaFileManagerTest.java
@@ -161,6 +161,19 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
     assertCannotFind(fileWithEmptyName, ".foo");
   }
 
+  public void testSeveralClassesInOneFile() throws Exception {
+    CoreJavaFileManager manager = configureManager("package foo;\n\n" +
+                                                   "public class One {}\n" +
+                                                   "class Two {}\n" +
+                                                   "class Three {}", "One");
+
+    assertCanFind(manager, "foo.One");
+
+    //NOTE: this is unsupported
+    assertCannotFind(manager, "foo.Two");
+    assertCannotFind(manager, "foo.Three");
+  }
+
   @NotNull
   private CoreJavaFileManager configureManager(@Language("JAVA") @NotNull String text, @NotNull String className) throws Exception {
     VirtualFile root = PsiTestUtil.createTestProjectStructure(myProject, myModule, myFilesToDelete);

--- a/java/java-tests/testSrc/com/intellij/psi/CoreJavaFileManagerTest.java
+++ b/java/java-tests/testSrc/com/intellij/psi/CoreJavaFileManagerTest.java
@@ -174,6 +174,13 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
     assertCannotFind(manager, "foo.Three");
   }
 
+  public void testScopeCheck() throws Exception {
+    CoreJavaFileManager manager = configureManager("package foo;\n\n" + "public class Test {}\n", "Test");
+
+    assertNotNull("Should find class in all scope", manager.findClass("foo.Test", GlobalSearchScope.allScope(getProject())));
+    assertNull("Should not find class in empty scope", manager.findClass("foo.Test", GlobalSearchScope.EMPTY_SCOPE));
+  }
+
   @NotNull
   private CoreJavaFileManager configureManager(@Language("JAVA") @NotNull String text, @NotNull String className) throws Exception {
     VirtualFile root = PsiTestUtil.createTestProjectStructure(myProject, myModule, myFilesToDelete);

--- a/java/java-tests/testSrc/com/intellij/psi/CoreJavaFileManagerTest.java
+++ b/java/java-tests/testSrc/com/intellij/psi/CoreJavaFileManagerTest.java
@@ -39,6 +39,10 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
     assertCanFind(manager, "foo.TopLevel");
     assertCanFind(manager, "foo.TopLevel.Inner");
     assertCanFind(manager, "foo.TopLevel.Inner.Inner");
+
+    assertCannotFind(manager, "foo.TopLevel$Inner.Inner");
+    assertCannotFind(manager, "foo.TopLevel.Inner$Inner");
+    assertCannotFind(manager, "foo.TopLevel.Inner.Inner.Inner");
   }
 
   public void testInnerClassesWithDollars() throws Exception {
@@ -78,6 +82,8 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
     assertCanFind(manager, "foo.TopLevel.I$nner.Inner$$");
     assertCanFind(manager, "foo.TopLevel.I$nner.$$$$$");
 
+    assertCannotFind(manager, "foo.TopLevel.I.nner.$$$$$");
+
     assertCanFind(manager, "foo.TopLevel.Inner$");
     assertCanFind(manager, "foo.TopLevel.Inner$.I$nner");
     assertCanFind(manager, "foo.TopLevel.Inner$.$Inner");
@@ -85,12 +91,16 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
     assertCanFind(manager, "foo.TopLevel.Inner$.Inner$$");
     assertCanFind(manager, "foo.TopLevel.Inner$.$$$$$");
 
+    assertCannotFind(manager, "foo.TopLevel.Inner..$$$$$");
+
     assertCanFind(manager, "foo.TopLevel.In$ner$$");
     assertCanFind(manager, "foo.TopLevel.In$ner$$.I$nner");
     assertCanFind(manager, "foo.TopLevel.In$ner$$.$Inner");
     assertCanFind(manager, "foo.TopLevel.In$ner$$.In$ne$r$");
     assertCanFind(manager, "foo.TopLevel.In$ner$$.Inner$$");
     assertCanFind(manager, "foo.TopLevel.In$ner$$.$$$$$");
+
+    assertCannotFind(manager, "foo.TopLevel.In.ner$$.$$$$$");
   }
 
   public void testTopLevelClassesWithDollars() throws Exception {
@@ -102,6 +112,7 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
 
     CoreJavaFileManager multiple = configureManager("package foo;\n\n public class Top$Lev$el$ {}", "Top$Lev$el$");
     assertCanFind(multiple, "foo.Top$Lev$el$");
+    assertCannotFind(multiple, "foo.Top.Lev$el$");
 
     CoreJavaFileManager twoBucks = configureManager("package foo;\n\n public class $$ {}", "$$");
     assertCanFind(twoBucks, "foo.$$");
@@ -137,6 +148,17 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
     assertCanFind(manager, "foo.Top$Level$$.I$nner.$Inner");
     assertCanFind(manager, "foo.Top$Level$$.I$nner.$");
     assertCanFind(manager, "foo.Top$Level$$.I$nner.$$$$$");
+
+    assertCannotFind(manager, "foo.Top.Level$$.I$nner.$$$$$");
+  }
+
+  public void testDoNotThrowOnMalformedInput() throws Exception {
+    CoreJavaFileManager fileWithEmptyName = configureManager("package foo;\n\n public class Top$Level {}", "");
+    assertCannotFind(fileWithEmptyName, "foo.");
+    assertCannotFind(fileWithEmptyName, ".");
+    assertCannotFind(fileWithEmptyName, "..");
+    assertCannotFind(fileWithEmptyName, "");
+    assertCannotFind(fileWithEmptyName, ".foo");
   }
 
   @NotNull
@@ -155,5 +177,10 @@ public class CoreJavaFileManagerTest extends PsiTestCase {
     PsiClass foundClass = manager.findClass(qName, GlobalSearchScope.allScope(getProject()));
     assertNotNull("Could not find:" + qName, foundClass);
     assertEquals("Found " + foundClass.getQualifiedName() + " instead of " + qName, qName, foundClass.getQualifiedName());
+  }
+
+  private void assertCannotFind(@NotNull CoreJavaFileManager manager, @NotNull String qName) {
+    PsiClass foundClass = manager.findClass(qName, GlobalSearchScope.allScope(getProject()));
+    assertNull("Found, but shouldn't have:" + qName, foundClass);
   }
 }


### PR DESCRIPTION
* Fix for top level class with dollars in name.
* Fix for java file with several top level classes.
* Checking scope.
* Tests.

Needed for Kotlin. See https://youtrack.jetbrains.com/issue/KT-6444