### PR TITLE
Inplace renaming of elements from different Psi trees 

### DIFF
--- a/platform/lang-impl/src/com/intellij/refactoring/rename/inplace/MemberInplaceRenamer.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/rename/inplace/MemberInplaceRenamer.java
@@ -144,7 +144,9 @@ public class MemberInplaceRenamer extends VariableInplaceRenamer {
     final PsiFile currentFile = PsiDocumentManager.getInstance(myProject).getPsiFile(myEditor.getDocument());
     if (currentFile == null) return true;
     InjectedLanguageManager manager = InjectedLanguageManager.getInstance(containingFile.getProject());
-    return manager.getTopLevelFile(containingFile) != manager.getTopLevelFile(currentFile);
+    PsiFile containingTopLevelFile = manager.getTopLevelFile(containingFile);
+    PsiFile currentTopLevelFile = manager.getTopLevelFile(currentFile);
+    return containingTopLevelFile == null || currentTopLevelFile == null || containingTopLevelFile.getViewProvider() != currentTopLevelFile.getViewProvider();
   }
 
   @Override


### PR DESCRIPTION
Current implementation does not allow inplace renaming when related elements are in different subtrees of a MultiPsi file. This should fix this