### PR TITLE
LightVirtualFile type fix

### DIFF
--- a/platform/core-impl/src/com/intellij/psi/impl/PsiFileFactoryImpl.java
+++ b/platform/core-impl/src/com/intellij/psi/impl/PsiFileFactoryImpl.java
@@ -78,7 +78,10 @@ public class PsiFileFactoryImpl extends PsiFileFactory {
                                     boolean eventSystemEnabled, boolean markAsCopy, boolean noSizeLimit,
                                     @Nullable VirtualFile original) {
     LightVirtualFile virtualFile = new LightVirtualFile(name, language, text);
-    if (original != null) virtualFile.setOriginalFile(original);
+    if (original != null){
+      virtualFile.setOriginalFile(original);
+      virtualFile.setFileType(original.getFileType());
+    }
     if (noSizeLimit) {
       SingleRootFileViewProvider.doNotCheckFileSizeLimit(virtualFile);
     }


### PR DESCRIPTION
LigthVirtualFile contains incorrect file type when created from text but has originalFile