### PR TITLE
Notify frameworks about absence of library

### DIFF
--- a/java/idea-ui/src/com/intellij/facet/impl/ui/libraries/LibraryOptionsPanel.java
+++ b/java/idea-ui/src/com/intellij/facet/impl/ui/libraries/LibraryOptionsPanel.java
@@ -509,6 +509,18 @@ public class LibraryOptionsPanel implements Disposable {
     return mySettings;
   }
 
+  public boolean isLibrarySelected() {
+    Choice selected = myButtonEnumModel.getSelected();
+    switch (selected) {
+      case USE_LIBRARY:
+        return myExistingLibraryComboBox.getSelectedItem() != null;
+      case SETUP_LIBRARY_LATER:
+        return false;
+      default:
+        return true;
+    }
+  }
+
   @Nullable
   public LibraryCompositionSettings apply() {
     if (mySettings == null) return null;

--- a/java/idea-ui/src/com/intellij/framework/addSupport/FrameworkSupportInModuleConfigurable.java
+++ b/java/idea-ui/src/com/intellij/framework/addSupport/FrameworkSupportInModuleConfigurable.java
@@ -57,6 +57,10 @@ public abstract class FrameworkSupportInModuleConfigurable implements Disposable
     return true;
   }
 
+  public boolean validateNoLibrary() {
+    return true;
+  }
+
   @Override
   public void dispose() {
   }

--- a/java/idea-ui/src/com/intellij/ide/projectWizard/ProjectTypeStep.java
+++ b/java/idea-ui/src/com/intellij/ide/projectWizard/ProjectTypeStep.java
@@ -559,7 +559,15 @@ public class ProjectTypeStep extends ModuleWizardStep implements SettingsStep, D
       if (!mySettingsStep.validate()) return false;
     }
     ModuleWizardStep step = getCustomStep();
-    return step != null ? step.validate() : super.validate();
+    if (step != null && !step.validate()) {
+      return false;
+    }
+
+    if (isFrameworksMode() && !myFrameworksPanel.validate()) {
+      return false;
+    }
+
+    return super.validate();
   }
 
   @Override

--- a/java/idea-ui/src/com/intellij/ide/util/frameworkSupport/AddFrameworkSupportDialog.java
+++ b/java/idea-ui/src/com/intellij/ide/util/frameworkSupport/AddFrameworkSupportDialog.java
@@ -87,6 +87,10 @@ public class AddFrameworkSupportDialog extends DialogWrapper {
   }
 
   protected void doOKAction() {
+    if (!myAddSupportPanel.validate()) {
+      return;
+    }
+
     if (myAddSupportPanel.hasSelectedFrameworks()) {
       if (!myAddSupportPanel.downloadLibraries()) {
         int answer = Messages.showYesNoDialog(myAddSupportPanel.getMainPanel(),
@@ -110,6 +114,7 @@ public class AddFrameworkSupportDialog extends DialogWrapper {
         }
       });
     }
+
     super.doOKAction();
   }
 

--- a/java/idea-ui/src/com/intellij/ide/util/newProjectWizard/AddSupportForFrameworksPanel.java
+++ b/java/idea-ui/src/com/intellij/ide/util/newProjectWizard/AddSupportForFrameworksPanel.java
@@ -194,6 +194,31 @@ public class AddSupportForFrameworksPanel implements Disposable {
     }
   }
 
+  public boolean validate() {
+    List<FrameworkSupportNode> selectedFrameworks = getSelectedNodes();
+    sortFrameworks(selectedFrameworks);
+
+    for (FrameworkSupportNode node : selectedFrameworks) {
+
+      FrameworkSupportOptionsComponent optionsComponent = myInitializedOptionsComponents.get(node);
+      if (optionsComponent == null) continue;
+
+      final LibraryOptionsPanel optionsPanel = optionsComponent.getLibraryOptionsPanel();
+      if (optionsPanel == null) continue;
+
+      FrameworkSupportInModuleConfigurable configurable = node.getConfigurable();
+
+      boolean librarySelected = optionsPanel.isLibrarySelected();
+      if (!librarySelected) {
+        if (!configurable.validateNoLibrary()) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
   @Override
   public void dispose() {
   }


### PR DESCRIPTION
 It's easy to skip configuring library during project creation but it can be difficult to configure libraries afterwards.
 It can cause problems for Kotlin (KT-10488), Scala, Groovy

 This callback can be used to give an additional warning similar to "No SDK Specified" (title.no.jdk.specified)