### PR TITLE
Disabled `PointlessArithmetic` inspection when the expression is non-resolvable

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/PointlessArithmeticExpressionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/PointlessArithmeticExpressionInspection.java
@@ -28,6 +28,7 @@ import com.siyeh.ig.BaseInspection;
 import com.siyeh.ig.BaseInspectionVisitor;
 import com.siyeh.ig.InspectionGadgetsFix;
 import com.siyeh.ig.PsiReplacementUtil;
+import com.siyeh.ig.psiutils.ClassUtils;
 import com.siyeh.ig.psiutils.EquivalenceChecker;
 import com.siyeh.ig.psiutils.ExpressionUtils;
 import com.siyeh.ig.psiutils.SideEffectChecker;
@@ -200,16 +201,12 @@ public class PointlessArithmeticExpressionInspection
       super.visitPolyadicExpression(expression);
       final PsiType expressionType = expression.getType();
       if (expressionType == null ||
-          PsiType.DOUBLE.equals(expressionType) ||
-          PsiType.FLOAT.equals(expressionType)) {
+          !ClassUtils.isIntegral(expressionType) ||
+          !arithmeticTokens.contains(expression.getOperationTokenType()) ||
+          PsiUtilCore.hasErrorElementChild(expression)) {
         return;
       }
-      if (!arithmeticTokens.contains(expression.getOperationTokenType())) {
-        return;
-      }
-      if (ExpressionUtils.hasStringType(expression) || PsiUtilCore.hasErrorElementChild(expression)) {
-        return;
-      }
+
       final PsiExpression[] operands = expression.getOperands();
       final IElementType tokenType = expression.getOperationTokenType();
       final boolean isPointless;

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/numeric/pointless_arithmetic_expression/PointlessArithmeticExpression.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/numeric/pointless_arithmetic_expression/PointlessArithmeticExpression.java
@@ -67,6 +67,10 @@ public class PointlessArithmeticExpression
         return 1.1 * d;
     }
 
+    Object boom(){
+        return "" + 1;
+    }
+
     void doubleDoom(int i) {
 
         if (i > Integer.MAX_VALUE) {

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/confusing/GroovyPointlessArithmeticInspection.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/confusing/GroovyPointlessArithmeticInspection.java
@@ -19,7 +19,6 @@ import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.tree.TokenSet;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -122,31 +121,27 @@ public class GroovyPointlessArithmeticInspection extends BaseInspection {
 
   private static class PointlessArithmeticVisitor extends BaseInspectionVisitor {
 
-    private final TokenSet arithmeticTokens = TokenSet.create(GroovyTokenTypes.mPLUS, GroovyTokenTypes.mMINUS, GroovyTokenTypes.mSTAR,
-                                                              GroovyTokenTypes.mDIV);
-
     @Override
     public void visitBinaryExpression(@NotNull GrBinaryExpression expression) {
       super.visitBinaryExpression(expression);
-      final GrExpression rhs = expression.getRightOperand();
-      if (rhs == null) return;
 
-      final IElementType sign = expression.getOperationTokenType();
-      if (!arithmeticTokens.contains(sign)) return;
+      if (expression.getType() == null) return;
 
       final GrExpression lhs = expression.getLeftOperand();
+      final IElementType operator = expression.getOperationTokenType();
+      final GrExpression rhs = expression.getRightOperand();
 
       final boolean isPointless;
-      if (sign.equals(GroovyTokenTypes.mPLUS)) {
+      if (operator.equals(GroovyTokenTypes.mPLUS)) {
         isPointless = additionExpressionIsPointless(lhs, rhs);
       }
-      else if (sign.equals(GroovyTokenTypes.mMINUS)) {
+      else if (operator.equals(GroovyTokenTypes.mMINUS)) {
         isPointless = subtractionExpressionIsPointless(rhs);
       }
-      else if (sign.equals(GroovyTokenTypes.mSTAR)) {
+      else if (operator.equals(GroovyTokenTypes.mSTAR)) {
         isPointless = multiplyExpressionIsPointless(lhs, rhs);
       }
-      else if (sign.equals(GroovyTokenTypes.mDIV)) {
+      else if (operator.equals(GroovyTokenTypes.mDIV)) {
         isPointless = divideExpressionIsPointless(rhs);
       }
       else {

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/spock/SpockTest.groovy
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/spock/SpockTest.groovy
@@ -22,7 +22,10 @@ import com.intellij.psi.PsiVariable
 import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
 import com.intellij.util.containers.ContainerUtil
 import org.jetbrains.plugins.groovy.codeInspection.assignment.GroovyAssignabilityCheckInspection
+import org.jetbrains.plugins.groovy.codeInspection.confusing.GroovyPointlessArithmeticInspection
 import org.jetbrains.plugins.groovy.codeInspection.untypedUnresolvedAccess.GrUnresolvedAccessInspection
+
+import static org.jetbrains.plugins.groovy.GroovyFileType.GROOVY_FILE_TYPE
 
 /**
  * @author Sergey Evdokimov
@@ -229,6 +232,25 @@ class FooSpec extends spock.lang.Specification {
 """)
 
     myFixture.checkHighlighting(true, false, true)
+  }
+
+  public void testPointlessArithmeticWarnings() {
+    myFixture.enableInspections GroovyPointlessArithmeticInspection
+
+    myFixture.configureByText GROOVY_FILE_TYPE, """
+      class Spec extends spock.lang.Specification {
+        def "GroovyPointlessArithmeticInspection"() {
+          given:  def a = Mock(A)
+          and:    <warning descr="1 * 1 can be replaced with '1'">1 * 1</warning>
+          and:    <warning descr="''.hashCode() + 0 can be replaced with '''.hashCode()'">''.hashCode() + 0</warning>
+
+          when:   a.b()
+          then:   1 * a.b()
+        }
+      }
+    """
+
+    myFixture.checkHighlighting()
   }
 
   public void testVariable_NotExistingInCompletion() {


### PR DESCRIPTION
Spock's [Mock interactions](https://spockframework.github.io/spock/docs/1.0/interaction_based_testing.html#_mocking) shouldn't be flagged as `PointlessArithmeticExpression`, e.g.
`0 * mockAmazonCloudWatchClient.putMetricAlarm(_)`
