### PR TITLE
PY-19541: Fix test runner progress for py.test

### DIFF
--- a/python/helpers/pycharm/pytest_teamcity.py
+++ b/python/helpers/pycharm/pytest_teamcity.py
@@ -43,6 +43,9 @@ if PYVERSION > [1, 4, 0]:
   current_file = None
   current_file_suite = None
 
+  def pytest_collection_finish(session):
+    messages.testCount(len(session.items))
+
   def pytest_runtest_logstart(nodeid, location):
     path = "file://" + os.path.realpath(os.path.join(CURRENT_DIR_NAME, location[0]))
     if location[1]:


### PR DESCRIPTION
This change fixes an issue where the PyCharm pytest runner did not report the number of tests to the test runner, resulting in a progress bar stuck at 50%.

https://youtrack.jetbrains.com/issue/PY-19541