### PR TITLE
Improve messages displayed when a plugin is disabled or not installed

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/PluginAdvertiserEditorNotificationProvider.java
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/PluginAdvertiserEditorNotificationProvider.java
@@ -92,7 +92,7 @@ public class PluginAdvertiserEditorNotificationProvider extends EditorNotificati
   private EditorNotificationPanel createPanel(final String extension, final Set<PluginsAdvertiser.Plugin> plugins) {
     final EditorNotificationPanel panel = new EditorNotificationPanel();
     
-    panel.setText("Plugins supporting " + extension + " files are found");
+    panel.setText("Plugins supporting " + extension + " files found.");
     final IdeaPluginDescriptor disabledPlugin = PluginsAdvertiser.getDisabledPlugin(plugins);
     if (disabledPlugin != null) {
       panel.createActionLabel("Enable " + disabledPlugin.getName() + " plugin", () -> {

--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/PluginsAdvertiser.java
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/PluginsAdvertiser.java
@@ -387,9 +387,8 @@ public class PluginsAdvertiser implements StartupActivity {
                                                                                entry -> entry.getKey() + "[" + StringUtil.join(entry.getValue(), ", ") + "]", ", ");
         final int addressedFeaturesNumber = addressedFeatures.keySet().size();
         final int pluginsNumber = ids.size();
-        return "Unknown feature" + (addressedFeaturesNumber == 1 ? "" : "s") +
-                         " (" + addressedFeaturesPresentation + ") covered by " + (myPlugins.isEmpty() ? "disabled" : "non-bundled") + " plugin" + (pluginsNumber == 1 ? "" : "s") +
-                         " detected.<br>";
+        return "Plugin" + (pluginsNumber == 1 ? "" : "s") + " supporting feature" + (addressedFeaturesNumber == 1 ? "" : "s") +
+               " (" + addressedFeaturesPresentation + ") is currently " + (myPlugins.isEmpty() ? "disabled" : "not installed") + ".<br>";
       }
     }));
   }


### PR DESCRIPTION
Improve messages displayed when a plugin is disabled or not installed:

* File type notification: Change to active (not passive), and properly terminate sentence.

* Feature notification: Simplify sentence, and make it more directed towards the action the user can take (current message is very system centric)
