### PR TITLE
IDEA-91198 Maximize views in floating mode

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/FloatingDecorator.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/FloatingDecorator.java
@@ -40,7 +40,7 @@ import java.awt.event.WindowEvent;
  * @author Anton Katilin
  * @author Vladimir Kondratyev
  */
-public final class FloatingDecorator extends JDialog {
+public final class FloatingDecorator extends JFrame {
   private static final Logger LOG=Logger.getInstance("#com.intellij.openapi.wm.impl.FloatingDecorator");
 
   static final int DIVIDER_WIDTH = 3;
@@ -66,12 +66,11 @@ public final class FloatingDecorator extends JDialog {
   private float myEndRatio; // start and end alpha ratio for transparency animation
 
 
-  FloatingDecorator(final IdeFrameImpl owner,final WindowInfoImpl info,final InternalDecorator internalDecorator){
-    super(owner,internalDecorator.getToolWindow().getId());
+  FloatingDecorator(final WindowInfoImpl info,final InternalDecorator internalDecorator){
+    super(internalDecorator.getToolWindow().getId());
     MnemonicHelper.init(getContentPane());
     myInternalDecorator=internalDecorator;
 
-    setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
     final JComponent cp=(JComponent)getContentPane();
     cp.setLayout(new BorderLayout());
 
@@ -84,11 +83,13 @@ public final class FloatingDecorator extends JDialog {
       cp.add(myInternalDecorator,BorderLayout.CENTER);
     }else{
       // Due to JDK's bug #4234645 we cannot support custom decoration on Linux platform.
-      // The prblem is that Window.setLocation() doesn't work properly wjen the dialod is displayable.
+      // The problem is that Window.setLocation() doesn't work properly when the dialog is displayable.
       // Therefore we use native WM decoration.
       // TODO[vova] investigate the problem under Mac OSX.
       cp.add(myInternalDecorator,BorderLayout.CENTER);
-      getRootPane().putClientProperty("Window.style", "small");
+
+      // Due to a problem with rendering full screen button in small window style, using normal style for now
+      //getRootPane().putClientProperty("Window.style", "small");
     }
 
     setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowManagerImpl.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.openapi.wm.impl;
 
+import com.apple.eawt.FullScreenUtilities;
 import com.intellij.ide.FrameStateManager;
 import com.intellij.ide.IdeEventQueue;
 import com.intellij.ide.actions.ActivateToolWindowAction;
@@ -2096,7 +2097,7 @@ public final class ToolWindowManagerImpl extends ToolWindowManagerEx implements 
      */
     private AddFloatingDecoratorCmd(final InternalDecorator decorator, final WindowInfoImpl info) {
       super(myWindowManager.getCommandProcessor());
-      myFloatingDecorator = new FloatingDecorator(myFrame, info.copy(), decorator);
+      myFloatingDecorator = new FloatingDecorator(info.copy(), decorator);
       myId2FloatingDecorator.put(info.getId(), myFloatingDecorator);
       final Rectangle bounds = info.getFloatingBounds();
       if (bounds != null &&
@@ -2118,6 +2119,7 @@ public final class ToolWindowManagerImpl extends ToolWindowManagerEx implements 
     @Override
     public void run() {
       try {
+        FullScreenUtilities.setWindowCanFullScreen(myFloatingDecorator, true);
         myFloatingDecorator.show();
       }
       finally {


### PR DESCRIPTION
by making floating mode window a full-fledged 
frame thus making it possible to expand the window 
by double-click and use multiple desktops feature 
on Mac which is especially useful with split views