### PR TITLE
IDEA-118247 fix application of Color Scheme to Terminal.

### DIFF
--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/JBTerminalSchemeColorPalette.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/JBTerminalSchemeColorPalette.java
@@ -38,8 +38,8 @@ public class JBTerminalSchemeColorPalette extends ColorPalette {
 
   @Override
   public Color[] getIndexColors() {
-    Color[] result = XTERM_PALETTE.getIndexColors();
-    for (int i = 1; i < 7; i++) {
+    Color[] result = new Color[ 16 ];
+    for (int i = 0; i < result.length; i++) {
       result[i] = myColorsScheme.getAttributes(ColoredOutputTypeRegistry.getAnsiColorKey(i)).getForegroundColor();
     }
     return result;


### PR DESCRIPTION
Previously the Terminal view only used ANSI colors 1-6 (the non-bright colors except for black and white) from the Color Scheme and inherited colors 0 and 7-15 from the JediTerm defaults. That resulted in strange partial application of the Color Scheme and, frequently, unreadable text. This corrects the palette implementation to pull all 16 ANSI colors from the Color Scheme.

This resolves [IDEA-118247](https://youtrack.jetbrains.com/issue/IDEA-118247).