### PR TITLE
align chained methods with comments properly

### DIFF
--- a/java/java-impl/src/com/intellij/psi/formatter/java/AbstractJavaBlock.java
+++ b/java/java-impl/src/com/intellij/psi/formatter/java/AbstractJavaBlock.java
@@ -701,9 +701,9 @@ public abstract class AbstractJavaBlock extends AbstractBlock implements JavaBlo
     ASTNode child = node.getFirstChildNode();
     while (child != null) {
       if (!FormatterUtil.containsWhiteSpacesOnly(child)) {
-        if (child.getElementType() == JavaElementType.METHOD_CALL_EXPRESSION || child.getElementType() ==
-                                                                                JavaElementType
-                                                                                  .REFERENCE_EXPRESSION) {
+        IElementType type = child.getElementType();
+        if (type == JavaElementType.METHOD_CALL_EXPRESSION ||
+            type == JavaElementType.REFERENCE_EXPRESSION) {
           collectNodes(nodes, child);
         }
         else {

--- a/java/java-impl/src/com/intellij/psi/formatter/java/ChainMethodCallsBlockBuilder.java
+++ b/java/java-impl/src/com/intellij/psi/formatter/java/ChainMethodCallsBlockBuilder.java
@@ -75,8 +75,10 @@ class ChainMethodCallsBlockBuilder {
     for (int i = 0; i < methodCall.size(); i++) {
       ChainedCallChunk currentCallChunk = methodCall.get(i);
       if (isMethodCall(currentCallChunk)) {
-        if (myWrap == null) myWrap = createCallChunkWrap(i, methodCall);
-        if (myChainedCallsAlignment == null) myChainedCallsAlignment = createCallChunkAlignment(i, methodCall);
+        if (myWrap == null)
+          myWrap = createCallChunkWrap(i, methodCall);
+        if (myChainedCallsAlignment == null)
+          myChainedCallsAlignment = createCallChunkAlignment(i, methodCall);
       }
       else {
         myWrap = null;
@@ -137,7 +139,7 @@ class ChainMethodCallsBlockBuilder {
 
   private boolean isMethodCall(@NotNull ChainedCallChunk callChunk) {
     List<ASTNode> nodes = callChunk.nodes;
-    return !nodes.isEmpty() && nodes.get(nodes.size() - 1).getElementType() == JavaElementType.EXPRESSION_LIST;
+    return nodes.size() >= 3 && nodes.get(2).getElementType() == JavaElementType.EXPRESSION_LIST;
   }
 }
 

--- a/java/java-tests/testSrc/com/intellij/psi/formatter/java/JavaFormatterAlignmentTest.java
+++ b/java/java-tests/testSrc/com/intellij/psi/formatter/java/JavaFormatterAlignmentTest.java
@@ -51,16 +51,17 @@ public class JavaFormatterAlignmentTest extends AbstractJavaFormatterTest {
 
   public void testChainedMethodWithComments() throws Exception {
     getSettings().ALIGN_MULTILINE_CHAINED_METHODS = true;
-    doMethodTest("AA.bb()\n" +
-                 ".cc() // comment after line\n" +
-                 ".dd()\n " +
-                 "        /* block comment on empty line */\n" +
-                 ".ee();",
-                 "AA.bb()\n" +
-                 "  .cc() // comment after line\n" +
-                 "  .dd()\n " +
-                 "/* block comment on empty line */\n" +
-                 "  .ee();");
+    doMethodTest("AAAAA.b()\n" +
+                 ".c() // comment after line\n" +
+                 ".d()\n" +
+                 "        /* unaligned block comment on separate line */\n" +
+                 ".e();",
+
+                 "AAAAA.b()\n" +
+                 "     .c() // comment after line\n" +
+                 "     .d()\n" +
+                 "/* unaligned block comment on separate line */\n" +
+                 "     .e();");
   }
 
   public void testMultipleMethodAnnotationsCommentedInTheMiddle() throws Exception {

--- a/java/java-tests/testSrc/com/intellij/psi/formatter/java/JavaFormatterAlignmentTest.java
+++ b/java/java-tests/testSrc/com/intellij/psi/formatter/java/JavaFormatterAlignmentTest.java
@@ -49,6 +49,20 @@ public class JavaFormatterAlignmentTest extends AbstractJavaFormatterTest {
     );
   }
 
+  public void testChainedMethodWithComments() throws Exception {
+    getSettings().ALIGN_MULTILINE_CHAINED_METHODS = true;
+    doMethodTest("AA.bb()\n" +
+                 ".cc() // comment after line\n" +
+                 ".dd()\n " +
+                 "        /* block comment on empty line */\n" +
+                 ".ee();",
+                 "AA.bb()\n" +
+                 "  .cc() // comment after line\n" +
+                 "  .dd()\n " +
+                 "/* block comment on empty line */\n" +
+                 "  .ee();");
+  }
+
   public void testMultipleMethodAnnotationsCommentedInTheMiddle() throws Exception {
     getSettings().BLANK_LINES_AFTER_CLASS_HEADER = 1;
     getSettings().getRootSettings().getIndentOptions(StdFileTypes.JAVA).INDENT_SIZE = 4;
@@ -256,7 +270,7 @@ public class JavaFormatterAlignmentTest extends AbstractJavaFormatterTest {
       "}"
     );
   }
-  
+
   public void testAnnotatedAndNonAnnotatedFieldsInColumnsAlignment() {
     // Inspired by IDEA-60237
 
@@ -281,10 +295,10 @@ public class JavaFormatterAlignmentTest extends AbstractJavaFormatterTest {
       "}"
     );
   }
-  
+
   public void testAlignThrowsKeyword() throws Exception {
     // Inspired by IDEA-63820
-    
+
     getSettings().ALIGN_THROWS_KEYWORD = true;
     doClassTest(
       "public void test()\n" +


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IDEA-122802: 'Comments between chained calls aren't indented properly' and https://youtrack.jetbrains.com/issue/IDEA-136980: 'Comments at end of the line during chained calls break allignment'