### PR TITLE
Remove a special Windows-only call to WinPtyProcess.destroy

### DIFF
--- a/platform/platform-api/src/com/intellij/execution/process/OSProcessHandler.java
+++ b/platform/platform-api/src/com/intellij/execution/process/OSProcessHandler.java
@@ -48,14 +48,6 @@ public class OSProcessHandler extends BaseOSProcessHandler {
     myHasErrorStream = !commandLine.isRedirectErrorStream();
     setHasPty(commandLine instanceof PtyCommandLine);
     myFilesToDelete = commandLine.getUserData(DELETE_FILES_ON_TERMINATION);
-    if (myHasPty && SystemInfo.isWindows) { // explicitly destroy pty on process termination, see IDEA-156065
-      addProcessListener(new ProcessAdapter() {
-        @Override
-        public void processTerminated(ProcessEvent event) {
-          getProcess().destroy();
-        }
-      });
-    }
   }
 
   /** @deprecated use {@link #OSProcessHandler(Process, String)} or any other ctor (to be removed in IDEA 17) */


### PR DESCRIPTION
This code isn't necessary anymore.  The agent process automatically exits
once it flushes the last of the scraped CONOUT/CONERR into its output
pipes (WINPTY_SPAWN_FLAG_EXIT_AFTER_SHUTDOWN).  We wouldn't want to kill
the agent before that point, because we'd generally lose data.

Even without WINPTY_SPAWN_FLAG_EXIT_AFTER_SHUTDOWN, it shouldn't be
necessary anymore to kill the agent.  Once all (one or both) of the
WinPtyProcess's WinPTYInputStream instances have been closed, the WinPty
object is closed, which calls winpty_free, which kills the agent.

Analogously, with UnixPtyProcess, the pty master FDs are closed when the
input streams are closed.

In theory, I think this code could prematurely close the agent connection
while it still has data in its CONOUT/CONERR NamedPipe output queues.  If
that happened, the data would be lost.