### PR TITLE
[Fernflower] ClassReference14Processor cleanup

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java
@@ -118,7 +118,7 @@ public class BasicBlock implements IGraphNode {
     block.removePredecessor(this);
   }
 
-  // FIXME: unify block comparisons: id or direkt equality
+  // FIXME: unify block comparisons: id or direct equality
   public void replaceSuccessor(BasicBlock oldBlock, BasicBlock newBlock) {
     for (int i = 0; i < succs.size(); i++) {
       if (succs.get(i).id == oldBlock.id) {

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassReference14Processor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassReference14Processor.java
@@ -38,12 +38,11 @@ import java.util.Map.Entry;
 
 public class ClassReference14Processor {
 
-  public final ExitExprent bodyexprent;
+  public static final ExitExprent bodyexprent;
 
-  public final ExitExprent handlerexprent;
+  public static final ExitExprent handlerexprent;
 
-
-  public ClassReference14Processor() {
+  static {
 
     InvocationExprent invfor = new InvocationExprent();
     invfor.setName("forName");
@@ -65,7 +64,7 @@ public class ClassReference14Processor {
     constr.setDescriptor(MethodDescriptor.parseDescriptor("()V"));
 
     NewExprent newexpr =
-      new NewExprent(new VarType(CodeConstants.TYPE_OBJECT, 0, "java/lang/NoClassDefFoundError"), new ArrayList<Exprent>(), null);
+      new NewExprent(new VarType(CodeConstants.TYPE_OBJECT, 0, "java/lang/NoClassDefFoundError"), new ArrayList<>(), null);
     newexpr.setConstructor(constr);
 
     InvocationExprent invcause = new InvocationExprent();
@@ -82,32 +81,13 @@ public class ClassReference14Processor {
                                      null, null);
   }
 
-
-  public void processClassReferences(ClassNode node) {
-
-    ClassWrapper wrapper = node.getWrapper();
-
-    //		int major_version = wrapper.getClassStruct().major_version;
-    //		int minor_version = wrapper.getClassStruct().minor_version;
-    //
-    //		if(major_version > 48 || (major_version == 48 && minor_version > 0)) {
-    //			// version 1.5 or above
-    //			return;
-    //		}
-
-    if (wrapper.getClassStruct().isVersionGE_1_5()) {
-      // version 1.5 or above
-      return;
-    }
-
+  public static void processClassReferences(ClassNode node) {
     // find the synthetic method Class class$(String) if present
     HashMap<ClassWrapper, MethodWrapper> mapClassMeths = new HashMap<ClassWrapper, MethodWrapper>();
     mapClassMethods(node, mapClassMeths);
-
     if (mapClassMeths.isEmpty()) {
       return;
     }
-
     HashSet<ClassWrapper> setFound = new HashSet<ClassWrapper>();
     processClassRec(node, mapClassMeths, setFound);
 
@@ -173,7 +153,7 @@ public class ClassReference14Processor {
     }
   }
 
-  private void mapClassMethods(ClassNode node, Map<ClassWrapper, MethodWrapper> map) {
+  private static void mapClassMethods(ClassNode node, Map<ClassWrapper, MethodWrapper> map) {
     boolean noSynthFlag = DecompilerContext.getOption(IFernflowerPreferences.SYNTHETIC_NOT_SET);
 
     ClassWrapper wrapper = node.getWrapper();

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -54,7 +54,7 @@ public class ClassWriter {
     interceptor = DecompilerContext.getPoolInterceptor();
   }
 
-  private void invokeProcessors(ClassNode node) {
+  private static void invokeProcessors(ClassNode node) {
     ClassWrapper wrapper = node.getWrapper();
     StructClass cl = wrapper.getClassStruct();
 

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -368,7 +368,7 @@ public class ExprProcessor implements CodeConstants {
           }
           else if (cn instanceof LinkConstant) {
             //TODO: for now treat Links as Strings
-            pushEx(stack, exprlist, new ConstExprent(VarType.VARTYPE_STRING, ((LinkConstant)cn).elementname , bytecode_offsets));
+            pushEx(stack, exprlist, new ConstExprent(VarType.VARTYPE_STRING, ((LinkConstant)cn).elementname, bytecode_offsets));
           }
           break;
         case opc_iload:
@@ -422,7 +422,8 @@ public class ExprProcessor implements CodeConstants {
           Exprent index_store = stack.pop();
           Exprent arr_store = stack.pop();
           AssignmentExprent arrassign =
-            new AssignmentExprent(new ArrayExprent(arr_store, index_store, arrtypes[instr.opcode - opc_iastore], bytecode_offsets), value, bytecode_offsets);
+            new AssignmentExprent(new ArrayExprent(arr_store, index_store, arrtypes[instr.opcode - opc_iastore], bytecode_offsets), value,
+                                  bytecode_offsets);
           exprlist.add(arrassign);
           break;
         case opc_iadd:
@@ -523,7 +524,7 @@ public class ExprProcessor implements CodeConstants {
         case opc_tableswitch:
         case opc_lookupswitch:
           exprlist.add(new SwitchExprent(stack.pop(), bytecode_offsets));
-        break;
+          break;
         case opc_ireturn:
         case opc_lreturn:
         case opc_freturn:
@@ -538,7 +539,7 @@ public class ExprProcessor implements CodeConstants {
                                        : ((MethodDescriptor)DecompilerContext
                                          .getProperty(DecompilerContext.CURRENT_METHOD_DESCRIPTOR)).ret,
                                        bytecode_offsets));
-        break;
+          break;
         case opc_monitorenter:
         case opc_monitorexit:
           exprlist.add(new MonitorExprent(func8[instr.opcode - opc_monitorenter], stack.pop(), bytecode_offsets));
@@ -552,13 +553,15 @@ public class ExprProcessor implements CodeConstants {
         case opc_getstatic:
         case opc_getfield:
           pushEx(stack, exprlist,
-                 new FieldExprent(pool.getLinkConstant(instr.getOperand(0)), instr.opcode == opc_getstatic ? null : stack.pop(), bytecode_offsets));
+                 new FieldExprent(pool.getLinkConstant(instr.getOperand(0)), instr.opcode == opc_getstatic ? null : stack.pop(),
+                                  bytecode_offsets));
           break;
         case opc_putstatic:
         case opc_putfield:
           Exprent valfield = stack.pop();
           Exprent exprfield =
-            new FieldExprent(pool.getLinkConstant(instr.getOperand(0)), instr.opcode == opc_putstatic ? null : stack.pop(), bytecode_offsets);
+            new FieldExprent(pool.getLinkConstant(instr.getOperand(0)), instr.opcode == opc_putstatic ? null : stack.pop(),
+                             bytecode_offsets);
           exprlist.add(new AssignmentExprent(exprfield, valfield, bytecode_offsets));
           break;
         case opc_invokevirtual:
@@ -755,7 +758,7 @@ public class ExprProcessor implements CodeConstants {
     return prlst;
   }
 
-  public static boolean endsWithSemikolon(Exprent expr) {
+  public static boolean endsWithSemicolon(Exprent expr) {
     int type = expr.type;
     return !(type == Exprent.EXPRENT_SWITCH ||
              type == Exprent.EXPRENT_MONITOR ||
@@ -768,7 +771,8 @@ public class ExprProcessor implements CodeConstants {
     if (stat instanceof BasicBlockStatement) {
       BasicBlock block = ((BasicBlockStatement)stat).getBlock();
       List<Integer> offsets = block.getInstrOldOffsets();
-      if (!offsets.isEmpty() && offsets.size() > block.getSeq().length()) { // some instructions have been deleted, but we still have offsets
+      if (!offsets.isEmpty() &&
+          offsets.size() > block.getSeq().length()) { // some instructions have been deleted, but we still have offsets
         tracer.addMapping(offsets.get(offsets.size() - 1)); // add the last offset
       }
     }
@@ -840,7 +844,7 @@ public class ExprProcessor implements CodeConstants {
         if (expr.type == Exprent.EXPRENT_MONITOR && ((MonitorExprent)expr).getMonType() == MonitorExprent.MONITOR_ENTER) {
           buf.append("{}"); // empty synchronized block
         }
-        if (endsWithSemikolon(expr)) {
+        if (endsWithSemicolon(expr)) {
           buf.append(";");
         }
         buf.appendLineSeparator();

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java
@@ -68,7 +68,9 @@ public class BasicBlockStatement extends Statement {
   // *****************************************************************************
 
   public TextBuffer toJava(int indent, BytecodeMappingTracer tracer) {
-    return ExprProcessor.listToJava(varDefinitions, indent, tracer).append(ExprProcessor.listToJava(exprents, indent, tracer));
+    TextBuffer tb = ExprProcessor.listToJava(varDefinitions, indent, tracer);
+    tb.append(ExprProcessor.listToJava(exprents, indent, tracer));
+    return tb;
   }
 
   public Statement getSimpleCopy() {


### PR DESCRIPTION
ClassReference14Processor has been made static similar to how EnumProcessor and InitializerProcessor are setup. This prevents a lot of redundant InvocationExprent creation. I also fixed a couple typos that I noticed while working on the codebase and split BasicBlockStatement.toJava(int indent, BytecodeMappingTracer tracer) into two lines to make it easier to interpret stack traces involving it.

I've previously signed the contributor license agreement.