### PR TITLE
RemoveUsageAction: Now selects a next item from the usage tree…

### DIFF
--- a/platform/usageView/src/com/intellij/usages/actions/RemoveUsageAction.java
+++ b/platform/usageView/src/com/intellij/usages/actions/RemoveUsageAction.java
@@ -18,14 +18,40 @@ package com.intellij.usages.actions;
 import com.intellij.usages.Usage;
 import com.intellij.usages.UsageView;
 
+import java.util.List;
+
 /**
  * @author Manuel Stadelmann
  */
 public class RemoveUsageAction extends IncludeExcludeActionBase {
+
   @Override
   protected void process(Usage[] usages, UsageView usageView) {
+
+    Usage nextToSelect = null;
+
     for (Usage usage : usages) {
+      Usage toSelect = getNextToSelect(usageView, usage);
       usageView.removeUsage(usage);
+      nextToSelect = toSelect;
     }
+
+    if (nextToSelect != null) {
+      usageView.selectUsages(new Usage[]{nextToSelect});
+    }
+  }
+
+  private Usage getNextToSelect(UsageView usageView, Usage toDelete) {
+    List<Usage> sortedUsages = usageView.getSortedUsages();
+    int curIndex = sortedUsages.indexOf(toDelete);
+
+    int selectIndex = 0;
+    if (curIndex < sortedUsages.size() - 1) {
+      selectIndex = curIndex + 1;
+    }
+    else if (curIndex > 0) {
+      selectIndex = curIndex - 1;
+    }
+    return sortedUsages.get(selectIndex);
   }
 }


### PR DESCRIPTION
RemoveUsageAction: Now selects a next item from the usage tree after removing one or several items. This makes the function easier to use with the keyboard.

This is an addition to the now merged pull request [#279](https://github.com/JetBrains/intellij-community/pull/279) fixing [IDEA-22996](https://youtrack.jetbrains.com/issue/IDEA-22996).
It's basically the same code as I use in my [Remove Usage Plugin](https://plugins.jetbrains.com/plugin/7833).