### PR TITLE
added and marked as deprecated removed constructor ArchiveHandler.Ent…

### DIFF
--- a/platform/core-api/src/com/intellij/openapi/vfs/impl/ArchiveHandler.java
+++ b/platform/core-api/src/com/intellij/openapi/vfs/impl/ArchiveHandler.java
@@ -51,6 +51,11 @@ public abstract class ArchiveHandler {
       this.length = length;
       this.timestamp = timestamp;
     }
+    
+    @Deprecated
+    public EntryInfo(EntryInfo parent, @NotNull String shortName, boolean isDirectory, long length, long timestamp) {
+      this(parent, (CharSequence) shortName, isDirectory, length, timestamp);
+    }
   }
 
   @NotNull


### PR DESCRIPTION
…ryInfo

This is import in order to support Kotlin plugin