### PR TITLE
Comment out checking maven settings by file name

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/MavenDomUtil.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/MavenDomUtil.java
@@ -90,8 +90,8 @@ public class MavenDomUtil {
   public static boolean isSettingsFile(PsiFile file) {
     if (!(file instanceof XmlFile)) return false;
 
-    String name = file.getName();
-    if (!name.equals(MavenConstants.SETTINGS_XML)) return false;
+    //String name = file.getName();
+    //if (!name.equals(MavenConstants.SETTINGS_XML)) return false;
 
     XmlTag rootTag = ((XmlFile)file).getRootTag();
     if (rootTag == null || !"settings".equals(rootTag.getName())) return false;


### PR DESCRIPTION
Comment out checking maven settings by file name. 
This check prevents navigation to maven profile defined in file with name differs from "settings.xml".
Mentioned navigation usually very helpful from Maven Projects tool window by pressing F4 key on corresponding profile.