### PR TITLE
Add support for paramaterizing varargs in PyCharm

### DIFF
--- a/python/src/com/jetbrains/python/codeInsight/PyTypingTypeProvider.java
+++ b/python/src/com/jetbrains/python/codeInsight/PyTypingTypeProvider.java
@@ -27,6 +27,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.containers.HashSet;
 import com.jetbrains.python.PyNames;
 import com.jetbrains.python.psi.*;
+import com.jetbrains.python.psi.impl.PyBuiltinCache;
 import com.jetbrains.python.psi.impl.PyExpressionCodeFragmentImpl;
 import com.jetbrains.python.psi.resolve.PyResolveContext;
 import com.jetbrains.python.psi.types.*;
@@ -85,8 +86,10 @@ public class PyTypingTypeProvider extends PyTypeProviderBase {
       if (value != null) {
         final PyType type = getType(value, new Context(context));
         if (type != null) {
+          final PyType containerType = getContainerTypeForPositionalOrKeywordArg(param, type);
           final PyType optionalType = getOptionalTypeFromDefaultNone(param, type, context);
-          return Ref.create(optionalType != null ? optionalType : type);
+          return Ref.create(containerType != null ? containerType :
+                            optionalType != null ? optionalType : type);
         }
       }
     }
@@ -190,7 +193,7 @@ public class PyTypingTypeProvider extends PyTypeProviderBase {
   }
 
   /**
-   * Checks that text of a comment starts with the "type:" prefix and returns trimmed part afterwards. This trailing part is supposed to 
+   * Checks that text of a comment starts with the "type:" prefix and returns trimmed part afterwards. This trailing part is supposed to
    * contain type annotation in PEP 484 compatible format, that can be parsed with either {@link PyTypeParser#parse(PsiElement, String)}
    * or {@link PyTypeParser#parsePep484FunctionTypeComment(PsiElement, String)}.
    */
@@ -219,6 +222,28 @@ public class PyTypingTypeProvider extends PyTypeProviderBase {
       }
     }
     return null;
+  }
+
+  @Nullable
+  private static PyType getContainerTypeForPositionalOrKeywordArg(@NotNull PyNamedParameter param, @NotNull PyType argType) {
+    if (param.isPositionalContainer()) {
+      // in the case of a positional container, the actual parameter type is a homogeneous tuple type
+      argType = PyTupleType.createHomogeneous(param, argType);
+    }
+    else if (param.isKeywordContainer()) {
+      final PyClassType dictClassType = PyBuiltinCache.getInstance(param).getDictType();
+      if (dictClassType == null) {
+        return null;
+      }
+      final PyClass dictClass = dictClassType.getPyClass();
+      final PyType strType = PyBuiltinCache.getInstance(param).getStrType();
+      argType = new PyCollectionTypeImpl(dictClass, false, Arrays.asList(strType, argType));
+      ;
+    } else {
+      return null;
+    }
+
+    return argType;
   }
 
   @Nullable

--- a/python/src/com/jetbrains/python/psi/types/PyTypeChecker.java
+++ b/python/src/com/jetbrains/python/psi/types/PyTypeChecker.java
@@ -150,7 +150,7 @@ public class PyTypeChecker {
         else if (superTupleType.isHomogeneous() && !subTupleType.isHomogeneous()) {
           final PyType expectedElementType = superTupleType.getElementType(0);
           for (int i = 0; i < subTupleType.getElementCount(); i++) {
-            if (!match(expectedElementType, subTupleType.getElementType(i), context)) {
+            if (!match(expectedElementType, subTupleType.getElementType(i), context, substitutions, recursive)) {
               return false;
             }
           }
@@ -160,7 +160,7 @@ public class PyTypeChecker {
           return false;
         }
         else {
-          return match(superTupleType.getElementType(0), subTupleType.getElementType(0), context);
+          return match(superTupleType.getElementType(0), subTupleType.getElementType(0), context, substitutions, recursive);
         }
       }
       else if (matchClasses(superClass, subClass, context)) {
@@ -385,25 +385,22 @@ public class PyTypeChecker {
     final Map<PyGenericType, PyType> substitutions = unifyReceiver(receiver, context);
     for (Map.Entry<PyExpression, PyNamedParameter> entry : arguments.entrySet()) {
       final PyNamedParameter p = entry.getValue();
-      final PyType paramType = context.getType(p);
 
+      final PyType paramType = context.getType(p);
       PyType argType = context.getType(entry.getKey());
       if (p.isPositionalContainer()) {
-        final PyClassType tupleClassType = PyBuiltinCache.getInstance(p).getTupleType();
-        if (tupleClassType == null) {
-          return null;
-        }
-        final PyClass tupleClass = tupleClassType.getPyClass();
-        argType = new PyCollectionTypeImpl(tupleClass, false, argType);
-      } else if (p.isKeywordContainer()) {
+        // in the case of a positional container, the actual parameter type is a homogeneous tuple type
+        argType = PyTupleType.createHomogeneous(p, argType);
+      }
+       else if (p.isKeywordContainer()) {
         final PyClassType dictClassType = PyBuiltinCache.getInstance(p).getDictType();
         if (dictClassType == null) {
           return null;
         }
         final PyClass dictClass = dictClassType.getPyClass();
         final PyType strType = PyBuiltinCache.getInstance(p).getStrType();
-        final PyType dictType = PyTupleType.create(p, new PyType[] {strType, argType});
-        argType = new PyCollectionTypeImpl(dictClass, false, dictType);
+        // in the case of a keyword container, the actual parameter type is a dict[str, argType]
+        argType = new PyCollectionTypeImpl(dictClass, false, Arrays.asList(strType, argType));
       }
       if (!match(paramType, argType, context, substitutions)) {
         return null;

--- a/python/testData/inspections/PyTypeCheckerInspection/FunctionVarardicTypeVars.py
+++ b/python/testData/inspections/PyTypeCheckerInspection/FunctionVarardicTypeVars.py
@@ -1,0 +1,25 @@
+import typing
+
+
+def verify_is_int(x: int):
+    return "{} is an int".format(x)
+
+
+def verify_is_str(x: str):
+    return "{} is a str".format(x)
+
+def verify_is_tuple(x: typing.Tuple):
+    return "{} is a tuple".format(x)
+
+T = typing.TypeVar('T', int, str)
+V = typing.TypeVar('V', int, str)
+def f(*args: T, **kwargs: V) -> typing.Tuple[T, V]:
+    first_arg = args[0]
+    print(args[<warning descr="Expected type 'Union[Integral, slice]', got 'str' instead">'test'</warning>])
+    verify_is_tuple(first_arg)
+    return args[0], kwargs['foo']
+
+
+result = f('test', foo=2)
+verify_is_int(<warning descr="Expected type 'int', got 'str' instead">result[0]</warning>)
+verify_is_str(<warning descr="Expected type 'str', got 'int' instead">result[1]</warning>)

--- a/python/testSrc/com/jetbrains/python/PyTypeTest.java
+++ b/python/testSrc/com/jetbrains/python/PyTypeTest.java
@@ -22,6 +22,7 @@ import com.jetbrains.python.psi.LanguageLevel;
 import com.jetbrains.python.psi.PyExpression;
 import com.jetbrains.python.psi.impl.PythonLanguageLevelPusher;
 import com.jetbrains.python.psi.types.PyClassType;
+import com.jetbrains.python.psi.types.PyCollectionTypeImpl;
 import com.jetbrains.python.psi.types.PyType;
 import com.jetbrains.python.psi.types.TypeEvalContext;
 import org.jetbrains.annotations.NotNull;
@@ -370,48 +371,49 @@ public class PyTypeTest extends PyTestCase {
   }
 
   public void testGenericVarargsOneArg() {
-    PyExpression expr = parseExpr("def f(*args):\n" +
-                                  "    '''\n" +
-                                  "    :type args: tuple[T]\n" +
-                                  "    :rtype: T\n" +
-                                  "    '''\n" +
-                                  "    return args[0]\n" +
-                                  "\n" +
-                                  "expr = f(1)\n");
-    TypeEvalContext context = getTypeEvalContext(expr);
-    PyType actual = context.getType(expr);
-    assertNotNull(actual);
-    assertEquals("int", actual.getName());
+    doTest("int", "def f(*args):\n" +
+                  "    '''\n" +
+                  "    :type args: T\n" +
+                  "    :rtype: T\n" +
+                  "    '''\n" +
+                  "    return args[0]\n" +
+                  "\n" +
+                  "expr = f(1)\n");
   }
 
   public void testGenericVarargsTwoArgs() {
-    PyExpression expr = parseExpr("def f(*args):\n" +
-                                  "    '''\n" +
-                                  "    :type args: tuple[T]\n" +
-                                  "    :rtype: T\n" +
-                                  "    '''\n" +
-                                  "    return args[0]\n" +
-                                  "\n" +
-                                  "expr = f(1, 2)\n");
-    TypeEvalContext context = getTypeEvalContext(expr);
-    PyType actual = context.getType(expr);
-    assertNotNull(actual);
-    assertEquals("int", actual.getName());
+    doTest("int", "def f(*args):\n" +
+                  "    '''\n" +
+                  "    :type args: T\n" +
+                  "    :rtype: T\n" +
+                  "    '''\n" +
+                  "    return args[0]\n" +
+                  "\n" +
+                  "expr = f(1, 2)\n");
   }
 
   public void testGenericKwargs() {
-    PyExpression expr = parseExpr("def f(**kwargs):\n" +
-                                  "    '''\n" +
-                                  "    :type kwargs: dict[str, T]\n" +
-                                  "    :rtype: T\n" +
-                                  "    '''\n" +
-                                  "    return args[0]\n" +
-                                  "\n" +
-                                  "expr = f(arg=1, arg2=2)\n");
-    TypeEvalContext context = getTypeEvalContext(expr);
-    PyType actual = context.getType(expr);
-    assertNotNull(actual);
-    assertEquals("int", actual.getName());
+    doTest("int", "def f(**kwargs):\n" +
+                  "    '''\n" +
+                  "    :type kwargs: T\n" +
+                  "    :rtype: T\n" +
+                  "    '''\n" +
+                  "    return args['arg']\n" +
+                  "\n" +
+                  "expr = f(arg=1, arg2=2)\n");
+
+  }
+
+  public void testGenericVarargsAndKwargs() {
+    doTest("tuple[int, str]", "def f(*args, **kwargs):\n" +
+                              "    '''\n" +
+                              "    :type args: T\n" +
+                              "    :type kwargs: V\n" +
+                              "    :rtype: tuple[T, V]\n" +
+                              "    '''\n" +
+                              "    return args[0], kwargs['foo']\n" +
+                              "\n" +
+                              "expr = f(1, foo='bar')\n");
   }
 
   // PY-5831

--- a/python/testSrc/com/jetbrains/python/PyTypeTest.java
+++ b/python/testSrc/com/jetbrains/python/PyTypeTest.java
@@ -369,6 +369,51 @@ public class PyTypeTest extends PyTestCase {
                   "expr = f(1)\n");
   }
 
+  public void testGenericVarargsOneArg() {
+    PyExpression expr = parseExpr("def f(*args):\n" +
+                                  "    '''\n" +
+                                  "    :type args: tuple[T]\n" +
+                                  "    :rtype: T\n" +
+                                  "    '''\n" +
+                                  "    return args[0]\n" +
+                                  "\n" +
+                                  "expr = f(1)\n");
+    TypeEvalContext context = getTypeEvalContext(expr);
+    PyType actual = context.getType(expr);
+    assertNotNull(actual);
+    assertEquals("int", actual.getName());
+  }
+
+  public void testGenericVarargsTwoArgs() {
+    PyExpression expr = parseExpr("def f(*args):\n" +
+                                  "    '''\n" +
+                                  "    :type args: tuple[T]\n" +
+                                  "    :rtype: T\n" +
+                                  "    '''\n" +
+                                  "    return args[0]\n" +
+                                  "\n" +
+                                  "expr = f(1, 2)\n");
+    TypeEvalContext context = getTypeEvalContext(expr);
+    PyType actual = context.getType(expr);
+    assertNotNull(actual);
+    assertEquals("int", actual.getName());
+  }
+
+  public void testGenericKwargs() {
+    PyExpression expr = parseExpr("def f(**kwargs):\n" +
+                                  "    '''\n" +
+                                  "    :type kwargs: dict[str, T]\n" +
+                                  "    :rtype: T\n" +
+                                  "    '''\n" +
+                                  "    return args[0]\n" +
+                                  "\n" +
+                                  "expr = f(arg=1, arg2=2)\n");
+    TypeEvalContext context = getTypeEvalContext(expr);
+    PyType actual = context.getType(expr);
+    assertNotNull(actual);
+    assertEquals("int", actual.getName());
+  }
+
   // PY-5831
   public void testYieldType() {
     doTest("Any", "def f():\n" +

--- a/python/testSrc/com/jetbrains/python/inspections/Py3TypeCheckerInspectionTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/Py3TypeCheckerInspectionTest.java
@@ -92,7 +92,7 @@ public class Py3TypeCheckerInspectionTest extends PyTestCase {
   public void testStrFormatPy3() {
     doTest();
   }
-  
+
   // PY-18762
   public void testHomogeneousTuples() {
     myFixture.copyDirectoryToProject("typing/typing.py", TEST_DIRECTORY);
@@ -106,6 +106,9 @@ public class Py3TypeCheckerInspectionTest extends PyTestCase {
 
   // PY-9924
   public void testListGetItemWithSlice() {
+  }
+  
+  public void testFunctionVarardicTypeVars() {
     doTest();
   }
 }


### PR DESCRIPTION
Previously, `*args` and `**kwargs` were skipped when matching against parameterized types in the type checker.  This prevented pycharm from understanding type hints on functions whose return type are a function of the varardic parameters.

This can be reproduced with the following code:

``` python
def f(*args):
    """
    :type args: tuple[T]
    :rtype: T
    """
    return args[0]

expr = f(1)  # expect expr to be of type "int"
```
