### PR TITLE
avoid duplicate String instances of JpsElementChildRoleBase.myDebugName

### DIFF
--- a/jps/model-api/src/org/jetbrains/jps/model/ex/JpsElementChildRoleBase.java
+++ b/jps/model-api/src/org/jetbrains/jps/model/ex/JpsElementChildRoleBase.java
@@ -25,7 +25,7 @@ public class JpsElementChildRoleBase<E extends JpsElement> extends JpsElementChi
   private String myDebugName;
 
   protected JpsElementChildRoleBase(String debugName) {
-    myDebugName = debugName;
+    myDebugName = debugName.intern();
   }
 
   @Override


### PR DESCRIPTION
I was playing with MAT on IDEA and found 2500+ instance of this class (subclasses included).
and there're 600+ instance of String "collection of library root".

So intern() should make sense here.

Null check is not performed as it seems not necessary :-)