### PR TITLE
[Fernflower] new option -osc: solves problems with method/field selection

### DIFF
--- a/plugins/java-decompiler/engine/readme.txt
+++ b/plugins/java-decompiler/engine/readme.txt
@@ -36,7 +36,7 @@ java -jar fernflower.jar -dgs=1 c:\Temp\binary\library.jar c:\Temp\binary\Boot.c
 With the exception of mpm and urc the value of 1 means the option is activated, 0 - deactivated. Default 
 value, if any, is given between parentheses.
 
-Typically, the following options will be changed by user, if any: hes, hdc, dgs, mpm, ren, urc 
+Typically, the following options will be changed by user, if any: hes, hdc, dgs, mpm, ren, urc, osc 
 The rest of options can be left as they are: they are aimed at professional reverse engineers.
 
 rbr (1): hide bridge methods
@@ -47,6 +47,9 @@ das (1): decompile assertions
 hes (1): hide empty super invocation
 hdc (1): hide empty default constructor
 dgs (0): decompile generic signatures
+osc (0): add more casts to output to make sure correct methods/fields are selected
+         Fernflower by default tries to create nice looking code, which can be incorrect or even illegal.
+         Casts in original code can lead to illegal access of private fields/methods or wrong field/method selection.
 ner (1): assume return not throwing exceptions
 den (1): decompile enumerations
 rgn (1): remove getClass() invocation, when it is part of a qualified new statement

--- a/plugins/java-decompiler/engine/readme.txt
+++ b/plugins/java-decompiler/engine/readme.txt
@@ -48,8 +48,9 @@ hes (1): hide empty super invocation
 hdc (1): hide empty default constructor
 dgs (0): decompile generic signatures
 osc (0): add more casts to output to make sure correct methods/fields are selected
-         Fernflower by default tries to create nice looking code, which can be incorrect or even illegal.
-         Casts in original code can lead to illegal access of private fields/methods or wrong field/method selection.
+         Fernflower by default tries to create nice looking code, which can be incorrect
+         or even illegal. Casts in original code can lead to illegal access of private
+         fields/methods or wrong field/method selection.
 ner (1): assume return not throwing exceptions
 den (1): decompile enumerations
 rgn (1): remove getClass() invocation, when it is part of a qualified new statement

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -44,6 +44,7 @@ public interface IFernflowerPreferences {
   String IDEA_NOT_NULL_ANNOTATION = "inn";
   String LAMBDA_TO_ANONYMOUS_CLASS = "lac";
   String BYTECODE_SOURCE_MAPPING = "bsm";
+  String OVERLOADING_SAFETY_CASTS = "osc";
 
   String LOG_LEVEL = "log";
   String MAX_PROCESSING_METHOD = "mpm";
@@ -86,6 +87,7 @@ public interface IFernflowerPreferences {
     defaults.put(IDEA_NOT_NULL_ANNOTATION, "1");
     defaults.put(LAMBDA_TO_ANONYMOUS_CLASS, "0");
     defaults.put(BYTECODE_SOURCE_MAPPING, "0");
+    defaults.put(OVERLOADING_SAFETY_CASTS, "0");
 
     defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
     defaults.put(MAX_PROCESSING_METHOD, "0");

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
@@ -851,12 +851,12 @@ public class ExprProcessor implements CodeConstants {
                                          TextBuffer buffer,
                                          int indent,
                                          boolean castNull,
-                                         boolean castAlways,
+                                         boolean requiresExactTypeMatch,
                                          BytecodeMappingTracer tracer) {
     VarType rightType = exprent.getExprType();
 
     boolean cast =
-      castAlways ||
+      (requiresExactTypeMatch && !leftType.equals(exprent.getExprType())) ||
       (!leftType.isSuperset(rightType) && (rightType.equals(VarType.VARTYPE_OBJECT) || leftType.type != CodeConstants.TYPE_OBJECT)) ||
       (castNull && rightType.type == CodeConstants.TYPE_NULL && !UNDEFINED_TYPE_STRING.equals(getTypeName(leftType))) ||
       (isIntConstant(exprent) && rightType.isStrictSuperset(leftType));

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
@@ -20,6 +20,7 @@ import org.jetbrains.java.decompiler.main.ClassesProcessor.ClassNode;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.TextBuffer;
 import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
 import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
 import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
@@ -131,7 +132,8 @@ public class FieldExprent extends Exprent {
       }
       else {
         TextBuffer buff = new TextBuffer();
-        boolean casted = ExprProcessor.getCastedExprent(instance, new VarType(CodeConstants.TYPE_OBJECT, 0, classname), buff, indent, true, tracer);
+        boolean forceSameType = DecompilerContext.getOption(IFernflowerPreferences.OVERLOADING_SAFETY_CASTS);
+        boolean casted = ExprProcessor.getCastedExprent(instance, new VarType(CodeConstants.TYPE_OBJECT, 0, classname), buff, indent, true, forceSameType, tracer);
         String res = buff.toString();
 
         if (casted || instance.getPrecedence() > getPrecedence()) {

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
@@ -214,6 +214,8 @@ public class InvocationExprent extends Exprent {
     boolean isInstanceThis = false;
 
     tracer.addMapping(bytecode);
+    
+    boolean overloadingSafetyCasts = DecompilerContext.getOption(IFernflowerPreferences.OVERLOADING_SAFETY_CASTS);
 
     if (isStatic) {
       ClassNode node = (ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE);
@@ -261,7 +263,7 @@ public class InvocationExprent extends Exprent {
           VarType rightType = instance.getExprType();
           VarType leftType = new VarType(CodeConstants.TYPE_OBJECT, 0, classname);
 
-          if (rightType.equals(VarType.VARTYPE_OBJECT) && !leftType.equals(rightType)) {
+          if ((overloadingSafetyCasts || rightType.equals(VarType.VARTYPE_OBJECT)) && !leftType.equals(rightType)) {
             buf.append("((").append(ExprProcessor.getCastTypeName(leftType)).append(")");
 
             if (instance.getPrecedence() >= FunctionExprent.getPrecedence(FunctionExprent.FUNCTION_CAST)) {
@@ -340,8 +342,8 @@ public class InvocationExprent extends Exprent {
         }
 
         TextBuffer buff = new TextBuffer();
-        boolean ambiguous = setAmbiguousParameters.get(i);
-        ExprProcessor.getCastedExprent(lstParameters.get(i), descriptor.params[i], buff, indent, true, ambiguous, tracer);
+        boolean forceSameType = overloadingSafetyCasts || setAmbiguousParameters.get(i);
+        ExprProcessor.getCastedExprent(lstParameters.get(i), descriptor.params[i], buff, indent, true, forceSameType, tracer);
         buf.append(buff);
 
         firstParameter = false;

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
@@ -205,6 +205,7 @@ public class NewExprent extends Exprent {
           }
         }
 
+        boolean forceSameType = DecompilerContext.getOption(IFernflowerPreferences.OVERLOADING_SAFETY_CASTS);
         boolean firstParam = true;
         int start = 0, end = invSuper.getLstParameters().size();
         if (enumConst) {
@@ -225,7 +226,7 @@ public class NewExprent extends Exprent {
               }
             }
 
-            ExprProcessor.getCastedExprent(param, invSuper.getDescriptor().params[i], buf, indent, true, tracer);
+            ExprProcessor.getCastedExprent(param, invSuper.getDescriptor().params[i], buf, indent, true, forceSameType, tracer);
 
             firstParam = false;
           }
@@ -312,7 +313,10 @@ public class NewExprent extends Exprent {
         int start = enumConst ? 2 : 0;
         if (!enumConst || start < lstParameters.size()) {
           buf.append('(');
-
+          
+          boolean forceSameType = DecompilerContext.getOption(IFernflowerPreferences.OVERLOADING_SAFETY_CASTS);
+          
+          //wouldn't that code have to check AmbiguousParameters like in InvocationExprent?
           boolean firstParam = true;
           for (int i = start; i < lstParameters.size(); i++) {
             if (sigFields == null || sigFields.get(i) == null) {
@@ -330,7 +334,7 @@ public class NewExprent extends Exprent {
                 buf.append(", ");
               }
 
-              ExprProcessor.getCastedExprent(expr, leftType, buf, indent, true, tracer);
+              ExprProcessor.getCastedExprent(expr, leftType, buf, indent, true, forceSameType, tracer);
 
               firstParam = false;
             }


### PR DESCRIPTION
New option -osc (OVERLOADING_SAFETY_CASTS), turned off by default.
Fix for IDEA-135385 and others.

Overloaded and hidden fields and methods caused errors. All parameters types and the caller type must match the descriptor exactly, if not a cast is needed. The reason is that the current instance could have been cast to a sub/super class in the original code and we cannot know that. And we don't know if the method/field is overloaded on that sub/super class.

This options adds a lot more casts to the decompiler output, but it is much safer and can solve many cases that fail otherwise.
Test cases included in this pull request: https://github.com/JetBrains/intellij-community/pull/390
