### PR TITLE
Replace assertTrue(stable.equals(stable))

### DIFF
--- a/xml/dom-tests/tests/com/intellij/util/xml/DomBasicsTest.java
+++ b/xml/dom-tests/tests/com/intellij/util/xml/DomBasicsTest.java
@@ -515,7 +515,7 @@ public class DomBasicsTest extends DomTestCase {
     final MyElement stable = getDomManager().createStableValue(() -> element[0]);
     element[0] = null;
     ((StableElement) stable).invalidate();
-    assertTrue(stable.equals(stable));
+    assertEquals(stable, stable);
     assertEquals(oldElement.toString(), stable.toString());
   }
 


### PR DESCRIPTION
… with assertEquals(stable, stable), to avoid inspection EqualsWithItself and http://errorprone.info/bugpattern/SelfEquals.