### PR TITLE
Allow to set breakpoints in non-".py" files.

### DIFF
--- a/python/src/com/jetbrains/python/debugger/PyLineBreakpointType.java
+++ b/python/src/com/jetbrains/python/debugger/PyLineBreakpointType.java
@@ -62,6 +62,11 @@ public class PyLineBreakpointType extends XLineBreakpointTypeBase {
           stoppable.set(false);
         }
       }
+      else
+        // Non-Pythonfiles may be debuggable, too, as python allows to provide
+        // custom module importers that import non-python source code and compile them to
+        // to (debuggable) python vm code.
+        return true;
     }
 
     return stoppable.get();


### PR DESCRIPTION
As Python allows to define your own [module loaders](https://docs.python.org/3/glossary.html#term-loader) it can be arbitrarly extended by custom DSL modules, that are imported via import statement.
A typical use case is a templating engine, which compiles the template to python VM code and which allows to import the templates via `import`-statement. Due to the source maps integrated into the python VM code you can even debug these templates then.

But in PyCharm this is supported only partly:
- you can step into the code generated by the importer
- you can use "Run to Cursor" to jump to a specific line of code
- you can view all stack frames including variables

**But:**
- you cannot set line breakpoints, as PyCharm currently allows only to set breakpoints in .py files!!!

This Pull Request changes this behaviour to allow settings breakpoints in any non-python file (in python file it keeps the current behaviour)
