### PR TITLE
IDEA-158882 Adding support for setting.xml set via .mvn/maven.config

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/MavenDomProjectProcessorUtils.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/MavenDomProjectProcessorUtils.java
@@ -442,7 +442,7 @@ public class MavenDomProjectProcessorUtils {
                                                 Function<? super MavenDomProfile, T> domProfileFunction) {
     MavenGeneralSettings settings = MavenProjectsManager.getInstance(project).getGeneralSettings();
 
-    for (VirtualFile each : settings.getEffectiveSettingsFiles()) {
+    for (VirtualFile each : settings.getEffectiveSettingsFiles(project.getBasePath())) {
       MavenDomSettingsModel settingsDom = MavenDomUtil.getMavenDomModel(project, each, MavenDomSettingsModel.class);
       if (settingsDom == null) continue;
 

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/references/MavenPropertyPsiReference.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/references/MavenPropertyPsiReference.java
@@ -279,7 +279,7 @@ public class MavenPropertyPsiReference extends MavenPsiReference {
   private PsiElement resolveSettingsModelProperty() {
     if (!schemaHasProperty(MavenSchemaProvider.MAVEN_SETTINGS_SCHEMA_URL, myText)) return null;
 
-    for (VirtualFile each : myProjectsManager.getGeneralSettings().getEffectiveSettingsFiles()) {
+    for (VirtualFile each : myProjectsManager.getGeneralSettings().getEffectiveSettingsFiles(null)) {
       MavenDomSettingsModel settingsDom = MavenDomUtil.getMavenDomModel(myProject, each, MavenDomSettingsModel.class);
       if (settingsDom == null) continue;
       PsiElement result = MavenDomUtil.findTag(settingsDom, myText);

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/navigator/MavenProjectsStructure.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/navigator/MavenProjectsStructure.java
@@ -677,7 +677,7 @@ public class MavenProjectsStructure extends SimpleTreeStructure {
 
       // search in "Per User Maven Settings" - %USER_HOME%/.m2/settings.xml
       // and in "Global Maven Settings" - %M2_HOME%/conf/settings.xml
-      for (VirtualFile virtualFile : myProjectsManager.getGeneralSettings().getEffectiveSettingsFiles()) {
+      for (VirtualFile virtualFile : myProjectsManager.getGeneralSettings().getEffectiveSettingsFiles(myProject.getBasePath())) {
         if (virtualFile != null) {
           final MavenDomSettingsModel model = MavenDomUtil.getMavenDomModel(myProject, virtualFile, MavenDomSettingsModel.class);
           if (model != null) {

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenEnvironmentForm.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenEnvironmentForm.java
@@ -85,7 +85,7 @@ public class MavenEnvironmentForm implements PanelWithAnchor {
       new PathOverrider(settingsFileComponent, settingsOverrideCheckBox, listener, new PathProvider() {
         @Nullable
         protected File getFile() {
-          return MavenUtil.resolveUserSettingsFile("");
+          return MavenUtil.resolveUserSettingsFile(null, null, null);
         }
       });
 

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenGeneralSettings.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenGeneralSettings.java
@@ -179,8 +179,8 @@ public class MavenGeneralSettings implements Cloneable {
   }
 
   @Nullable
-  public File getEffectiveUserSettingsIoFile() {
-    return MavenUtil.resolveUserSettingsFile(getUserSettingsFile());
+  public File getEffectiveUserSettingsIoFile(String projectBaseDir) {
+    return MavenUtil.resolveUserSettingsFile(getUserSettingsFile(), getMavenHome(), projectBaseDir);
   }
 
   @Nullable
@@ -189,14 +189,14 @@ public class MavenGeneralSettings implements Cloneable {
   }
 
   @Nullable
-  public VirtualFile getEffectiveUserSettingsFile() {
-    File file = getEffectiveUserSettingsIoFile();
+  public VirtualFile getEffectiveUserSettingsFile(@Nullable String projectBaseDir) {
+    File file = getEffectiveUserSettingsIoFile(projectBaseDir);
     return file == null ? null : LocalFileSystem.getInstance().findFileByIoFile(file);
   }
 
-  public List<VirtualFile> getEffectiveSettingsFiles() {
+  public List<VirtualFile> getEffectiveSettingsFiles(String projectBaseDir) {
     List<VirtualFile> result = new ArrayList<VirtualFile>(2);
-    VirtualFile file = getEffectiveUserSettingsFile();
+    VirtualFile file = getEffectiveUserSettingsFile(projectBaseDir);
     if (file != null) result.add(file);
     file = getEffectiveGlobalSettingsFile();
     if (file != null) result.add(file);

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsManagerWatcher.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsManagerWatcher.java
@@ -200,7 +200,7 @@ public class MavenProjectsManagerWatcher {
   private void updateSettingsFilePointers() {
     LocalFileSystem.getInstance().removeWatchedRoots(myWatchedRoots);
     mySettingsFilesPointers.clear();
-    addFilePointer(myGeneralSettings.getEffectiveUserSettingsIoFile(),
+    addFilePointer(myGeneralSettings.getEffectiveUserSettingsIoFile(myProject.getBasePath()),
                    myGeneralSettings.getEffectiveGlobalSettingsIoFile());
   }
 

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsTree.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProjectsTree.java
@@ -671,7 +671,7 @@ public class MavenProjectsTree {
       VirtualFile profilesXmlFile = mavenProject.getProfilesXmlFile();
       long profilesTimestamp = getFileTimestamp(profilesXmlFile);
 
-      long userSettingsTimestamp = getFileTimestamp(generalSettings.getEffectiveUserSettingsFile());
+      long userSettingsTimestamp = getFileTimestamp(generalSettings.getEffectiveUserSettingsFile(mavenProject.getDirectory()));
       long globalSettingsTimestamp = getFileTimestamp(generalSettings.getEffectiveGlobalSettingsFile());
 
       int profilesHashCode = explicitProfiles.hashCode();

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/actions/OpenOrCreateSettingsXmlAction.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/actions/OpenOrCreateSettingsXmlAction.java
@@ -28,7 +28,7 @@ public class OpenOrCreateSettingsXmlAction extends MavenOpenOrCreateFilesAction 
   protected List<File> getFiles(AnActionEvent e) {
     final MavenProjectsManager projectsManager = MavenActionUtil.getProjectsManager(e.getDataContext());
     if(projectsManager == null) return Collections.<File>emptyList();
-    File file = projectsManager.getGeneralSettings().getEffectiveUserSettingsIoFile();
+    File file = projectsManager.getGeneralSettings().getEffectiveUserSettingsIoFile(projectsManager.getRootProjects().get(0).getPath());
     return file != null ? Collections.singletonList(file) : Collections.<File>emptyList();
   }
 

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/server/MavenServerManager.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/server/MavenServerManager.java
@@ -532,7 +532,7 @@ public class MavenServerManager extends RemoteObjectWrapper<MavenServer> impleme
     result.setLoggingLevel(settings.getOutputLevel().getLevel());
     result.setOffline(settings.isWorkOffline());
     result.setMavenHome(settings.getEffectiveMavenHome());
-    result.setUserSettingsFile(settings.getEffectiveUserSettingsIoFile());
+    result.setUserSettingsFile(settings.getEffectiveUserSettingsIoFile(null));
     result.setGlobalSettingsFile(settings.getEffectiveGlobalSettingsIoFile());
     result.setLocalRepository(settings.getEffectiveLocalRepository());
     result.setPluginUpdatePolicy(settings.getPluginUpdatePolicy().getServerPolicy());

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenGotoSettingsFileContributor.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenGotoSettingsFileContributor.java
@@ -58,6 +58,6 @@ public class MavenGotoSettingsFileContributor implements ChooseByNameContributor
   }
 
   private static List<VirtualFile> getSettingsFiles(Project project) {
-    return MavenProjectsManager.getInstance(project).getGeneralSettings().getEffectiveSettingsFiles();
+    return MavenProjectsManager.getInstance(project).getGeneralSettings().getEffectiveSettingsFiles(project.getBasePath());
   }
 }

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenUtil.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenUtil.java
@@ -31,6 +31,7 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.application.impl.ApplicationInfoImpl;
 import com.intellij.openapi.application.impl.LaterInvocator;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
@@ -57,7 +58,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.util.DisposeAwareRunnable;
-import com.intellij.util.Function;
 import com.intellij.util.SystemProperties;
 import com.intellij.util.concurrency.Semaphore;
 import com.intellij.util.containers.ContainerUtil;
@@ -84,6 +84,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -634,6 +636,11 @@ public class MavenUtil {
     return version != null && version.compareTo("3.0.0") >= 0;
   }
 
+  public static boolean isMaven33(String mavenHome) {
+    String version = getMavenVersion(mavenHome);
+    return version != null && version.compareTo("3.3.0") >= 0;
+  }
+
   @Nullable
   public static File resolveGlobalSettingsFile(@Nullable String overriddenMavenHome) {
     File directory = resolveMavenHomeDirectory(overriddenMavenHome);
@@ -641,9 +648,48 @@ public class MavenUtil {
   }
 
   @NotNull
-  public static File resolveUserSettingsFile(@Nullable String overriddenUserSettingsFile) {
+  public static File resolveUserSettingsFile(@Nullable String overriddenUserSettingsFile,
+                                             @Nullable String overriddenMavenHome,
+                                             @Nullable String projectBaseDir) {
     if (!isEmptyOrSpaces(overriddenUserSettingsFile)) return new File(overriddenUserSettingsFile);
+
+    File path = resolveProjectMvnConfigSettings(overriddenMavenHome, projectBaseDir);
+    if (path != null) return path;
+
     return new File(resolveM2Dir(), SETTINGS_XML);
+  }
+
+  @Nullable
+  private static File resolveProjectMvnConfigSettings(@Nullable String overriddenMavenHome, @Nullable String projectBaseDir) {
+    if (!isEmptyOrSpaces(projectBaseDir)) {
+      File mavenHome = resolveMavenHomeDirectory(overriddenMavenHome);
+      if (isMaven33(mavenHome.getAbsolutePath())) {
+        File dotMvnDir = new File(projectBaseDir, ".mvn");
+        if (dotMvnDir.isDirectory()) {
+          File mavenConfig = new File(dotMvnDir, "maven.config");
+          try {
+            String mavenOpts = FileUtil.loadFile(mavenConfig, "UTF-8");
+            ParametersList mavenOptsList = new ParametersList();
+            mavenOptsList.addParametersString(mavenOpts);
+            if (mavenOptsList.hasParameter("--settings") || mavenOptsList.hasParameter("-s")) {
+              String[] params = mavenOptsList.getArray();
+              for (int i = 0; i < params.length - 1; i++) {
+                if ("--settings".equals(params[i]) || "-s".equals(params[i])) {
+                  java.nio.file.Path path = Paths.get(projectBaseDir).resolve(Paths.get(params[i + 1]));
+                  if (Files.isRegularFile(path)) {
+                    return path.toFile();
+                  }
+                }
+              }
+            }
+          }
+          catch (IOException ex) {
+            Logger.getInstance(MavenUtil.class).debug("Failed to read " + mavenConfig, ex);
+          }
+        }
+      }
+    }
+    return null;
   }
 
   @NotNull
@@ -658,7 +704,7 @@ public class MavenUtil {
     File result = null;
     if (!isEmptyOrSpaces(overriddenLocalRepository)) result = new File(overriddenLocalRepository);
     if (result == null) {
-      result = doResolveLocalRepository(resolveUserSettingsFile(overriddenUserSettingsFile),
+      result = doResolveLocalRepository(resolveUserSettingsFile(overriddenUserSettingsFile, null, null),
                                         resolveGlobalSettingsFile(overriddenMavenHome));
     }
     try {


### PR DESCRIPTION
Maven 3.3 provides support for supplying project-specific maven execution arguments via `.mvn/maven.config` under the project base directory. This patch address issue IDEA-158882 to honors the `--settings` or `-s` argument supplied in that file.
