### PR TITLE
PY-11943 Add MutableMapping test and check

### DIFF
--- a/python/psi-api/src/com/jetbrains/python/PyNames.java
+++ b/python/psi-api/src/com/jetbrains/python/PyNames.java
@@ -139,6 +139,7 @@ public class PyNames {
   public static final String CALLABLE = "Callable";
   public static final String SEQUENCE = "Sequence";
   public static final String MAPPING = "Mapping";
+  public static final String MUTABLE_MAPPING = "MutableMapping";
   public static final String ABC_SET = "Set";
   public static final String ABC_MUTABLE_SET = "MutableSet";
   

--- a/python/src/com/jetbrains/python/psi/types/PyABCUtil.java
+++ b/python/src/com/jetbrains/python/psi/types/PyABCUtil.java
@@ -69,6 +69,11 @@ public class PyABCUtil {
     if (PyNames.MAPPING.equals(superClassName)) {
       return isSized && hasIter && isContainer && hasGetItem && hasMethod(subClass, PyNames.KEYS, inherited, context);
     }
+    if (PyNames.MUTABLE_MAPPING.equals(superClassName)) {
+      final boolean hasSetItem = hasMethod(subClass, PyNames.SETITEM, inherited, context);
+      final boolean hasUpdate = hasMethod(subClass, PyNames.UPDATE, inherited, context);
+      return isSized && hasIter && isContainer && hasGetItem && hasSetItem && hasUpdate;
+    }
     if (PyNames.ABC_SET.equals(superClassName)) {
       return isSized && hasIter && isContainer;
     }

--- a/python/testData/inspections/PyTypeCheckerInspection/MutableMapping.py
+++ b/python/testData/inspections/PyTypeCheckerInspection/MutableMapping.py
@@ -1,0 +1,9 @@
+def foo(x):
+    """
+    :type x: collections.MutableMapping
+    :rtype: int
+    """
+    return {v: k for k, v in x.iteritems()}
+
+d = dict(a=1, b=2)
+foo(d)

--- a/python/testSrc/com/jetbrains/python/inspections/PyTypeCheckerInspectionTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/PyTypeCheckerInspectionTest.java
@@ -305,4 +305,9 @@ public class PyTypeCheckerInspectionTest extends PyTestCase {
   public void testSetMethods() {
     doTest();
   }
+
+  // PY-11943
+  public void testMutableMapping() {
+    doTest();
+  }
 }


### PR DESCRIPTION
Type checker has separate checks to perform type casting to abstract
base classes like Mapping, but it didn't support MutableMapping so this
commit added MutableMapping inspection to type checker.