### PR TITLE
Address FieldAccessor.get compilation failure in JDK 9

### DIFF
--- a/plugins/maven/maven3-server-common/src/org/jetbrains/idea/maven/server/embedder/FieldAccessor.java
+++ b/plugins/maven/maven3-server-common/src/org/jetbrains/idea/maven/server/embedder/FieldAccessor.java
@@ -40,8 +40,4 @@ public class FieldAccessor<FIELD_TYPE> {
   private static Object getFieldValue(Class c, String fieldName, Object o) {
     return ReflectionUtil.getField(c, o, null, fieldName);
   }
-
-  public static <FIELD_TYPE> FIELD_TYPE get(Class hostClass, Object host, String fieldName) {
-    return (FIELD_TYPE)getFieldValue(hostClass, fieldName, host);
-  }
 }

--- a/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3ServerEmbedderImpl.java
+++ b/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3ServerEmbedderImpl.java
@@ -239,18 +239,18 @@ public class Maven3ServerEmbedderImpl extends Maven3ServerEmbedder {
 
     myContainer.getLoggerManager().setThreshold(serverSettings.getLoggingLevel());
 
-    mySystemProperties = FieldAccessor.get(cliRequestClass, cliRequest, "systemProperties");
+    mySystemProperties = ReflectionUtil.getField(cliRequestClass, cliRequest, Properties.class, "systemProperties");
 
     if (serverSettings.getProjectJdk() != null) {
       mySystemProperties.setProperty("java.home", serverSettings.getProjectJdk());
     }
 
     if (settingsBuilder == null) {
-      settingsBuilder = FieldAccessor.get(MavenCli.class, cli, "settingsBuilder");
+      settingsBuilder = ReflectionUtil.getField(MavenCli.class, cli, SettingsBuilder.class, "settingsBuilder");
     }
 
     myMavenSettings = buildSettings(settingsBuilder, serverSettings, mySystemProperties,
-                                    FieldAccessor.<Properties>get(cliRequestClass, cliRequest, "userProperties"));
+                                    ReflectionUtil.getField(cliRequestClass, cliRequest, Properties.class, "userProperties"));
 
     myLocalRepository = createLocalRepository();
   }

--- a/plugins/maven/maven30-server-impl/src/org/jetbrains/idea/maven/server/Maven30ServerEmbedderImpl.java
+++ b/plugins/maven/maven30-server-impl/src/org/jetbrains/idea/maven/server/Maven30ServerEmbedderImpl.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.ExceptionUtil;
 import com.intellij.util.Function;
+import com.intellij.util.ReflectionUtil;
 import com.intellij.util.SystemProperties;
 import com.intellij.util.containers.ContainerUtil;
 import gnu.trove.THashMap;
@@ -203,18 +204,18 @@ public class Maven30ServerEmbedderImpl extends Maven3ServerEmbedder {
     }
 
     // reset threshold
-    myContainer = FieldAccessor.get(MavenCli.class, cli, "container");
+    myContainer = ReflectionUtil.getField(MavenCli.class, cli, DefaultPlexusContainer.class, "container");
     myContainer.getLoggerManager().setThreshold(settings.getLoggingLevel());
 
-    mySystemProperties = FieldAccessor.get(cliRequestClass, cliRequest, "systemProperties");
+    mySystemProperties = ReflectionUtil.getField(cliRequestClass, cliRequest, Properties.class, "systemProperties");
 
     if (settings.getProjectJdk() != null) {
       mySystemProperties.setProperty("java.home", settings.getProjectJdk());
     }
 
     myMavenSettings =
-      buildSettings(FieldAccessor.<SettingsBuilder>get(MavenCli.class, cli, "settingsBuilder"), settings, mySystemProperties,
-                    FieldAccessor.<Properties>get(cliRequestClass, cliRequest, "userProperties"));
+      buildSettings(ReflectionUtil.getField(MavenCli.class, cli, SettingsBuilder.class, "settingsBuilder"), settings, mySystemProperties,
+                    ReflectionUtil.getField(cliRequestClass, cliRequest, Properties.class, "userProperties"));
 
     myLocalRepository = createLocalRepository();
   }


### PR DESCRIPTION
The first commit replaces uses of the method, which is all we apparently need at the moment to compile with JDK 9. The second commit removes the method—separate because I'm not sure if it needs to be kept in case of uses outside the project.