### PR TITLE
IDEA-139310: Find Usages reports source code usages first

### DIFF
--- a/platform/usageView/src/com/intellij/usages/impl/rules/NonCodeUsageGroupingRule.java
+++ b/platform/usageView/src/com/intellij/usages/impl/rules/NonCodeUsageGroupingRule.java
@@ -44,7 +44,7 @@ public class NonCodeUsageGroupingRule implements UsageGroupingRule {
     private static final UsageGroup INSTANCE = new CodeUsageGroup();
 
     private CodeUsageGroup() {
-      super(1);
+      super(0);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class NonCodeUsageGroupingRule implements UsageGroupingRule {
     public static final UsageGroup INSTANCE = new UsageInGeneratedCodeGroup();
 
     private UsageInGeneratedCodeGroup() {
-      super(2);
+      super(3);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class NonCodeUsageGroupingRule implements UsageGroupingRule {
     public static final UsageGroup INSTANCE = new NonCodeUsageGroup();
 
     private NonCodeUsageGroup() {
-      super(0);
+      super(2);
     }
 
     @Override
@@ -105,7 +105,7 @@ public class NonCodeUsageGroupingRule implements UsageGroupingRule {
     @NonNls private static final String DYNAMIC_CAPTION = "Dynamic usages";
 
     public DynamicUsageGroup() {
-      super(3);
+      super(1);
     }
 
     @Override


### PR DESCRIPTION
This builds upon 327c0facb1ed52945d2d24b3429ca456b6068416 and does what the [issue](https://youtrack.jetbrains.com/issue/IDEA-139310) asks for and people require: source code usages
(static or "dynamic") first, non-code usages (documentation) second, and generated code last..

No CLA necessary. If you agree, please apply the change in your name.