### PR TITLE
Fix memory leak inside the Gradle daemon caused by Idea Gradle plugin

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/ExtraModelBuilder.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/ExtraModelBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.jetbrains.plugins.gradle.tooling.internal;
 
+import com.google.common.collect.Lists;
 import org.gradle.api.Project;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 import org.gradle.util.GradleVersion;
@@ -25,6 +26,7 @@ import org.jetbrains.plugins.gradle.tooling.ModelBuilderService;
 import org.jetbrains.plugins.gradle.tooling.annotation.TargetVersions;
 import org.jetbrains.plugins.gradle.tooling.util.VersionMatcher;
 
+import java.util.List;
 import java.util.ServiceLoader;
 
 /**
@@ -33,25 +35,24 @@ import java.util.ServiceLoader;
  */
 @SuppressWarnings("UnusedDeclaration")
 public class ExtraModelBuilder implements ToolingModelBuilder {
-
-  private ServiceLoader<ModelBuilderService> buildersLoader =
-    ServiceLoader.load(ModelBuilderService.class, ExtraModelBuilder.class.getClassLoader());
+  private final List<ModelBuilderService> modelBuilderServices;
 
   @NotNull
   private final GradleVersion myCurrentGradleVersion;
 
   public ExtraModelBuilder() {
-    this.myCurrentGradleVersion = GradleVersion.current();
+    this(GradleVersion.current());
   }
 
   @TestOnly
   public ExtraModelBuilder(@NotNull GradleVersion gradleVersion) {
     this.myCurrentGradleVersion = gradleVersion;
+    this.modelBuilderServices = Lists.newArrayList(ServiceLoader.load(ModelBuilderService.class, ExtraModelBuilder.class.getClassLoader()));
   }
 
   @Override
   public boolean canBuild(String modelName) {
-    for (ModelBuilderService service : buildersLoader) {
+    for (ModelBuilderService service : modelBuilderServices) {
       if (service.canBuild(modelName) && isVersionMatch(service)) return true;
     }
     return false;
@@ -59,7 +60,7 @@ public class ExtraModelBuilder implements ToolingModelBuilder {
 
   @Override
   public Object buildAll(String modelName, Project project) {
-    for (ModelBuilderService service : buildersLoader) {
+    for (ModelBuilderService service : modelBuilderServices) {
       if (service.canBuild(modelName) && isVersionMatch(service)) {
         final long startTime = System.currentTimeMillis();
         try {

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/ExtraModelBuilder.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/ExtraModelBuilder.java
@@ -34,7 +34,7 @@ import java.util.ServiceLoader;
 @SuppressWarnings("UnusedDeclaration")
 public class ExtraModelBuilder implements ToolingModelBuilder {
 
-  private static ServiceLoader<ModelBuilderService> buildersLoader =
+  private ServiceLoader<ModelBuilderService> buildersLoader =
     ServiceLoader.load(ModelBuilderService.class, ExtraModelBuilder.class.getClassLoader());
 
   @NotNull

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.jetbrains.plugins.gradle.tooling.internal.ExtraModelBuilder
 
 @SuppressWarnings("GrPackage")
 class JetGradlePlugin implements Plugin<Project> {
@@ -25,20 +26,18 @@ class JetGradlePlugin implements Plugin<Project> {
   }
 
   public void apply(Project project) {
-    registry.register(project.jetExtraModelBuilderClass.newInstance())
+    registry.register(new ExtraModelBuilder())
   }
 }
 
-try {
-  System.setProperty("idea.active", "true");
-  String[] paths = ${EXTENSIONS_JARS_PATH}
-  URL[] urls = paths.collect{ new File(it).toURI().toURL() }
-  URLClassLoader classLoader = new URLClassLoader(urls, getClass().classLoader)
-  Class modelClass = classLoader.loadClass('org.jetbrains.plugins.gradle.tooling.internal.ExtraModelBuilder')
-  allprojects {
-    ext.jetExtraModelBuilderClass = modelClass
-    apply plugin: JetGradlePlugin
+System.setProperty("idea.active", "true")
+
+initscript {
+  dependencies {
+    classpath files(${EXTENSIONS_JARS_PATH})
   }
 }
-catch (all) {
+
+allprojects {
+  apply plugin: JetGradlePlugin
 }

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
@@ -26,7 +26,7 @@ class JetGradlePlugin implements Plugin<Project> {
   }
 
   public void apply(Project project) {
-    registry.register(new ExtraModelBuilder())
+    registry.register(project.extraModelBuilder)
   }
 }
 
@@ -38,6 +38,8 @@ initscript {
   }
 }
 
+def extraModelBuilderInstance = new ExtraModelBuilder()
 allprojects {
+  ext.extraModelBuilder = extraModelBuilderInstance
   apply plugin: JetGradlePlugin
 }


### PR DESCRIPTION
This fixes a memory leak inside the Gradle daemon caused by Idea Gradle plugin.

Here's a description of the memory leak:
The custom classloader created by `ijinit.gradle` was not garbage collected and it was keeping references to a lot of object instances. The instances were held in the static `ExtraModelBuilder.buildersLoader` field. This field referenced an instance of `ExternalProjectBuilderImpl` which has a `cache` field with a lot of instances. 
Each new call using the same Gradle daemon instance would leak more memory.