### PR TITLE
LightCodeInsightFixtureTestCase: override hook replacing tempDirFixture

### DIFF
--- a/java/testFramework/src/com/intellij/testFramework/fixtures/LightCodeInsightFixtureTestCase.java
+++ b/java/testFramework/src/com/intellij/testFramework/fixtures/LightCodeInsightFixtureTestCase.java
@@ -108,13 +108,23 @@ public abstract class LightCodeInsightFixtureTestCase extends UsefulTestCase {
     IdeaTestFixtureFactory factory = IdeaTestFixtureFactory.getFixtureFactory();
     TestFixtureBuilder<IdeaProjectTestFixture> fixtureBuilder = factory.createLightFixtureBuilder(getProjectDescriptor());
     final IdeaProjectTestFixture fixture = fixtureBuilder.getFixture();
-    myFixture = JavaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture, new LightTempDirTestFixtureImpl(true));
+    myFixture = JavaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture, getTempDirFixture());
 
     myFixture.setUp();
     myFixture.setTestDataPath(getTestDataPath());
 
     myModule = myFixture.getModule();
     LanguageLevelProjectExtension.getInstance(getProject()).setLanguageLevel(LanguageLevel.JDK_1_6);
+  }
+  
+  /**
+   *  Override to control temp file creation strategy. by default temp project files are created in-memory. 
+   *  
+   * @return TempDirTestFixture to be used for this test fixure 
+   */
+  @NotNull
+  protected TempDirTestFixture getTempDirFixture() {
+      return new LightTempDirTestFixtureImpl(true);
   }
 
   /**


### PR DESCRIPTION
Add an override hook to initialize an instance of `TempDirTestFixture` in Test classes derived from `LightCodeInsightFixtureTestCase`. By default it uses an in-memory implementation - `LightTempDirTestFixtureImpl`. Would be nice to be able to replace it with a persistent filesystem implementation - `TempDirTestFixtureImpl`.
