### PR TITLE
fix debuggability for ipy notebook kernels

### DIFF
--- a/python/helpers/pydev/pydevd.py
+++ b/python/helpers/pydev/pydevd.py
@@ -901,6 +901,10 @@ class PyDB:
                 sys.stderr.write("No module named %s\n" % file)
                 return
             else:
+                if filename.endswith('__init__.py'):
+                    new_target = os.path.join(os.path.dirname(filename), '__main__.py')
+                if os.path.isfile(new_target):
+                    filename = new_target
                 file = filename
 
         if os.path.isdir(file):


### PR DESCRIPTION
the ipy nb kernels are subprocesses launched with `-m ipykernel`, while pydev generally has problems in debugging -m startups, the simple modification in this PR has enabled me to debug ipy kernels with PyCharm.

It exploits the fact that `__main__` of ipykernel does not fire relative imports as `__init__` does. It wouldn't work without this fact.

However I'm not sure whether running `__main__` instead of `__init__` for a module will break things in other cases.
