### PR TITLE
Fill subject and description in Github Pull Request creation dialog

### DIFF
--- a/plugins/github/src/org/jetbrains/plugins/github/GithubCreatePullRequestWorker.java
+++ b/plugins/github/src/org/jetbrains/plugins/github/GithubCreatePullRequestWorker.java
@@ -420,7 +420,7 @@ public class GithubCreatePullRequestWorker {
         VcsCommitMetadata targetCommit = commits.get(1);
 
         if (localCommit.getParents().contains(targetCommit.getId())) {
-          return Couple.of(localCommit.getSubject(), localCommit.getFullMessage());
+          return GithubUtil.getGithubLikeFormattedDescriptionMessage(localCommit.getFullMessage());
         }
         return getSimpleDefaultDescriptionMessage(branch);
       }

--- a/plugins/github/src/org/jetbrains/plugins/github/util/GithubUtil.java
+++ b/plugins/github/src/org/jetbrains/plugins/github/util/GithubUtil.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.Couple;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.ThrowableComputable;
@@ -446,5 +447,37 @@ public class GithubUtil {
       GithubNotifications.showError(project, "Can't add remote", e);
       return false;
     }
+  }
+
+  /**
+   * Splits full commit message into subject and description in GitHub style:
+   * First line becomes subject, everything after first line becomes description
+   * Also supports empty line that separates subject and description
+   *
+   * @param commitMessage full commit message
+   * @return couple of subject and description based on full commit message
+   */
+  public static Couple<String> getGithubLikeFormattedDescriptionMessage(String commitMessage) {
+    //Trim original
+    String message = commitMessage == null ? "" : commitMessage.trim();
+    if (message.isEmpty()) {
+      return Couple.of("", "");
+    }
+    int firstLineEnd = message.indexOf("\n");
+    String subject;
+    String description;
+    if (firstLineEnd > -1) {
+      //Subject is always first line
+      subject = message.substring(0, firstLineEnd).trim();
+      //Description is all text after first line, we also trim it to remove empty lines on start of description
+      description = message.substring(firstLineEnd + 1).trim();
+    } else {
+      //If we don't have any line separators and cannot detect description,
+      //we just assume that it is one-line commit and use full message as subject with empty description
+      subject = message;
+      description = "";
+    }
+
+    return Couple.of(subject, description);
   }
 }

--- a/plugins/github/test/org/jetbrains/plugins/github/GithubUtilTest.java
+++ b/plugins/github/test/org/jetbrains/plugins/github/GithubUtilTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.github;
+
+import com.intellij.openapi.util.Couple;
+import org.junit.Test;
+
+import static org.jetbrains.plugins.github.util.GithubUtil.getGithubLikeFormattedDescriptionMessage;
+import static org.junit.Assert.assertEquals;
+
+public class GithubUtilTest {
+  @Test
+  public void splitCommitMessageToSubjectAndDescriptionInGithubStyle() {
+    assertCommitMessage("Subject", "Message", "Subject\n\nMessage");
+    assertCommitMessage("Subject", "Message", "Subject\n\r\n\rMessage");
+    assertCommitMessage("Subject", "", "Subject");
+    assertCommitMessage("Subject", "", "\n\n\nSubject\n\n\n");
+    assertCommitMessage("Subject", "Message\n\n\nText", "\n\n\nSubject\n\n\nMessage\n\n\nText");
+    assertCommitMessage("Subject", "Message\nText", "Subject\nMessage\nText");
+    assertCommitMessage("Subject", "Message Text", "Subject\nMessage Text");
+    assertCommitMessage("Subject", "Multiline\nMessage", "Subject\n\nMultiline\nMessage");
+    assertCommitMessage("", "", null);
+    //No crop for long messages without line separators
+    assertCommitMessage(
+      "Very long subject string 123 Very long subject string Very long subject string Very long subject string Message",
+      "",
+      "Very long subject string 123 Very long subject string Very long subject string Very long subject string Message");
+    //Yes, we don't crop subject even if subject is long and description is short,
+    //we use this behaviour for better consistency and to avoid unelected cases, when you long title is long by design
+    //Actually, it's the same behaviour that used in GitHub CLI (https://github.com/github/hub)
+    assertCommitMessage(
+      "Very long subject string 123 Very long subject string Very long subject string Very long subject string Message",
+      "Appendix",
+      "Very long subject string 123 Very long subject string Very long subject string Very long subject string Message\nAppendix");
+    assertCommitMessage(
+      "Very long subject string 123 Very long subject string Very long subject string Very long subject string Message",
+      "Appendix",
+      "Very long subject string 123 Very long subject string Very long subject string Very long subject string Message\n\nAppendix");
+
+  }
+
+  private static void assertCommitMessage(String expectedSubject, String expectedDescription, String fullMessage) {
+    Couple<String> message = getGithubLikeFormattedDescriptionMessage(fullMessage);
+    assertEquals(expectedSubject, message.first);
+    assertEquals(expectedDescription, message.second);
+  }
+}


### PR DESCRIPTION
When you create PR now the title is the first line of commit message and description is another text.
It's the same behaviour that used when you create PR from Github website or using hub (Github CLI tools)