### PR TITLE
Update appName pattern

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/actions/ShowFilePathAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/ShowFilePathAction.java
@@ -87,7 +87,7 @@ public class ShowFilePathAction extends AnAction {
       }
 
       String appName = ExecUtil.execAndReadLine(new GeneralCommandLine("xdg-mime", "query", "default", "inode/directory"));
-      if (appName == null || !appName.matches("nautilus.*\\.desktop")) return false;
+      if (appName == null || !appName.matches(".*(?i:nautilus).*\\.desktop")) return false;
 
       String version = ExecUtil.execAndReadLine(new GeneralCommandLine("nautilus", "--version"));
       if (version == null) return false;


### PR DESCRIPTION
Update appName pattern to match xdg-mime output of Debian 8 which is `org.gnome.Nautilus.desktop`

Fixes https://youtrack.jetbrains.com/issue/IDEA-162050