### PR TITLE
added and marked as deprecated removed constructor ArchiveHandler.Ent…

### DIFF
--- a/platform/core-api/src/com/intellij/openapi/vfs/impl/ArchiveHandler.java
+++ b/platform/core-api/src/com/intellij/openapi/vfs/impl/ArchiveHandler.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public abstract class ArchiveHandler {
+public abstract class ArchiveHandler1 {
   public static final long DEFAULT_LENGTH = 0L;
   public static final long DEFAULT_TIMESTAMP = -1L;
 
@@ -51,6 +51,11 @@ public abstract class ArchiveHandler {
       this.length = length;
       this.timestamp = timestamp;
     }
+    
+    @Deprecated
+    public EntryInfo(EntryInfo parent, @NotNull String shortName, boolean isDirectory, long length, long timestamp) {
+      this(parent, (CharSequence) shortName, isDirectory, length, timestamp);
+    }
   }
 
   @NotNull
@@ -59,7 +64,7 @@ public abstract class ArchiveHandler {
   private volatile Reference<Map<String, EntryInfo>> myEntries = new SoftReference<Map<String, EntryInfo>>(null);
   private boolean myCorrupted;
 
-  protected ArchiveHandler(@NotNull String path) {
+  protected ArchiveHandler1(@NotNull String path) {
     myPath = new File(path);
   }
 


### PR DESCRIPTION
…ryInfo
This is important in order to support Kotlin plugin