### PR TITLE
Fix file length check

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/persistent/PersistentFS.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/persistent/PersistentFS.java
@@ -64,6 +64,12 @@ public abstract class PersistentFS extends ManagingFS {
 
   public abstract String getName(int id);
 
+  /**
+   * Get the last length recorded for this file. If the file has changed since the length was recorded, this will return the stale length
+   * value.
+   */
+  public abstract long getLastRecordedLength(@NotNull VirtualFile file);
+
   public abstract boolean isHidden(@NotNull VirtualFile file);
 
   @Attributes

--- a/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/persistent/PersistentFSImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/persistent/PersistentFSImpl.java
@@ -400,14 +400,19 @@ public class PersistentFSImpl extends PersistentFS implements ApplicationCompone
   }
 
   @Override
+  public long getLastRecordedLength(@NotNull final VirtualFile file) {
+    final int id = getFileId(file);
+    return FSRecords.getLength(id);
+  }
+
+  @Override
   public long getLength(@NotNull final VirtualFile file) {
     long len;
     if (mustReloadContent(file)) {
       len = reloadLengthFromDelegate(file, getDelegate(file));
     }
     else {
-      final int id = getFileId(file);
-      len = FSRecords.getLength(id);
+      len = getLastRecordedLength(file);
     }
 
     return len;

--- a/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/persistent/RefreshWorker.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/persistent/RefreshWorker.java
@@ -136,7 +136,7 @@ public class RefreshWorker {
       else {
         long currentTimestamp = persistence.getTimeStamp(file);
         long upToDateTimestamp = attributes.lastModified;
-        long currentLength = persistence.getLength(file);
+        long currentLength = persistence.getLastRecordedLength(file);
         long upToDateLength = attributes.length;
 
         if (currentTimestamp != upToDateTimestamp || currentLength != upToDateLength) {


### PR DESCRIPTION
IJ uses the timestamp and file length to determine if two files
differ. In almost all cases, the timestamp will be sufficient
but there are some important use cases were timestamps are
manipulated inside of archives to ensure the archives only
differ when their actual contents differ.

The operation of reading the currently stored file size could
cause a read of file size from disk. That makes the up-to-date
check broken since it will be comparing the new file size to the
file size just read from disk, which should be the same as the
new file size.

Change-Id: I8d5d0e160c8d7fd4f1847af187e17226aebe7453