### PR TITLE
IDEA-165963 Gradle run configurations cannot be profiled

### DIFF
--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/execution/ExternalSystemTaskExecutionSettings.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/execution/ExternalSystemTaskExecutionSettings.java
@@ -15,7 +15,9 @@
  */
 package com.intellij.openapi.externalSystem.model.execution;
 
+import com.intellij.execution.configurations.ParametersList;
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtilRt;
 import com.intellij.util.xmlb.annotations.Tag;
@@ -36,6 +38,7 @@ import java.util.List;
 public class ExternalSystemTaskExecutionSettings implements Cloneable {
 
   @NotNull @NonNls public static final String TAG_NAME = "ExternalSystemSettings";
+  @NotNull @NonNls public static final Key<ParametersList> DEBUGGER_SETUP_KEY = Key.create("debuggerSetup");
 
   private List<String> myTaskNames = ContainerUtilRt.newArrayList();
   private List<String> myTaskDescriptions = ContainerUtilRt.newArrayList();

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemRunConfiguration.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemRunConfiguration.java
@@ -4,6 +4,7 @@ import com.intellij.diagnostic.logging.LogConfigurationPanel;
 import com.intellij.execution.*;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.LocatableConfigurationBase;
+import com.intellij.execution.configurations.ParametersList;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.console.DuplexConsoleView;
 import com.intellij.execution.executors.DefaultDebugExecutor;
@@ -169,6 +170,11 @@ public class ExternalSystemRunConfiguration extends LocatableConfigurationBase {
       String debuggerSetup = null;
       if (myDebugPort > 0) {
         debuggerSetup = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=" + myDebugPort;
+      } else {
+        ParametersList parametersList = myEnv.getUserData(ExternalSystemTaskExecutionSettings.DEBUGGER_SETUP_KEY);
+        if (parametersList != null) {
+          debuggerSetup = parametersList.getParametersString();
+        }
       }
 
       ApplicationManager.getApplication().assertIsDispatchThread();

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
@@ -671,7 +671,7 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
         "gradle.taskGraph.beforeTask { Task task ->",
         "    if (task instanceof JavaForkOptions && (" + names + ".contains(task.name) || " + names + ".contains(task.path))) {",
         "        def jvmArgs = task.jvmArgs.findAll{!it?.startsWith('-agentlib') && !it?.startsWith('-Xrunjdwp')}",
-        "        jvmArgs << '" + debuggerSetup.trim() + '\'',
+        "        jvmArgs << '" + debuggerSetup.trim().replace("\\", "\\\\") + '\'',
         "        task.jvmArgs jvmArgs",
         "    }" +
         "}",


### PR DESCRIPTION
Provide a way for executors other than the debugging executor to set VM parameters that are patched into the gradle Java task. This is solved with a special key that can be set in the user data of the ExecutionEnvironment.