### PR TITLE
Create From Usage: Introduce JVMElementMutableView to modify elements in other JVM-compliant languages

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateAnnotationMethodFromUsageFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateAnnotationMethodFromUsageFix.java
@@ -58,7 +58,7 @@ public class CreateAnnotationMethodFromUsageFix extends CreateFromUsageBaseFix {
   }
 
   @Override
-  protected void invokeImpl(final PsiClass targetClass) {
+  protected void invokeImpl(final PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     if (targetClass == null) return;
 
     PsiNameValuePair nameValuePair = getNameValuePair();
@@ -84,7 +84,7 @@ public class CreateAnnotationMethodFromUsageFix extends CreateFromUsageBaseFix {
     final ExpectedTypeInfo[] expectedTypes =
       new ExpectedTypeInfo[]{ExpectedTypesProvider.createInfo(type, ExpectedTypeInfo.TYPE_OR_SUBTYPE, type, TailType.NONE)};
     CreateMethodFromUsageFix.doCreate(targetClass, method, true, ContainerUtil.map2List(PsiExpression.EMPTY_ARRAY, Pair.<PsiExpression, PsiType>createFunction(null)),
-                                      getTargetSubstitutor(nameValuePair), expectedTypes, context);
+                                      getTargetSubstitutor(nameValuePair), expectedTypes, context, mutableView);
   }
 
   @Nullable

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateConstructorFromCallFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateConstructorFromCallFix.java
@@ -30,6 +30,7 @@ import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class CreateConstructorFromCallFix extends CreateFromUsageBaseFix {
   }
 
   @Override
-  protected void invokeImpl(final PsiClass targetClass) {
+  protected void invokeImpl(final PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     final Project project = myConstructorCall.getProject();
     JVMElementFactory elementFactory = JVMElementFactories.getFactory(targetClass.getLanguage(), project);
     if (elementFactory == null) elementFactory = JavaPsiFacade.getElementFactory(project);
@@ -67,7 +68,7 @@ public class CreateConstructorFromCallFix extends CreateFromUsageBaseFix {
 
       constructor = CodeInsightUtilCore.forcePsiPostprocessAndRestoreElement(constructor);
       Template template = templateBuilder.buildTemplate();
-      final Editor editor = positionCursor(project, targetClass.getContainingFile(), targetClass);
+      final Editor editor = positionCursor(project, targetClass.getContainingFile(), targetClass, mutableView);
       if (editor == null) return;
       final TextRange textRange = constructor.getTextRange();
       editor.getDocument().deleteString(textRange.getStartOffset(), textRange.getEndOffset());

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateConstructorFromThisOrSuperFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateConstructorFromThisOrSuperFix.java
@@ -33,6 +33,7 @@ import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -75,7 +76,7 @@ public abstract class CreateConstructorFromThisOrSuperFix extends CreateFromUsag
   }
 
   @Override
-  protected void invokeImpl(PsiClass targetClass) {
+  protected void invokeImpl(PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     final PsiFile callSite = myMethodCall.getContainingFile();
     final Project project = myMethodCall.getProject();
     PsiElementFactory elementFactory = JavaPsiFacade.getInstance(project).getElementFactory();
@@ -102,7 +103,7 @@ public abstract class CreateConstructorFromThisOrSuperFix extends CreateFromUsag
       rangeMarker.dispose();
 
       Template template = templateBuilder.buildTemplate();
-      final Editor editor = positionCursor(project, targetClass.getContainingFile(), targetClass);
+      final Editor editor = positionCursor(project, targetClass.getContainingFile(), targetClass, mutableView);
       if (editor == null) return;
       final TextRange textRange = constructor.getTextRange();
       final PsiFile file = targetClass.getContainingFile();

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateEnumConstantFromUsageFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateEnumConstantFromUsageFix.java
@@ -31,6 +31,7 @@ import com.intellij.psi.*;
 import com.intellij.psi.util.PsiUtil;
 import com.intellij.util.Function;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,7 @@ public class CreateEnumConstantFromUsageFix extends CreateVarFromUsageFix implem
   }
 
   @Override
-  protected void invokeImpl(final PsiClass targetClass) {
+  protected void invokeImpl(final PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     LOG.assertTrue(targetClass.isEnum());
     final String name = myReferenceExpression.getReferenceName();
     LOG.assertTrue(name != null);
@@ -79,7 +80,7 @@ public class CreateEnumConstantFromUsageFix extends CreateVarFromUsageFix implem
         final Template template = builder.buildTemplate();
 
         final Project project = targetClass.getProject();
-        final Editor newEditor = positionCursor(project, targetClass.getContainingFile(), enumConstant);
+        final Editor newEditor = positionCursor(project, targetClass.getContainingFile(), enumConstant, mutableView);
         if (newEditor != null) {
           final TextRange range = enumConstant.getTextRange();
           newEditor.getDocument().deleteString(range.getStartOffset(), range.getEndOffset());

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateFieldFromUsageFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateFieldFromUsageFix.java
@@ -27,6 +27,7 @@ import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,7 +68,7 @@ public class CreateFieldFromUsageFix extends CreateVarFromUsageFix {
   }
 
   @Override
-  protected void invokeImpl(final PsiClass targetClass) {
+  protected void invokeImpl(final PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     final Project project = myReferenceExpression.getProject();
     JVMElementFactory factory = JVMElementFactories.getFactory(targetClass.getLanguage(), project);
     if (factory == null) factory = JavaPsiFacade.getElementFactory(project);
@@ -107,7 +108,7 @@ public class CreateFieldFromUsageFix extends CreateVarFromUsageFix {
 
     setupVisibility(parentClass, targetClass, field.getModifierList());
 
-    createFieldFromUsageTemplate(targetClass, project, expectedTypes, field, createConstantField(), myReferenceExpression);
+    createFieldFromUsageTemplate(targetClass, project, expectedTypes, field, createConstantField(), myReferenceExpression, mutableView);
   }
 
   public static void createFieldFromUsageTemplate(final PsiClass targetClass,
@@ -115,9 +116,10 @@ public class CreateFieldFromUsageFix extends CreateVarFromUsageFix {
                                                   final ExpectedTypeInfo[] expectedTypes,
                                                   final PsiField field,
                                                   final boolean createConstantField,
-                                                  final PsiElement context) {
+                                                  final PsiElement context,
+                                                  @Nullable JVMElementMutableView mutator) {
     final PsiFile targetFile = targetClass.getContainingFile();
-    final Editor newEditor = positionCursor(project, targetFile, field);
+    final Editor newEditor = positionCursor(project, targetFile, field, mutator);
     if (newEditor == null) return;
     Template template =
       CreateFieldFromUsageHelper.setupTemplate(field, expectedTypes, targetClass, newEditor, context, createConstantField);

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateGetterSetterPropertyFromUsageFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateGetterSetterPropertyFromUsageFix.java
@@ -16,12 +16,10 @@
 package com.intellij.codeInsight.daemon.impl.quickfix;
 
 import com.intellij.codeInsight.generation.GenerateMembersUtil;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.*;
 import com.intellij.psi.util.PropertyUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -56,7 +54,7 @@ public class CreateGetterSetterPropertyFromUsageFix extends CreatePropertyFromUs
   }
 
   @Override
-  protected void beforeTemplateFinished(PsiClass aClass, PsiField field) {
+  protected void beforeTemplateFinished(PsiClass aClass, PsiField field, @Nullable JVMElementMutableView mutator) {
     PsiMethod getterPrototype = GenerateMembersUtil.generateSimpleGetterPrototype(field);
     if (aClass.findMethodsBySignature(getterPrototype, false).length == 0) {
       aClass.add(getterPrototype);
@@ -68,6 +66,6 @@ public class CreateGetterSetterPropertyFromUsageFix extends CreatePropertyFromUs
       aClass.add(setterPrototype);
     }
     
-    super.beforeTemplateFinished(aClass, field);
+    super.beforeTemplateFinished(aClass, field, mutator);
   }
 }

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateInnerClassFromNewFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateInnerClassFromNewFix.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.util.Comparing;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author yole
@@ -43,7 +44,7 @@ public class CreateInnerClassFromNewFix extends CreateClassFromNewFix {
   }
 
   @Override
-  protected void invokeImpl(final PsiClass targetClass) {
+  protected void invokeImpl(final PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     PsiNewExpression newExpression = getNewExpression();
     PsiJavaCodeReferenceElement ref = newExpression.getClassOrAnonymousClassReference();
     assert ref != null;
@@ -67,7 +68,7 @@ public class CreateInnerClassFromNewFix extends CreateClassFromNewFix {
     created = (PsiClass)targetClass.add(created);
 
     setupGenericParameters(created, ref);
-    setupClassFromNewExpression(created, newExpression);
+    setupClassFromNewExpression(created, newExpression, mutableView);
   }
 
   private static boolean isInThisOrSuperCall(PsiNewExpression newExpression) {

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateLocalFromUsageFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateLocalFromUsageFix.java
@@ -32,6 +32,7 @@ import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Mike
@@ -62,7 +63,7 @@ public class CreateLocalFromUsageFix extends CreateVarFromUsageFix {
   }
 
   @Override
-  protected void invokeImpl(final PsiClass targetClass) {
+  protected void invokeImpl(final PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     if (CreateFromUsageUtils.isValidReference(myReferenceExpression, false)) {
       return;
     }
@@ -120,7 +121,7 @@ public class CreateLocalFromUsageFix extends CreateVarFromUsageFix {
     builder.setEndVariableAfter(var.getNameIdentifier());
     Template template = builder.buildTemplate();
 
-    final Editor newEditor = positionCursor(project, targetFile, var);
+    final Editor newEditor = positionCursor(project, targetFile, var, null);
     if (newEditor == null) return;
     TextRange range = var.getTextRange();
     newEditor.getDocument().deleteString(range.getStartOffset(), range.getEndOffset());

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateLocalVarFromInstanceofAction.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateLocalVarFromInstanceofAction.java
@@ -215,7 +215,7 @@ public class CreateLocalVarFromInstanceofAction extends BaseIntentionAction {
 
       Template template = generateTemplate(project, localVariable.getInitializer(), localVariable.getType());
 
-      Editor newEditor = CreateFromUsageBaseFix.positionCursor(project, file, localVariable.getNameIdentifier());
+      Editor newEditor = CreateFromUsageBaseFix.positionCursor(project, file, localVariable.getNameIdentifier(), null);
       if (newEditor == null) return;
       TextRange range = localVariable.getNameIdentifier().getTextRange();
       newEditor.getDocument().deleteString(range.getStartOffset(), range.getEndOffset());

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateMethodFromMethodReferenceFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateMethodFromMethodReferenceFix.java
@@ -79,7 +79,7 @@ public class CreateMethodFromMethodReferenceFix extends CreateFromUsageBaseFix {
   }
 
   @Override
-  protected void invokeImpl(final PsiClass targetClass) {
+  protected void invokeImpl(final PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     if (targetClass == null) return;
     PsiMethodReferenceExpression expression = getMethodReference();
     if (expression == null) return;
@@ -97,8 +97,9 @@ public class CreateMethodFromMethodReferenceFix extends CreateFromUsageBaseFix {
     JVMElementFactory elementFactory = JVMElementFactories.getFactory(targetClass.getLanguage(), project);
     if (elementFactory == null) elementFactory = JavaPsiFacade.getElementFactory(project);
 
-    PsiMethod method = expression.isConstructor() ? (PsiMethod)targetClass.add(elementFactory.createConstructor()) 
-                                                  : CreateMethodFromUsageFix.createMethod(targetClass, parentClass, enclosingContext, methodName);
+    PsiMethod method = expression.isConstructor()
+                       ? (PsiMethod)targetClass.add(elementFactory.createConstructor())
+                       : CreateMethodFromUsageFix.createMethod(targetClass, parentClass, enclosingContext, methodName, mutableView);
     if (method == null) {
       return;
     }
@@ -134,7 +135,7 @@ public class CreateMethodFromMethodReferenceFix extends CreateFromUsageBaseFix {
                                         }
                                       }),
                                       PsiSubstitutor.EMPTY,
-                                      expectedTypes, context);
+                                      expectedTypes, context, mutableView);
   }
 
   

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateParameterFromUsageFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateParameterFromUsageFix.java
@@ -33,6 +33,7 @@ import com.intellij.refactoring.changeSignature.JavaChangeSignatureDialog;
 import com.intellij.refactoring.changeSignature.ParameterInfoImpl;
 import com.intellij.refactoring.introduceParameter.IntroduceParameterHandler;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,7 +70,7 @@ public class CreateParameterFromUsageFix extends CreateVarFromUsageFix {
   }
 
   @Override
-  protected void invokeImpl(PsiClass targetClass) {
+  protected void invokeImpl(PsiClass targetClass, @Nullable JVMElementMutableView mutableView) {
     if (CreateFromUsageUtils.isValidReference(myReferenceExpression, false)) return;
 
     final Project project = myReferenceExpression.getProject();

--- a/java/java-psi-api/src/com/intellij/psi/JVMElementMutableView.java
+++ b/java/java-psi-api/src/com/intellij/psi/JVMElementMutableView.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.psi;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface JVMElementMutableView {
+  /**
+   * @return mutable representation of the root element this view was created for (e.g. PsiClass)
+   */
+  @NotNull
+  PsiElement getMutableRoot();
+
+  /**
+   * Navigate to the element inside of the mutable root
+   */
+  void navigateToElement(@NotNull PsiElement element);
+}

--- a/java/java-psi-api/src/com/intellij/psi/JVMElementMutableViewProvider.java
+++ b/java/java-psi-api/src/com/intellij/psi/JVMElementMutableViewProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.psi;
+
+import com.intellij.lang.LanguageExtension;
+import com.intellij.openapi.util.Pass;
+import org.jetbrains.annotations.NotNull;
+
+public interface JVMElementMutableViewProvider {
+  LanguageExtension<JVMElementMutableViewProvider> EXTENSION_POINT =
+    new LanguageExtension<JVMElementMutableViewProvider>("com.intellij.psi.jvmElementMutableViewProvider");
+
+  /**
+   * Create mutable view corresponding to the rootElement, let updater modify it, then propagate changes back to the rootElement
+   */
+  void runWithMutableView(@NotNull PsiElement rootElement,
+                          @NotNull Pass<JVMElementMutableView> updater);
+}

--- a/plugins/javaFX/src/org/jetbrains/plugins/javaFX/fxml/codeInsight/inspections/JavaFxUnresolvedFxIdReferenceInspection.java
+++ b/plugins/javaFX/src/org/jetbrains/plugins/javaFX/fxml/codeInsight/inspections/JavaFxUnresolvedFxIdReferenceInspection.java
@@ -164,7 +164,7 @@ public class JavaFxUnresolvedFxIdReferenceInspection extends XmlSuppressableInsp
       final PsiClassType fieldType = factory.createType(checkContext(reference.getXmlAttributeValue()));
       final ExpectedTypeInfo[] types = {new ExpectedTypeInfoImpl(fieldType, ExpectedTypeInfo.TYPE_OR_SUBTYPE, fieldType, TailType.NONE,
                                                                  null, ExpectedTypeInfoImpl.NULL)};
-      CreateFieldFromUsageFix.createFieldFromUsageTemplate(targetClass, project, types, field, false, psiElement);
+      CreateFieldFromUsageFix.createFieldFromUsageTemplate(targetClass, project, types, field, false, psiElement, null);
     }
   }
 }

--- a/resources/src/META-INF/IdeaPlugin.xml
+++ b/resources/src/META-INF/IdeaPlugin.xml
@@ -228,6 +228,10 @@
       <with attribute="implementationClass" implements="com.intellij.refactoring.memberPullUp.PullUpHelperFactory"/>
     </extensionPoint>
 
+    <extensionPoint name="psi.jvmElementMutableViewProvider" beanClass="com.intellij.lang.LanguageExtensionPoint">
+      <with attribute="implementationClass" implements="com.intellij.psi.JVMElementMutableViewProvider"/>
+    </extensionPoint>
+
     <extensionPoint name="classTypePointerFactory" interface="com.intellij.psi.ClassTypePointerFactory"/>
 
     <!--<extensionPoint name="expectedTypesProvider" interface="com.intellij.codeInsight.ExpectedTypesProviderExtension"/>-->


### PR DESCRIPTION
The primary goal is to allow applying Java quick fixes to Kotlin declarations (see [KT-7641](https://youtrack.jetbrains.com/issue/KT-7641))
