### PR TITLE
Disabled `PointlessBoolean` inspection for Spock's data tables

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitor.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitor.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.util.Condition;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.PsiSubstitutorImpl;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.util.TypeConversionUtil;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
@@ -79,6 +78,7 @@ import java.util.Map;
 
 import static com.intellij.psi.util.PsiUtil.extractIterableTypeParameter;
 import static org.jetbrains.plugins.groovy.codeInspection.type.GroovyTypeCheckVisitorHelper.*;
+import static org.jetbrains.plugins.groovy.spock.SpockUtils.isSpockTimesOperator;
 
 public class GroovyTypeCheckVisitor extends BaseInspectionVisitor {
 

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitorHelper.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitorHelper.java
@@ -18,7 +18,6 @@ package org.jetbrains.plugins.groovy.codeInspection.type;
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.openapi.util.Pair;
 import com.intellij.psi.*;
-import com.intellij.psi.util.InheritanceUtil;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
@@ -29,7 +28,6 @@ import org.jetbrains.plugins.groovy.codeInspection.assignment.CallInfo;
 import org.jetbrains.plugins.groovy.codeInspection.assignment.ParameterCastFix;
 import org.jetbrains.plugins.groovy.codeInspection.utils.ControlFlowUtils;
 import org.jetbrains.plugins.groovy.findUsages.LiteralConstructorReference;
-import org.jetbrains.plugins.groovy.lang.lexer.GroovyTokenTypes;
 import org.jetbrains.plugins.groovy.lang.psi.GrControlFlowOwner;
 import org.jetbrains.plugins.groovy.lang.psi.GroovyPsiElement;
 import org.jetbrains.plugins.groovy.lang.psi.api.GroovyResolveResult;
@@ -45,7 +43,6 @@ import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrAssign
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrBinaryExpression;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrExpression;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrReferenceExpression;
-import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.literals.GrLiteral;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.path.GrIndexProperty;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.path.GrMethodCallExpression;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.typedef.members.GrMember;
@@ -56,7 +53,6 @@ import org.jetbrains.plugins.groovy.lang.psi.impl.signatures.GrClosureSignatureU
 import org.jetbrains.plugins.groovy.lang.psi.impl.statements.expressions.TypesUtil;
 import org.jetbrains.plugins.groovy.lang.psi.util.GdkMethodUtil;
 import org.jetbrains.plugins.groovy.lang.psi.util.PsiUtil;
-import org.jetbrains.plugins.groovy.spock.SpockUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -134,20 +130,6 @@ public class GroovyTypeCheckVisitorHelper {
     for (PsiElement child = e.getFirstChild(); child != null; child = child.getNextSibling()) {
       if (child instanceof PsiErrorElement) return true;
     }
-    return false;
-  }
-
-  public static boolean isSpockTimesOperator(GrBinaryExpression call) {
-    if (call.getOperationTokenType() == GroovyTokenTypes.mSTAR && PsiUtil.isExpressionStatement(call)) {
-      GrExpression operand = call.getLeftOperand();
-      if (operand instanceof GrLiteral && TypesUtil.isNumericType(operand.getType())) {
-        PsiClass aClass = PsiUtil.getContextClass(call);
-        if (InheritanceUtil.isInheritor(aClass, false, SpockUtils.SPEC_CLASS_NAME)) {
-          return true;
-        }
-      }
-    }
-
     return false;
   }
 

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/spock/SpockTest.groovy
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/spock/SpockTest.groovy
@@ -22,7 +22,10 @@ import com.intellij.psi.PsiVariable
 import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
 import com.intellij.util.containers.ContainerUtil
 import org.jetbrains.plugins.groovy.codeInspection.assignment.GroovyAssignabilityCheckInspection
+import org.jetbrains.plugins.groovy.codeInspection.confusing.GroovyPointlessBooleanInspection
 import org.jetbrains.plugins.groovy.codeInspection.untypedUnresolvedAccess.GrUnresolvedAccessInspection
+
+import static org.jetbrains.plugins.groovy.GroovyFileType.GROOVY_FILE_TYPE
 
 /**
  * @author Sergey Evdokimov
@@ -245,4 +248,21 @@ class FooSpec extends spock.lang.Specification {
     assert !elements.contains("_")
   }
 
+  public void testPointlessBooleanWarnings() {
+    myFixture.enableInspections GroovyPointlessBooleanInspection
+
+    myFixture.configureByText GROOVY_FILE_TYPE, '''
+      class Spec extends spock.lang.Specification {
+        def "GroovyPointlessBooleanInspection"() {
+          expect: <warning descr="false || true can be simplified to 'true'">false || true</warning>
+          where:  isA    || isB
+                  false  || true
+                  (a==b) || false
+                  true   || (1==0)
+        }
+      }
+    '''
+
+    myFixture.checkHighlighting()
+  }
 }


### PR DESCRIPTION
Spock's [data tables](https://spockframework.github.io/spock/docs/1.0/data_driven_testing.html#data-tables) aren't real boolean expressions, and shouldn't be flagged as `PointlessBoolean`, e.g.

```
where:  isA    || isB
        false  || true
        (a==b) || false
        true   || (1==0)
```

(I did this PR, because it has id #314 :p)
![pi](https://cloud.githubusercontent.com/assets/1841944/10717974/4e816ae8-7b70-11e5-8b44-f34f453291ed.png)
