### PR TITLE
Make the `createCompleteMatchInfo` method public

### DIFF
--- a/platform/structuralsearch/source/com/intellij/structuralsearch/plugin/ui/UIUtil.java
+++ b/platform/structuralsearch/source/com/intellij/structuralsearch/plugin/ui/UIUtil.java
@@ -291,7 +291,7 @@ public class UIUtil {
   }
 
   @NotNull
-  static JComponent createCompleteMatchInfo(final Producer<Configuration> configurationProducer) {
+  public static JComponent createCompleteMatchInfo(final Producer<Configuration> configurationProducer) {
     final JLabel completeMatchInfo = new JLabel(AllIcons.RunConfigurations.Variables);
     final Point location = completeMatchInfo.getLocation();
     final JLabel label = new JLabel(SSRBundle.message("complete.match.variable.tooltip.message",


### PR DESCRIPTION
Please make the `createCompleteMatchInfo` method public. I'm working on a plugin that uses structural search to find potential coding issues, and I need a custom structural search dialog, that reuses some of the existing structural search UI code.
