### PR TITLE
Fix incorrect manual watch root calculations.

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/FileWatcher.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/FileWatcher.java
@@ -184,9 +184,7 @@ public class FileWatcher {
 
     @Override
     public void notifyManualWatchRoots(@NotNull Collection<String> roots) {
-      if (!roots.isEmpty()) {
-        myManualWatchRoots.add(ContainerUtil.newHashSet(roots));
-      }
+      myManualWatchRoots.add(ContainerUtil.newHashSet(roots));
       notifyOnAnyEvent();
     }
 


### PR DESCRIPTION
Previously, if these were met:

* You have more than one file watcher, and
* One of the file watchers have unwatchable roots, and
* Some other file watcher can watch everything

You would get spurious "Cannot be watched" notifications
and manual watch roots from the system.