### PR TITLE
Fix for Go to Class window loses focus during typing.

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/util/gotoByName/ChooseByNameBase.java
+++ b/platform/lang-impl/src/com/intellij/ide/util/gotoByName/ChooseByNameBase.java
@@ -56,10 +56,7 @@ import com.intellij.openapi.ui.popup.*;
 import com.intellij.openapi.util.*;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.wm.IdeFocusManager;
-import com.intellij.openapi.wm.ToolWindow;
-import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.openapi.wm.WindowManager;
+import com.intellij.openapi.wm.*;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.codeStyle.MinusculeMatcher;
@@ -166,6 +163,7 @@ public abstract class ChooseByNameBase {
   static final boolean ourLoadNamesEachTime = FileBasedIndex.ourEnableTracingOfKeyHashToVirtualFileMapping;
   private boolean myFixLostTyping = true;
   private boolean myAlwaysHasMore = false;
+  private Point myFocusPoint;
 
   public boolean checkDisposed() {
     if (myDisposedFlag && myPostponedOkAction != null && !myPostponedOkAction.isProcessed()) {
@@ -509,6 +507,18 @@ public abstract class ChooseByNameBase {
       myTextField.addFocusListener(new FocusAdapter() {
         @Override
         public void focusLost(@NotNull final FocusEvent e) {
+          if (myFocusPoint != null) {
+            PointerInfo pointerInfo = MouseInfo.getPointerInfo();
+            if (pointerInfo != null && myFocusPoint.equals(pointerInfo.getLocation())) {
+              // Ignore the loss of focus if the mouse hasn't moved between the last dropdown resize
+              // and the loss of focus event. This happens in focus follows mouse mode if the mouse is
+              // over the dropdown and it resizes to leave the mouse outside the dropdown.
+              IdeFocusManager.getInstance(myProject).requestFocus(myTextField, true);
+              myFocusPoint = null;
+              return;
+            }
+          }
+          myFocusPoint = null;
           cancelListUpdater(); // cancel thread as early as possible
           myHideAlarm.addRequest(new Runnable() {
             @Override
@@ -1044,6 +1054,12 @@ public abstract class ChooseByNameBase {
   private void setElementsToList(int pos, @NotNull Collection<?> elements) {
     myListUpdater.cancelAll();
     if (checkDisposed()) return;
+    if (isCloseByFocusLost()) {
+      PointerInfo pointerInfo = MouseInfo.getPointerInfo();
+      if (pointerInfo != null) {
+        myFocusPoint = pointerInfo.getLocation();
+      }
+    }
     if (elements.isEmpty()) {
       myListModel.clear();
       myTextField.setForeground(JBColor.red);


### PR DESCRIPTION
The reason this bug occurs is that when the goto by name dialog dropdown resizes while the mouse is over it. If the window manager uses sloppy focus or focus-follows-mouse, then it will send a focus event to the underlying IDE window since the dialog is not modal. The IDE treats this like any other click in the underlying pane and typically the focus now goes to an underlying editor which is corrupted by further keystrokes, meanwhile, the use thinks she is still typing into the dialog box. 

This could be fixed by:
- modal dialogs (this is really how it should be fixed, but that is a behavioural change)
- implementing a dialog that doesn't have windows shrinking and losing focus
- detecting that the mouse hasn't moved and retaining the focus

This change uses the third method. It retains focus in the goto dialog if the mouse hasn't moved between a dropdown list resize and the focus loss event.

Please note that the check for the mouse not moved could have false positives and could be tightened up by adding a fast timer, or checking that the focus event.getOpposite() instanceof IdeFrame, however in all my testing I didn't find any case where it behaved unexpectedly, that includes testing it when typing into the dialog, testing when alt-tabbing away from the IDE, switching workspaces, etc.

Tested on Linux/Ubuntu with Cinnamon window manager with sloppy focus, focus-follows-mouse, and click to focus. 

Bug: https://youtrack.jetbrains.com/issue/IDEA-112015