### PR TITLE
Gradle wrapper location fix IDEA-145249

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleManager.java
@@ -216,6 +216,12 @@ public class GradleManager
         LOG.info("Instructing gradle to use java from " + javaHome);
       }
       result.setJavaHome(javaHome);
+      if (distributionType==DistributionType.DEFAULT_WRAPPED) {
+        File wrapperPropertiesFile = GradleUtil.findDefaultWrapperPropertiesFile(pair.second);
+        if (wrapperPropertiesFile!=null && wrapperPropertiesFile.isFile()) {
+          result.setWrapperPropertyFile(wrapperPropertiesFile.getAbsolutePath());
+        }
+      }
       String ideProjectPath;
       if (project.getBasePath() == null ||
           (project.getProjectFilePath() != null && StringUtil.endsWith(project.getProjectFilePath(), ".ipr"))) {


### PR DESCRIPTION
IDEA fails to locate the gradle wrapper at project import if there is a settings.gradle in the parent directory.
It finds the wrapper, but then ignores its own detection and delegates to Gradle tooling API, which looks for it in the parent directory and fails.
A related PR was submitted to Gradle: https://github.com/gradle/gradle/pull/474
