### PR TITLE
Show line numbers by default

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/editor/ex/EditorSettingsExternalizable.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/ex/EditorSettingsExternalizable.java
@@ -50,7 +50,7 @@ public class EditorSettingsExternalizable implements PersistentStateComponent<Ed
     public boolean IS_CARET_BLINKING = true;
     public int CARET_BLINKING_PERIOD = 500;
     public boolean IS_RIGHT_MARGIN_SHOWN = true;
-    public boolean ARE_LINE_NUMBERS_SHOWN = false;
+    public boolean ARE_LINE_NUMBERS_SHOWN = true;
     public boolean IS_FOLDING_OUTLINE_SHOWN = true;
 
     public boolean SMART_HOME = true;


### PR DESCRIPTION
The EditorSettingsExternalizable class is used in the [EditorAppearanceConfigurable ](https://github.com/JetBrains/intellij-community/blob/master/platform/lang-impl/src/com/intellij/application/options/editor/EditorAppearanceConfigurable.java) class to set the selected state of the 'Show line numbers' JCheckBox by reading the value from the isLineNumbersShown() method which returns the default value of the setting.

Why show line numbers by default?
* Because I'm getting tired of enabling 'Show line numbers' every single time I install a JetBrains product on a new machine!
* Because code navigation matters! How do you read and refer to code in a file with a couple hundred/thousand lines of code without line numbers?
* Because debugging maters! How do you debug anything without using line numbers?
* **Because it's the *right* choice for this setting to be enabled by default!**
* Because it's time! You don't want people getting easy points on StackOverflow from asking questions about poor defaults, do you? https://stackoverflow.com/questions/13751/how-can-i-permanently-have-line-numbers-in-intellij  (question asked in 2008, the situation is still the same today...)

->![What year is it?](https://i.imgur.com/DTeuE3c.gif)<-