### PR TITLE
[Fernflower] Renaming support for .class field access and assertions

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/AssertProcessor.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/AssertProcessor.java
@@ -105,7 +105,17 @@ public class AssertProcessor {
 
                     ClassNode nd = node;
                     while (nd != null) {
-                      if (nd.getWrapper().getClassStruct().qualifiedName.equals(cexpr.getValue())) {
+                      Object ndFullName = cexpr.getValue();
+                      //we must check renamer... (does the need for this just mask another bug?)
+                      if (DecompilerContext.getPoolInterceptor() != null) {
+                        String lookupName = (String) cexpr.getValue();
+                        lookupName = lookupName.replace('.', '/');
+                        String newName = DecompilerContext.getPoolInterceptor().getName(lookupName);
+                        if (newName != null) {
+                          ndFullName = newName;
+                        }
+                      }
+                      if (nd.getWrapper().getClassStruct().qualifiedName.equals(ndFullName)) {
                         break;
                       }
                       nd = nd.parent;

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
@@ -239,6 +239,19 @@ public class ConstExprent extends Exprent {
         }
         else if (constType.equals(VarType.VARTYPE_CLASS)) {
           String stringVal = value.toString();
+          
+          //we must check renamer...
+          if (DecompilerContext.getPoolInterceptor() != null) {
+              String lookupName = stringVal;
+              if (lookupName.charAt(0) == '[') {
+                  lookupName = lookupName.substring(1);
+              }
+              lookupName = lookupName.replace('.', '/');
+              String newName = DecompilerContext.getPoolInterceptor().getName(lookupName);
+              if (newName != null) {
+                stringVal = newName;
+              }
+          }
           VarType type = new VarType(stringVal, !stringVal.startsWith("["));
           return new TextBuffer(ExprProcessor.getCastTypeName(type)).append(".class");
         }


### PR DESCRIPTION
If you use renaming, .class field access and assertions don't decompile correctly in some cases (output contains synthetics).

Examples:
https://github.com/droid666/intellij-community/tree/398801bec078efc14529078b22e4b109f7efcadf/plugins/java-decompiler/engine/testData/src-stdout/javadefault/renaming

The examples are part of this pull request: https://github.com/JetBrains/intellij-community/pull/390
They are deactivate in the pull by default because they fail without this fix.

Example B needs the first commit of this pull to work (access to .class on renamed class).
Example A also needs the 2nd commit of this pull to work (Assertion location is not recognized as Assertion without adding renaming there).

The question is if this is the correct fix or if these 2 problems mean something does not work as it should?
