### PR TITLE
Support modifying directory rendering.

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/projectView/impl/nodes/PsiDirectoryNode.java
+++ b/platform/lang-impl/src/com/intellij/ide/projectView/impl/nodes/PsiDirectoryNode.java
@@ -69,6 +69,10 @@ public class PsiDirectoryNode extends BasePsiNode<PsiDirectory> implements Navig
     return !PlatformUtils.isCidr();
   }
 
+  protected boolean shouldShowSourcesRoot() {
+    return true;
+  }
+
   @Override
   protected void updateImpl(PresentationData data) {
     Project project = getProject();
@@ -104,7 +108,7 @@ public class PsiDirectoryNode extends BasePsiNode<PsiDirectory> implements Navig
           final String location = FileUtil.getLocationRelativeToUserHome(directoryFile.getPresentableUrl());
           data.addText(" (" + location + ")", SimpleTextAttributes.GRAYED_ATTRIBUTES);
         }
-        else {
+        else if (shouldShowSourcesRoot()) {
           SourceFolder sourceRoot = ProjectRootsUtil.getModuleSourceRoot(directoryFile, project);
           if (sourceRoot != null) {
             ModuleSourceRootEditHandler<?> handler = ModuleSourceRootEditHandler.getEditHandler(sourceRoot.getRootType());


### PR DESCRIPTION
* Module names shown/not shown
* Source roots shown/not shown

This is used by TreeStructureProviders to suppress the rendering of the
above.

Change-Id: I9c6ccf82b6c85043adebc56c588e714e3e54203f