### PR TITLE
Sort when writing plugin list

### DIFF
--- a/platform/core-impl/src/com/intellij/ide/plugins/PluginManagerCore.java
+++ b/platform/core-impl/src/com/intellij/ide/plugins/PluginManagerCore.java
@@ -209,7 +209,8 @@ public class PluginManagerCore {
 
   public static void writePluginsList(@NotNull Collection<String> ids, @NotNull Writer writer) throws IOException {
     try {
-      for (String id : ids) {
+      PriorityQueue<String> sortedIds = new PriorityQueue<String>(ids);
+      for (String id : sortedIds) {
         writer.write(id);
         writer.write(LineSeparator.getSystemLineSeparator().getSeparatorString());
       }


### PR DESCRIPTION
This sorts plugin lists when writing to disk.

I try to keep as much of my IntelliJ configuration in version control as possible. `disabled_plugins.txt` is an obnoxious file because it gets jumbled into a different order every time it's written to disk, resulting in a lot of unnecessary diffs. So it's nice to have it sorted just to keep the order consistent.

I haven't been able to successfully build this project yet, so this change is untested. I'm hoping it's simple enough, though.