### PR TITLE
Make RunContentManagerImpl.DESCRIPTOR_KEY public

### DIFF
--- a/platform/lang-impl/src/com/intellij/execution/ui/RunContentManagerImpl.java
+++ b/platform/lang-impl/src/com/intellij/execution/ui/RunContentManagerImpl.java
@@ -63,7 +63,7 @@ import java.util.*;
 public class RunContentManagerImpl implements RunContentManager, Disposable {
   public static final Key<Boolean> ALWAYS_USE_DEFAULT_STOPPING_BEHAVIOUR_KEY = Key.create("ALWAYS_USE_DEFAULT_STOPPING_BEHAVIOUR_KEY");
   private static final Logger LOG = Logger.getInstance(RunContentManagerImpl.class);
-  private static final Key<RunContentDescriptor> DESCRIPTOR_KEY = Key.create("Descriptor");
+  public static final Key<RunContentDescriptor> DESCRIPTOR_KEY = Key.create("Descriptor");
 
   private final Project myProject;
   private final Map<String, ContentManager> myToolwindowIdToContentManagerMap = new THashMap<>();


### PR DESCRIPTION
Rationale: I'm writing a plugin for a profiler integration which defines its own executor. Apart from the live profiling runs that are associated with a console, I want to add other tabs for snapshots and attach sessions to the tool window that have a different layout without any console. `Content` objects in the tool window need a user data value with the above key, otherwise an exception is thrown.

Current workaround: I'm using `Key.findKeyByName("Descriptor") as Key<RunContentDescriptor>`, but that is deprecated.