### PR TITLE
check myAssertThreading before using assertIsDispatchThread

### DIFF
--- a/platform/core-impl/src/com/intellij/openapi/editor/impl/DocumentImpl.java
+++ b/platform/core-impl/src/com/intellij/openapi/editor/impl/DocumentImpl.java
@@ -1022,7 +1022,8 @@ public class DocumentImpl extends UserDataHolderBase implements DocumentEx {
 
   @Override
   public final void setInBulkUpdate(boolean value) {
-    ApplicationManager.getApplication().assertIsDispatchThread();
+    if (myAssertThreading)
+      ApplicationManager.getApplication().assertIsDispatchThread();
     if (myDoingBulkUpdate == value) {
       // do not fire listeners or otherwise updateStarted() will be called more times than updateFinished()
       return;
@@ -1084,7 +1085,8 @@ public class DocumentImpl extends UserDataHolderBase implements DocumentEx {
   }
 
   void requestTabTracking() {
-    ApplicationManager.getApplication().assertIsDispatchThread();
+    if (myAssertThreading)
+      ApplicationManager.getApplication().assertIsDispatchThread();
     if (myTabTrackingRequestors++ == 0) {
       myMightContainTabs = false;
       updateMightContainTabs(myText);
@@ -1092,7 +1094,8 @@ public class DocumentImpl extends UserDataHolderBase implements DocumentEx {
   }
 
   void giveUpTabTracking() {
-    ApplicationManager.getApplication().assertIsDispatchThread();
+    if (myAssertThreading)
+      ApplicationManager.getApplication().assertIsDispatchThread();
     if (--myTabTrackingRequestors == 0) {
       myMightContainTabs = true;
     }


### PR DESCRIPTION
The DocumentImpl constructor takes an argument called forUseInNonAWTThread, which is stored in the myAssertThreading field. While this field is checked before some assertions, it is not checked before others. 

This change checks the field before all assertIsDispatchThread calls, enabling users to use more features of DocumentImpl outside the dispatch thread (as indicated by the constructor parameter).

(It is unclear to me why the assertIsDispatchThread assertions are there at all -- the functions don't seem to require it at all. This is the least intrusive change, remove the assertions completely should maybe be considered.)