### PR TITLE
[PyCharm] Fix python crash in module Qt5Gui.dll

### DIFF
--- a/python/helpers/pycharm_generator_utils/module_redeclarator.py
+++ b/python/helpers/pycharm_generator_utils/module_redeclarator.py
@@ -106,8 +106,15 @@ class ModuleRedeclarator(object):
 
     def _initializeQApp5(self):
         try:
-            from PyQt5.QtCore import QCoreApplication
-            self.app = QCoreApplication([])
+            if 'PyQt5.QtWidgets' in sys.modules:
+                from PyQt5.QtWidgets import QApplication
+                self.app = QApplication([])
+            elif 'PyQt5.QtGui' in sys.modules:
+                from PyQt5.QtGui import QGuiApplication
+                self.app = QGuiApplication([])
+            else:
+                from PyQt5.QtCore import QCoreApplication
+                self.app = QCoreApplication([])
             return
         except ImportError:
             pass


### PR DESCRIPTION
Current skeleton generation cause application crash in module Qt5Gui.dll with exception 0xc0000005 when it called for modules "PyQt5.Qt" and "PyQt5.QtGui".

This patch fix reason of this crash.
