### PR TITLE
Fix broken link in plugin README

### DIFF
--- a/plugins/settings-repository/README.md
+++ b/plugins/settings-repository/README.md
@@ -11,7 +11,7 @@ Don't try to install plugin from disk — otherwise you have to be aware of comp
 Use File -> Settings Repository… to configure.
 
 Specify URL of upstream Git repository. File URL is supported, you will be prompted to init repository if specified path is not exists or repository is not created.
-[GitHub](www.github.com) could be used to store settings.
+[GitHub](https://www.github.com) could be used to store settings.
 
 Synchronization is performed automatically after successful completion of "Update Project" or "Push" actions. Also you can do sync using "VCS -> Sync Settings". The idea is do not disturb you. If you invoke such actions, so, you are ready to solve possible problems.
 


### PR DESCRIPTION
Link to GitHub was broken due to missing `https` prefix (was treated as `https://github.com/JetBrains/intellij-community/blob/master/plugins/settings-repository/www.github.com`).