### PR TITLE
IDEA-146472 "Close Unmodified" also closes pinned tabs

### DIFF
--- a/platform/vcs-impl/src/com/intellij/ide/actions/CloseAllUnmodifiedEditorsAction.java
+++ b/platform/vcs-impl/src/com/intellij/ide/actions/CloseAllUnmodifiedEditorsAction.java
@@ -25,7 +25,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 public class CloseAllUnmodifiedEditorsAction extends CloseEditorsActionBase {
 
   protected boolean isFileToClose(final EditorComposite editor, final EditorWindow window) {
-    return !window.getManager().isChanged (editor);
+    return !window.getManager().isChanged(editor) && !window.isFilePinned(editor.getFile());
   }
 
   @Override


### PR DESCRIPTION
This is a fix for https://youtrack.jetbrains.com/issue/IDEA-146472 - using "Close Unmodified" also closed pinned tabs.