### PR TITLE
Do allocation-less clear() operations for empty structures.

### DIFF
--- a/platform/util/src/com/intellij/util/containers/SLRUMap.java
+++ b/platform/util/src/com/intellij/util/containers/SLRUMap.java
@@ -141,15 +141,19 @@ public class SLRUMap<K,V> {
   }
 
   public void clear() {
-    for (Map.Entry<K, V> entry : myProtectedQueue.entrySet()) {
-      onDropFromCache(entry.getKey(), entry.getValue());
+    if (!myProtectedQueue.isEmpty()) {
+      for (Map.Entry<K, V> entry : myProtectedQueue.entrySet()) {
+        onDropFromCache(entry.getKey(), entry.getValue());
+      }
+      myProtectedQueue.clear();
     }
-    myProtectedQueue.clear();
 
-    for (Map.Entry<K, V> entry : myProbationalQueue.entrySet()) {
-      onDropFromCache(entry.getKey(), entry.getValue());
+    if (!myProbationalQueue.isEmpty()) {
+      for (Map.Entry<K, V> entry : myProbationalQueue.entrySet()) {
+        onDropFromCache(entry.getKey(), entry.getValue());
+      }
+      myProbationalQueue.clear();
     }
-    myProbationalQueue.clear();
   }
 
   protected K getStableKey(K key) {

--- a/platform/util/src/com/intellij/util/containers/hash/HashMap.java
+++ b/platform/util/src/com/intellij/util/containers/hash/HashMap.java
@@ -70,6 +70,10 @@ public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
   @Override
   public void clear() {
 
+    if (isEmpty())
+
+      return;
+
     clear(0);
   }
 

--- a/platform/util/src/com/intellij/util/containers/hash/LinkedHashMap.java
+++ b/platform/util/src/com/intellij/util/containers/hash/LinkedHashMap.java
@@ -77,6 +77,8 @@ public class LinkedHashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> 
 
   @Override
   public void clear() {
+    if (isEmpty())
+      return;
     clear(0);
   }
 


### PR DESCRIPTION
In SLRUMap, HashMap and LinkedHashMap, the clear() operation performs
allocations when these structures are already empty. These are called on
worker threads regularly, resulting in a lot of allocations being made
for what is essentially a no-op.