### PR TITLE
PY-20771: Fix dataframe rendering issue in frames 100+ columns

### DIFF
--- a/python/helpers/pydev/_pydevd_bundle/pydevd_vars.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_vars.py
@@ -570,9 +570,9 @@ def dataframe_to_xml(df, name, roffset, coffset, rows, cols, format):
     # need to precompute column bounds here before slicing!
     col_bounds = [None] * cols
     for col in range(cols):
-        dtype = df.dtypes.iloc[col].kind
+        dtype = df.dtypes.iloc[coffset + col].kind
         if dtype in "biufc":
-            cvalues = df.iloc[:, col]
+            cvalues = df.iloc[:, coffset + col]
             bounds = (cvalues.min(), cvalues.max())
         else:
             bounds = (0, 0)


### PR DESCRIPTION
PY-20771: Min and max values for columns 100 and above were computed incorrectly sometimes causing exceptions during rendering.
The UI exceptions are also one of the reasons for poor performance