### PR TITLE
IDEA-160742: Ctrl+Shift+F12 doesn't work in Terminal tool window. 

### DIFF
--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/JBTerminalPanel.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/JBTerminalPanel.java
@@ -69,6 +69,7 @@ public class JBTerminalPanel extends TerminalPanel implements FocusListener, Ter
     "ActivateStructureToolWindow",
     "ActivateHierarchyToolWindow",
     "ActivateVersionControlToolWindow",
+    "HideAllWindows",
 
     "ShowBookmarks",
     "GotoBookmark0",


### PR DESCRIPTION
Add 'HideAllWindows' to a whitelist of actions for Terminal tool window.