### PR TITLE
Make NativeFileWatcherImpl#isRepetition protected.

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
@@ -458,7 +458,7 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
     }
   }
 
-  private boolean isRepetition(String path) {
+  protected boolean isRepetition(String path) {
     // collapse subsequent change file change notifications that happen once we copy large file,
     // this allows reduction of path checks at least 20% for Windows
     synchronized (myLastChangedPaths) {


### PR DESCRIPTION
Some file systems aren't 100% accurate in their VFS events,
causing missed events. For instance, consider for a single file:

CHANGE - DELETE - CREATE - CHANGE

If the create is missed, then the file won't be updated because
it looks like a repetition.

This allows implementors for those file systems to override this
and get the CHANGE event.