### PR TITLE
Move "$@@product_uc@@_VM_OPTIONS" to the end of line.

### DIFF
--- a/bin/scripts/unix/idea.sh
+++ b/bin/scripts/unix/idea.sh
@@ -135,7 +135,7 @@ fi
 
 VM_OPTIONS=""
 VM_OPTIONS_FILES_USED=""
-for vm_opts_file in "$@@product_uc@@_VM_OPTIONS" "$HOME/.@@system_selector@@/@@vm_options@@$BITS.vmoptions" "$IDE_BIN_HOME/@@vm_options@@$BITS.vmoptions"; do
+for vm_opts_file in "$HOME/.@@system_selector@@/@@vm_options@@$BITS.vmoptions" "$IDE_BIN_HOME/@@vm_options@@$BITS.vmoptions" "$@@product_uc@@_VM_OPTIONS"; do
   if [ -r "$vm_opts_file" ]; then
     VM_OPTIONS_DATA=`"$CAT" "$vm_opts_file" | "$GREP" -v "^#.*" | "$TR" '\n' ' '`
     VM_OPTIONS="$VM_OPTIONS $VM_OPTIONS_DATA"


### PR DESCRIPTION
Hi!

This change will enable JVM variable overriding. Oracle's JVM uses the last variable, which means that if we have the same variable defined twice, only the second value will be used, e.g. if -Xmx is defined twice, once in user's _VM_OPTIONS file and once in idea.vmoptions in bin/idea.vmoptions, user's -Xmx will be used by JVM.

Let me know if you need anything else.

Thanks,
Krystian Kichewko