### PR TITLE
Fixed typo in Groovy description for missing switch branch

### DIFF
--- a/plugins/groovy/groovy-psi/resources/intentionDescriptions/GrCreateMissingSwitchBranchesIntention/description.html
+++ b/plugins/groovy/groovy-psi/resources/intentionDescriptions/GrCreateMissingSwitchBranchesIntention/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This intention will fill in any missing case labels on a switch statement with an enumerated type as it's switch expression
+This intention will fill in any missing case labels on a switch statement with an enumerated type as its switch expression
 </body>
 </html>


### PR DESCRIPTION
The possessive form of "it" does not have an apostrophe.

[IDEA-159748](https://youtrack.jetbrains.com/issue/IDEA-159748)