### PR TITLE
Fixed `FlipCommaIntention` for Groovy files

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/auxiliary/GrListOrMapImpl.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/auxiliary/GrListOrMapImpl.java
@@ -47,6 +47,8 @@ import org.jetbrains.plugins.groovy.lang.psi.impl.statements.expressions.TypesUt
 import org.jetbrains.plugins.groovy.lang.psi.util.GroovyCommonClassNames;
 import org.jetbrains.plugins.groovy.lang.psi.util.PsiUtil;
 
+import static com.intellij.psi.util.PsiUtil.*;
+
 /**
  * @author ilyas
  */
@@ -73,12 +75,17 @@ public class GrListOrMapImpl extends GrExpressionImpl implements GrListOrMap {
 
   @Override
   public ASTNode addInternal(ASTNode first, ASTNode last, ASTNode anchor, Boolean before) {
-    if (getInitializers().length == 0) {
-      return super.addInternal(first, last, getNode().getFirstChildNode(), false);
+    ASTNode result = super.addInternal(first, last, anchor, before);
+    if (first == last) {
+      if (anchor == null) {
+        anchor = result;
+      }
+      if (!before) {
+        anchor = anchor.getTreeNext();
+      }
+      getNode().addLeaf(GroovyTokenTypes.mCOMMA, ",", anchor);
     }
-    final ASTNode lastChild = getNode().getLastChildNode();
-    getNode().addLeaf(GroovyTokenTypes.mCOMMA, ",", lastChild);
-    return super.addInternal(first, last, lastChild.getTreePrev(), false);
+    return result;
   }
 
   @Override
@@ -195,8 +202,8 @@ public class GrListOrMapImpl extends GrExpressionImpl implements GrListOrMap {
           PsiClass hashMap = facade.findClass(GroovyCommonClassNames.JAVA_UTIL_LINKED_HASH_MAP, scope);
           if (hashMap != null) {
             PsiSubstitutor mapSubstitutor = PsiSubstitutor.EMPTY.
-              put(hashMap.getTypeParameters()[0], com.intellij.psi.util.PsiUtil.substituteTypeParameter(lType,  CommonClassNames.JAVA_UTIL_MAP, 0, false)).
-              put(hashMap.getTypeParameters()[1], com.intellij.psi.util.PsiUtil.substituteTypeParameter(lType,  CommonClassNames.JAVA_UTIL_MAP, 1, false));
+              put(hashMap.getTypeParameters()[0], substituteTypeParameter(lType, CommonClassNames.JAVA_UTIL_MAP, 0, false)).
+              put(hashMap.getTypeParameters()[1], substituteTypeParameter(lType, CommonClassNames.JAVA_UTIL_MAP, 1, false));
             return facade.getElementFactory().createType(hashMap, mapSubstitutor);
           }
         }
@@ -218,7 +225,8 @@ public class GrListOrMapImpl extends GrExpressionImpl implements GrListOrMap {
           if (arrayList == null) arrayList = facade.findClass(CommonClassNames.JAVA_UTIL_LIST, scope);
           if (arrayList != null) {
             PsiSubstitutor arrayListSubstitutor = PsiSubstitutor.EMPTY.
-              put(arrayList.getTypeParameters()[0], com.intellij.psi.util.PsiUtil.substituteTypeParameter(lType, CommonClassNames.JAVA_UTIL_LIST, 0, false));
+              put(arrayList.getTypeParameters()[0],
+                  substituteTypeParameter(lType, CommonClassNames.JAVA_UTIL_LIST, 0, false));
             return facade.getElementFactory().createType(arrayList, arrayListSubstitutor);
           }
         }

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/statements/params/GrParameterListImpl.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/statements/params/GrParameterListImpl.java
@@ -88,69 +88,19 @@ public class GrParameterListImpl extends GrStubElementBase<EmptyStub> implements
     return -1;
   }
 
-  /*@Override
-  public PsiElement addAfter(@NotNull PsiElement element, PsiElement anchor) throws IncorrectOperationException {
-    GrParameter[] params = getParameters();
-
-    if (params.length == 0) {
-      element = add(element);
-    }
-    else {
-      element = super.addAfter(element, anchor);
-      final ASTNode astNode = getNode();
-      if (anchor != null) {
-        astNode.addLeaf(mCOMMA, ",", element.getNode());
-      }
-      else {
-        astNode.addLeaf(mCOMMA, ",", element.getNextSibling().getNode());
-      }
-      CodeStyleManager.getInstance(getManager().getProject()).reformat(this);
-    }
-
-    return element;
-  }
-
-  @Override
-  public PsiElement addBefore(@NotNull PsiElement element, PsiElement anchor) throws IncorrectOperationException {
-    GrParameter[] params = getParameters();
-
-    if (params.length == 0) {
-      element = add(element);
-    }
-    else {
-      element = super.addBefore(element, anchor);
-      final ASTNode astNode = getNode();
-      if (anchor != null) {
-        astNode.addLeaf(mCOMMA, ",", anchor.getNode());
-      }
-      else {
-        astNode.addLeaf(mCOMMA, ",", element.getNode());
-      }
-      CodeStyleManager.getInstance(getManager().getProject()).reformat(this);
-    }
-
-    return element;
-  }*/
-
-
   @Override
   public ASTNode addInternal(ASTNode first, ASTNode last, ASTNode anchor, Boolean before) {
     GrParameter[] params = getParameters();
 
     ASTNode result = super.addInternal(first, last, anchor, before);
     if (first == last && first.getPsi() instanceof GrParameter && params.length > 0) {
-      if (before.booleanValue() && anchor != null) {
-        getNode().addLeaf(GroovyTokenTypes.mCOMMA, ",", anchor);
+      if (anchor == null) {
+        anchor = result;
       }
-      else if (before.booleanValue() && anchor == null) {
-        getNode().addLeaf(GroovyTokenTypes.mCOMMA, ",", result);
+      if (!before) {
+        anchor = anchor.getTreeNext();
       }
-      else if (!before.booleanValue() && anchor != null) {
-        getNode().addLeaf(GroovyTokenTypes.mCOMMA, ",", result);
-      }
-      else if (!before.booleanValue() && anchor == null) {
-        getNode().addLeaf(GroovyTokenTypes.mCOMMA, ",", result.getTreeNext());
-      }
+      getNode().addLeaf(GroovyTokenTypes.mCOMMA, ",", anchor);
     }
     return result;
   }

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/intentions/FlipCommaTest.groovy
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/intentions/FlipCommaTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.groovy.intentions
+
+import com.intellij.codeInsight.daemon.QuickFixBundle
+
+class FlipCommaTest extends GrIntentionTestCase {
+  FlipCommaTest() {
+    super(QuickFixBundle.message('flip.comma.intention'))
+  }
+
+  void testFlipFirstAndMiddleParameters() {
+    doTextTest('def m(String a<caret>, int b, boolean c) {}',
+               'def m(int b<caret>, String a, boolean c) {}')
+    doTextTest('def m(String a,<caret> int b, boolean c) {}',
+               'def m(int b, String a, boolean c) {}')
+  }
+
+  void testFlipMiddleAndLastParameters() {
+    doTextTest('def m(String a, int b<caret>, boolean c) {}',
+               'def m(String a, boolean c<caret>, int b) {}')
+    doTextTest('def m(String a, int b,<caret> boolean c) {}',
+               'def m(String a, boolean c, int b) {}')
+  }
+
+  void testFlipFirstAndMiddleListElements() {
+    doTextTest('[1<caret>, 2, 3]',
+               '[2<caret>, 1, 3]')
+    doTextTest('[1,<caret> 2, 3]',
+               '[2, 1, 3]')
+  }
+
+  void testFlipMiddleAndLastListElements() {
+    doTextTest('[1, 2<caret>, 3]',
+               '[1, 3<caret>, 2]')
+    doTextTest('[1, 2,<caret> 3]',
+               '[1, 3, 2]')
+  }
+}

--- a/resources-en/src/messages/QuickFixBundle.properties
+++ b/resources-en/src/messages/QuickFixBundle.properties
@@ -67,6 +67,7 @@ create.constructor.from.super.call.family=Create Constructor From super() Call
 create.constructor.from.this.call.family=Create Constructor From this() Call
 create.constructor.text=Create constructor in ''{0}''
 create.constructor.matching.super=Create constructor matching super
+flip.comma.intention=Flip ','
 super.class.constructors.chooser.title=Choose Super Class Constructors
 create.field.from.usage.family=Create field from Usage
 create.field.from.usage.text=Create field ''{0}''


### PR DESCRIPTION
## Flip `b` and `c` in a Groovy parameter list

### Before the fix:
```Groovy
def m(String a, int b, boolean c) {}
def m(String a  boolean c,, ,int b) {}
```
### After the fix:
```Groovy
def m(String a, int b, boolean c) {}
def m(String a, boolean c, int b) {}
```
## Flip `1` and `2` in a Groovy list
### Before the fix:
```Groovy
[1, 2, 3]
[  3,2,1]
```
### After the fix:
```Groovy
[1, 2, 3]
[2, 1, 3]
```
I have checked that `Change signature` is still working.

@maxmedvedev, @ignatov 