### PR TITLE
[Fernflower] Refactored IIdentifierRenamer, Fixed renaming annotations on classes, Fixed the location of generated comments relative to annotations, Improved the default renaming scheme.

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -299,6 +299,8 @@ public class ClassWriter {
       appendDeprecation(buffer, indent);
     }
 
+    appendAnnotations(buffer, cl, indent);
+
     if (interceptor != null) {
       String oldName = interceptor.getOldName(cl.qualifiedName);
       appendRenameComment(buffer, oldName, MType.CLASS, indent);
@@ -307,8 +309,6 @@ public class ClassWriter {
     if (isSynthetic) {
       appendComment(buffer, "synthetic class", indent);
     }
-
-    appendAnnotations(buffer, cl, indent);
 
     buffer.appendIndent(indent);
 
@@ -395,6 +395,8 @@ public class ClassWriter {
       appendDeprecation(buffer, indent);
     }
 
+    appendAnnotations(buffer, fd, indent);
+
     if (interceptor != null) {
       String oldName = interceptor.getOldName(cl.qualifiedName + " " + fd.getName() + " " + fd.getDescriptor());
       appendRenameComment(buffer, oldName, MType.FIELD, indent);
@@ -404,7 +406,7 @@ public class ClassWriter {
       appendComment(buffer, "synthetic field", indent);
     }
 
-    appendAnnotations(buffer, fd, indent);
+
 
     buffer.appendIndent(indent);
 
@@ -611,6 +613,8 @@ public class ClassWriter {
         appendDeprecation(buffer, indent);
       }
 
+      appendAnnotations(buffer, mt, indent);
+
       if (interceptor != null) {
         String oldName = interceptor.getOldName(cl.qualifiedName + " " + mt.getName() + " " + mt.getDescriptor());
         appendRenameComment(buffer, oldName, MType.METHOD, indent);
@@ -624,8 +628,6 @@ public class ClassWriter {
       if (isBridge) {
         appendComment(buffer, "bridge method", indent);
       }
-
-      appendAnnotations(buffer, mt, indent);
 
       buffer.appendIndent(indent);
 

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -80,8 +80,9 @@ public class ClassesProcessor {
               }
               else if (simpleName != null && DecompilerContext.getOption(IFernflowerPreferences.RENAME_ENTITIES)) {
                 IIdentifierRenamer renamer = DecompilerContext.getPoolInterceptor().getHelper();
-                if (renamer.toBeRenamed(IIdentifierRenamer.Type.ELEMENT_CLASS, simpleName, null, null)) {
-                  simpleName = renamer.getNextClassName(innerName, simpleName);
+                // TODO: rename packages using renamer.getNextPackageName
+                if (renamer.shouldRenameClass(simpleName, innerName)) {
+                  simpleName = renamer.getNextClassName(simpleName, innerName);
                   mapNewSimpleNames.put(innerName, simpleName);
                 }
               }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
@@ -17,11 +17,17 @@ package org.jetbrains.java.decompiler.main.extern;
 
 public interface IIdentifierRenamer {
 
-  enum Type {ELEMENT_CLASS, ELEMENT_FIELD, ELEMENT_METHOD}
+  boolean shouldRenamePackage(String name);
 
-  boolean toBeRenamed(Type elementType, String className, String element, String descriptor);
+  boolean shouldRenameClass(String shortName, String fullName);
 
-  String getNextClassName(String fullName, String shortName);
+  boolean shouldRenameField(String className, String field, String descriptor);
+
+  boolean shouldRenameMethod(String className, String method, String descriptor);
+
+  String getNextPackageName(String name);
+
+  String getNextClassName(String shortName, String fullName);
 
   String getNextFieldName(String className, String field, String descriptor);
 

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
@@ -16,10 +16,14 @@
 package org.jetbrains.java.decompiler.main.extern;
 
 public interface IIdentifierRenamer {
-
+  /**
+   * Determines if the package should be renamed.
+   * @param name the package name
+   * @return true if the package should be renamed
+   */
   boolean shouldRenamePackage(String name);
 
-  boolean shouldRenameClass(String shortName, String fullName);
+  boolean shouldRenameClass(String simpleName, String fullName);
 
   boolean shouldRenameField(String className, String field, String descriptor);
 
@@ -27,7 +31,13 @@ public interface IIdentifierRenamer {
 
   String getNextPackageName(String name);
 
-  String getNextClassName(String shortName, String fullName);
+  /**
+   * Generates the next simple name for a class
+   * @param simpleName the current simple name of the class
+   * @param fullName the current full name of the class
+   * @return a generated String that is a valid class name
+   */
+  String getNextClassName(String simpleName, String fullName);
 
   String getNextFieldName(String className, String field, String descriptor);
 

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -23,32 +23,80 @@ import java.util.Set;
 
 public class ConverterHelper implements IIdentifierRenamer {
 
-  private static final Set<String> KEYWORDS = new HashSet<String>(Arrays.asList(
+  private static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
     "abstract", "do", "if", "package", "synchronized", "boolean", "double", "implements", "private", "this", "break", "else", "import",
     "protected", "throw", "byte", "extends", "instanceof", "public", "throws", "case", "false", "int", "return", "transient", "catch",
     "final", "interface", "short", "true", "char", "finally", "long", "static", "try", "class", "float", "native", "strictfp", "void",
     "const", "for", "new", "super", "volatile", "continue", "goto", "null", "switch", "while", "default", "assert", "enum"));
-  private static final Set<String> RESERVED_WINDOWS_NAMESPACE = new HashSet<String>(Arrays.asList(
+  private static final Set<String> RESERVED_WINDOWS_NAMESPACE = new HashSet<>(Arrays.asList(
     "aux", "prn", "aux", "nul",
     "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
     "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"));
 
+  private int packageCounter = 0;
   private int classCounter = 0;
   private int fieldCounter = 0;
   private int methodCounter = 0;
-  private final Set<String> setNonStandardClassNames = new HashSet<String>();
+  private final Set<String> setNonStandardClassNames = new HashSet<>();
+  private final Set<String> setKnownClassNames = new HashSet<>();
+  private final Set<String> setKnownPackageNames = new HashSet<>();
 
   @Override
-  public boolean toBeRenamed(Type elementType, String className, String element, String descriptor) {
-    String value = elementType == Type.ELEMENT_CLASS ? className : element;
-    return value == null || value.length() == 0 || value.length() <= 2 || KEYWORDS.contains(value) || Character.isDigit(value.charAt(0))
-      || elementType == Type.ELEMENT_CLASS && RESERVED_WINDOWS_NAMESPACE.contains(value.toLowerCase());
+  public boolean shouldRenamePackage(String name) {
+    if (name == null) {
+      return false;
+    }
+    String lowerCaseName = name.toLowerCase();
+    if (setKnownPackageNames.contains(lowerCaseName)) {
+      return true;
+    }
+    setKnownPackageNames.add(lowerCaseName);
+    for (String segment : lowerCaseName.split("/")) {
+      if (RESERVED_WINDOWS_NAMESPACE.contains(segment)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean shouldRenameClass(String shortName, String fullName) {
+    if (shortName == null || fullName == null) {
+      return true;
+    }
+    try {
+      return shortName.length() == 0 || shortName.length() <= 2
+             || Character.isDigit(shortName.charAt(0))
+             || KEYWORDS.contains(shortName)
+             || RESERVED_WINDOWS_NAMESPACE.contains(shortName.toLowerCase())
+             || setKnownClassNames.contains(fullName.toLowerCase());
+    }
+    finally {
+      setKnownClassNames.add(fullName.toLowerCase());
+    }
+  }
+
+  @Override
+  public boolean shouldRenameField(String className, String field, String descriptor) {
+    return field == null || field.length() == 0 || field.length() <= 2
+           || Character.isDigit(field.charAt(0)) || KEYWORDS.contains(field);
+  }
+
+  @Override
+  public boolean shouldRenameMethod(String className, String method, String descriptor) {
+    return method == null || method.length() == 0 || method.length() <= 2
+           || Character.isDigit(method.charAt(0)) || KEYWORDS.contains(method);
+  }
+
+  @Override
+  public String getNextPackageName(String name) {
+    return "package_" + (packageCounter++) + "/";
   }
 
   // TODO: consider possible conflicts with not renamed classes, fields and methods!
   // We should get all relevant information here.
   @Override
-  public String getNextClassName(String fullName, String shortName) {
+  public String getNextClassName(String shortName, String fullName) {
 
     if (shortName == null) {
       return "class_" + (classCounter++);
@@ -58,7 +106,6 @@ public class ConverterHelper implements IIdentifierRenamer {
     while (Character.isDigit(shortName.charAt(index))) {
       index++;
     }
-
     if (index == 0 || index == shortName.length()) {
       return "class_" + (classCounter++);
     }
@@ -94,6 +141,14 @@ public class ConverterHelper implements IIdentifierRenamer {
   }
 
   public static String replaceSimpleClassName(String fullName, String newName) {
-    return fullName.substring(0, fullName.lastIndexOf('/') + 1) + newName;
+    return getPackageName(fullName) + newName;
+  }
+
+  public static String getPackageName(String fullName) {
+    return fullName.substring(0, fullName.lastIndexOf('/') + 1);
+  }
+
+  public static String replacePackageName(String fullName, String newName) {
+    return newName + getSimpleClassName(fullName);
   }
 }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
@@ -49,7 +49,8 @@ public class IdentifierConverter implements NewClassNameBuilder {
         try {
           helper = (IIdentifierRenamer)IdentifierConverter.class.getClassLoader().loadClass(user_class).newInstance();
         }
-        catch (Exception ignored) { }
+        catch (Exception ignored) {
+        }
       }
 
       if (helper == null) {
@@ -178,13 +179,13 @@ public class IdentifierConverter implements NewClassNameBuilder {
 
     String classOldFullName = cl.qualifiedName;
 
-    // TODO: rename packages
+    // TODO: rename packages using helper.getNextPackageName
     String clSimpleName = ConverterHelper.getSimpleClassName(classOldFullName);
-    if (helper.toBeRenamed(IIdentifierRenamer.Type.ELEMENT_CLASS, clSimpleName, null, null)) {
+    if (helper.shouldRenameClass(clSimpleName, classOldFullName)) {
       String classNewFullName;
 
       do {
-        String classname = helper.getNextClassName(classOldFullName, ConverterHelper.getSimpleClassName(classOldFullName));
+        String classname = helper.getNextClassName(ConverterHelper.getSimpleClassName(classOldFullName), classOldFullName);
         classNewFullName = ConverterHelper.replaceSimpleClassName(classOldFullName, classname);
       }
       while (context.getClasses().containsKey(classNewFullName));
@@ -223,7 +224,7 @@ public class IdentifierConverter implements NewClassNameBuilder {
           names.put(key, name);
         }
       }
-      else if (helper.toBeRenamed(IIdentifierRenamer.Type.ELEMENT_METHOD, classOldFullName, name, mt.getDescriptor())) {
+      else if (helper.shouldRenameMethod(classOldFullName, name, mt.getDescriptor())) {
         if (isPrivate || !names.containsKey(key)) {
           do {
             name = helper.getNextMethodName(classOldFullName, name, mt.getDescriptor());
@@ -256,7 +257,7 @@ public class IdentifierConverter implements NewClassNameBuilder {
     }
 
     for (StructField fd : cl.getFields()) {
-      if (helper.toBeRenamed(IIdentifierRenamer.Type.ELEMENT_FIELD, classOldFullName, fd.getName(), fd.getDescriptor())) {
+      if (helper.shouldRenameField(classOldFullName, fd.getName(), fd.getDescriptor())) {
         String newName;
         do {
           newName = helper.getNextFieldName(classOldFullName, fd.getName(), fd.getDescriptor());

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/attr/StructAnnotationAttribute.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/attr/StructAnnotationAttribute.java
@@ -52,7 +52,7 @@ public class StructAnnotationAttribute extends StructGeneralAttribute {
   }
 
   public static AnnotationExprent parseAnnotation(DataInputStream data, ConstantPool pool) throws IOException {
-    String className = pool.getPrimitiveConstant(data.readUnsignedShort()).getString();
+    String className = pool.getPrimitiveConstant(data.readUnsignedShort(), true).getString();
 
     List<String> names;
     List<Exprent> values;

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
@@ -184,10 +184,13 @@ public class ConstantPool implements NewClassNameBuilder {
   }
 
   public PrimitiveConstant getPrimitiveConstant(int index) {
-    PrimitiveConstant cn = (PrimitiveConstant)getConstant(index);
+    return getPrimitiveConstant(index, false);
+  }
 
+  public PrimitiveConstant getPrimitiveConstant(int index, boolean forceRename) {
+    PrimitiveConstant cn = (PrimitiveConstant)getConstant(index);
     if (cn != null && interceptor != null) {
-      if (cn.type == CodeConstants.CONSTANT_Class) {
+      if (forceRename || cn.type == CodeConstants.CONSTANT_Class) {
         String newName = buildNewClassname(cn.getString());
         if (newName != null) {
           cn = new PrimitiveConstant(CodeConstants.CONSTANT_Class, newName);


### PR DESCRIPTION
Restructured the IIdentifierRenamer class to be more flexible and allow for easy expansion. Annotations on classes and class members are now also correctly renamed (they weren't before because they're loaded from the constant pool as Utf8 instead of Class or similar). I've also wrote a preliminary version of IIdentifierRenamer#shouldRenamePackage (usage of the method and it's utilities is not implemented). Classes sharing names that are the same except for differing in case are also now renamed so that the files can be properly extracted from the resulting archive. Comments in the generated source code are now placed directly above the class/field/method and below their annotations.

I've previously signed the contributor license agreement.