### PR TITLE
Structure popup should check if filters are reverted

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/util/FileStructureDialog.java
+++ b/platform/lang-impl/src/com/intellij/ide/util/FileStructureDialog.java
@@ -305,7 +305,7 @@ public class FileStructureDialog extends DialogWrapper {
           }
         }
         final boolean state = chkFilter.isSelected();
-        myTreeActionsOwner.setActionIncluded(action, action instanceof FileStructureFilter ? !state : state);
+        myTreeActionsOwner.setActionIncluded(action, action instanceof FileStructureFilter && ((FileStructureFilter) action).isReverted() ? !state : state);
         myTreeStructure.rebuildTree();
         if (builder != null) {
           if (currentParent != null) {

--- a/platform/lang-impl/src/com/intellij/ide/util/FileStructurePopup.java
+++ b/platform/lang-impl/src/com/intellij/ide/util/FileStructurePopup.java
@@ -788,7 +788,7 @@ public class FileStructurePopup implements Disposable, TreeActionsOwner {
 
     final boolean selected = getDefaultValue(action);
     chkFilter.setSelected(selected);
-    myTreeActionsOwner.setActionIncluded(action, action instanceof FileStructureFilter ? !selected : selected);
+    myTreeActionsOwner.setActionIncluded(action, action instanceof FileStructureFilter && ((FileStructureFilter) action).isReverted() ? !selected : selected);
     chkFilter.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent e) {
@@ -796,7 +796,7 @@ public class FileStructurePopup implements Disposable, TreeActionsOwner {
         if (!myAutoClicked.contains(chkFilter)) {
           saveState(action, state);
         }
-        myTreeActionsOwner.setActionIncluded(action, action instanceof FileStructureFilter ? !state : state);
+        myTreeActionsOwner.setActionIncluded(action, action instanceof FileStructureFilter && ((FileStructureFilter) action).isReverted() ? !state : state);
         //final String filter = mySpeedSearch.isPopupActive() ? mySpeedSearch.getEnteredPrefix() : null;
         //mySpeedSearch.hidePopup();
         Object selection = ContainerUtil.getFirstItem(myAbstractTreeBuilder.getSelectedElements());


### PR DESCRIPTION
When I configure a structure filter as a FileStructureFilter so that it's shown in the structure popup as well, matching nodes are removed from the tree although the checkbox is not checked. That's because the algorithm assumes the filters are reverted by default (which is the case in the few implementations I've seen so far).
In my case, the filter is not reverted, so nodes shouldn't be removed from the tree *unless* the checkbox is checked. This PR will apply filters if they are checked and not reverted, or if they are not checked and reverted.