### PR TITLE
Add a custom python package identifier extension point

### DIFF
--- a/python/psi-api/src/com/jetbrains/python/psi/PyCustomPackageIdentifier.java
+++ b/python/psi-api/src/com/jetbrains/python/psi/PyCustomPackageIdentifier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jetbrains.python.psi;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
+
+public interface PyCustomPackageIdentifier {
+  ExtensionPointName<PyCustomPackageIdentifier> EP_NAME = ExtensionPointName.create("Pythonid.customPackageIdentifier");
+
+  /**
+   * Checks whether the given PsiDirectory can be treated as Python package.
+   * Used to loosen the default package checking behavior in PyUtil#isPackage.
+   */
+  boolean isPackage(PsiDirectory directory);
+
+  /**
+   * Checks whether the given PsiFile is a python package file (i.e. an __init__.py file).
+   * Use to treat files other than __init__.py files as python package files.
+   */
+  boolean isPackageFile(PsiFile file);
+}
+

--- a/python/src/META-INF/python-core-common.xml
+++ b/python/src/META-INF/python-core-common.xml
@@ -644,6 +644,7 @@
     <extensionPoint qualifiedName="Pythonid.pep8ProblemSuppressor" interface="com.jetbrains.python.validation.Pep8ProblemSuppressor"/>
     <extensionPoint qualifiedName="Pythonid.pythonFlavorProvider" interface="com.jetbrains.python.sdk.flavors.PythonFlavorProvider"/>
     <extensionPoint qualifiedName="Pythonid.debugSessionFactory" interface="com.jetbrains.python.debugger.PyDebugSessionFactory"/>
+    <extensionPoint qualifiedName="Pythonid.customPackageIdentifier" interface="com.jetbrains.python.psi.PyCustomPackageIdentifier"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="Pythonid">

--- a/python/src/com/jetbrains/python/psi/PyUtil.java
+++ b/python/src/com/jetbrains/python/psi/PyUtil.java
@@ -1000,6 +1000,11 @@ public class PyUtil {
    * @see PyNames#isIdentifier(String)
    */
   public static boolean isPackage(@NotNull PsiDirectory directory, boolean checkSetupToolsPackages, @Nullable PsiElement anchor) {
+    for (PyCustomPackageIdentifier customPackageIdentifier : PyCustomPackageIdentifier.EP_NAME.getExtensions()) {
+      if (customPackageIdentifier.isPackage(directory)) {
+        return true;
+      }
+    }
     if (directory.findFile(PyNames.INIT_DOT_PY) != null) {
       return true;
     }
@@ -1013,6 +1018,11 @@ public class PyUtil {
   }
 
   public static boolean isPackage(@NotNull PsiFile file) {
+    for (PyCustomPackageIdentifier customPackageIdentifier : PyCustomPackageIdentifier.EP_NAME.getExtensions()) {
+      if (customPackageIdentifier.isPackageFile(file)) {
+        return true;
+      }
+    }
     return PyNames.INIT_DOT_PY.equals(file.getName());
   }
 


### PR DESCRIPTION
This allows bypassing the default 'is package' check in PyUtil, giving the option of foregoing __init__.py files prior to python 3.3.

We're writing a plugin allowing python development with IntelliJ at Google. The only blocker is the requirement for __init__.py files through the source tree, which we can't practically enforce.

This patch should have minimal risk or performance cost, and would provide a big benefit to our internal users. 