### PR TITLE
IDEA-162949 myTaskPriority set to verbosive

### DIFF
--- a/java/java-runtime/src/com/intellij/rt/ant/execution/IdeaAntLogger2.java
+++ b/java/java-runtime/src/com/intellij/rt/ant/execution/IdeaAntLogger2.java
@@ -48,7 +48,7 @@ public final class IdeaAntLogger2 extends DefaultLogger {
 
   private final Priority myMessagePriority = new MessagePriority();
   private final Priority myTargetPriority = new StatePriority(Project.MSG_INFO);
-  private final Priority myTaskPriority = new StatePriority(Project.MSG_INFO);
+  private final Priority myTaskPriority = new StatePriority(Project.MSG_VERBOSE);
   private final Priority myAlwaysSend = new Priority() {
     public void setPriority(int level) {}
 


### PR DESCRIPTION
myTaskPriority needs to be set to verbose in order to be able to turn it off by AntBuildFileImpl.VERBOSE.set(editPropertyContainer, false);

Signed-off-by: Martin Zdarsky-Jones zdary@zdary.cz
