### PR TITLE
[Fernflower] Make the default renamer rename classes that have a name that is reserved by the windows namespace

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -28,6 +28,10 @@ public class ConverterHelper implements IIdentifierRenamer {
     "protected", "throw", "byte", "extends", "instanceof", "public", "throws", "case", "false", "int", "return", "transient", "catch",
     "final", "interface", "short", "true", "char", "finally", "long", "static", "try", "class", "float", "native", "strictfp", "void",
     "const", "for", "new", "super", "volatile", "continue", "goto", "null", "switch", "while", "default", "assert", "enum"));
+  private static final Set<String> RESERVED_WINDOWS_NAMESPACE = new HashSet<String>(Arrays.asList(
+    "aux", "prn", "aux", "nul",
+    "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+    "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"));
 
   private int classCounter = 0;
   private int fieldCounter = 0;
@@ -37,7 +41,8 @@ public class ConverterHelper implements IIdentifierRenamer {
   @Override
   public boolean toBeRenamed(Type elementType, String className, String element, String descriptor) {
     String value = elementType == Type.ELEMENT_CLASS ? className : element;
-    return value == null || value.length() == 0 || value.length() <= 2 || KEYWORDS.contains(value) || Character.isDigit(value.charAt(0));
+    return value == null || value.length() == 0 || value.length() <= 2 || KEYWORDS.contains(value) || Character.isDigit(value.charAt(0))
+      || elementType == Type.ELEMENT_CLASS && RESERVED_WINDOWS_NAMESPACE.contains(value.toLowerCase());
   }
 
   // TODO: consider possible conflicts with not renamed classes, fields and methods!

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
@@ -208,7 +208,8 @@ public class ConstantPool implements NewClassNameBuilder {
       String newClassName = buildNewClassname(ln.classname);
       String newElement = interceptor.getName(ln.classname + ' ' + ln.elementname + ' ' + ln.descriptor);
       String newDescriptor = buildNewDescriptor(ln.type == CodeConstants.CONSTANT_Fieldref, ln.descriptor);
-
+      //TODO: Fix newElement being null caused by ln.classname being a leaf class instead of the class that declared the field/method.
+      //See the comments of IDEA-137253 for more information.
       if (newClassName != null || newElement != null || newDescriptor != null) {
         String className = newClassName == null ? ln.classname : newClassName;
         String elementName = newElement == null ? ln.elementname : newElement.split(" ")[1];


### PR DESCRIPTION
This commit makes fernflowers default renamer rename classes that have a name that is reserved by the windows namespace. See [https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#naming_conventions](url) for more information on names reserved by the windows namespace. There are currently obfuscators that take advantage of the fact that classes with these names cannot be extracted from a jar. An example of one such obfuscator is Allatori [http://www.allatori.com/doc.html#property-classes-naming](url).

I have previously signed the CLA.