### PR TITLE
fsNotifier: Fix glibc version specifier for ppc64

### DIFF
--- a/native/fsNotifier/linux/inotify.c
+++ b/native/fsNotifier/linux/inotify.c
@@ -29,6 +29,8 @@
 
 #ifdef __amd64__
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+#elif defined(__powerpc64__)
+__asm__(".symver memcpy,memcpy@GLIBC_2.3");
 #else
 __asm__(".symver memcpy,memcpy@GLIBC_2.0");
 #endif


### PR DESCRIPTION
On Linux/PPC64, glibc does not contain `memcpy@GLIBC_2.0`, so changing that to `memcpy@GLIBC_2.3` which does exist.