### PR TITLE
New GIT option to disable fast-forward when merging into master from a log window

### DIFF
--- a/plugins/git4idea/src/git4idea/GitTaskHandler.java
+++ b/plugins/git4idea/src/git4idea/GitTaskHandler.java
@@ -61,7 +61,7 @@ public class GitTaskHandler extends DvcsTaskHandler<GitRepository> {
 
   @Override
   protected void mergeAndClose(@NotNull String branch, @NotNull List<GitRepository> repositories) {
-    myBrancher.merge(branch, GitBrancher.DeleteOnMergeOption.DELETE, repositories);
+    myBrancher.merge(branch, GitBrancher.DeleteOnMergeOption.DELETE, false, repositories);
   }
 
   @Override

--- a/plugins/git4idea/src/git4idea/branch/GitBranchWorker.java
+++ b/plugins/git4idea/src/git4idea/branch/GitBranchWorker.java
@@ -112,13 +112,13 @@ public final class GitBranchWorker {
   }
 
   public void merge(@NotNull final String branchName, @NotNull final GitBrancher.DeleteOnMergeOption deleteOnMerge,
-                    @NotNull final List<GitRepository> repositories) {
+                    boolean noFastForward, @NotNull final List<GitRepository> repositories) {
     updateInfo(repositories);
     Map<GitRepository, String> revisions = new HashMap<GitRepository, String>();
     for (GitRepository repository : repositories) {
       revisions.put(repository, repository.getCurrentRevision());
     }
-    new GitMergeOperation(myProject, myFacade, myGit, myUiHandler, repositories, branchName, deleteOnMerge, revisions).execute();
+    new GitMergeOperation(myProject, myFacade, myGit, myUiHandler, repositories, branchName, deleteOnMerge, noFastForward, revisions).execute();
   }
 
   public void rebase(@NotNull List<GitRepository> repositories, @NotNull String branchName) {

--- a/plugins/git4idea/src/git4idea/branch/GitBrancher.java
+++ b/plugins/git4idea/src/git4idea/branch/GitBrancher.java
@@ -125,9 +125,10 @@ public interface GitBrancher {
    *
    * @param branchName    the branch to be merged into HEAD.
    * @param deleteOnMerge specify whether the branch should be automatically deleted or proposed to be deleted after merge.
+   * @param noFastForward do not allow fast forward (-no-ff)
    * @param repositories  repositories to operate on.
    */
-  void merge(@NotNull String branchName, @NotNull DeleteOnMergeOption deleteOnMerge, @NotNull List<GitRepository> repositories);
+  void merge(@NotNull String branchName, @NotNull DeleteOnMergeOption deleteOnMerge, boolean noFastForward, @NotNull List<GitRepository> repositories);
 
   /**
    * Call {@code git rebase <branchName>} for each of the given repositories.

--- a/plugins/git4idea/src/git4idea/branch/GitBrancherImpl.java
+++ b/plugins/git4idea/src/git4idea/branch/GitBrancherImpl.java
@@ -122,11 +122,11 @@ class GitBrancherImpl implements GitBrancher {
   }
 
   @Override
-  public void merge(@NotNull final String branchName, @NotNull final DeleteOnMergeOption deleteOnMerge,
+  public void merge(@NotNull final String branchName, @NotNull final DeleteOnMergeOption deleteOnMerge, boolean noFastForward,
                     @NotNull final List<GitRepository> repositories) {
     new CommonBackgroundTask(myProject, "Merging " + branchName, null) {
       @Override public void execute(@NotNull ProgressIndicator indicator) {
-        newWorker(indicator).merge(branchName, deleteOnMerge, repositories);
+        newWorker(indicator).merge(branchName, deleteOnMerge, noFastForward, repositories);
       }
     }.runInBackground();
   }

--- a/plugins/git4idea/src/git4idea/config/GitOptionsTopHitProvider.java
+++ b/plugins/git4idea/src/git4idea/config/GitOptionsTopHitProvider.java
@@ -67,6 +67,7 @@ public final class GitOptionsTopHitProvider extends OptionsTopHitProvider {
           options.add(option(project, "Git: Warn if CRLF line separators are about to be committed", "warnAboutCrlf", "setWarnAboutCrlf"));
           options.add(option(project, "Git: Warn when committing in detached HEAD or during rebase", "warnAboutDetachedHead", "setWarnAboutDetachedHead"));
           options.add(option(project, "Git: Allow force push", "isForcePushAllowed", "setForcePushAllowed"));
+          options.add(option(project, "Git: Disable fast forward for merge from log", "isNoFfLogMerge", "setNoFfLogMerge"));
           return Collections.unmodifiableCollection(options);
         }
       }

--- a/plugins/git4idea/src/git4idea/config/GitSharedSettings.java
+++ b/plugins/git4idea/src/git4idea/config/GitSharedSettings.java
@@ -31,6 +31,7 @@ public class GitSharedSettings implements PersistentStateComponent<GitSharedSett
 
   public static class State {
     public List<String> FORCE_PUSH_PROHIBITED_PATTERNS = ContainerUtil.newArrayList("master");
+    public List<String> NO_FF_PATTERNS = ContainerUtil.newArrayList("master");
   }
 
   private State myState = new State();
@@ -55,4 +56,12 @@ public class GitSharedSettings implements PersistentStateComponent<GitSharedSett
     myState.FORCE_PUSH_PROHIBITED_PATTERNS = new ArrayList<String>(patterns);
   }
 
+  @NotNull
+  public List<String> getNoFfPatterns() {
+    return Collections.unmodifiableList(myState.NO_FF_PATTERNS);
+  }
+
+  public void setNoFfPatterns(@NotNull List<String> patterns) {
+    myState.NO_FF_PATTERNS = new ArrayList<String>(patterns);
+  }
 }

--- a/plugins/git4idea/src/git4idea/config/GitVcsPanel.form
+++ b/plugins/git4idea/src/git4idea/config/GitVcsPanel.form
@@ -14,9 +14,6 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-        </clientProperties>
         <border type="none"/>
         <children>
           <component id="b1a9d" class="javax.swing.JLabel">
@@ -91,7 +88,7 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <grid id="4d15a" layout-manager="GridLayoutManager" row-count="7" column-count="8" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="4d15a" layout-manager="GridLayoutManager" row-count="8" column-count="8" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -134,9 +131,26 @@
               <text value="Allow &amp;force push"/>
             </properties>
           </component>
+          <component id="9dde3" class="javax.swing.JCheckBox" binding="myNoFfLogMerge" default-binding="true">
+            <constraints>
+              <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="true"/>
+              <text value="No fast forward when &amp;merging from log"/>
+            </properties>
+          </component>
           <component id="b0317" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myProtectedBranchesButton" custom-create="true" default-binding="true">
             <constraints>
               <grid row="6" column="7" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="dacd6" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myNoFfBranchesButton" custom-create="true" default-binding="true">
+            <constraints>
+              <grid row="7" column="7" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value=""/>
@@ -148,6 +162,14 @@
             </constraints>
             <properties>
               <text value="Protected branches:"/>
+            </properties>
+          </component>
+          <component id="20433" class="com.intellij.ui.components.JBLabel" binding="myNoFfBranchesLabel" default-binding="true">
+            <constraints>
+              <grid row="7" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="For branches:"/>
             </properties>
           </component>
           <component id="2e80d" class="com.intellij.ui.components.JBCheckBox" binding="mySyncControl">

--- a/plugins/git4idea/src/git4idea/config/GitVcsSettings.java
+++ b/plugins/git4idea/src/git4idea/config/GitVcsSettings.java
@@ -77,6 +77,7 @@ public class GitVcsSettings implements PersistentStateComponent<GitVcsSettings.S
     public boolean WARN_ABOUT_DETACHED_HEAD = true;
     public GitResetMode RESET_MODE = null;
     public boolean FORCE_PUSH_ALLOWED = false;
+    public boolean NO_FF_LOG_MERGE = false;
     public GitPushTagMode PUSH_TAGS = null;
 
     @AbstractCollection(surroundWithTag = false)
@@ -230,6 +231,14 @@ public class GitVcsSettings implements PersistentStateComponent<GitVcsSettings.S
 
   public void setForcePushAllowed(boolean allowed) {
     myState.FORCE_PUSH_ALLOWED = allowed;
+  }
+
+  public boolean isNoFfLogMerge() {
+    return myState.NO_FF_LOG_MERGE;
+  }
+
+  public void setNoFfLogMerge(boolean allowed) {
+    myState.NO_FF_LOG_MERGE = allowed;
   }
 
   @Nullable

--- a/plugins/git4idea/src/git4idea/history/GitLogParser.java
+++ b/plugins/git4idea/src/git4idea/history/GitLogParser.java
@@ -109,7 +109,7 @@ public class GitLogParser {
    * Options which may be passed to 'git log --pretty=format:' as placeholders and then parsed from the result.
    * These are the pieces of information about a commit which we want to get from 'git log'.
    */
-  enum GitLogOption {
+  public enum GitLogOption {
     HASH("H"), COMMIT_TIME("ct"), AUTHOR_NAME("an"), AUTHOR_TIME("at"), AUTHOR_EMAIL("ae"), COMMITTER_NAME("cn"),
     COMMITTER_EMAIL("ce"), SUBJECT("s"), BODY("b"), PARENTS("P"), REF_NAMES("d"), SHORT_REF_LOG_SELECTOR("gd"),
     RAW_BODY("B");
@@ -122,7 +122,7 @@ public class GitLogParser {
   /**
    * Constructs new parser with the given options and no names of changed files in the output.
    */
-  GitLogParser(Project project, GitLogOption... options) {
+  public GitLogParser(Project project, GitLogOption... options) {
     this(project, NameStatus.NONE, options);
   }
 
@@ -130,7 +130,7 @@ public class GitLogParser {
    * Constructs new parser with the specified options.
    * Only these options will be parsed out and thus will be available from the GitLogRecord.
    */
-  GitLogParser(Project project, NameStatus nameStatusOption, GitLogOption... options) {
+  public GitLogParser(Project project, NameStatus nameStatusOption, GitLogOption... options) {
     myFormat = makeFormatFromOptions(options);
     myOptions = options;
     myNameStatusOption = nameStatusOption;
@@ -147,7 +147,7 @@ public class GitLogParser {
     return RECORD_START_GIT + StringUtil.join(options, function, ITEMS_SEPARATOR_GIT) + RECORD_END_GIT;
   }
 
-  String getPretty() {
+  public String getPretty() {
     return "--pretty=format:" + myFormat;
   }
 
@@ -158,7 +158,7 @@ public class GitLogParser {
    *         The list is sorted as usual for git log - the first is the newest, the last is the oldest.
    */
   @NotNull
-  List<GitLogRecord> parse(@NotNull String output) {
+  public List<GitLogRecord> parse(@NotNull String output) {
     // Here is what git log returns for --pretty=tformat:^%H#%s$
     // ^2c815939f45fbcfda9583f84b14fe9d393ada790#sample commit$
     //

--- a/plugins/git4idea/src/git4idea/history/GitLogRecord.java
+++ b/plugins/git4idea/src/git4idea/history/GitLogRecord.java
@@ -41,7 +41,7 @@ import static git4idea.history.GitLogParser.GitLogOption.*;
  * BUT if one tries to get an option which was not specified to the GitLogParser, one will get null.
  * @see git4idea.history.GitLogParser
  */
-class GitLogRecord {
+public class GitLogRecord {
 
   private static final Logger LOG = Logger.getInstance(GitLogRecord.class);
 
@@ -52,7 +52,7 @@ class GitLogRecord {
 
   private GitHandler myHandler;
 
-  GitLogRecord(@NotNull Map<GitLogParser.GitLogOption, String> options, @NotNull List<String> paths, @NotNull List<GitLogStatusInfo> statusInfo, boolean supportsRawBody) {
+  public GitLogRecord(@NotNull Map<GitLogParser.GitLogOption, String> options, @NotNull List<String> paths, @NotNull List<GitLogStatusInfo> statusInfo, boolean supportsRawBody) {
     myOptions = options;
     myPaths = paths;
     myStatusInfo = statusInfo;
@@ -85,20 +85,20 @@ class GitLogRecord {
   }
 
   // trivial access methods
-  String getHash() { return lookup(HASH); }
-  String getAuthorName() { return lookup(AUTHOR_NAME); }
-  String getAuthorEmail() { return lookup(AUTHOR_EMAIL); }
-  String getCommitterName() { return lookup(COMMITTER_NAME); }
-  String getCommitterEmail() { return lookup(COMMITTER_EMAIL); }
-  String getSubject() { return lookup(SUBJECT); }
-  String getBody() { return lookup(BODY); }
-  String getRawBody() { return lookup(RAW_BODY); }
-  String getShortenedRefLog() { return lookup(SHORT_REF_LOG_SELECTOR); }
+  public String getHash() { return lookup(HASH); }
+  public String getAuthorName() { return lookup(AUTHOR_NAME); }
+  public String getAuthorEmail() { return lookup(AUTHOR_EMAIL); }
+  public String getCommitterName() { return lookup(COMMITTER_NAME); }
+  public String getCommitterEmail() { return lookup(COMMITTER_EMAIL); }
+  public String getSubject() { return lookup(SUBJECT); }
+  public String getBody() { return lookup(BODY); }
+  public String getRawBody() { return lookup(RAW_BODY); }
+  public String getShortenedRefLog() { return lookup(SHORT_REF_LOG_SELECTOR); }
 
   // access methods with some formatting or conversion
 
   @NotNull
-  Date getDate() {
+  public Date getDate() {
     return new Date(getCommitTime());
   }
 

--- a/plugins/git4idea/src/git4idea/merge/TrivialMergeDetector.java
+++ b/plugins/git4idea/src/git4idea/merge/TrivialMergeDetector.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package git4idea.merge;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.vcs.VcsException;
+import com.intellij.openapi.vfs.VirtualFile;
+import git4idea.GitUtil;
+import git4idea.commands.GitCommand;
+import git4idea.commands.GitSimpleHandler;
+import git4idea.history.GitLogParser;
+import git4idea.history.GitLogRecord;
+import git4idea.history.browser.SHAHash;
+import git4idea.repo.GitRepository;
+import git4idea.repo.GitRepositoryManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+
+import static com.intellij.util.ObjectUtils.assertNotNull;
+import static git4idea.history.GitLogParser.GitLogOption.BODY;
+import static git4idea.history.GitLogParser.GitLogOption.HASH;
+import static git4idea.history.GitLogParser.GitLogOption.SUBJECT;
+
+/**
+ * Detect a trivial merge
+ * Trivial merge happens when we are merging a single commit
+ * It makes no sense to avoid fast-forwarding such commits
+ * */
+
+
+public class TrivialMergeDetector {
+  private final HashSet<String> myUnmergedPaths = new HashSet<String>();
+  private final Project myProject;
+  private final VirtualFile myRoot;
+  private final String myStart;
+  private final String myMergeFrom;
+
+  public TrivialMergeDetector(final Project project, final VirtualFile root, final String mergeFrom) {
+    myProject = project;
+    myRoot = root;
+    GitRepositoryManager manager = GitUtil.getRepositoryManager(project);
+    GitRepository repository = assertNotNull(manager.getRepositoryForRoot(root));
+    myStart = repository.getCurrentRevision();
+    myMergeFrom = mergeFrom;
+  }
+
+  public boolean isTrivial() throws VcsException {
+    String root = myRoot.getPath();
+    GitLogParser parser = new GitLogParser(myProject, HASH, SUBJECT);
+    GitSimpleHandler h = new GitSimpleHandler(myProject, myRoot, GitCommand.LOG);
+    h.setSilent(true);
+    // --first-parent: if a commit is a merge, we are not interested in its content
+    // -n 2: get last two commits
+    h.addParameters("--name-status", "-n 2", "--first-parent", myMergeFrom);
+    h.addParameters(parser.getPretty(), "--encoding=UTF-8");
+    h.endOptions();
+
+    String output = h.run();
+
+    final List<Pair<SHAHash, String>> rc = new ArrayList<Pair<SHAHash, String>>();
+    for (GitLogRecord record : parser.parse(output)) {
+      record.setUsedHandler(h);
+      rc.add(Pair.create(new SHAHash(record.getHash()), record.getSubject()));
+    }
+
+    // TODO: parse and check
+    if (rc.size()==2) {
+      // the commit before is the head, the merged branch is trivial
+      if (rc.get(1).first.getValue().equals(myStart)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/plugins/git4idea/src/git4idea/repo/GitRepositoryFiles.java
+++ b/plugins/git4idea/src/git4idea/repo/GitRepositoryFiles.java
@@ -312,7 +312,7 @@ public class GitRepositoryFiles {
   }
 
   @NotNull
-  Collection<VirtualFile> getRootDirs() {
+  public Collection<VirtualFile> getRootDirs() {
     return ContainerUtil.newHashSet(myMainDir, myWorktreeDir);
   }
 }

--- a/plugins/git4idea/src/git4idea/ui/branch/GitBranchPopupActions.java
+++ b/plugins/git4idea/src/git4idea/ui/branch/GitBranchPopupActions.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
@@ -50,6 +51,8 @@ class GitBranchPopupActions {
 
   private final Project myProject;
   private final GitRepository myRepository;
+
+  private final static Logger LOG = Logger.getInstance(GitBranchPopupActions.class.getName());
 
   GitBranchPopupActions(Project project, GitRepository repository) {
     myProject = project;
@@ -447,7 +450,7 @@ class GitBranchPopupActions {
               try {
                 return !mergeDetector.isTrivial() && isNoFfLogMerge(currentBranch.getName());
               } catch (VcsException e) {
-                // TODO: handle / display exceptions somewhere?
+                LOG.warn("Error when checking for trivial commits in " + mergeRoot, e);
               }
             }
 

--- a/plugins/git4idea/src/git4idea/ui/branch/GitBranchPopupActions.java
+++ b/plugins/git4idea/src/git4idea/ui/branch/GitBranchPopupActions.java
@@ -25,9 +25,9 @@ import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Condition;
-import com.intellij.util.Consumer;
 import com.intellij.util.containers.ContainerUtil;
 import git4idea.GitBranch;
+import git4idea.GitLocalBranch;
 import git4idea.branch.GitBranchUtil;
 import git4idea.branch.GitBrancher;
 import git4idea.config.GitSharedSettings;
@@ -427,8 +427,8 @@ class GitBranchPopupActions {
         myNoFfLogMerge = ContainerUtil.exists(repositories, new Condition<GitRepository>() {
           @Override
           public boolean value(GitRepository gitRepository) {
-            String name = gitRepository.getCurrentBranch().getName();
-            return isNoFfLogMerge(name);
+            GitLocalBranch currentBranch = gitRepository.getCurrentBranch();
+            return currentBranch != null && isNoFfLogMerge(currentBranch.getName());
           }
         });
       } else {

--- a/plugins/git4idea/tests/git4idea/branch/GitBranchWorkerTest.java
+++ b/plugins/git4idea/tests/git4idea/branch/GitBranchWorkerTest.java
@@ -918,7 +918,7 @@ public class GitBranchWorkerTest extends GitPlatformTest {
 
   private void mergeBranch(String name, GitBranchUiHandler uiHandler) {
     GitBranchWorker brancher = new GitBranchWorker(myProject, myPlatformFacade, myGit, uiHandler);
-    brancher.merge(name, GitBrancher.DeleteOnMergeOption.PROPOSE, myRepositories);
+    brancher.merge(name, GitBrancher.DeleteOnMergeOption.PROPOSE, false, myRepositories);
   }
 
   private void deleteBranch(String name, GitBranchUiHandler uiHandler) {


### PR DESCRIPTION
This is a PR for git4idea plugin.

Merging with a context menu from a log window is very convenient, however it is not possible to specify Merge options when doing so.

One merge option I am missing very much is "No fast forward".

This PR adds an option to automatically set "No fast forward" for any non-trivial merges into selected branches (typically to "master").