### PR TITLE
spell checker: levenshtein->damerau-levenstein

### DIFF
--- a/platform/util/testSrc/com/intellij/util/text/EditDistanceTest.java
+++ b/platform/util/testSrc/com/intellij/util/text/EditDistanceTest.java
@@ -40,6 +40,7 @@ public class EditDistanceTest {
 
   @Test
   public void optimalAlignment() {
+    assertEquals(0, EditDistance.optimalAlignment("", "", true));
     assertEquals(1, EditDistance.optimalAlignment("ab", "ba", true));
     assertEquals(2, EditDistance.optimalAlignment("AB", "ba", true));
     assertEquals(3, EditDistance.optimalAlignment("ca", "abc", true));
@@ -48,6 +49,7 @@ public class EditDistanceTest {
 
   @Test
   public void optimalAlignmentCaseInsensitive() {
+    assertEquals(0, EditDistance.optimalAlignment("", "", false));
     assertEquals(1, EditDistance.optimalAlignment("ab", "ba", false));
     assertEquals(1, EditDistance.optimalAlignment("AB", "ba", false));
     assertEquals(3, EditDistance.optimalAlignment("ca", "abc", false));

--- a/spellchecker/src/com/intellij/spellchecker/engine/BaseSpellChecker.java
+++ b/spellchecker/src/com/intellij/spellchecker/engine/BaseSpellChecker.java
@@ -223,7 +223,7 @@ public class BaseSpellChecker implements SpellCheckerEngine {
 
     List<Suggestion> suggestions = new ArrayList<Suggestion>(rawSuggestions.size());
     for (String rawSuggestion : rawSuggestions) {
-      int distance = EditDistance.levenshtein(transformed, rawSuggestion, true);
+      int distance = EditDistance.optimalAlignment(transformed, rawSuggestion, true);
       suggestions.add(new Suggestion(rawSuggestion, distance));
     }
 


### PR DESCRIPTION
Word distance algorithm changed to Damerau-Levenshtein
https://en.wikipedia.org/wiki/Levenshtein_distance
https://en.wikipedia.org/wiki/Damerau–Levenshtein_distance

motivation: transposition error is really common
For example: versoin (Typo:Change to...).
expected: version. 
actual: vermin, vernon ...