### PR TITLE
Make NativeFileWatcherImpl more generic

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
@@ -133,12 +133,16 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
     setWatchRoots(recursive, flat, false);
   }
 
-  /* helper methods subclasses can override to launch custom binary */
-
+  /**
+   * Subclasses should override this method if they want to use custom logic to disable their file watcher.
+   */
   protected boolean isDisabled() {
     return Boolean.parseBoolean(System.getProperty(PROPERTY_WATCHER_DISABLED));
   }
 
+  /**
+   * Subclasses should override this method to provide a custom binary to run.
+   */
   @Nullable
   protected File getExecutable() {
     String execPath = System.getProperty(PROPERTY_WATCHER_EXECUTABLE_PATH);

--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
@@ -84,7 +84,7 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
     myNotificationSink = notificationSink;
 
     boolean disabled = isDisabled();
-    myExecutable = getWatcherExecutable();
+    myExecutable = getExecutable();
 
     if (disabled) {
       LOG.info("Native file watcher is disabled");
@@ -140,14 +140,7 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
   }
 
   @Nullable
-  protected File getWatcherExecutable() {
-    return getExecutable();
-  }
-
-  /* internal stuff */
-
-  @Nullable
-  private static File getExecutable() {
+  protected File getExecutable() {
     String execPath = System.getProperty(PROPERTY_WATCHER_EXECUTABLE_PATH);
     if (execPath != null) return new File(execPath);
 
@@ -179,6 +172,8 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
 
     return null;
   }
+
+  /* internal stuff */
 
   private void notifyOnFailure(String cause, @Nullable NotificationListener listener) {
     myNotificationSink.notifyUserOnFailure(cause, listener);

--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
@@ -59,6 +59,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class NativeFileWatcherImpl extends PluggableFileWatcher {
   private static final Logger LOG = Logger.getInstance(NativeFileWatcherImpl.class);
 
+  private static final String PROPERTY_WATCHER_DISABLED = "idea.filewatcher.disabled";
+  private static final String PROPERTY_WATCHER_EXECUTABLE_PATH = "idea.filewatcher.executable.path";
   private static final String ROOTS_COMMAND = "ROOTS";
   private static final String EXIT_COMMAND = "EXIT";
   private static final int MAX_PROCESS_LAUNCH_ATTEMPT_COUNT = 10;
@@ -76,74 +78,13 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
   private final String[] myLastChangedPaths = new String[2];
   private int myLastChangedPathIndex;
 
-  protected interface WatcherSettingsProvider {
-    boolean isWatcherDisabled();
-    @Nullable
-    File getWatcherExecutablePath();
-  }
-
-  protected static final class NativeWatcherSettingsProvider implements WatcherSettingsProvider {
-    private static final String PROPERTY_WATCHER_DISABLED = "idea.filewatcher.disabled";
-    private static final String PROPERTY_WATCHER_EXECUTABLE_PATH = "idea.filewatcher.executable.path";
-
-    @Override
-    public boolean isWatcherDisabled() {
-      return Boolean.parseBoolean(System.getProperty(PROPERTY_WATCHER_DISABLED));
-    }
-
-    @Nullable
-    @Override
-    public File getWatcherExecutablePath() {
-      String execPath = System.getProperty(PROPERTY_WATCHER_EXECUTABLE_PATH);
-      if (execPath != null) return new File(execPath);
-
-      String[] names = null;
-      String prefix = null;
-      if (SystemInfo.isWindows) {
-        names = SystemInfo.is64Bit ? new String[]{"fsnotifier64.exe", "fsnotifier.exe"} : new String[]{"fsnotifier.exe"};
-        prefix = "win";
-      }
-      else if (SystemInfo.isMac) {
-        names = new String[]{"fsnotifier"};
-        prefix = "mac";
-      }
-      else if (SystemInfo.isLinux) {
-        String arch = "arm".equals(SystemInfo.OS_ARCH) ? "-arm" : "ppc".equals(SystemInfo.OS_ARCH) ? "-ppc" : "";
-        String bits = SystemInfo.is64Bit ? "64" : "";
-        names = new String[]{"fsnotifier" + arch + bits};
-        prefix = "linux";
-      }
-      if (names == null) return null;
-
-      String[] dirs = {PathManager.getBinPath(), PathManager.getHomePath() + "/community/bin/" + prefix, PathManager.getBinPath() + '/' + prefix};
-      for (String dir : dirs) {
-        for (String name : names) {
-          File candidate = new File(dir, name);
-          if (candidate.exists()) return candidate;
-        }
-      }
-
-      return null;
-    }
-  }
-
-  @NotNull private final WatcherSettingsProvider myWatcherSettingsProvider;
-
-  public NativeFileWatcherImpl() {
-    this(new NativeWatcherSettingsProvider());
-  }
-
-  protected NativeFileWatcherImpl(@NotNull WatcherSettingsProvider watcherSettingsProvider) {
-    this.myWatcherSettingsProvider = watcherSettingsProvider;
-  }
-
   @Override
   public void initialize(@NotNull ManagingFS managingFS, @NotNull FileWatcherNotificationSink notificationSink) {
     myManagingFS = managingFS;
     myNotificationSink = notificationSink;
 
-    boolean disabled = myWatcherSettingsProvider.isWatcherDisabled();
-    myExecutable = myWatcherSettingsProvider.getWatcherExecutablePath();
+    boolean disabled = isDisabled();
+    myExecutable = getWatcherExecutable();
 
     if (disabled) {
       LOG.info("Native file watcher is disabled");
@@ -192,7 +133,53 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
     setWatchRoots(recursive, flat, false);
   }
 
+  /* helper methods subclasses can override to launch custom binary */
+
+  protected boolean isDisabled() {
+    return Boolean.parseBoolean(System.getProperty(PROPERTY_WATCHER_DISABLED));
+  }
+
+  @Nullable
+  protected File getWatcherExecutable() {
+    return getExecutable();
+  }
+
   /* internal stuff */
+
+  @Nullable
+  private static File getExecutable() {
+    String execPath = System.getProperty(PROPERTY_WATCHER_EXECUTABLE_PATH);
+    if (execPath != null) return new File(execPath);
+
+    String[] names = null;
+    String prefix = null;
+    if (SystemInfo.isWindows) {
+      names = SystemInfo.is64Bit ? new String[]{"fsnotifier64.exe", "fsnotifier.exe"} : new String[]{"fsnotifier.exe"};
+      prefix = "win";
+    }
+    else if (SystemInfo.isMac) {
+      names = new String[]{"fsnotifier"};
+      prefix = "mac";
+    }
+    else if (SystemInfo.isLinux) {
+      String arch = "arm".equals(SystemInfo.OS_ARCH) ? "-arm" : "ppc".equals(SystemInfo.OS_ARCH) ? "-ppc" : "";
+      String bits = SystemInfo.is64Bit ? "64" : "";
+      names = new String[]{"fsnotifier" + arch + bits};
+      prefix = "linux";
+    }
+    if (names == null) return null;
+
+    String[] dirs = {PathManager.getBinPath(), PathManager.getHomePath() + "/community/bin/" + prefix, PathManager.getBinPath() + '/' + prefix};
+    for (String dir : dirs) {
+      for (String name : names) {
+        File candidate = new File(dir, name);
+        if (candidate.exists()) return candidate;
+      }
+    }
+
+    return null;
+  }
+
   private void notifyOnFailure(String cause, @Nullable NotificationListener listener) {
     myNotificationSink.notifyUserOnFailure(cause, listener);
   }


### PR DESCRIPTION
NativeFileWatcherImpl is nearly generic. It currently hard codes
the property name to look up to find the path to fsnotifier and
the property name to look up to see if the file watcher should
be disabled.

This pushes those values into a provider that subclasses can
provide.