### PR TITLE
PY-18144 Support Pycharm import from zip files.

### DIFF
--- a/python/helpers/pycharm/pycharm_run_utils.py
+++ b/python/helpers/pycharm/pycharm_run_utils.py
@@ -33,7 +33,7 @@ def import_system_module(name):
   try:
     f, filename, desc = imp.find_module(name)
     return imp.load_module('pycharm_' + name, f, filename, desc)
-  except:
+  except ImportError:
     # Hack for python files in a zip file. Imp doesnt work correctly in it.
     import importlib
     mod = importlib.import_module(name)

--- a/python/helpers/pycharm/pycharm_run_utils.py
+++ b/python/helpers/pycharm/pycharm_run_utils.py
@@ -30,8 +30,15 @@ def adjust_django_sys_path():
 def import_system_module(name):
   if sys.platform == "cli":    # hack for the ironpython
       return __import__(name)
-  f, filename, desc = imp.find_module(name)
-  return imp.load_module('pycharm_' + name, f, filename, desc)
+  try:
+    f, filename, desc = imp.find_module(name)
+    return imp.load_module('pycharm_' + name, f, filename, desc)
+  except:
+    # Hack for python files in a zip file. Imp doesnt work correctly in it.
+    import importlib
+    mod = importlib.import_module(name)
+    mod.__name__ = 'pycharm_' + name
+    return mod
 
 def getModuleName(prefix, cnt):
   return prefix + "%" + str(cnt)


### PR DESCRIPTION
PY-18144 Update. In response to Ilya Kazakevich's response, I have submitted my patch and created a PR.

We are falling back to importlib to load a module from within a zip file. Imp does not support this.
