### PR TITLE
idea.bat: Honor IDEA_JDK_64 environment variable

### DIFF
--- a/bin/scripts/win/idea.bat
+++ b/bin/scripts/win/idea.bat
@@ -6,9 +6,10 @@
 
 :: ---------------------------------------------------------------------
 :: Locate a JDK installation directory which will be used to run the IDE.
-:: Try (in order): @@product_uc@@_JDK, @@vm_options@@.jdk, ..\jre, JDK_HOME, JAVA_HOME.
+:: Try (in order): @@product_uc@@_JDK_%BITS%, @@product_uc@@_JDK, @@vm_options@@.jdk, ..\jre, JDK_HOME, JAVA_HOME.
 :: ---------------------------------------------------------------------
 IF EXIST "%@@product_uc@@_JDK%" SET JDK=%@@product_uc@@_JDK%
+IF EXIST "%@@product_uc@@_JDK%_%BITS%" SET JDK=%@@product_uc@@_JDK%_%BITS%
 IF NOT "%JDK%" == "" GOTO jdk
 SET USER_JDK_FILE=%USERPROFILE%\.@@system_selector@@\config\@@vm_options@@.jdk
 IF EXIST "%USER_JDK_FILE%" SET/pJDK=<%USER_JDK_FILE%


### PR DESCRIPTION
If %BITS% is set to "64" and the path specified in %IDEA_JDK_64% exists, it is used as JDK path.