### PR TITLE
IDEA-165738 Gradle import is very slow in multi-module projects

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/DependencyResolverImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/DependencyResolverImpl.groovy
@@ -136,7 +136,7 @@ class DependencyResolverImpl implements DependencyResolver {
         //noinspection GroovyAssignabilityCheck
         Set<ComponentArtifactsResult> componentResults = myProject.dependencies.createArtifactResolutionQuery()
           .forComponents(resolvedArtifacts
-                           .findAll{ !isDependencySubstitutionsSupported || it.id.componentIdentifier instanceof ModuleComponentIdentifier }
+                           .findAll { !isDependencySubstitutionsSupported || it.id.componentIdentifier instanceof ModuleComponentIdentifier }
                            .collect { toComponentIdentifier(it.moduleVersion.id) })
           .withArtifacts(jvmLibrary, artifactTypes)
           .execute()

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/DependencyResolverImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/DependencyResolverImpl.groovy
@@ -135,7 +135,9 @@ class DependencyResolverImpl implements DependencyResolver {
         resolvedArtifacts.each { artifactMap.put(it.moduleVersion.id, it) }
         //noinspection GroovyAssignabilityCheck
         Set<ComponentArtifactsResult> componentResults = myProject.dependencies.createArtifactResolutionQuery()
-          .forComponents(resolvedArtifacts.collect { toComponentIdentifier(it.moduleVersion.id) })
+          .forComponents(resolvedArtifacts
+                           .findAll{ !isDependencySubstitutionsSupported || it.id.componentIdentifier instanceof ModuleComponentIdentifier }
+                           .collect { toComponentIdentifier(it.moduleVersion.id) })
           .withArtifacts(jvmLibrary, artifactTypes)
           .execute()
           .getResolvedComponents()

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/DependencyResolverImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/DependencyResolverImpl.groovy
@@ -136,7 +136,7 @@ class DependencyResolverImpl implements DependencyResolver {
         //noinspection GroovyAssignabilityCheck
         Set<ComponentArtifactsResult> componentResults = myProject.dependencies.createArtifactResolutionQuery()
           .forComponents(resolvedArtifacts
-                           .findAll { !isDependencySubstitutionsSupported || it.id.componentIdentifier instanceof ModuleComponentIdentifier }
+                           .findAll { !isProjectDependencyArtifact(it) }
                            .collect { toComponentIdentifier(it.moduleVersion.id) })
           .withArtifacts(jvmLibrary, artifactTypes)
           .execute()
@@ -909,7 +909,7 @@ class DependencyResolverImpl implements DependencyResolver {
                 def packaging = it.extension ?: 'jar'
                 def classifier = it.classifier
                 final dependency
-                if (isDependencySubstitutionsSupported && artifact.id.componentIdentifier instanceof ProjectComponentIdentifier) {
+                if (isProjectDependencyArtifact(artifact)) {
                   def artifactComponentIdentifier = artifact.id.componentIdentifier as ProjectComponentIdentifier
                   dependency = new DefaultExternalProjectDependency(
                     name: name,
@@ -978,6 +978,10 @@ class DependencyResolverImpl implements DependencyResolver {
 
       return dependencies
     }
+  }
+
+  private static boolean isProjectDependencyArtifact(ResolvedArtifact artifact) {
+    return isDependencySubstitutionsSupported && artifact.id.componentIdentifier instanceof ProjectComponentIdentifier
   }
 
   private static toMyModuleIdentifier(ModuleVersionIdentifier id) {


### PR DESCRIPTION
The gradle import resolves source and javadoc JAR files for all artifacts, including project dependency artifacts. These artifacts do not exist in external repositories and so gradle makes many unsuccessful HTTP calls to pom files as well as source and javadoc JARs across all configured repositories every time the project is imported. For large multi-module projects with many external repositories these unsuccessful HTTP calls can take a long time, on the order of many minutes.

This fix limits the resolved artifacts to those from external dependencies. I have checked that all tests in gradle-tooling-extension-impl still pass.