### PR TITLE
Add support for sending a module name to pydevd

### DIFF
--- a/python/helpers/pydev/pydev_monkey.py
+++ b/python/helpers/pydev/pydev_monkey.py
@@ -51,8 +51,13 @@ def patch_args(args):
             return args
 
         i = 1
+        is_module = False
         while i < len(args):
-            if args[i].startswith('-'):
+            if args[i] == "-m":
+                is_module = True
+                i += 1
+                break
+            elif args[i].startswith('-'):
                 new_args.append(args[i])
             else:
                 break
@@ -68,6 +73,8 @@ def patch_args(args):
                 arg = x
             new_args.append(arg)
             if x == '--file':
+                if is_module:
+                    new_args.insert(-1, '--module')
                 break
 
         while i < len(args):


### PR DESCRIPTION
Previously, the args for a subprocess spawned under debug with a module specified via `-m` would get rewritten incorrectly, resulting in the `-m` flag being split from the module name. This resulted in running a command similar to `/usr/bin/python -m /path/to/pydevd.py --someargs --file [module]`, which doesn't work. This removes the `-m` from that command and adds a `--command` flag passed to pydevd, which results in correctly running as a module instead of a file.