### PR TITLE
Ensuring project directory is given priority prior to settings import

### DIFF
--- a/python/helpers/pycharm/django_test_manage.py
+++ b/python/helpers/pycharm/django_test_manage.py
@@ -9,14 +9,17 @@ from pycharm_run_utils import import_system_module
 
 inspect = import_system_module("inspect")
 
+project_directory = sys.argv.pop()
+
+#ensure project directory is given priority when looking for settings files
+sys.path.insert(0, project_directory)
+
 #import settings to prevent circular dependencies later on import django.db
 try:
     from django.conf import settings
     apps = settings.INSTALLED_APPS
 except:
     pass
-
-project_directory = sys.argv.pop()
 
 from django.core import management
 from django.core.management.commands.test import Command


### PR DESCRIPTION
I'm developing a reusable Django app which has settings in `example_project.settings`. The `example_project` provides a project which is both a bare-bones example, and a bootstrap for the tests.

However – and perhaps unsurprisingly – another Django app also contained an `example_project`. Moreover, my project directories entry on `sys.path` only appears towards the end of the list, after many dependencies. In my case, the result was that the incorrect settings file would be imported.

I don't think this change should have any negative consequences, but I'm very much open for input.

PS. I couldn't see an email address to send the CLA to