### PR TITLE
enable debugging varargs where the first argument resolves to null

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/engine/evaluation/expression/EvaluatorBuilderImpl.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/evaluation/expression/EvaluatorBuilderImpl.java
@@ -1416,10 +1416,6 @@ public class EvaluatorBuilderImpl implements EvaluatorBuilder {
                                          final Evaluator[] argumentEvaluators) {
     int lastParam = declaredParams.length - 1;
     if (lastParam >= 0 && declaredParams[lastParam].isVarArgs() && argumentEvaluators.length > lastParam) {
-      // only wrap if the first varargs parameter is null for now
-      if (!TypeConversionUtil.isNullType(actualArgumentExpressions[lastParam].getType())) {
-        return argumentEvaluators;
-      }
       // do not wrap arrays twice
       if (argumentEvaluators.length - lastParam == 1 && actualArgumentExpressions[lastParam].getType() instanceof PsiArrayType) {
         return argumentEvaluators;


### PR DESCRIPTION
Varargs don't get wrapped if the first argument resolves to null (but they do if it is actually null)

![image](https://cloud.githubusercontent.com/assets/4395571/16161715/abc223ac-34d7-11e6-9fdf-a5b61c35dfce.png)

![image](https://cloud.githubusercontent.com/assets/4395571/16161842/5edbb48a-34d8-11e6-92e9-3140652cc4a7.png)

The original author put in extra effort to make sure that this doesn't case doesn't get wrapped into varargs but he did not provide an explanation as to why this is. Also there are currently no tests that cover varargs conversion in ExpressionBuilderImpl (or any other class in the debugger)

Since we don't know what it was protecting against, I suppose that we can remove it until the case that it was trying to avoid comes up and we can see if we can handle it in a different way?