### PR TITLE
 Make plugins/settings-repository/resources a resources root

### DIFF
--- a/plugins/settings-repository/intellij.settingsRepository.iml
+++ b/plugins/settings-repository/intellij.settingsRepository.iml
@@ -3,8 +3,8 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/resources" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="org.jetbrains.settingsRepository" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
… instead of a sources root, since it contains only a plugin.xml and a .properties file.