### PR TITLE
Update error messages for version control plugins to be more readable.

### DIFF
--- a/plugins/git4idea/src/git4idea/i18n/GitBundle.properties
+++ b/plugins/git4idea/src/git4idea/i18n/GitBundle.properties
@@ -460,13 +460,13 @@ vfs.listener.delete.title=Delete Files from Git
 
 general.error = Git error
 executable.error.title = Git executable problem
-executable.error.description = Git couldn't be started. Probably the path to Git executable is not valid. <a href="">Fix it.</a>
+executable.error.description = Git couldn't be started. The path to the Git executable is probably not valid. <a href="">Fix it.</a>
 
 git.commit.message.empty=Please specify commit message
 git.commit.message.empty.title=Commit Message Is Empty
 
 git.executable.notification.title=Can't start Git
-git.executable.notification.description=Probably the path to Git executable is not valid.
+git.executable.notification.description=The path to Git executable is probably not valid.
 git.executable.dialog.title=Git executable
 git.executable.dialog.description=Specify the full path to Git executable
 git.executable.dialog.error=It doesn't appear to be a valid Git executable

--- a/plugins/hg4idea/resources/org/zmlx/hg4idea/HgVcsMessages.properties
+++ b/plugins/hg4idea/resources/org/zmlx/hg4idea/HgVcsMessages.properties
@@ -65,7 +65,7 @@ hg4idea.commit.partial.merge.title=Partial Merge Commit
 hg4idea.commit.error.messageEmpty=Please provide a commit message
 
 hg4idea.executable.notification.title=Can't start Mercurial
-hg4idea.executable.notification.description=Probably the path to hg executable is not valid.
+hg4idea.executable.notification.description=The path to the hg executable is probably not valid.
 
 hg4idea.init.dialog.title=Create Mercurial repository
 hg4idea.init.dialog.incorrect.path=The specified path is incorrect

--- a/plugins/svn4idea/src/org/jetbrains/idea/svn/SvnBundle.properties
+++ b/plugins/svn4idea/src/org/jetbrains/idea/svn/SvnBundle.properties
@@ -1,7 +1,7 @@
 subversion.name=Subversion
 
 subversion.executable.notification.title=Can't use Subversion command line client
-subversion.executable.notification.description=Probably the path to Subversion executable is wrong.
+subversion.executable.notification.description=The path to the Subversion executable is probably wrong.
 subversion.executable.too.old=Subversion command line client version is too old ({0}).
 
 subversion.roots.detection.errors.found.description=Errors found while detecting svn working copies. <a href="FIX">Fix it</a>.


### PR DESCRIPTION
The current error messages are a bit awkward to read so I just changed them up a bit.