### PR TITLE
Allowing users to specify environment variables in their embedded terminal sessions

### DIFF
--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalOptionsProvider.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalOptionsProvider.java
@@ -22,6 +22,8 @@ import com.intellij.openapi.util.SystemInfo;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author traff
@@ -55,6 +57,8 @@ public class TerminalOptionsProvider implements PersistentStateComponent<Termina
     myState.myCopyOnSelection = state.myCopyOnSelection;
     myState.myPasteOnMiddleMouseButton = state.myPasteOnMiddleMouseButton;
     myState.myOverrideIdeShortcuts = state.myOverrideIdeShortcuts;
+    myState.myPassParentEnvs = state.myPassParentEnvs;
+    myState.myUserSpecifiedEnvs = state.myUserSpecifiedEnvs == null ? new HashMap<String, String>() : state.myUserSpecifiedEnvs;
   }
 
   public boolean closeSessionOnLogout() {
@@ -90,6 +94,8 @@ public class TerminalOptionsProvider implements PersistentStateComponent<Termina
     public boolean myCopyOnSelection = true;
     public boolean myPasteOnMiddleMouseButton = true;
     public boolean myOverrideIdeShortcuts = true;
+    public Map<String, String> myUserSpecifiedEnvs = getDefaultExtraEnvironmentVars();
+    public boolean myPassParentEnvs = true;
   }
 
   public String getShellPath() {
@@ -109,6 +115,12 @@ public class TerminalOptionsProvider implements PersistentStateComponent<Termina
     else {
       return "cmd.exe";
     }
+  }
+
+  private static Map<String, String> getDefaultExtraEnvironmentVars() {
+    Map<String, String> defaultEnvs = new HashMap<String, String>();
+    defaultEnvs.put("PROJECT_DIR", "$PROJECT_DIR$");
+    return defaultEnvs;
   }
 
   public void setShellPath(String shellPath) {
@@ -145,6 +157,22 @@ public class TerminalOptionsProvider implements PersistentStateComponent<Termina
 
   public void setPasteOnMiddleMouseButton(boolean pasteOnMiddleMouseButton) {
     myState.myPasteOnMiddleMouseButton = pasteOnMiddleMouseButton;
+  }
+
+  public Map<String, String> getUserSpecifiedEnvs() {
+    return myState.myUserSpecifiedEnvs;
+  }
+
+  public void setUserSpecifiedEnvs(Map<String, String> userSpecifiedEnvs) {
+    myState.myUserSpecifiedEnvs = userSpecifiedEnvs;
+  }
+
+  public void setPassParentEnvs(boolean passParentEnvs) {
+    myState.myPassParentEnvs = passParentEnvs;
+  }
+
+  public boolean passParentEnvs() {
+    return myState.myPassParentEnvs;
   }
 
   @Override

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalSettingsPanel.form
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalSettingsPanel.form
@@ -14,12 +14,9 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value=""/>
-        </clientProperties>
         <border type="none"/>
         <children>
-          <grid id="57ec0" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="57ec0" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -58,6 +55,22 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
+              </component>
+              <component id="a7470" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Environment Variables"/>
+                </properties>
+              </component>
+              <component id="9454c" class="com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton" binding="myEnvVarField">
+                <constraints>
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
               </component>
             </children>
           </grid>

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalSettingsPanel.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalSettingsPanel.java
@@ -15,6 +15,7 @@
  */
 package org.jetbrains.plugins.terminal;
 
+import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
@@ -37,6 +38,7 @@ public class TerminalSettingsPanel {
   private JBCheckBox myPasteOnMiddleButtonCheckBox;
   private JBCheckBox myCopyOnSelectionCheckBox;
   private JBCheckBox myOverrideIdeShortcuts;
+  private EnvironmentVariablesTextFieldWithBrowseButton myEnvVarField;
   private TerminalOptionsProvider myOptionsProvider;
 
   public JComponent createPanel(@NotNull TerminalOptionsProvider provider) {
@@ -65,6 +67,8 @@ public class TerminalSettingsPanel {
            || (myCopyOnSelectionCheckBox.isSelected() != myOptionsProvider.copyOnSelection())
            || (myPasteOnMiddleButtonCheckBox.isSelected() != myOptionsProvider.pasteOnMiddleMouseButton())
            || (myOverrideIdeShortcuts.isSelected() != myOptionsProvider.overrideIdeShortcuts())
+           || !Comparing.equal(myEnvVarField.getEnvs(), myOptionsProvider.getUserSpecifiedEnvs())
+           || (myEnvVarField.isPassParentEnvs() != myOptionsProvider.passParentEnvs())
       ;
   }
 
@@ -77,6 +81,8 @@ public class TerminalSettingsPanel {
     myOptionsProvider.setCopyOnSelection(myCopyOnSelectionCheckBox.isSelected());
     myOptionsProvider.setPasteOnMiddleMouseButton(myPasteOnMiddleButtonCheckBox.isSelected());
     myOptionsProvider.setOverrideIdeShortcuts(myOverrideIdeShortcuts.isSelected());
+    myOptionsProvider.setUserSpecifiedEnvs(myEnvVarField.getEnvs());
+    myOptionsProvider.setPassParentEnvs(myEnvVarField.isPassParentEnvs());
   }
 
   public void reset() {
@@ -88,5 +94,7 @@ public class TerminalSettingsPanel {
     myCopyOnSelectionCheckBox.setSelected(myOptionsProvider.copyOnSelection());
     myPasteOnMiddleButtonCheckBox.setSelected(myOptionsProvider.pasteOnMiddleMouseButton());
     myOverrideIdeShortcuts.setSelected(myOptionsProvider.overrideIdeShortcuts());
+    myEnvVarField.setEnvs(myOptionsProvider.getUserSpecifiedEnvs());
+    myEnvVarField.setPassParentEnvs(myOptionsProvider.passParentEnvs());
   }
 }

--- a/plugins/terminal/terminal.iml
+++ b/plugins/terminal/terminal.iml
@@ -10,6 +10,8 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="lang-api" />
     <orderEntry type="module" module-name="platform-impl" />
+    <orderEntry type="module" module-name="projectModel-impl" />
+    <orderEntry type="module" module-name="lang-impl" />
     <orderEntry type="module-library">
       <library name="jediterm-pty">
         <CLASSES>
@@ -25,4 +27,3 @@
     <orderEntry type="library" name="purejavacomm" level="project" />
   </component>
 </module>
-


### PR DESCRIPTION
I've added the environment variables dialog to the Embedded Terminal Settings. Any macro variables in the values are expanded. This provides a hook for passing in things like the `PROJECT_DIR` ([IDEA-126640](https://youtrack.jetbrains.com/issue/IDEA-126640)), `IDEA_HOME` ([IDEA-134992](https://youtrack.jetbrains.com/issue/IDEA-134992)), and anything else the user might want. I settled on `PROJECT_DIR` as the default because I wanted it myself, it seemed like a good example to show what users could do with the dialog, and it seemed it would provide a good base for a lot of tricks users might dream up.
