### PR TITLE
IDEA-157903 add "keep blank lines" option in properties code style

### DIFF
--- a/plugins/properties/properties-psi-api/src/com/intellij/lang/properties/psi/codeStyle/PropertiesCodeStyleSettings.java
+++ b/plugins/properties/properties-psi-api/src/com/intellij/lang/properties/psi/codeStyle/PropertiesCodeStyleSettings.java
@@ -38,6 +38,7 @@ public class PropertiesCodeStyleSettings extends CustomCodeStyleSettings {
   }
 
   public boolean SPACES_AROUND_KEY_VALUE_DELIMITER = false;
+  public boolean KEEP_BLANK_LINES = false;
   public int KEY_VALUE_DELIMITER_CODE = 0;
 
   public char getDelimiter() {

--- a/plugins/properties/properties-psi-api/src/com/intellij/lang/properties/psi/codeStyle/PropertiesCodeStyleSettingsPanel.java
+++ b/plugins/properties/properties-psi-api/src/com/intellij/lang/properties/psi/codeStyle/PropertiesCodeStyleSettingsPanel.java
@@ -51,6 +51,8 @@ public class PropertiesCodeStyleSettingsPanel extends OptionTableWithPreviewPane
                      "KEY_VALUE_DELIMITER_CODE",
                      "Key-value delimiter", null,
                      new String[]{"=", ":", "whitespace symbol"}, new int[]{0, 1, 2});
+    showCustomOption(PropertiesCodeStyleSettings.class, "KEEP_BLANK_LINES",
+                     "Keep blank lines", null);
   }
 
   @Nullable
@@ -69,7 +71,7 @@ public class PropertiesCodeStyleSettingsPanel extends OptionTableWithPreviewPane
   @Override
   protected String getPreviewText() {
     return "key1=value\n" +
-           "some_key=some_value\n" +
+           "some_key=some_value\n\n" +
            "#commentaries\n" +
            "last.key=some text here";
   }

--- a/plugins/properties/src/com/intellij/lang/properties/formatting/PropertiesRootBlock.java
+++ b/plugins/properties/src/com/intellij/lang/properties/formatting/PropertiesRootBlock.java
@@ -107,7 +107,8 @@ public class PropertiesRootBlock extends AbstractBlock {
     return (mySettings.getCustomSettings(PropertiesCodeStyleSettings.class).SPACES_AROUND_KEY_VALUE_DELIMITER &&
             (isSeparator(child1) || isSeparator(child2))) || isKeyValue(child1, child2)
            ? Spacing.createSpacing(1, 1, 0, true, 0)
-           : Spacing.createSpacing(0, 0, 0, true, 0);
+           : Spacing.createSpacing(0, 0, 0, true,
+                                   mySettings.getCustomSettings(PropertiesCodeStyleSettings.class).KEEP_BLANK_LINES ? 999 : 0);
   }
 
   private static boolean isKeyValue(Block maybeKey, Block maybeValue) {

--- a/plugins/properties/testSrc/com/intellij/lang/properties/PropertiesFormatterTest.java
+++ b/plugins/properties/testSrc/com/intellij/lang/properties/PropertiesFormatterTest.java
@@ -37,6 +37,7 @@ public class PropertiesFormatterTest extends FormatterTestCase {
     myCustomSettings = settings.getCustomSettings(PropertiesCodeStyleSettings.class);
     mySettings.ALIGN_GROUP_FIELD_DECLARATIONS = false;
     myCustomSettings.SPACES_AROUND_KEY_VALUE_DELIMITER = false;
+    myCustomSettings.KEEP_BLANK_LINES = false;
   }
 
   @Override
@@ -80,6 +81,33 @@ public class PropertiesFormatterTest extends FormatterTestCase {
 
   public void testWhitespaceDelimiter() {
     doTextTest("k    v", "k v");
+  }
+
+  public void testKeepBlankLines() {
+    myCustomSettings.KEEP_BLANK_LINES = true;
+    String propertiesWithBlankLines =
+      "#comment\n" +
+      "\n" +
+      "key1=value1\n" +
+      "\n" +
+      "\n" +
+      "key2=value2\n";
+
+    doTextTest(propertiesWithBlankLines, propertiesWithBlankLines);
+  }
+
+  public void testDoNotKeepBlankLines() {
+    myCustomSettings.KEEP_BLANK_LINES = false;
+    doTextTest("#comment\n" +
+               "\n" +
+               "key1=value1\n" +
+               "\n" +
+               "\n" +
+               "key2=value2\n",
+
+               "#comment\n" +
+               "key1=value1\n" +
+               "key2=value2\n");
   }
 
   protected void doTextTest(String text) {


### PR DESCRIPTION
Currently blank lines in properties files are automatically removed by the formatter. This is very annoying when, for instance, you have spent some time separating groups of related properties using blank lines and then at commit time, the “reformat option” being checked, the formatter screw this up in your back (true story :-().

This patch adds a new properties code style option (checkbox) to choose if the blank lines should be preserved.

By default, the option is disabled to keep the current behavior (removing blank lines).
