### PR TITLE
Minor pycharm fixes

### DIFF
--- a/python/python-community-configure/src/com/jetbrains/python/configuration/PythonSdkDetailsDialog.java
+++ b/python/python-community-configure/src/com/jetbrains/python/configuration/PythonSdkDetailsDialog.java
@@ -226,6 +226,7 @@ public class PythonSdkDetailsDialog extends DialogWrapper {
       mySdkSettingsWereModified.run();
     }
     for (SdkModificator modificator : myModifiedModificators) {
+      /* This should always be true barring bug elsewhere, log error on else? */
       if (modificator.isWritable()) {
         modificator.commitChanges();
       }
@@ -433,8 +434,13 @@ public class PythonSdkDetailsDialog extends DialogWrapper {
   }
 
   private void reloadSdk(@NotNull Sdk currentSdk) {
-    // XXX: Here we are reusing a modifier that we are going to commit later
-    PythonSdkUpdater.update(currentSdk, myModificators.get(currentSdk), myProject, null);
+    /* PythonSdkUpdater.update invalidates the modificator so we need to create a new
+      one for further changes
+     */
+    if (PythonSdkUpdater.update(currentSdk, myModificators.get(currentSdk), myProject, null)){
+      myModifiedModificators.remove(myModificators.get(currentSdk));
+      myModificators.put(currentSdk, currentSdk.getSdkModificator());
+    }
   }
 
   private class ToggleVirtualEnvFilterButton extends ToggleActionButton implements DumbAware {

--- a/python/src/com/jetbrains/python/testing/VFSTestFrameworkListener.java
+++ b/python/src/com/jetbrains/python/testing/VFSTestFrameworkListener.java
@@ -28,7 +28,9 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.util.Alarm;
 import com.intellij.util.messages.MessageBus;
+import com.intellij.util.ui.UIUtil;
 import com.intellij.util.ui.update.MergingUpdateQueue;
 import com.intellij.util.ui.update.Update;
 import com.jetbrains.python.PyNames;
@@ -44,7 +46,7 @@ import java.util.List;
  */
 public class VFSTestFrameworkListener {
   private static final Logger LOG = Logger.getInstance("#com.jetbrains.python.testing.VFSTestFrameworkListener");
-  private final MergingUpdateQueue myQueue = new MergingUpdateQueue("TestFrameworkChecker", 5000, true, null);
+  private final MergingUpdateQueue myQueue;
   private final PyTestFrameworkService myService;
 
   public VFSTestFrameworkListener() {
@@ -86,6 +88,7 @@ public class VFSTestFrameworkListener {
         }
       }
     });
+    myQueue = new MergingUpdateQueue("TestFrameworkChecker", 5000, true, null, ApplicationManager.getApplication(), null, Alarm.ThreadToUse.POOLED_THREAD);
   }
 
   public void updateAllTestFrameworks(final Sdk sdk) {
@@ -100,8 +103,8 @@ public class VFSTestFrameworkListener {
       @Override
       public void run() {
         final Boolean installed = isTestFrameworkInstalled(sdk, testPackageName);
-        if (installed != null)
-          testInstalled(installed, sdk.getHomePath(), testPackageName);
+        if (installed != null) ApplicationManager.getApplication().invokeLater( ( ()-> testInstalled(installed, sdk.getHomePath(), testPackageName)));
+
       }
     });
   }


### PR DESCRIPTION
Details:
One issue is refreshing the sdk in details dialog invokes PySdkUpdater, which in turn invalidates the modificator. the dialog tries to then use the invated modificator causing an assertion error and an NPE.

Issue two is framewok updater waits for process output on UI thread causing a major lockup