### PR TITLE
Fix WM_CLASS x property not being null-terminated

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/AppUIUtil.java
+++ b/platform/platform-impl/src/com/intellij/ui/AppUIUtil.java
@@ -108,10 +108,11 @@ public class AppUIUtil {
 
   public static void updateFrameClass() {
     try {
+      String wmClass = getFrameClass() + "\0"; //needs to be null-terminated as defined in the icccm spec 4.1.2.5
       final Toolkit toolkit = Toolkit.getDefaultToolkit();
       final Class<? extends Toolkit> aClass = toolkit.getClass();
       if ("sun.awt.X11.XToolkit".equals(aClass.getName())) {
-        ReflectionUtil.setField(aClass, toolkit, null, "awtAppClassName", getFrameClass());
+        ReflectionUtil.setField(aClass, toolkit, null, "awtAppClassName", wmClass);
       }
     }
     catch (Exception ignore) { }


### PR DESCRIPTION
The WM_CLASS must be null-terminated according to the icccm spec 4.1.2.5:

>  The WM_CLASS property (of type STRING without control characters) contains two consecutive null-terminated strings. These specify the Instance and Class names to be used by both the client and the window manager for looking up resources for the application or as identifying information. This property must be present when the window leaves the Withdrawn state and may be changed only while the window is in the Withdrawn state. Window managers may examine the property only when they start up and when the window leaves the Withdrawn state, but there should be no need for a client to change its state dynamically.

https://tronche.com/gui/x/icccm/sec-4.html

This fixes the icon for the jetbrains IDEs appearing twice due to random memory being added to the WM_CLASS because it missed the null-terminator. This happened for example in the gnome launcher.