### PR TITLE
Include more details for FS case setting mismatch

### DIFF
--- a/platform/platform-resources-en/src/messages/ApplicationBundle.properties
+++ b/platform/platform-resources-en/src/messages/ApplicationBundle.properties
@@ -612,7 +612,7 @@ watcher.non.watchable.project=Project files cannot be watched (are they under ne
 fs.case.sensitivity.mismatch.title=Filesystem Case-Sensitivity Mismatch
 fs.case.sensitivity.mismatch.message=\
   The project seems to be located on a case-{0,choice,0#|1#in}sensitive file system.<br> \
-  This doesn't match IDE settings. \
+  This does not match the IDE setting, which is controlled by property "<tt>idea.case.sensitive.fs</tt>"<br> \
   <a href="https://confluence.jetbrains.com/display/IDEADEV/Filesystem+Case-Sensitivity+Mismatch">More details.</a>
 
 arrangement.title.settings.tab=Arrangement


### PR DESCRIPTION
Per the discussion on YouTrack [IDEA-135546](https://youtrack.jetbrains.com/issue/IDEA-135546), the message was updated to detail which system property one should adjust. For those unfamiliar with the situation, the Confluence page will still explain it. For those who see this a lot, the system property will remind them which property needs adjustment.

If one wishes to put back the contraction (doesn't), then please escape the apostrophe ('') since MessageFormat uses apostrophe as its escape character. This bug is even present in the screenshot on the Confluence page.