### PR TITLE
[Fernflower] Refactored IIdentifierRenamer to be more flexible.

### DIFF
--- a/plugins/java-decompiler/engine/readme.txt
+++ b/plugins/java-decompiler/engine/readme.txt
@@ -78,11 +78,13 @@ code leads to a great number of conflicts. Therefore it is advisable to let the 
 ensuring uniqueness of each identifier.
 
 Option 'ren' (i.e. -ren=1) activates renaming functionality. Default renaming strategy goes as follows:
-- rename an element if its name is a reserved word or is shorter than 3 characters
-- new names are built according to a simple pattern: (class|method|field)_<consecutive unique number>  
-You can overwrite this rules by providing your own implementation of the 4 key methods invoked by the decompiler while renaming. Simply 
+- rename a class member element if its name is shorter than 3 characters, is reserved in java as a keyword, or it starts with a digit.
+- rename a class if it meets the criteria for renaming a class member element, its simple name is a reserved word in the windows
+  namespace (case insensitive), or its name is equal to another class's name (case insensitive).
+- new names are built according to a simple pattern: (class|interface|annotation|enum|method|field)_<consecutive unique number>
+You can overwrite these rules by providing your own implementation of the 6 key methods invoked by the decompiler while renaming. Simply
 pass a class that implements org.jetbrains.java.decompiler.main.extern.IIdentifierRenamer in the option 'urc'
 (e.g. -urc=com.mypackage.MyRenamer) to Fernflower. The class must be available on the application classpath.
 
-The meaning of each method should be clear from naming: toBeRenamed determine whether the element will be renamed, while the other three
-provide new names for classes, methods and fields respectively.  
+The meaning of the methods should be clear from their names: shouldRename(Class|Method|Field) determines whether or not a specified element
+should be renamed while getNext(Class|Method|Field)Name provides new names for the elements.

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2016 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,9 +79,9 @@ public class ClassesProcessor {
                 simpleName = savedName;
               }
               else if (simpleName != null && DecompilerContext.getOption(IFernflowerPreferences.RENAME_ENTITIES)) {
-                IIdentifierRenamer renamer = DecompilerContext.getPoolInterceptor().getHelper();
+                IIdentifierRenamer renamer = DecompilerContext.getPoolInterceptor().getRenamer();
                 if (renamer.shouldRenameClass(simpleName, innerName)) {
-                  simpleName = renamer.getNextClassName(simpleName, innerName);
+                  simpleName = renamer.getNextClassName(simpleName, innerName, entry.accessFlags);
                   mapNewSimpleNames.put(innerName, simpleName);
                 }
               }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
@@ -80,15 +80,17 @@ public class ClassesProcessor {
               }
               else if (simpleName != null && DecompilerContext.getOption(IFernflowerPreferences.RENAME_ENTITIES)) {
                 IIdentifierRenamer renamer = DecompilerContext.getPoolInterceptor().getHelper();
-                if (renamer.toBeRenamed(IIdentifierRenamer.Type.ELEMENT_CLASS, simpleName, null, null)) {
-                  simpleName = renamer.getNextClassName(innerName, simpleName);
+                if (renamer.shouldRenameClass(simpleName, innerName)) {
+                  simpleName = renamer.getNextClassName(simpleName, innerName);
                   mapNewSimpleNames.put(innerName, simpleName);
                 }
               }
 
               Inner rec = new Inner();
               rec.simpleName = simpleName;
-              rec.type = entry.outerNameIdx != 0 ? ClassNode.CLASS_MEMBER : entry.simpleNameIdx != 0 ? ClassNode.CLASS_LOCAL : ClassNode.CLASS_ANONYMOUS;
+              rec.type = entry.outerNameIdx != 0
+                         ? ClassNode.CLASS_MEMBER
+                         : entry.simpleNameIdx != 0 ? ClassNode.CLASS_LOCAL : ClassNode.CLASS_ANONYMOUS;
               rec.accessFlags = entry.accessFlags;
 
               // enclosing class
@@ -160,7 +162,8 @@ public class ClassesProcessor {
               StructInnerClassesAttribute inner = (StructInnerClassesAttribute)scl.getAttributes().getWithKey("InnerClasses");
 
               if (inner == null || inner.getEntries().isEmpty()) {
-                DecompilerContext.getLogger().writeMessage(superClass + " does not contain inner classes!", IFernflowerLogger.Severity.WARN);
+                DecompilerContext.getLogger()
+                  .writeMessage(superClass + " does not contain inner classes!", IFernflowerLogger.Severity.WARN);
                 continue;
               }
 
@@ -183,7 +186,7 @@ public class ClassesProcessor {
                 Inner rec = mapInnerClasses.get(nestedClass);
 
                 //if ((Integer)arr[2] == ClassNode.CLASS_MEMBER) {
-                  // FIXME: check for consistent naming
+                // FIXME: check for consistent naming
                 //}
 
                 nestedNode.simpleName = rec.simpleName;

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
@@ -38,7 +38,7 @@ public interface IIdentifierRenamer {
    * @param fullName the current simple name of the class
    * @return a generated String that is a valid class name
    */
-  String getNextClassName(String simpleName, String fullName);
+  String getNextClassName(String simpleName, String fullName, int accessFlags);
 
   /**
    * Generates the next name for a field

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IIdentifierRenamer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2016 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,44 @@ package org.jetbrains.java.decompiler.main.extern;
 
 public interface IIdentifierRenamer {
 
-  enum Type {ELEMENT_CLASS, ELEMENT_FIELD, ELEMENT_METHOD}
+  /**
+   * Determines whether or not the specified class should be renamed
+   */
+  boolean shouldRenameClass(String simpleName, String fullName);
 
-  boolean toBeRenamed(Type elementType, String className, String element, String descriptor);
+  /**
+   * Determines whether or not the specified field should be renamed
+   */
+  boolean shouldRenameField(String owner, String name, String descriptor);
 
-  String getNextClassName(String fullName, String shortName);
+  /**
+   * Determines whether or not the specified method should be renamed
+   */
+  boolean shouldRenameMethod(String owner, String name, String descriptor);
 
-  String getNextFieldName(String className, String field, String descriptor);
+  /**
+   * Generates the next simple name for a class
+   * @param simpleName the current full name of the class
+   * @param fullName the current simple name of the class
+   * @return a generated String that is a valid class name
+   */
+  String getNextClassName(String simpleName, String fullName);
 
-  String getNextMethodName(String className, String method, String descriptor);
+  /**
+   * Generates the next name for a field
+   * @param owner the fields owner
+   * @param name the fields current name
+   * @param descriptor the fields descriptor
+   * @return a generated String that is a valid field name
+   */
+  String getNextFieldName(String owner, String name, String descriptor);
+
+  /**
+   * Generates the next name for a method
+   * @param owner the methods owner
+   * @param name the methods current name
+   * @param descriptor the methods descriptor
+   * @return a generated String that is a valid method name
+   */
+  String getNextMethodName(String owner, String name, String descriptor);
 }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -15,6 +15,8 @@
  */
 package org.jetbrains.java.decompiler.modules.renamer;
 
+import org.jetbrains.java.decompiler.code.CodeConstants;
+
 public class ConverterHelper {
 
   // *****************************************************************************
@@ -31,5 +33,17 @@ public class ConverterHelper {
 
   public static String getPackageName(String fullName) {
     return fullName.substring(0, fullName.lastIndexOf('/') + 1);
+  }
+
+  public static String getClassPrefix(int accessFlags) {
+    if ((accessFlags & CodeConstants.ACC_INTERFACE) == CodeConstants.ACC_INTERFACE) {
+      return "interface_";
+    }
+    else if ((accessFlags & CodeConstants.ACC_ENUM) == CodeConstants.ACC_ENUM) {
+      return "enum_";
+    }
+    else {
+      return "class_";
+    }
   }
 }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -35,12 +35,16 @@ public class ConverterHelper {
     return fullName.substring(0, fullName.lastIndexOf('/') + 1);
   }
 
-  public static String getClassPrefix(int accessFlags) {
-    if ((accessFlags & CodeConstants.ACC_INTERFACE) == CodeConstants.ACC_INTERFACE) {
-      return "interface_";
-    }
-    else if ((accessFlags & CodeConstants.ACC_ENUM) == CodeConstants.ACC_ENUM) {
+  public static String getNextClassNamePrefix(int accessFlags) {
+    if ((accessFlags & CodeConstants.ACC_ENUM) == CodeConstants.ACC_ENUM) {
       return "enum_";
+    }
+    //ACC_INTERFACE must be set whenever ACC_ANNOTATION is set, so we need to do the ACC_ANNOTATION check first
+    else if ((accessFlags & CodeConstants.ACC_ANNOTATION) == CodeConstants.ACC_ANNOTATION) {
+      return "annotation_";
+    }
+    else if ((accessFlags & CodeConstants.ACC_INTERFACE) == CodeConstants.ACC_INTERFACE) {
+      return "interface_";
     }
     else {
       return "class_";

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2015 JetBrains s.r.o.
+ * Copyright 2000-2016 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,75 +15,7 @@
  */
 package org.jetbrains.java.decompiler.modules.renamer;
 
-import org.jetbrains.java.decompiler.main.extern.IIdentifierRenamer;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-public class ConverterHelper implements IIdentifierRenamer {
-
-  private static final Set<String> KEYWORDS = new HashSet<String>(Arrays.asList(
-    "abstract", "do", "if", "package", "synchronized", "boolean", "double", "implements", "private", "this", "break", "else", "import",
-    "protected", "throw", "byte", "extends", "instanceof", "public", "throws", "case", "false", "int", "return", "transient", "catch",
-    "final", "interface", "short", "true", "char", "finally", "long", "static", "try", "class", "float", "native", "strictfp", "void",
-    "const", "for", "new", "super", "volatile", "continue", "goto", "null", "switch", "while", "default", "assert", "enum"));
-  private static final Set<String> RESERVED_WINDOWS_NAMESPACE = new HashSet<String>(Arrays.asList(
-    "aux", "prn", "aux", "nul",
-    "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
-    "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"));
-
-  private int classCounter = 0;
-  private int fieldCounter = 0;
-  private int methodCounter = 0;
-  private final Set<String> setNonStandardClassNames = new HashSet<String>();
-
-  @Override
-  public boolean toBeRenamed(Type elementType, String className, String element, String descriptor) {
-    String value = elementType == Type.ELEMENT_CLASS ? className : element;
-    return value == null || value.length() == 0 || value.length() <= 2 || KEYWORDS.contains(value) || Character.isDigit(value.charAt(0))
-      || elementType == Type.ELEMENT_CLASS && RESERVED_WINDOWS_NAMESPACE.contains(value.toLowerCase());
-  }
-
-  // TODO: consider possible conflicts with not renamed classes, fields and methods!
-  // We should get all relevant information here.
-  @Override
-  public String getNextClassName(String fullName, String shortName) {
-
-    if (shortName == null) {
-      return "class_" + (classCounter++);
-    }
-
-    int index = 0;
-    while (Character.isDigit(shortName.charAt(index))) {
-      index++;
-    }
-
-    if (index == 0 || index == shortName.length()) {
-      return "class_" + (classCounter++);
-    }
-    else {
-      String name = shortName.substring(index);
-
-      if (setNonStandardClassNames.contains(name)) {
-        return "Inner" + name + "_" + (classCounter++);
-      }
-      else {
-        setNonStandardClassNames.add(name);
-        return "Inner" + name;
-      }
-    }
-  }
-
-  @Override
-  public String getNextFieldName(String className, String field, String descriptor) {
-    return "field_" + (fieldCounter++);
-  }
-
-  @Override
-  public String getNextMethodName(String className, String method, String descriptor) {
-    return "method_" + (methodCounter++);
-  }
+public class ConverterHelper {
 
   // *****************************************************************************
   // static methods
@@ -94,6 +26,10 @@ public class ConverterHelper implements IIdentifierRenamer {
   }
 
   public static String replaceSimpleClassName(String fullName, String newName) {
-    return fullName.substring(0, fullName.lastIndexOf('/') + 1) + newName;
+    return getPackageName(fullName) + newName;
+  }
+
+  public static String getPackageName(String fullName) {
+    return fullName.substring(0, fullName.lastIndexOf('/') + 1);
   }
 }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/DefaultIIdentifierRenamer.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/DefaultIIdentifierRenamer.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.java.decompiler.modules.renamer;
+
+import org.jetbrains.java.decompiler.main.extern.IIdentifierRenamer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class DefaultIIdentifierRenamer implements IIdentifierRenamer {
+  //Packages, classes, fields, and methods may have these names due to obfuscation, but they're not valid names in Java.
+  private static final Set<String> RESERVED_JAVA_KEYWORDS = new HashSet<>(Arrays.asList(
+    "abstract", "do", "if", "package", "synchronized", "boolean", "double", "implements", "private", "this", "break", "else", "import",
+    "protected", "throw", "byte", "extends", "instanceof", "public", "throws", "case", "false", "int", "return", "transient", "catch",
+    "final", "interface", "short", "true", "char", "finally", "long", "static", "try", "class", "float", "native", "strictfp", "void",
+    "const", "for", "new", "super", "volatile", "continue", "goto", "null", "switch", "while", "default", "assert", "enum"));
+  //Packages and Classes cannot be extracted from an archive if they have a variation of any of these names.
+  private static final Set<String> RESERVED_WINDOWS_NAMESPACE = new HashSet<>(Arrays.asList(
+    "aux", "prn", "aux", "nul",
+    "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+    "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"));
+
+  private int classCounter = 0;
+  private int fieldCounter = 0;
+  private int methodCounter = 0;
+  private final Set<String> setNonStandardClassNames = new HashSet<>();
+  private final Set<String> setKnownClassNames = new HashSet<>();
+
+  @Override
+  public boolean shouldRenameClass(String simpleName, String fullName) {
+    if (simpleName == null || fullName == null) {
+      return true;
+    }
+    simpleName = simpleName.toLowerCase();
+    fullName = fullName.toLowerCase();
+    if (simpleName.length() == 0 || simpleName.length() <= 2
+        || Character.isDigit(simpleName.charAt(0))
+        || RESERVED_JAVA_KEYWORDS.contains(simpleName)
+        || RESERVED_WINDOWS_NAMESPACE.contains(simpleName)
+        || setKnownClassNames.contains(fullName)) {
+      return true;
+    }
+    setKnownClassNames.add(fullName);
+    return false;
+  }
+
+  @Override
+  public boolean shouldRenameField(String className, String field, String descriptor) {
+    return field == null || field.length() == 0 || field.length() <= 2
+           || Character.isDigit(field.charAt(0)) || RESERVED_JAVA_KEYWORDS.contains(field);
+  }
+
+  @Override
+  public boolean shouldRenameMethod(String className, String method, String descriptor) {
+    return method == null || method.length() == 0 || method.length() <= 2
+           || Character.isDigit(method.charAt(0)) || RESERVED_JAVA_KEYWORDS.contains(method);
+  }
+
+  // TODO: consider possible conflicts with not renamed classes, fields and methods!
+  // We should get all relevant information here.
+  @Override
+  public String getNextClassName(String simpleName, String fullName) {
+    if (fullName == null) {
+      return "class_" + (classCounter++);
+    }
+
+    int index = 0;
+    while (Character.isDigit(fullName.charAt(index))) {
+      index++;
+    }
+    if (index == 0 || index == fullName.length()) {
+      return "class_" + (classCounter++);
+    }
+    else {
+      String name = fullName.substring(index);
+
+      if (setNonStandardClassNames.contains(name)) {
+        return "Inner" + name + "_" + (classCounter++);
+      }
+      else {
+        setNonStandardClassNames.add(name);
+        return "Inner" + name;
+      }
+    }
+  }
+
+  @Override
+  public String getNextFieldName(String className, String field, String descriptor) {
+    return "field_" + (fieldCounter++);
+  }
+
+  @Override
+  public String getNextMethodName(String className, String method, String descriptor) {
+    return "method_" + (methodCounter++);
+  }
+}

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/DefaultIIdentifierRenamer.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/DefaultIIdentifierRenamer.java
@@ -75,7 +75,7 @@ public class DefaultIIdentifierRenamer implements IIdentifierRenamer {
   @Override
   public String getNextClassName(String simpleName, String fullName, int accessFlags) {
     if (fullName == null) {
-      return ConverterHelper.getClassPrefix(accessFlags) + (classCounter++);
+      return ConverterHelper.getNextClassNamePrefix(accessFlags) + (classCounter++);
     }
 
     int index = 0;
@@ -83,7 +83,7 @@ public class DefaultIIdentifierRenamer implements IIdentifierRenamer {
       index++;
     }
     if (index == 0 || index == fullName.length()) {
-      return ConverterHelper.getClassPrefix(accessFlags) + (classCounter++);
+      return ConverterHelper.getNextClassNamePrefix(accessFlags) + (classCounter++);
     }
     else {
       String name = fullName.substring(index);

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/DefaultIIdentifierRenamer.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/DefaultIIdentifierRenamer.java
@@ -73,9 +73,9 @@ public class DefaultIIdentifierRenamer implements IIdentifierRenamer {
   // TODO: consider possible conflicts with not renamed classes, fields and methods!
   // We should get all relevant information here.
   @Override
-  public String getNextClassName(String simpleName, String fullName) {
+  public String getNextClassName(String simpleName, String fullName, int accessFlags) {
     if (fullName == null) {
-      return "class_" + (classCounter++);
+      return ConverterHelper.getClassPrefix(accessFlags) + (classCounter++);
     }
 
     int index = 0;
@@ -83,7 +83,7 @@ public class DefaultIIdentifierRenamer implements IIdentifierRenamer {
       index++;
     }
     if (index == 0 || index == fullName.length()) {
-      return "class_" + (classCounter++);
+      return ConverterHelper.getClassPrefix(accessFlags) + (classCounter++);
     }
     else {
       String name = fullName.substring(index);

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/IdentifierConverter.java
@@ -185,7 +185,7 @@ public class IdentifierConverter implements NewClassNameBuilder {
       String classNewFullName;
 
       do {
-        String classname = renamer.getNextClassName(classOldSimpleName, classOldFullName);
+        String classname = renamer.getNextClassName(classOldSimpleName, classOldFullName, cl.getAccessFlags());
         classNewFullName = ConverterHelper.replaceSimpleClassName(classOldFullName, classname);
       }
       while (context.getClasses().containsKey(classNewFullName));

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/PoolInterceptor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/PoolInterceptor.java
@@ -21,14 +21,14 @@ import java.util.HashMap;
 
 public class PoolInterceptor {
 
-  private final IIdentifierRenamer helper;
+  private final IIdentifierRenamer renamer;
 
   private final HashMap<String, String> mapOldToNewNames = new HashMap<String, String>();
 
   private final HashMap<String, String> mapNewToOldNames = new HashMap<String, String>();
 
-  public PoolInterceptor(IIdentifierRenamer helper) {
-    this.helper = helper;
+  public PoolInterceptor(IIdentifierRenamer renamer) {
+    this.renamer = renamer;
   }
 
   public void addName(String oldName, String newName) {
@@ -44,7 +44,7 @@ public class PoolInterceptor {
     return mapNewToOldNames.get(newName);
   }
 
-  public IIdentifierRenamer getHelper() {
-    return helper;
+  public IIdentifierRenamer getRenamer() {
+    return renamer;
   }
 }


### PR DESCRIPTION
I went ahead and refactored the IIdentifierRenamer class and added some basic documentation to it. I also separated the default implementation of it into a separate class called DefaultIIdentifierRenamer and left the ConverterHelper class in place to store static methods that are useful and related to the renaming process. Classes with names differing only in case are also now renamed by default since you can't properly extract them on windows without them overwriting each other. In addition, I made it so that getNextClassName has a new argument of int accessFlags which I used to change the default class prefix from "class_" to "interface_", "enum_", and "annotation_" if appropriate. By doing that it's now easier to find what you're looking for at a glance.