### PR TITLE
Fix regression of PY-8165: Update precedence of pytest keyword format

### DIFF
--- a/python/src/com/jetbrains/python/testing/pytest/PyTestConfigurationProducer.java
+++ b/python/src/com/jetbrains/python/testing/pytest/PyTestConfigurationProducer.java
@@ -118,15 +118,15 @@ public class PyTestConfigurationProducer extends PythonTestConfigurationProducer
         final PyPackageManager packageManager = PyPackageManager.getInstance(sdk);
         try {
           final PyPackage pytestPackage = packageManager.findPackage("pytest", false);
-          if (pytestPackage != null && PackageVersionComparator.VERSION_COMPARATOR.compare(pytestPackage.getVersion(), "2.3.3") >= 0) {
-            keywords = pyClass.getName() + " and " + keywords;
+          if (pytestPackage != null && PackageVersionComparator.VERSION_COMPARATOR.compare(pytestPackage.getVersion(), "2.3.3") < 0) {
+            keywords = pyClass.getName() + "." + keywords;
           }
           else {
-            keywords = pyClass.getName() + "." + keywords;
+            keywords = pyClass.getName() + " and " + keywords;
           }
         }
         catch (ExecutionException e) {
-          keywords = pyClass.getName() + "." + keywords;
+          keywords = pyClass.getName() + " and " + keywords;
         }
       }
     }


### PR DESCRIPTION
Using modern (less than 4 years old) versions of pytest in an environment which PyCharm has trouble detecting the versions of packages causes a regression of [PY-8165](https://youtrack.jetbrains.com/issue/PY-8165).  It seems like the old format for pytest keywords filters is sufficiently old that in the absence of the known package version, PyCharm should default to the new format.

A few developers at our organization ran into this issue recently, caused by a particular combination of pip, setuptools, and ipython... I wasn't able to figure out how to reproduce the root problem (upgrading pip and ipython seems to solve the problem), but this change makes the pytest test runner more robust to this problem (and makes pycharm a little more robust for anyone else running into this issue going forward).
