### PR TITLE
Show commits in git log history (IDEA-134161)

### DIFF
--- a/plugins/git4idea/src/git4idea/history/GitHistoryUtils.java
+++ b/plugins/git4idea/src/git4idea/history/GitHistoryUtils.java
@@ -826,7 +826,7 @@ public class GitHistoryUtils {
     GitSimpleHandler h = new GitSimpleHandler(project, root, GitCommand.LOG);
     GitLogParser.NameStatus status = withChanges ? GitLogParser.NameStatus.STATUS : GitLogParser.NameStatus.NONE;
     GitLogParser.GitLogOption[] options = { HASH, COMMIT_TIME, AUTHOR_NAME, AUTHOR_TIME, AUTHOR_EMAIL, COMMITTER_NAME, COMMITTER_EMAIL,
-      PARENTS, SUBJECT, BODY, RAW_BODY };
+      PARENTS, SUBJECT, BODY, RAW_BODY, NOTES };
     if (withRefs) {
       options = ArrayUtil.append(options, REF_NAMES);
     }

--- a/plugins/git4idea/src/git4idea/history/GitLogParser.java
+++ b/plugins/git4idea/src/git4idea/history/GitLogParser.java
@@ -15,6 +15,7 @@
  */
 package git4idea.history;
 
+import com.google.common.base.Strings;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.Function;
@@ -112,7 +113,7 @@ public class GitLogParser {
   enum GitLogOption {
     HASH("H"), COMMIT_TIME("ct"), AUTHOR_NAME("an"), AUTHOR_TIME("at"), AUTHOR_EMAIL("ae"), COMMITTER_NAME("cn"),
     COMMITTER_EMAIL("ce"), SUBJECT("s"), BODY("b"), PARENTS("P"), REF_NAMES("d"), SHORT_REF_LOG_SELECTOR("gd"),
-    RAW_BODY("B");
+    RAW_BODY("B"), NOTES("N");
 
     private String myPlaceholder;
     GitLogOption(String placeholder) { myPlaceholder = placeholder; }
@@ -247,7 +248,8 @@ public class GitLogParser {
         }
       }
     }
-    return new GitLogRecord(res, paths, statuses, mySupportsRawBody);
+    String notes = Strings.emptyToNull(StringUtil.trim(res.get(GitLogOption.NOTES)));
+    return new GitLogRecord(res, paths, statuses, notes, mySupportsRawBody);
   }
 
 

--- a/plugins/git4idea/src/git4idea/history/GitLogRecord.java
+++ b/plugins/git4idea/src/git4idea/history/GitLogRecord.java
@@ -49,14 +49,20 @@ class GitLogRecord {
   private final List<String> myPaths;
   private final List<GitLogStatusInfo> myStatusInfo;
   private final boolean mySupportsRawBody;
+  private final String myNotes;
 
   private GitHandler myHandler;
 
-  GitLogRecord(@NotNull Map<GitLogParser.GitLogOption, String> options, @NotNull List<String> paths, @NotNull List<GitLogStatusInfo> statusInfo, boolean supportsRawBody) {
+  GitLogRecord(@NotNull Map<GitLogParser.GitLogOption, String> options,
+               @NotNull List<String> paths,
+               @NotNull List<GitLogStatusInfo> statusInfo,
+               @Nullable String notes,
+               boolean supportsRawBody) {
     myOptions = options;
     myPaths = paths;
     myStatusInfo = statusInfo;
     mySupportsRawBody = supportsRawBody;
+    myNotes = notes;
   }
 
   private List<String> getPaths() {
@@ -94,6 +100,7 @@ class GitLogRecord {
   String getBody() { return lookup(BODY); }
   String getRawBody() { return lookup(RAW_BODY); }
   String getShortenedRefLog() { return lookup(SHORT_REF_LOG_SELECTOR); }
+  @Nullable String getNotes() { return myNotes; }
 
   // access methods with some formatting or conversion
 
@@ -123,7 +130,8 @@ class GitLogRecord {
   }
 
   String getFullMessage() {
-    return mySupportsRawBody ? getRawBody().trim() : ((getSubject() + "\n\n" + getBody()).trim());
+    String notes = myNotes == null ? "" : "\n\nNotes:\n " + myNotes;
+    return mySupportsRawBody ? getRawBody().trim() + notes : ((getSubject() + "\n\n" + getBody() + notes).trim());
   }
 
   String[] getParentsHashes() {


### PR DESCRIPTION
This is a bit of a hack, as I did not want to midfy VcsFileRevision, which is shared for multiple VCS implementations. That's why I just added those git notes to the commit message. 
The null check in GitLogParserTest is to make sure, that the test conforms to the acutal behavior. If not adding the check, the test would get "null" as String, which is wrong. When executing IDEA, GitLogParser returns null for unset git notes.

If the pull request is ok, a backport to IDEA 15 would be great.

Referencing issue: https://youtrack.jetbrains.com/issue/IDEA-134161

Just as a side note: I did already submit the developer agreement.

BTW: How do you handle those code style issues and warnings within your code? In my pull requests, I did not want to resolve anything but the issue itself. However, there are loads of lines that do not conform to your codestyle and huge amounts of warnings, i.e. for unnecessary generics. Is it ok to resolve those in pull requests?