### PR TITLE
Test Hash comparisons using assertThat

### DIFF
--- a/platform/vcs-log/impl/test/com/intellij/vcs/log/impl/HashEqualsTest.java
+++ b/platform/vcs-log/impl/test/com/intellij/vcs/log/impl/HashEqualsTest.java
@@ -18,7 +18,7 @@ package com.intellij.vcs.log.impl;
 import com.intellij.vcs.log.Hash;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author erokhins
@@ -27,27 +27,26 @@ public class HashEqualsTest {
   @Test
   public void testEqualsSelf() {
     Hash hash = HashImpl.build("adf");
-    //noinspection EqualsWithItself
-    assertTrue(hash.equals(hash));
+    assertThat(hash).isEqualTo(hash);
   }
 
   @Test
   public void testEqualsNull() {
     Hash hash = HashImpl.build("adf");
-    assertFalse(hash.equals(null));
+    assertThat(hash).isNotNull();
   }
 
   @Test
   public void testEquals() {
     Hash hash1 = HashImpl.build("adf");
     Hash hash2 = HashImpl.build("adf");
-    assertTrue(hash1.equals(hash2));
+    assertThat(hash1).isEqualTo(hash2);
   }
 
   @Test
   public void testEqualsNone() {
     Hash hash1 = HashImpl.build("");
     Hash hash2 = HashImpl.build("");
-    assertTrue(hash1.equals(hash2));
+    assertThat(hash1).isEqualTo(hash2);
   }
 }


### PR DESCRIPTION
… which makes failure messages (and maybe assertion code) more readable, and avoids http://errorprone.info/bugpattern/SelfEquals and inspection EqualsWithItself.