### PR TITLE
Refactored external system services to reduce amount or write actions

### DIFF
--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/service/project/PlatformFacade.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/service/project/PlatformFacade.java
@@ -1,6 +1,5 @@
 package com.intellij.openapi.externalSystem.service.project;
 
-import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.intellij.openapi.externalSystem.model.project.*;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -60,8 +59,7 @@ public interface PlatformFacade {
 
   /**
    * Creates a module of the specified type at the specified path and adds it to the project
-   * to which the module manager is related. {@link #commit()} must be called to
-   * bring the changes in effect.
+   * to which the module manager is related.
    *
    *
    * @param project

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/PlatformFacadeImpl.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/PlatformFacadeImpl.java
@@ -1,6 +1,5 @@
 package com.intellij.openapi.externalSystem.service.project;
 
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.externalSystem.model.project.*;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.module.Module;
@@ -11,7 +10,6 @@ import com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.containers.ContainerUtil;
@@ -76,16 +74,7 @@ public class PlatformFacadeImpl implements PlatformFacade {
   @Override
   public ModifiableRootModel getModuleModifiableModel(Module module) {
     final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
-    final ModifiableRootModel modifiableModel = moduleRootManager.getModifiableModel();
-    Disposer.register(module, new Disposable() {
-      @Override
-      public void dispose() {
-        if (!modifiableModel.isDisposed()) {
-          modifiableModel.dispose();
-        }
-      }
-    });
-    return modifiableModel;
+    return moduleRootManager.getModifiableModel();
   }
 
   @Nullable

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/PlatformFacadeImpl.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/PlatformFacadeImpl.java
@@ -1,5 +1,6 @@
 package com.intellij.openapi.externalSystem.service.project;
 
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.externalSystem.model.project.*;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.module.Module;
@@ -10,6 +11,7 @@ import com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.containers.ContainerUtil;
@@ -74,7 +76,16 @@ public class PlatformFacadeImpl implements PlatformFacade {
   @Override
   public ModifiableRootModel getModuleModifiableModel(Module module) {
     final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
-    return moduleRootManager.getModifiableModel();
+    final ModifiableRootModel modifiableModel = moduleRootManager.getModifiableModel();
+    Disposer.register(module, new Disposable() {
+      @Override
+      public void dispose() {
+        if (!modifiableModel.isDisposed()) {
+          modifiableModel.dispose();
+        }
+      }
+    });
+    return modifiableModel;
   }
 
   @Nullable

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractDependencyDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractDependencyDataService.java
@@ -134,19 +134,19 @@ public abstract class AbstractDependencyDataService<E extends AbstractDependency
   }
 
   @Override
-  public void removeData(@NotNull final Computable<Collection<I>> toRemoveComputable,
-                         @NotNull final Collection<DataNode<E>> toIgnore,
-                         @NotNull final ProjectData projectData,
-                         @NotNull final Project project,
-                         @NotNull final PlatformFacade platformFacade,
-                         final boolean synchronous) {
-    final List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
+  public void removeData(@NotNull Computable<Collection<I>> toRemoveComputable,
+                         @NotNull Collection<DataNode<E>> toIgnore,
+                         @NotNull ProjectData projectData,
+                         @NotNull Project project,
+                         @NotNull PlatformFacade platformFacade,
+                         boolean synchronous) {
+    List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
     try {
-      final Map<Module, Collection<ExportableOrderEntry>> byModule = groupByModule(toRemoveComputable.compute());
+      Map<Module, Collection<ExportableOrderEntry>> byModule = groupByModule(toRemoveComputable.compute());
       for (Map.Entry<Module, Collection<ExportableOrderEntry>> entry : byModule.entrySet()) {
-        final Module module = entry.getKey();
-        final Collection<ExportableOrderEntry> depsToRemove = entry.getValue();
-        final ModifiableRootModel model = platformFacade.getModuleModifiableModel(module);
+        Module module = entry.getKey();
+        Collection<ExportableOrderEntry> depsToRemove = entry.getValue();
+        ModifiableRootModel model = platformFacade.getModuleModifiableModel(module);
         removeData(depsToRemove, model);
         models.add(model);
       }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractDependencyDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractDependencyDataService.java
@@ -28,6 +28,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.*;
 import com.intellij.openapi.util.Computable;
 import com.intellij.util.Consumer;
+import com.intellij.util.ExceptionUtil;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.ContainerUtilRt;
 import com.intellij.util.containers.MultiMap;
@@ -151,9 +152,9 @@ public abstract class AbstractDependencyDataService<E extends AbstractDependency
       }
       ExternalSystemApiUtil.commitModels(synchronous, project, models);
     }
-    catch (Error e) {
+    catch (Throwable t) {
       ExternalSystemApiUtil.disposeModels(models);
-      throw e;
+      ExceptionUtil.rethrowUnchecked(t);
     }
   }
 

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ContentRootDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ContentRootDataService.java
@@ -28,7 +28,6 @@ import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.PlatformFacade;
 import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings;
 import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
-import com.intellij.openapi.externalSystem.util.DisposeAwareProjectChange;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
 import com.intellij.openapi.externalSystem.util.Order;
@@ -77,20 +76,20 @@ public class ContentRootDataService extends AbstractProjectDataService<ContentRo
   }
 
   @Override
-  public void importData(@NotNull final Collection<DataNode<ContentRootData>> toImport,
+  public void importData(@NotNull Collection<DataNode<ContentRootData>> toImport,
                          @Nullable ProjectData projectData,
-                         @NotNull final Project project,
-                         @NotNull final PlatformFacade platformFacade,
-                         final boolean synchronous) {
+                         @NotNull Project project,
+                         @NotNull PlatformFacade platformFacade,
+                         boolean synchronous) {
     if (toImport.isEmpty()) {
       return;
     }
 
-    final List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
+    List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
     try {
       MultiMap<DataNode<ModuleData>, DataNode<ContentRootData>> byModule = ExternalSystemApiUtil.groupBy(toImport, ProjectKeys.MODULE);
       for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<ContentRootData>>> entry : byModule.entrySet()) {
-        final Module module = platformFacade.findIdeModule(entry.getKey().getData(), project);
+        Module module = platformFacade.findIdeModule(entry.getKey().getData(), project);
         if (module == null) {
           LOG.warn(String.format(
             "Can't import content roots. Reason: target module (%s) is not found at the ide. Content roots: %s",
@@ -109,12 +108,12 @@ public class ContentRootDataService extends AbstractProjectDataService<ContentRo
   }
 
   @NotNull
-  private static ModifiableRootModel importData(@NotNull final Collection<DataNode<ContentRootData>> data,
-                                                @NotNull final Module module,
-                                                @NotNull final PlatformFacade platformFacade) {
-    final ModifiableRootModel model = platformFacade.getModuleModifiableModel(module);
-    final ContentEntry[] contentEntries = model.getContentEntries();
-    final Map<String, ContentEntry> contentEntriesMap = ContainerUtilRt.newHashMap();
+  private static ModifiableRootModel importData(@NotNull Collection<DataNode<ContentRootData>> data,
+                                                @NotNull Module module,
+                                                @NotNull PlatformFacade platformFacade) {
+    ModifiableRootModel model = platformFacade.getModuleModifiableModel(module);
+    ContentEntry[] contentEntries = model.getContentEntries();
+    Map<String, ContentEntry> contentEntriesMap = ContainerUtilRt.newHashMap();
     for(ContentEntry contentEntry : contentEntries) {
       contentEntriesMap.put(contentEntry.getUrl(), contentEntry);
     }
@@ -132,10 +131,10 @@ public class ContentRootDataService extends AbstractProjectDataService<ContentRo
       }
     }
 
-    for (final DataNode<ContentRootData> node : data) {
-      final ContentRootData contentRoot = node.getData();
+    for (DataNode<ContentRootData> node : data) {
+      ContentRootData contentRoot = node.getData();
 
-      final ContentEntry contentEntry = findOrCreateContentRoot(model, contentRoot.getRootPath());
+      ContentEntry contentEntry = findOrCreateContentRoot(model, contentRoot.getRootPath());
       contentEntry.clearExcludeFolders();
       contentEntry.clearSourceFolders();
       LOG.debug(String.format("Importing content root '%s' for module '%s'", contentRoot.getRootPath(), module.getName()));

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ContentRootDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ContentRootDataService.java
@@ -43,6 +43,7 @@ import com.intellij.openapi.vcs.changes.ChangeListManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.ExceptionUtil;
 import com.intellij.util.containers.ContainerUtilRt;
 import com.intellij.util.containers.MultiMap;
 import org.jetbrains.annotations.NotNull;
@@ -87,7 +88,7 @@ public class ContentRootDataService extends AbstractProjectDataService<ContentRo
 
     final List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
     try {
-      final MultiMap<DataNode<ModuleData>, DataNode<ContentRootData>> byModule = ExternalSystemApiUtil.groupBy(toImport, ProjectKeys.MODULE);
+      MultiMap<DataNode<ModuleData>, DataNode<ContentRootData>> byModule = ExternalSystemApiUtil.groupBy(toImport, ProjectKeys.MODULE);
       for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<ContentRootData>>> entry : byModule.entrySet()) {
         final Module module = platformFacade.findIdeModule(entry.getKey().getData(), project);
         if (module == null) {
@@ -101,9 +102,9 @@ public class ContentRootDataService extends AbstractProjectDataService<ContentRo
       }
       ExternalSystemApiUtil.commitModels(synchronous, project, models);
     }
-    catch (Error e) {
+    catch (Throwable t) {
       ExternalSystemApiUtil.disposeModels(models);
-      throw e;
+      ExceptionUtil.rethrowUnchecked(t);
     }
   }
 

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/LibraryDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/LibraryDataService.java
@@ -70,7 +70,6 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
                          @NotNull final Project project,
                          @NotNull final PlatformFacade platformFacade,
                          final boolean synchronous) {
-
     ExternalSystemApiUtil.executeProjectChangeAction(synchronous, new DisposeAwareProjectChange(project) {
       @Override
       public void execute() {
@@ -85,9 +84,9 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
                              @NotNull Project project,
                              @NotNull PlatformFacade platformFacade,
                              boolean synchronous) {
-    final Map<OrderRootType, Collection<File>> libraryFiles = prepareLibraryFiles(toImport);
+    Map<OrderRootType, Collection<File>> libraryFiles = prepareLibraryFiles(toImport);
 
-    final Library library = platformFacade.findIdeLibrary(toImport, project);
+    Library library = platformFacade.findIdeLibrary(toImport, project);
     if (library != null) {
       syncPaths(toImport, library, project, synchronous);
       return;
@@ -97,9 +96,9 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
 
   @NotNull
   public Map<OrderRootType, Collection<File>> prepareLibraryFiles(@NotNull LibraryData data) {
-    final Map<OrderRootType, Collection<File>> result = ContainerUtilRt.newHashMap();
+    Map<OrderRootType, Collection<File>> result = ContainerUtilRt.newHashMap();
     for (LibraryPathType pathType : LibraryPathType.values()) {
-      final Set<String> paths = data.getPaths(pathType);
+      Set<String> paths = data.getPaths(pathType);
       if (paths.isEmpty()) {
         continue;
       }
@@ -114,16 +113,16 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
                              @NotNull PlatformFacade platformFacade)
   {
     // Is assumed to be called from the EDT.
-    final LibraryTable libraryTable = platformFacade.getProjectLibraryTable(project);
-    final LibraryTable.ModifiableModel projectLibraryModel = libraryTable.getModifiableModel();
-    final Library intellijLibrary;
+    LibraryTable libraryTable = platformFacade.getProjectLibraryTable(project);
+    LibraryTable.ModifiableModel projectLibraryModel = libraryTable.getModifiableModel();
+    Library intellijLibrary;
     try {
       intellijLibrary = projectLibraryModel.createLibrary(libraryName);
     }
     finally {
       projectLibraryModel.commit();
     }
-    final Library.ModifiableModel libraryModel = intellijLibrary.getModifiableModel();
+    Library.ModifiableModel libraryModel = intellijLibrary.getModifiableModel();
     try {
       registerPaths(libraryFiles, libraryModel, libraryName);
     }
@@ -133,29 +132,29 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
   }
 
   @SuppressWarnings("MethodMayBeStatic")
-  public void registerPaths(@NotNull final Map<OrderRootType, Collection<File>> libraryFiles,
+  public void registerPaths(@NotNull Map<OrderRootType, Collection<File>> libraryFiles,
                             @NotNull Library.ModifiableModel model,
                             @NotNull String libraryName)
   {
     for (Map.Entry<OrderRootType, Collection<File>> entry : libraryFiles.entrySet()) {
       for (File file : entry.getValue()) {
-        final VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+        VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
         if (virtualFile == null) {
           if (ExternalSystemConstants.VERBOSE_PROCESSING && entry.getKey() == OrderRootType.CLASSES) {
             LOG.warn(
               String.format("Can't find %s of the library '%s' at path '%s'", entry.getKey(), libraryName, file.getAbsolutePath())
             );
           }
-          final String url = VfsUtil.getUrlForLibraryRoot(file);
+          String url = VfsUtil.getUrlForLibraryRoot(file);
 
-          final String[] urls = model.getUrls(entry.getKey());
+          String[] urls = model.getUrls(entry.getKey());
           if (!ArrayUtil.contains(url, urls)) {
             model.addRoot(url, entry.getKey());
           }
           continue;
         }
         if (virtualFile.isDirectory()) {
-          final VirtualFile[] files = model.getFiles(entry.getKey());
+          VirtualFile[] files = model.getFiles(entry.getKey());
           if (!ArrayUtil.contains(virtualFile, files)) {
             model.addRoot(virtualFile, entry.getKey());
           }
@@ -171,7 +170,7 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
               continue;
             }
           }
-          final VirtualFile[] files = model.getFiles(entry.getKey());
+          VirtualFile[] files = model.getFiles(entry.getKey());
           if (!ArrayUtil.contains(root, files)) {
             model.addRoot(root, entry.getKey());
           }
@@ -214,12 +213,12 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
     });
   }
 
-  public void syncPaths(@NotNull final LibraryData externalLibrary, @NotNull final Library ideLibrary, @NotNull final Project project, boolean synchronous) {
+  public void syncPaths(@NotNull LibraryData externalLibrary, @NotNull Library ideLibrary, @NotNull Project project, boolean synchronous) {
     if (externalLibrary.isUnresolved()) {
       return;
     }
-    final Map<OrderRootType, Set<String>> toRemove = ContainerUtilRt.newHashMap();
-    final Map<OrderRootType, Set<String>> toAdd = ContainerUtilRt.newHashMap();
+    Map<OrderRootType, Set<String>> toRemove = ContainerUtilRt.newHashMap();
+    Map<OrderRootType, Set<String>> toAdd = ContainerUtilRt.newHashMap();
     for (LibraryPathType pathType : LibraryPathType.values()) {
       OrderRootType ideType = myLibraryPathTypeMapper.map(pathType);
       HashSet<String> toAddPerType = ContainerUtilRt.newHashSet(externalLibrary.getPaths(pathType));
@@ -238,7 +237,7 @@ public class LibraryDataService extends AbstractProjectDataService<LibraryData, 
     if (toRemove.isEmpty() && toAdd.isEmpty()) {
       return;
     }
-    final Library.ModifiableModel model = ideLibrary.getModifiableModel();
+    Library.ModifiableModel model = ideLibrary.getModifiableModel();
     try {
       for (Map.Entry<OrderRootType, Set<String>> entry : toRemove.entrySet()) {
         for (String path : entry.getValue()) {

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/LibraryDependencyDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/LibraryDependencyDataService.java
@@ -80,12 +80,12 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
       return;
     }
 
-    final MyImporter importer = new MyImporter(platformFacade);
+    MyImporter importer = new MyImporter(platformFacade);
     try {
-      final MultiMap<DataNode<ModuleData>, DataNode<LibraryDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
+      MultiMap<DataNode<ModuleData>, DataNode<LibraryDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
       for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<LibraryDependencyData>>> entry : byModule.entrySet()) {
-        final Module module = platformFacade.findIdeModule(entry.getKey().getData(), project);
-        final Collection<DataNode<LibraryDependencyData>> libraryDependency = entry.getValue();
+        Module module = platformFacade.findIdeModule(entry.getKey().getData(), project);
+        Collection<DataNode<LibraryDependencyData>> libraryDependency = entry.getValue();
         if (module == null) {
           LOG.warn(String.format(
             "Can't import library dependencies %s. Reason: target module (%s) is not found at the ide and can't be imported",
@@ -133,7 +133,7 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
       return ContainerUtil.newUnmodifiableList(myLibraryModels);
     }
 
-    public void importData(@NotNull final Module module, @NotNull final Collection<DataNode<LibraryDependencyData>> nodesToImport) {
+    public void importData(@NotNull Module module, @NotNull Collection<DataNode<LibraryDependencyData>> nodesToImport) {
       // The general idea is to import all external project library dependencies and module libraries which don't present at the
       // ide side yet and remove all project library dependencies and module libraries which present at the ide but not at
       // the given collection.
@@ -165,7 +165,7 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
         }
       }
 
-      final ModifiableRootModel moduleRootModel = myPlatformFacade.getModuleModifiableModel(module);
+      ModifiableRootModel moduleRootModel = myPlatformFacade.getModuleModifiableModel(module);
       LibraryTable moduleLibraryTable = moduleRootModel.getModuleLibraryTable();
       LibraryTable libraryTable = myPlatformFacade.getProjectLibraryTable(module.getProject());
       syncExistingAndRemoveObsolete(moduleLibrariesToImport, projectLibrariesToImport, toImport, moduleRootModel, hasUnresolved);
@@ -182,16 +182,16 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
                                @NotNull LibraryTable moduleLibraryTable,
                                @NotNull LibraryTable libraryTable,
                                @NotNull Module module) {
-      for (final LibraryDependencyData dependencyData : toImport) {
-        final LibraryData libraryData = dependencyData.getTarget();
-        final String libraryName = libraryData.getInternalName();
+      for (LibraryDependencyData dependencyData : toImport) {
+        LibraryData libraryData = dependencyData.getTarget();
+        String libraryName = libraryData.getInternalName();
         switch (dependencyData.getLevel()) {
           case MODULE:
-            final Library moduleLib = moduleLibraryTable.createLibrary(libraryName);
+            Library moduleLib = moduleLibraryTable.createLibrary(libraryName);
             syncExistingLibraryDependency(dependencyData, moduleLib, moduleRootModel, module);
             break;
           case PROJECT:
-            final Library projectLib = libraryTable.getLibraryByName(libraryName);
+            Library projectLib = libraryTable.getLibraryByName(libraryName);
             if (projectLib == null) {
               syncExistingLibraryDependency(dependencyData, moduleLibraryTable.createLibrary(libraryName), moduleRootModel, module);
               break;
@@ -217,11 +217,11 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
                                                @NotNull Set<LibraryDependencyData> toImport,
                                                @NotNull ModifiableRootModel moduleRootModel,
                                                boolean hasUnresolvedLibraries) {
-      final Set<String> moduleLibraryKey = ContainerUtilRt.newHashSet();
+      Set<String> moduleLibraryKey = ContainerUtilRt.newHashSet();
       for (OrderEntry entry : moduleRootModel.getOrderEntries()) {
         if (entry instanceof ModuleLibraryOrderEntryImpl) {
-          final ModuleLibraryOrderEntryImpl moduleLibraryOrderEntry = (ModuleLibraryOrderEntryImpl)entry;
-          final Library library = moduleLibraryOrderEntry.getLibrary();
+          ModuleLibraryOrderEntryImpl moduleLibraryOrderEntry = (ModuleLibraryOrderEntryImpl)entry;
+          Library library = moduleLibraryOrderEntry.getLibrary();
           if (library == null) {
             LOG.warn("Skipping module-level library entry because it doesn't have backing Library object. Entry: " + entry);
             continue;
@@ -240,9 +240,9 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
           }
         }
         else if (entry instanceof LibraryOrderEntry) {
-          final LibraryOrderEntry libraryOrderEntry = (LibraryOrderEntry)entry;
-          final String libraryName = libraryOrderEntry.getLibraryName();
-          final LibraryDependencyData existing = projectLibrariesToImport.remove(libraryName + libraryOrderEntry.getScope().name());
+          LibraryOrderEntry libraryOrderEntry = (LibraryOrderEntry)entry;
+          String libraryName = libraryOrderEntry.getLibraryName();
+          LibraryDependencyData existing = projectLibrariesToImport.remove(libraryName + libraryOrderEntry.getScope().name());
           if (existing != null) {
             toImport.remove(existing);
           }
@@ -259,11 +259,11 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
                                                @NotNull Library library,
                                                @NotNull ModifiableRootModel moduleRootModel,
                                                @NotNull Module module) {
-      final Library.ModifiableModel libModel = library.getModifiableModel();
-      final String libraryName = libraryDependencyData.getInternalName();
-      final Map<OrderRootType, Collection<File>> files = myLibraryManager.prepareLibraryFiles(libraryDependencyData.getTarget());
+      Library.ModifiableModel libModel = library.getModifiableModel();
+      String libraryName = libraryDependencyData.getInternalName();
+      Map<OrderRootType, Collection<File>> files = myLibraryManager.prepareLibraryFiles(libraryDependencyData.getTarget());
       myLibraryManager.registerPaths(files, libModel, libraryName);
-      final LibraryOrderEntry orderEntry = moduleRootModel.findLibraryOrderEntry(library);
+      LibraryOrderEntry orderEntry = moduleRootModel.findLibraryOrderEntry(library);
       assert orderEntry != null;
       setLibraryScope(orderEntry, library, module, libraryDependencyData);
       myLibraryModels.add(libModel);

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/LibraryDependencyDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/LibraryDependencyDataService.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.externalSystem.model.Key;
 import com.intellij.openapi.externalSystem.model.ProjectKeys;
 import com.intellij.openapi.externalSystem.model.project.*;
 import com.intellij.openapi.externalSystem.service.project.PlatformFacade;
-import com.intellij.openapi.externalSystem.util.DisposeAwareProjectChange;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
 import com.intellij.openapi.externalSystem.util.Order;
@@ -35,6 +34,7 @@ import com.intellij.openapi.roots.impl.ModuleLibraryOrderEntryImpl;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.ContainerUtilRt;
 import com.intellij.util.containers.MultiMap;
 import org.jetbrains.annotations.NotNull;
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -78,17 +79,28 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
       return;
     }
 
-    MultiMap<DataNode<ModuleData>, DataNode<LibraryDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
-    for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<LibraryDependencyData>>> entry : byModule.entrySet()) {
-      Module module = platformFacade.findIdeModule(entry.getKey().getData(), project);
-      if (module == null) {
-        LOG.warn(String.format(
-          "Can't import library dependencies %s. Reason: target module (%s) is not found at the ide and can't be imported",
-          entry.getValue(), entry.getKey()
-        ));
-        continue;
+    final MyImporter importer = new MyImporter(platformFacade);
+    try {
+      final MultiMap<DataNode<ModuleData>, DataNode<LibraryDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
+      for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<LibraryDependencyData>>> entry : byModule.entrySet()) {
+        final Module module = platformFacade.findIdeModule(entry.getKey().getData(), project);
+        final Collection<DataNode<LibraryDependencyData>> libraryDependency = entry.getValue();
+        if (module == null) {
+          LOG.warn(String.format(
+            "Can't import library dependencies %s. Reason: target module (%s) is not found at the ide and can't be imported",
+            libraryDependency, entry.getKey()
+          ));
+          continue;
+        }
+        importer.importData(module, libraryDependency);
       }
-      importData(entry.getValue(), module, platformFacade, synchronous);
+      // change libraries first
+      ExternalSystemApiUtil.commitChangedModels(synchronous, project, importer.getLibraryModels());
+      ExternalSystemApiUtil.commitModels(synchronous, project, importer.getModels());
+    }
+    catch (Error e) {
+      ExternalSystemApiUtil.disposeModels(importer.getModels());
+      throw e;
     }
   }
 
@@ -103,158 +115,159 @@ public class LibraryDependencyDataService extends AbstractDependencyDataService<
     return orderEntry.getLibraryName();
   }
 
-  private void importData(@NotNull final Collection<DataNode<LibraryDependencyData>> nodesToImport,
-                         @NotNull final Module module,
-                         @NotNull final PlatformFacade platformFacade,
-                          final boolean synchronous) {
-    ExternalSystemApiUtil.executeProjectChangeAction(synchronous, new DisposeAwareProjectChange(module) {
-      @Override
-      public void execute() {
-        // The general idea is to import all external project library dependencies and module libraries which don't present at the
-        // ide side yet and remove all project library dependencies and module libraries which present at the ide but not at
-        // the given collection.
-        // The trick is that we should perform module settings modification inside try/finally block against target root model.
-        // That means that we need to prepare all necessary data, obtain a model and modify it as necessary.
-        Map<Set<String>/* library paths */, LibraryDependencyData> moduleLibrariesToImport = ContainerUtilRt.newHashMap();
-        Map<String/* library name + scope */, LibraryDependencyData> projectLibrariesToImport = ContainerUtilRt.newHashMap();
-        Set<LibraryDependencyData> toImport = ContainerUtilRt.newLinkedHashSet();
+  private class MyImporter {
+    private final PlatformFacade myPlatformFacade;
+    private final List<ModifiableRootModel> myModels = ContainerUtilRt.newArrayList();
+    private final List<Library.ModifiableModel> myLibraryModels = ContainerUtilRt.newArrayList();
 
-        boolean hasUnresolved = false;
-        for (DataNode<LibraryDependencyData> dependencyNode : nodesToImport) {
-          LibraryDependencyData dependencyData = dependencyNode.getData();
-          LibraryData libraryData = dependencyData.getTarget();
-          hasUnresolved |= libraryData.isUnresolved();
-          switch (dependencyData.getLevel()) {
-            case MODULE:
-              if (!libraryData.isUnresolved()) {
-                Set<String> paths = ContainerUtilRt.newHashSet();
-                for (String path : libraryData.getPaths(LibraryPathType.BINARY)) {
-                  paths.add(ExternalSystemApiUtil.toCanonicalPath(path) + dependencyData.getScope().name());
-                }
-                moduleLibrariesToImport.put(paths, dependencyData);
-                toImport.add(dependencyData);
+    private MyImporter(PlatformFacade platformFacade) {
+      myPlatformFacade = platformFacade;
+    }
+
+    public List<ModifiableRootModel> getModels() {
+      return ContainerUtil.newUnmodifiableList(myModels);
+    }
+
+    public List<Library.ModifiableModel> getLibraryModels() {
+      return ContainerUtil.newUnmodifiableList(myLibraryModels);
+    }
+
+    public void importData(@NotNull final Module module, @NotNull final Collection<DataNode<LibraryDependencyData>> nodesToImport) {
+      // The general idea is to import all external project library dependencies and module libraries which don't present at the
+      // ide side yet and remove all project library dependencies and module libraries which present at the ide but not at
+      // the given collection.
+      // The trick is that we should perform module settings modification inside try/finally block against target root model.
+      // That means that we need to prepare all necessary data, obtain a model and modify it as necessary.
+      Map<Set<String>/* library paths */, LibraryDependencyData> moduleLibrariesToImport = ContainerUtilRt.newHashMap();
+      Map<String/* library name + scope */, LibraryDependencyData> projectLibrariesToImport = ContainerUtilRt.newHashMap();
+      Set<LibraryDependencyData> toImport = ContainerUtilRt.newLinkedHashSet();
+
+      boolean hasUnresolved = false;
+      for (DataNode<LibraryDependencyData> dependencyNode : nodesToImport) {
+        LibraryDependencyData dependencyData = dependencyNode.getData();
+        LibraryData libraryData = dependencyData.getTarget();
+        hasUnresolved |= libraryData.isUnresolved();
+        switch (dependencyData.getLevel()) {
+          case MODULE:
+            if (!libraryData.isUnresolved()) {
+              Set<String> paths = ContainerUtilRt.newHashSet();
+              for (String path : libraryData.getPaths(LibraryPathType.BINARY)) {
+                paths.add(ExternalSystemApiUtil.toCanonicalPath(path) + dependencyData.getScope().name());
               }
-              break;
-            case PROJECT:
-              projectLibrariesToImport.put(libraryData.getInternalName() + dependencyData.getScope().name(), dependencyData);
+              moduleLibrariesToImport.put(paths, dependencyData);
               toImport.add(dependencyData);
-          }
-        }
-
-        final ModifiableRootModel moduleRootModel = platformFacade.getModuleModifiableModel(module);
-        LibraryTable moduleLibraryTable = moduleRootModel.getModuleLibraryTable();
-        LibraryTable libraryTable = platformFacade.getProjectLibraryTable(module.getProject());
-        try {
-          syncExistingAndRemoveObsolete(moduleLibrariesToImport, projectLibrariesToImport, toImport, moduleRootModel, hasUnresolved);
-
-          // Import missing library dependencies.
-          if (!toImport.isEmpty()) {
-            importMissing(toImport, moduleRootModel, moduleLibraryTable, libraryTable, module);
-          }
-        }
-        finally {
-          moduleRootModel.commit();
-        }
-      }
-    });
-  }
-
-  private void importMissing(@NotNull Set<LibraryDependencyData> toImport,
-                             @NotNull ModifiableRootModel moduleRootModel,
-                             @NotNull LibraryTable moduleLibraryTable,
-                             @NotNull LibraryTable libraryTable,
-                             @NotNull Module module) {
-    for (final LibraryDependencyData dependencyData : toImport) {
-      final LibraryData libraryData = dependencyData.getTarget();
-      final String libraryName = libraryData.getInternalName();
-      switch (dependencyData.getLevel()) {
-        case MODULE:
-          final Library moduleLib = moduleLibraryTable.createLibrary(libraryName);
-          syncExistingLibraryDependency(dependencyData, moduleLib, moduleRootModel, module);
-          break;
-        case PROJECT:
-          final Library projectLib = libraryTable.getLibraryByName(libraryName);
-          if (projectLib == null) {
-            syncExistingLibraryDependency(dependencyData, moduleLibraryTable.createLibrary(libraryName), moduleRootModel, module);
+            }
             break;
+          case PROJECT:
+            projectLibrariesToImport.put(libraryData.getInternalName() + dependencyData.getScope().name(), dependencyData);
+            toImport.add(dependencyData);
+        }
+      }
+
+      final ModifiableRootModel moduleRootModel = myPlatformFacade.getModuleModifiableModel(module);
+      LibraryTable moduleLibraryTable = moduleRootModel.getModuleLibraryTable();
+      LibraryTable libraryTable = myPlatformFacade.getProjectLibraryTable(module.getProject());
+      syncExistingAndRemoveObsolete(moduleLibrariesToImport, projectLibrariesToImport, toImport, moduleRootModel, hasUnresolved);
+
+      // Import missing library dependencies.
+      if (!toImport.isEmpty()) {
+        importMissing(toImport, moduleRootModel, moduleLibraryTable, libraryTable, module);
+      }
+      myModels.add(moduleRootModel);
+    }
+
+    private void importMissing(@NotNull Set<LibraryDependencyData> toImport,
+                               @NotNull ModifiableRootModel moduleRootModel,
+                               @NotNull LibraryTable moduleLibraryTable,
+                               @NotNull LibraryTable libraryTable,
+                               @NotNull Module module) {
+      for (final LibraryDependencyData dependencyData : toImport) {
+        final LibraryData libraryData = dependencyData.getTarget();
+        final String libraryName = libraryData.getInternalName();
+        switch (dependencyData.getLevel()) {
+          case MODULE:
+            final Library moduleLib = moduleLibraryTable.createLibrary(libraryName);
+            syncExistingLibraryDependency(dependencyData, moduleLib, moduleRootModel, module);
+            break;
+          case PROJECT:
+            final Library projectLib = libraryTable.getLibraryByName(libraryName);
+            if (projectLib == null) {
+              syncExistingLibraryDependency(dependencyData, moduleLibraryTable.createLibrary(libraryName), moduleRootModel, module);
+              break;
+            }
+            LibraryOrderEntry orderEntry = moduleRootModel.addLibraryEntry(projectLib);
+            setLibraryScope(orderEntry, projectLib, module, dependencyData);
+        }
+      }
+    }
+
+    private void setLibraryScope(@NotNull LibraryOrderEntry orderEntry,
+                                        @NotNull Library lib,
+                                        @NotNull Module module,
+                                        @NotNull LibraryDependencyData dependencyData) {
+      LOG.debug(String.format("Adding library dependency '%s' to module '%s'", lib.getName(), module.getName()));
+      orderEntry.setExported(dependencyData.isExported());
+      orderEntry.setScope(dependencyData.getScope());
+      LOG.debug(String.format("Configuring library dependency '%s' of module '%s' to be%s exported and have scope %s", lib.getName(), module.getName(), dependencyData.isExported() ? " not" : "", dependencyData.getScope()));
+    }
+
+    private List<Library.ModifiableModel> syncExistingAndRemoveObsolete(@NotNull Map<Set<String>, LibraryDependencyData> moduleLibrariesToImport,
+                                                                        @NotNull Map<String, LibraryDependencyData> projectLibrariesToImport,
+                                                                        @NotNull Set<LibraryDependencyData> toImport,
+                                                                        @NotNull ModifiableRootModel moduleRootModel,
+                                                                        boolean hasUnresolvedLibraries) {
+      final Set<String> moduleLibraryKey = ContainerUtilRt.newHashSet();
+      final List<Library.ModifiableModel> result = ContainerUtilRt.newArrayList();
+      for (OrderEntry entry : moduleRootModel.getOrderEntries()) {
+        if (entry instanceof ModuleLibraryOrderEntryImpl) {
+          final ModuleLibraryOrderEntryImpl moduleLibraryOrderEntry = (ModuleLibraryOrderEntryImpl)entry;
+          final Library library = moduleLibraryOrderEntry.getLibrary();
+          if (library == null) {
+            LOG.warn("Skipping module-level library entry because it doesn't have backing Library object. Entry: " + entry);
+            continue;
           }
-          LibraryOrderEntry orderEntry = moduleRootModel.addLibraryEntry(projectLib);
-          setLibraryScope(orderEntry, projectLib, module, dependencyData);
+          moduleLibraryKey.clear();
+          for (VirtualFile file : library.getFiles(OrderRootType.CLASSES)) {
+            moduleLibraryKey.add(ExternalSystemApiUtil.getLocalFileSystemPath(file) + moduleLibraryOrderEntry.getScope().name());
+          }
+          LibraryDependencyData existing = moduleLibrariesToImport.remove(moduleLibraryKey);
+          if (existing == null) {
+            moduleRootModel.removeOrderEntry(entry);
+          }
+          else {
+            syncExistingLibraryDependency(existing, library, moduleRootModel, moduleLibraryOrderEntry.getOwnerModule());
+            toImport.remove(existing);
+          }
+        }
+        else if (entry instanceof LibraryOrderEntry) {
+          final LibraryOrderEntry libraryOrderEntry = (LibraryOrderEntry)entry;
+          final String libraryName = libraryOrderEntry.getLibraryName();
+          final LibraryDependencyData existing = projectLibrariesToImport.remove(libraryName + libraryOrderEntry.getScope().name());
+          if (existing != null) {
+            toImport.remove(existing);
+          }
+          else if (!hasUnresolvedLibraries) {
+            // There is a possible case that a project has been successfully imported from external model and after
+            // that network/repo goes down. We don't want to drop existing binary mappings then.
+            moduleRootModel.removeOrderEntry(entry);
+          }
+        }
       }
+      return result;
     }
-  }
 
-  private static void setLibraryScope(@NotNull LibraryOrderEntry orderEntry,
-                                      @NotNull Library lib,
-                                      @NotNull Module module,
-                                      @NotNull LibraryDependencyData dependencyData) {
-    LOG.debug(String.format("Adding library dependency '%s' to module '%s'", lib.getName(), module.getName()));
-    orderEntry.setExported(dependencyData.isExported());
-    orderEntry.setScope(dependencyData.getScope());
-    LOG.debug(String.format(
-      "Configuring library dependency '%s' of module '%s' to be%s exported and have scope %s",
-      lib.getName(), module.getName(), dependencyData.isExported() ? " not" : "", dependencyData.getScope()
-    ));
-  }
-
-  private void syncExistingAndRemoveObsolete(@NotNull Map<Set<String>, LibraryDependencyData> moduleLibrariesToImport,
-                                             @NotNull Map<String, LibraryDependencyData> projectLibrariesToImport,
-                                             @NotNull Set<LibraryDependencyData> toImport,
-                                             @NotNull ModifiableRootModel moduleRootModel,
-                                             boolean hasUnresolvedLibraries) {
-    Set<String> moduleLibraryKey = ContainerUtilRt.newHashSet();
-    for (OrderEntry entry : moduleRootModel.getOrderEntries()) {
-      if (entry instanceof ModuleLibraryOrderEntryImpl) {
-        ModuleLibraryOrderEntryImpl moduleLibraryOrderEntry = (ModuleLibraryOrderEntryImpl)entry;
-        Library library = moduleLibraryOrderEntry.getLibrary();
-        if (library == null) {
-          LOG.warn("Skipping module-level library entry because it doesn't have backing Library object. Entry: " + entry);
-          continue;
-        }
-        moduleLibraryKey.clear();
-        for (VirtualFile file : library.getFiles(OrderRootType.CLASSES)) {
-          moduleLibraryKey.add(ExternalSystemApiUtil.getLocalFileSystemPath(file) + moduleLibraryOrderEntry.getScope().name());
-        }
-        LibraryDependencyData existing = moduleLibrariesToImport.remove(moduleLibraryKey);
-        if (existing == null) {
-          moduleRootModel.removeOrderEntry(entry);
-        }
-        else {
-          syncExistingLibraryDependency(existing, library, moduleRootModel, moduleLibraryOrderEntry.getOwnerModule());
-          toImport.remove(existing);
-        }
-      }
-      else if (entry instanceof LibraryOrderEntry) {
-        final LibraryOrderEntry libraryOrderEntry = (LibraryOrderEntry)entry;
-        final String libraryName = libraryOrderEntry.getLibraryName();
-        final LibraryDependencyData existing = projectLibrariesToImport.remove(libraryName + libraryOrderEntry.getScope().name());
-        if (existing != null) {
-          toImport.remove(existing);
-        }
-        else if (!hasUnresolvedLibraries) {
-          // There is a possible case that a project has been successfully imported from external model and after
-          // that network/repo goes down. We don't want to drop existing binary mappings then.
-          moduleRootModel.removeOrderEntry(entry);
-        }
-      }
-    }
-  }
-
-  private void syncExistingLibraryDependency(@NotNull LibraryDependencyData libraryDependencyData,
-                                             @NotNull Library library,
-                                             @NotNull ModifiableRootModel moduleRootModel,
-                                             @NotNull Module module) {
-    final Library.ModifiableModel libModel = library.getModifiableModel();
-    try {
+    private void syncExistingLibraryDependency(@NotNull LibraryDependencyData libraryDependencyData,
+                                               @NotNull Library library,
+                                               @NotNull ModifiableRootModel moduleRootModel,
+                                               @NotNull Module module) {
+      final Library.ModifiableModel libModel = library.getModifiableModel();
       final String libraryName = libraryDependencyData.getInternalName();
-      Map<OrderRootType, Collection<File>> files = myLibraryManager.prepareLibraryFiles(libraryDependencyData.getTarget());
+      final Map<OrderRootType, Collection<File>> files = myLibraryManager.prepareLibraryFiles(libraryDependencyData.getTarget());
       myLibraryManager.registerPaths(files, libModel, libraryName);
-      LibraryOrderEntry orderEntry = moduleRootModel.findLibraryOrderEntry(library);
+      final LibraryOrderEntry orderEntry = moduleRootModel.findLibraryOrderEntry(library);
       assert orderEntry != null;
       setLibraryScope(orderEntry, library, module, libraryDependencyData);
-    }
-    finally {
-      libModel.commit();
+      myLibraryModels.add(libModel);
     }
   }
 }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDataService.java
@@ -38,6 +38,7 @@ import com.intellij.ui.CheckBoxList;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.Consumer;
+import com.intellij.util.ExceptionUtil;
 import com.intellij.util.Function;
 import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
@@ -97,9 +98,9 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
         models.add(createModule(project, platformFacade, moduleData));
       }
     }
-    catch (Error e) {
+    catch (Throwable t) {
       ExternalSystemApiUtil.disposeModels(models);
-      throw e;
+      ExceptionUtil.rethrowUnchecked(t);
     }
     return models;
   }
@@ -166,9 +167,9 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
         }
       }
     }
-    catch (Error e) {
+    catch (Throwable t) {
       ExternalSystemApiUtil.disposeModels(models);
-      throw e;
+      ExceptionUtil.rethrowUnchecked(t);
     }
     return models;
   }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDataService.java
@@ -73,15 +73,15 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
   }
 
   @Override
-  public void importData(@NotNull final Collection<DataNode<ModuleData>> toImport,
+  public void importData(@NotNull Collection<DataNode<ModuleData>> toImport,
                          @Nullable ProjectData projectData,
-                         @NotNull final Project project,
-                         @NotNull final PlatformFacade platformFacade,
-                         final boolean synchronous) {
+                         @NotNull Project project,
+                         @NotNull PlatformFacade platformFacade,
+                         boolean synchronous) {
     if (toImport.isEmpty()) {
       return;
     }
-    final Collection<DataNode<ModuleData>> toCreate = filterExistingModules(toImport, project, platformFacade);
+    Collection<DataNode<ModuleData>> toCreate = filterExistingModules(toImport, project, platformFacade);
     if (!toCreate.isEmpty()) {
       ExternalSystemApiUtil.commitModels(synchronous, project, createModules(project, platformFacade, toCreate));
     }
@@ -92,7 +92,7 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
   private static List<ModifiableRootModel> createModules(@NotNull Project project,
                                                          @NotNull PlatformFacade platformFacade,
                                                          Collection<DataNode<ModuleData>> toCreate) {
-    final List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
+    List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
     try {
       for (DataNode<ModuleData> moduleData : toCreate) {
         models.add(createModule(project, platformFacade, moduleData));
@@ -108,15 +108,15 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
   private static ModifiableRootModel createModule(@NotNull Project project,
                                                   @NotNull PlatformFacade platformFacade,
                                                   @NotNull DataNode<ModuleData> module) {
-    final ModuleData data = module.getData();
-    final Module created = platformFacade.newModule(project, data.getModuleFilePath(), data.getModuleTypeId());
+    ModuleData data = module.getData();
+    Module created = platformFacade.newModule(project, data.getModuleFilePath(), data.getModuleTypeId());
 
     // Ensure that the dependencies are clear (used to be not clear when manually removing the module and importing it via gradle)
     final ModifiableRootModel moduleRootModel = platformFacade.getModuleModifiableModel(created);
     moduleRootModel.inheritSdk();
     setModuleOptions(created, module);
 
-    final RootPolicy<Object> visitor = new RootPolicy<Object>() {
+    RootPolicy<Object> visitor = new RootPolicy<Object>() {
       @Override
       public Object visitLibraryOrderEntry(LibraryOrderEntry libraryOrderEntry, Object value) {
         moduleRootModel.removeOrderEntry(libraryOrderEntry);
@@ -140,7 +140,7 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
                                                                         @NotNull Project project,
                                                                         @NotNull PlatformFacade platformFacade)
   {
-    final Collection<DataNode<ModuleData>> result = ContainerUtilRt.newArrayList();
+    Collection<DataNode<ModuleData>> result = ContainerUtilRt.newArrayList();
     for (DataNode<ModuleData> node : modules) {
       ModuleData moduleData = node.getData();
       Module module = platformFacade.findIdeModule(moduleData, project);
@@ -158,10 +158,10 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
   private List<ModifiableRootModel> syncModulesPaths(@NotNull Project project,
                                                      @NotNull PlatformFacade platformFacade,
                                                      Collection<DataNode<ModuleData>> toCreate) {
-    final List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
+    List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
     try {
       for (DataNode<ModuleData> moduleData : toCreate) {
-        final Module module = platformFacade.findIdeModule(moduleData.getData(), project);
+        Module module = platformFacade.findIdeModule(moduleData.getData(), project);
         if (module != null) {
           models.add(syncPaths(module, platformFacade, moduleData.getData()));
         }
@@ -176,18 +176,18 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
 
   @NotNull
   private static ModifiableRootModel syncPaths(@NotNull Module module, @NotNull PlatformFacade platformFacade, @NotNull ModuleData data) {
-    final ModifiableRootModel modifiableModel = platformFacade.getModuleModifiableModel(module);
+    ModifiableRootModel modifiableModel = platformFacade.getModuleModifiableModel(module);
     CompilerModuleExtension extension = modifiableModel.getModuleExtension(CompilerModuleExtension.class);
     if (extension == null) {
       LOG.warn(String.format("Can't sync paths for module '%s'. Reason: no compiler extension is found for it", module.getName()));
       return modifiableModel;
     }
-    final String compileOutputPath = data.getCompileOutputPath(ExternalSystemSourceType.SOURCE);
+    String compileOutputPath = data.getCompileOutputPath(ExternalSystemSourceType.SOURCE);
     if (compileOutputPath != null) {
       extension.setCompilerOutputPath(VfsUtilCore.pathToUrl(compileOutputPath));
     }
 
-    final String testCompileOutputPath = data.getCompileOutputPath(ExternalSystemSourceType.TEST);
+    String testCompileOutputPath = data.getCompileOutputPath(ExternalSystemSourceType.TEST);
     if (testCompileOutputPath != null) {
       extension.setCompilerOutputPathForTests(VfsUtilCore.pathToUrl(testCompileOutputPath));
     }
@@ -311,7 +311,7 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
     UIUtil.invokeLaterIfNeeded(new Runnable() {
       @Override
       public void run() {
-        final List<Module> toRemove = ContainerUtil.newSmartList();
+        List<Module> toRemove = ContainerUtil.newSmartList();
         if(ApplicationManager.getApplication().isHeadlessEnvironment()) {
           toRemove.addAll(orphanModules);
         } else {
@@ -334,7 +334,7 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
           content.add(orphanModulesList, ExternalSystemUiUtil.getFillLineConstraints(0));
           content.setBorder(IdeBorderFactory.createEmptyBorder(0, 0, 8, 0));
 
-          final DialogWrapper dialog = new DialogWrapper(project) {
+          DialogWrapper dialog = new DialogWrapper(project) {
             {
               setTitle(ExternalSystemBundle.message("import.title", externalSystemId.getReadableName()));
               init();
@@ -376,13 +376,13 @@ public class ModuleDataService extends AbstractProjectDataService<ModuleData, Mo
   }
 
   private static void setModuleOptions(Module module, DataNode<ModuleData> moduleDataNode) {
-    final ModuleData moduleData = moduleDataNode.getData();
+    ModuleData moduleData = moduleDataNode.getData();
     module.putUserData(MODULE_DATA_KEY, moduleData);
 
     module.setOption(ExternalSystemConstants.EXTERNAL_SYSTEM_ID_KEY, moduleData.getOwner().toString());
     module.setOption(ExternalSystemConstants.LINKED_PROJECT_ID_KEY, moduleData.getId());
     module.setOption(ExternalSystemConstants.LINKED_PROJECT_PATH_KEY, moduleData.getLinkedExternalProjectPath());
-    final ProjectData projectData = moduleDataNode.getData(ProjectKeys.PROJECT);
+    ProjectData projectData = moduleDataNode.getData(ProjectKeys.PROJECT);
     module.setOption(ExternalSystemConstants.ROOT_PROJECT_PATH_KEY, projectData != null ? projectData.getLinkedExternalProjectPath() : "");
 
     if (moduleData.getGroup() != null) {

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDependencyDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDependencyDataService.java
@@ -19,23 +19,17 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.Key;
 import com.intellij.openapi.externalSystem.model.ProjectKeys;
-import com.intellij.openapi.externalSystem.model.project.LibraryDependencyData;
 import com.intellij.openapi.externalSystem.model.project.ModuleData;
 import com.intellij.openapi.externalSystem.model.project.ModuleDependencyData;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.PlatformFacade;
-import com.intellij.openapi.externalSystem.util.DisposeAwareProjectChange;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
 import com.intellij.openapi.externalSystem.util.Order;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.*;
-import com.intellij.openapi.util.Computable;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Pair;
-import com.intellij.util.Processor;
-import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.ContainerUtilRt;
 import com.intellij.util.containers.MultiMap;
 import org.jetbrains.annotations.NotNull;
@@ -68,17 +62,25 @@ public class ModuleDependencyDataService extends AbstractDependencyDataService<M
                          @NotNull Project project,
                          @NotNull PlatformFacade platformFacade,
                          boolean synchronous) {
-    MultiMap<DataNode<ModuleData>, DataNode<ModuleDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
-    for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<ModuleDependencyData>>> entry : byModule.entrySet()) {
-      Module ideModule = platformFacade.findIdeModule(entry.getKey().getData(), project);
-      if (ideModule == null) {
-        LOG.warn(String.format(
-          "Can't import module dependencies %s. Reason: target module (%s) is not found at the ide and can't be imported",
-          entry.getValue(), entry.getKey()
-        ));
-        continue;
+    final List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
+    try {
+      final MultiMap<DataNode<ModuleData>, DataNode<ModuleDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
+      for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<ModuleDependencyData>>> entry : byModule.entrySet()) {
+        final Module ideModule = platformFacade.findIdeModule(entry.getKey().getData(), project);
+        if (ideModule == null) {
+          LOG.warn(String.format(
+            "Can't import module dependencies %s. Reason: target module (%s) is not found at the ide and can't be imported",
+            entry.getValue(), entry.getKey()
+          ));
+          continue;
+        }
+        models.add(importData(entry.getValue(), ideModule, platformFacade));
       }
-      importData(entry.getValue(), ideModule, platformFacade, synchronous);
+      ExternalSystemApiUtil.commitModels(synchronous, project, models);
+    }
+    catch (Error e) {
+      ExternalSystemApiUtil.disposeModels(models);
+      throw e;
     }
   }
 
@@ -93,62 +95,54 @@ public class ModuleDependencyDataService extends AbstractDependencyDataService<M
     return orderEntry.getModuleName();
   }
 
-  private void importData(@NotNull final Collection<DataNode<ModuleDependencyData>> toImport,
-                          @NotNull final Module module,
-                          @NotNull final PlatformFacade platformFacade,
-                          final boolean synchronous)
+  @NotNull
+  private ModifiableRootModel importData(@NotNull final Collection<DataNode<ModuleDependencyData>> toImport,
+                                         @NotNull final Module module,
+                                         @NotNull final PlatformFacade platformFacade)
   {
-    ExternalSystemApiUtil.executeProjectChangeAction(synchronous, new DisposeAwareProjectChange(module) {
-      @Override
-      public void execute() {
-        ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
-        Map<Pair<String /* dependency module internal name */, /* dependency module scope */DependencyScope> , ModuleOrderEntry> toRemove = ContainerUtilRt.newHashMap();
-        for (OrderEntry entry : moduleRootManager.getOrderEntries()) {
-          if (entry instanceof ModuleOrderEntry) {
-            ModuleOrderEntry e = (ModuleOrderEntry)entry;
-            toRemove.put(Pair.create(e.getModuleName(), e.getScope()), e);
-          }
+    final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+    Map<Pair<String /* dependency module internal name */, /* dependency module scope */DependencyScope>, ModuleOrderEntry> toRemove =
+      ContainerUtilRt.newHashMap();
+    for (OrderEntry entry : moduleRootManager.getOrderEntries()) {
+      if (entry instanceof ModuleOrderEntry) {
+        ModuleOrderEntry e = (ModuleOrderEntry)entry;
+        toRemove.put(Pair.create(e.getModuleName(), e.getScope()), e);
+      }
+    }
+
+    final ModifiableRootModel moduleRootModel = platformFacade.getModuleModifiableModel(module);
+    for (DataNode<ModuleDependencyData> dependencyNode : toImport) {
+      final ModuleDependencyData dependencyData = dependencyNode.getData();
+      toRemove.remove(Pair.create(dependencyData.getInternalName(), dependencyData.getScope()));
+      final String moduleName = dependencyData.getInternalName();
+      final Module ideDependencyModule = platformFacade.findIdeModule(moduleName, module.getProject());
+
+      ModuleOrderEntry orderEntry;
+      if (module.equals(ideDependencyModule)) {
+        // skip recursive module dependency check
+        continue;
+      }
+      else {
+        if (ideDependencyModule == null) {
+          LOG.warn(String.format("Can't import module dependency for '%s' module. Reason: target module (%s) is not found at the ide",
+                                 module.getName(), dependencyData));
         }
-
-        final ModifiableRootModel moduleRootModel = platformFacade.getModuleModifiableModel(module);
-        try {
-          for (DataNode<ModuleDependencyData> dependencyNode : toImport) {
-            final ModuleDependencyData dependencyData = dependencyNode.getData();
-            toRemove.remove(Pair.create(dependencyData.getInternalName(), dependencyData.getScope()));
-            final String moduleName = dependencyData.getInternalName();
-            Module ideDependencyModule = platformFacade.findIdeModule(moduleName, module.getProject());
-
-            ModuleOrderEntry orderEntry;
-            if (module.equals(ideDependencyModule)) {
-              // skip recursive module dependency check
-              continue;
-            } else  {
-              if(ideDependencyModule == null) {
-                LOG.warn(String.format(
-                  "Can't import module dependency for '%s' module. Reason: target module (%s) is not found at the ide",
-                  module.getName(), dependencyData
-                ));
-              }
-              orderEntry = platformFacade.findIdeModuleDependency(dependencyData, moduleRootModel);
-              if (orderEntry == null) {
-                orderEntry = ideDependencyModule == null
-                             ? moduleRootModel.addInvalidModuleEntry(moduleName)
-                             : moduleRootModel.addModuleOrderEntry(ideDependencyModule);
-              }
-            }
-
-            orderEntry.setScope(dependencyData.getScope());
-            orderEntry.setExported(dependencyData.isExported());
-          }
-        }
-        finally {
-          moduleRootModel.commit();
-        }
-
-        if (!toRemove.isEmpty()) {
-          removeData(toRemove.values(), module, platformFacade, synchronous);
+        orderEntry = platformFacade.findIdeModuleDependency(dependencyData, moduleRootModel);
+        if (orderEntry == null) {
+          orderEntry = ideDependencyModule == null
+                       ? moduleRootModel.addInvalidModuleEntry(moduleName)
+                       : moduleRootModel.addModuleOrderEntry(ideDependencyModule);
         }
       }
-    });
+
+      orderEntry.setScope(dependencyData.getScope());
+      orderEntry.setExported(dependencyData.isExported());
+    }
+
+    if (!toRemove.isEmpty()) {
+      removeData(toRemove.values(), moduleRootModel);
+    }
+
+    return moduleRootModel;
   }
 }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDependencyDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDependencyDataService.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.*;
 import com.intellij.openapi.util.Pair;
+import com.intellij.util.ExceptionUtil;
 import com.intellij.util.containers.ContainerUtilRt;
 import com.intellij.util.containers.MultiMap;
 import org.jetbrains.annotations.NotNull;
@@ -78,9 +79,9 @@ public class ModuleDependencyDataService extends AbstractDependencyDataService<M
       }
       ExternalSystemApiUtil.commitModels(synchronous, project, models);
     }
-    catch (Error e) {
+    catch (Throwable t) {
       ExternalSystemApiUtil.disposeModels(models);
-      throw e;
+      ExceptionUtil.rethrowUnchecked(t);
     }
   }
 

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDependencyDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ModuleDependencyDataService.java
@@ -63,11 +63,11 @@ public class ModuleDependencyDataService extends AbstractDependencyDataService<M
                          @NotNull Project project,
                          @NotNull PlatformFacade platformFacade,
                          boolean synchronous) {
-    final List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
+    List<ModifiableRootModel> models = ContainerUtilRt.newArrayList();
     try {
-      final MultiMap<DataNode<ModuleData>, DataNode<ModuleDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
+      MultiMap<DataNode<ModuleData>, DataNode<ModuleDependencyData>> byModule = ExternalSystemApiUtil.groupBy(toImport, MODULE);
       for (Map.Entry<DataNode<ModuleData>, Collection<DataNode<ModuleDependencyData>>> entry : byModule.entrySet()) {
-        final Module ideModule = platformFacade.findIdeModule(entry.getKey().getData(), project);
+        Module ideModule = platformFacade.findIdeModule(entry.getKey().getData(), project);
         if (ideModule == null) {
           LOG.warn(String.format(
             "Can't import module dependencies %s. Reason: target module (%s) is not found at the ide and can't be imported",
@@ -97,11 +97,11 @@ public class ModuleDependencyDataService extends AbstractDependencyDataService<M
   }
 
   @NotNull
-  private ModifiableRootModel importData(@NotNull final Collection<DataNode<ModuleDependencyData>> toImport,
-                                         @NotNull final Module module,
-                                         @NotNull final PlatformFacade platformFacade)
+  private ModifiableRootModel importData(@NotNull Collection<DataNode<ModuleDependencyData>> toImport,
+                                         @NotNull Module module,
+                                         @NotNull PlatformFacade platformFacade)
   {
-    final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+    ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
     Map<Pair<String /* dependency module internal name */, /* dependency module scope */DependencyScope>, ModuleOrderEntry> toRemove =
       ContainerUtilRt.newHashMap();
     for (OrderEntry entry : moduleRootManager.getOrderEntries()) {
@@ -111,12 +111,12 @@ public class ModuleDependencyDataService extends AbstractDependencyDataService<M
       }
     }
 
-    final ModifiableRootModel moduleRootModel = platformFacade.getModuleModifiableModel(module);
+    ModifiableRootModel moduleRootModel = platformFacade.getModuleModifiableModel(module);
     for (DataNode<ModuleDependencyData> dependencyNode : toImport) {
-      final ModuleDependencyData dependencyData = dependencyNode.getData();
+      ModuleDependencyData dependencyData = dependencyNode.getData();
       toRemove.remove(Pair.create(dependencyData.getInternalName(), dependencyData.getScope()));
-      final String moduleName = dependencyData.getInternalName();
-      final Module ideDependencyModule = platformFacade.findIdeModule(moduleName, module.getProject());
+      String moduleName = dependencyData.getInternalName();
+      Module ideDependencyModule = platformFacade.findIdeModule(moduleName, module.getProject());
 
       ModuleOrderEntry orderEntry;
       if (module.equals(ideDependencyModule)) {

--- a/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/ModuleRootManagerImpl.java
+++ b/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/ModuleRootManagerImpl.java
@@ -127,7 +127,7 @@ public class ModuleRootManagerImpl extends ModuleRootManager implements ModuleCo
         }
 
         for (OrderEntry entry : ModuleRootManagerImpl.this.getOrderEntries()) {
-          assert !((RootModelComponentBase)entry).isDisposed();
+          assert !((RootModelComponentBase)entry).isDisposed() : String.format("%s is not disposed!", entry.getPresentableName());
         }
       }
     };

--- a/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/libraries/LibraryImpl.java
+++ b/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/libraries/LibraryImpl.java
@@ -589,7 +589,9 @@ public class LibraryImpl extends TraceableDisposable implements LibraryEx.Modifi
   public void commit() {
     checkDisposed();
 
-    mySource.commit(this);
+    if (isChanged()) {
+      mySource.commit(this);
+    }
     Disposer.dispose(this);
   }
 

--- a/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/libraries/LibraryTableBase.java
+++ b/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/libraries/LibraryTableBase.java
@@ -167,6 +167,10 @@ public abstract class LibraryTableBase implements PersistentStateComponent<Eleme
   private void commit(LibraryModel model) {
     myFirstLoad = false;
     ApplicationManager.getApplication().assertWriteAccessAllowed();
+    if (!model.isChanged()) {
+      myModel = model;
+      return;
+    }
     //todo[nik] remove LibraryImpl#equals method instead of using identity sets
     Set<Library> addedLibraries = ContainerUtil.newIdentityTroveSet(model.myLibraries);
     addedLibraries.removeAll(myModel.myLibraries);


### PR DESCRIPTION
Description:

It appeared that most of the default services were executing a lot of write actions to commit models. Also services were committing models in write actions even if there were no changes to these models.

This refactoring tries to collect all the modifiable models and perform all commits in just one write action. Also before a commit all models are checked for changes. It affects performance of an incremental refresh drastically for huge projects.

Testing:

All 5 tests for external build system are passing. :-) Also manually tested on a project with 2227 modules. Incremental refresh on dependency/library changes was super fast!

It would be very nice if you guys can run the change on CI.