### PR TITLE
[junit5] Support FileSource and CompositeTestSource in 'Jump to Source'

### DIFF
--- a/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestExecutionListener.java
+++ b/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestExecutionListener.java
@@ -20,8 +20,11 @@ import com.intellij.junit4.JUnit4TestListener;
 import com.intellij.rt.execution.junit.ComparisonFailureData;
 import com.intellij.rt.execution.junit.MapSerializerUtil;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.CompositeTestSource;
+import org.junit.platform.engine.support.descriptor.FileSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
@@ -30,6 +33,7 @@ import org.opentest4j.AssertionFailedError;
 import org.opentest4j.MultipleFailuresError;
 import org.opentest4j.ValueWrapper;
 
+import java.io.File;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -39,6 +43,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class JUnit5TestExecutionListener implements TestExecutionListener {
+  private static final String NO_LOCATION_HINT = "";
+  private static final String NO_LOCATION_HINT_VALUE = "";
   private final PrintStream myPrintStream;
   private TestPlan myTestPlan;
   private long myCurrentTestStart;
@@ -98,7 +104,7 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
 
   @Override
   public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-    executionStarted (testIdentifier);
+    executionStarted(testIdentifier);
     executionFinished(testIdentifier, TestExecutionResult.Status.ABORTED, null, reason);
   }
 
@@ -108,18 +114,10 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
       testStarted(testIdentifier);
       myCurrentTestStart = System.currentTimeMillis();
     }
-    else if (!myRoots.contains(testIdentifier)){
+    else if (!myRoots.contains(testIdentifier)) {
       myFinishCount = 0;
-      myPrintStream.println("##teamcity[testSuiteStarted" + idAndName(testIdentifier) + "\']");
+      myPrintStream.println("##teamcity[testSuiteStarted" + idAndName(testIdentifier) + "]");
     }
-  }
-
-  private static String idAndName(TestIdentifier testIdentifier) {
-    return idAndName(testIdentifier, testIdentifier.getDisplayName());
-  }
-
-  private static String idAndName(TestIdentifier testIdentifier, String displayName) {
-    return " id=\'" + escapeName(testIdentifier.getUniqueId()) + "\' name=\'" + escapeName(displayName);
   }
 
   @Override
@@ -151,7 +149,7 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
       testFinished(testIdentifier, duration);
       myFinishCount++;
     }
-    else if (!myRoots.contains(testIdentifier)){
+    else if (!myRoots.contains(testIdentifier)) {
       String messageName = null;
       if (status == TestExecutionResult.Status.FAILED) {
         messageName = MapSerializerUtil.TEST_FAILED;
@@ -161,7 +159,7 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
       }
       if (messageName != null) {
         if (status == TestExecutionResult.Status.FAILED) {
-          myPrintStream.println("\n##teamcity[testStarted name=\'" + JUnit4TestListener.CLASS_CONFIGURATION + getLocationHint(testIdentifier) + "\']");
+          myPrintStream.println("\n##teamcity[testStarted name=\'" + JUnit4TestListener.CLASS_CONFIGURATION + "\' " + getLocationHint(testIdentifier) + "]");
           testFailure(JUnit4TestListener.CLASS_CONFIGURATION, JUnit4TestListener.CLASS_CONFIGURATION, messageName, throwableOptional, 0, reason, true);
           myPrintStream.println("\n##teamcity[testFinished name=\'" + JUnit4TestListener.CLASS_CONFIGURATION + "\']");
         }
@@ -176,7 +174,7 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
           myFinishCount = 0;
         }
       }
-      myPrintStream.println("##teamcity[testSuiteFinished " + idAndName(testIdentifier, displayName) + "\']");
+      myPrintStream.println("##teamcity[testSuiteFinished " + idAndName(testIdentifier, displayName) + "]");
     }
   }
 
@@ -185,11 +183,11 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
   }
 
   private void testStarted(TestIdentifier testIdentifier) {
-    myPrintStream.println("\n##teamcity[testStarted" + idAndName(testIdentifier) + getLocationHint(testIdentifier) + "\']");
+    myPrintStream.println("\n##teamcity[testStarted" + idAndName(testIdentifier) + " " + getLocationHint(testIdentifier) + "]");
   }
-  
+
   private void testFinished(TestIdentifier testIdentifier, long duration) {
-    myPrintStream.println("\n##teamcity[testFinished" + idAndName(testIdentifier) + (duration > 0 ? "\' duration=\'" + Long.toString(duration) : "") + "\']");
+    myPrintStream.println("\n##teamcity[testFinished" + idAndName(testIdentifier) + (duration > 0 ? " duration=\'" + Long.toString(duration) + "\'" : "") + "]");
   }
 
   private void testFailure(TestIdentifier testIdentifier,
@@ -235,7 +233,8 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
           try {
             failureData = ExpectedPatterns.createExceptionNotification(ex);
           }
-          catch (Throwable ignore) {}
+          catch (Throwable ignore) {
+          }
         }
 
         if (includeThrowable || failureData == null) {
@@ -277,7 +276,7 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
                                  HashSet<TestIdentifier> visited) {
     final String idAndName = idAndName(root);
     if (root.isContainer()) {
-      myPrintStream.println("##teamcity[suiteTreeStarted" + idAndName + getLocationHint(root) + "\']");
+      myPrintStream.println("##teamcity[suiteTreeStarted" + idAndName + " " + getLocationHint(root) + "]");
       for (TestIdentifier childIdentifier : testPlan.getChildren(root)) {
         if (visited.add(childIdentifier)) {
           sendTreeUnderRoot(testPlan, childIdentifier, visited);
@@ -286,19 +285,68 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
           System.err.println("Identifier \'" + childIdentifier.getUniqueId() + "\' is reused");
         }
       }
-      myPrintStream.println("##teamcity[suiteTreeEnded" + idAndName + "\']");
+      myPrintStream.println("##teamcity[suiteTreeEnded" + idAndName + "]");
     }
     else if (root.isTest()) {
-      myPrintStream.println("##teamcity[suiteTreeNode " + idAndName + getLocationHint(root) + "\']");
+      myPrintStream.println("##teamcity[suiteTreeNode " + idAndName + " " + getLocationHint(root) + "]");
     }
   }
 
-  private static String getLocationHint(TestIdentifier root) {
-    final String className = getClassName(root);
-    final String methodName = getMethodName(root);
-    return "\' locationHint=\'java:" + (root.isTest() ? "test" : "suite") + "://" + escapeName(className + (methodName != null ? "." + methodName : ""));
+  private static String idAndName(TestIdentifier testIdentifier) {
+    return idAndName(testIdentifier, testIdentifier.getDisplayName());
   }
 
+  private static String idAndName(TestIdentifier testIdentifier, String displayName) {
+    return " id=\'" + escapeName(testIdentifier.getUniqueId()) + "\' name=\'" + escapeName(displayName) + "\'";
+  }
+
+  static String getLocationHint(TestIdentifier root) {
+    return root.getSource()
+      .map(testSource -> getLocationHintValue(testSource, root.isTest()))
+      .filter(maybeLocationHintValue -> !NO_LOCATION_HINT_VALUE.equals(maybeLocationHintValue))
+      .map(locationHintValue -> "locationHint=\'" + locationHintValue + "\'")
+      .orElse(NO_LOCATION_HINT);
+  }
+
+  static String getLocationHintValue(TestSource testSource, boolean isTest) {
+
+    if (testSource instanceof CompositeTestSource) {
+      CompositeTestSource compositeTestSource = ((CompositeTestSource)testSource);
+      for (TestSource sourceFromComposite : compositeTestSource.getSources()) {
+        String locationHintValue = getLocationHintValue(sourceFromComposite, isTest);
+        if (!NO_LOCATION_HINT_VALUE.equals(locationHintValue)) {
+          return locationHintValue;
+        }
+      }
+      return NO_LOCATION_HINT_VALUE;
+    }
+
+    if (testSource instanceof FileSource) {
+      FileSource fileSource = (FileSource)testSource;
+      File file = fileSource.getFile();
+      String line = fileSource.getPosition().map(position -> ":" + position.getLine()).orElse("");
+      return "file://" + file.toString() + line;
+    }
+
+    if (testSource instanceof MethodSource) {
+      MethodSource methodSource = (MethodSource)testSource;
+      return javaLocation(methodSource.getClassName(), methodSource.getMethodName(), isTest);
+    }
+
+    if (testSource instanceof ClassSource) {
+      String className = ((ClassSource)testSource).getClassName();
+      return javaLocation(className, null, isTest);
+    }
+
+    return NO_LOCATION_HINT_VALUE;
+  }
+
+  private static String javaLocation(String className, String maybeMethodName, boolean isTest) {
+    String type = isTest ? "test" : "suite";
+    String methodName = maybeMethodName == null ? "" : "." + maybeMethodName;
+    String location = escapeName(className + methodName);
+    return "java:" + type + "://" + location;
+  }
 
   private static String escapeName(String str) {
     return MapSerializerUtil.escapeStr(str, MapSerializerUtil.STD_ESCAPER);

--- a/plugins/junit5_rt_tests/test/com/intellij/junit5/JUnit5NavigationTest.java
+++ b/plugins/junit5_rt_tests/test/com/intellij/junit5/JUnit5NavigationTest.java
@@ -19,8 +19,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.MethodTestDescriptor;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.*;
 import org.junit.platform.launcher.TestIdentifier;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import static java.util.Collections.singletonList;
 
 @DisplayName("junit 5 navigation features: location strings, etc")
 class JUnit5NavigationTest {
@@ -34,5 +41,155 @@ class JUnit5NavigationTest {
     Assertions.assertEquals(JUnit5NavigationTest.class.getName(), JUnit5TestExecutionListener.getClassName(testIdentifier));
     Assertions.assertEquals("methodNavigation", JUnit5TestExecutionListener.getMethodName(testIdentifier));
     //Assertions.assertEquals("methodNavigation", testIdentifier.getDisplayName()); todo methodNavigation()
+  }
+
+  private final ConfigurableTestDescriptor descriptor = new ConfigurableTestDescriptor();
+  private TestSource myTestSource = null;
+
+  @Test
+  void ignoreMissingTestSource() {
+    myTestSource = null;
+
+    Assertions.assertEquals("", locationHint());
+  }
+
+  @Test
+  void ignoreUnsupportedTestSources() {
+    myTestSource = anyUnsupportedTestSource();
+
+    Assertions.assertEquals("", locationHint());
+  }
+
+  @Test
+  void produceLocationHintForAnySupportedTestSource() {
+    myTestSource = anySupportedSource();
+    String locationHint = locationHint();
+
+    Assertions.assertTrue(locationHint.startsWith("locationHint='"), locationHint);
+    Assertions.assertTrue(locationHint.endsWith("'"), locationHint);
+  }
+
+  @Test
+  void locationHintValueForMethodSource() {
+    myTestSource = new MethodSource("className", "methodName");
+    descriptor.use(myTestSource);
+    String locationHintValue = locationHintValue();
+
+    Assertions.assertTrue(locationHintValue.startsWith("java:"), locationHintValue);
+    Assertions.assertTrue(locationHintValue.contains("://className.methodName"), locationHintValue);
+  }
+
+  @Test
+  void locationHintValueForClassSource() {
+    myTestSource = new ClassSource(String.class);
+    descriptor.use(myTestSource);
+    String locationHintValue = locationHintValue();
+
+    Assertions.assertTrue(locationHintValue.startsWith("java:"), locationHintValue);
+    Assertions.assertTrue(locationHintValue.contains("://java.lang.String"), locationHintValue);
+  }
+
+  @Test
+  void deriveSuiteOrTestFromDescription() {
+    myTestSource = methodOrClassSource();
+
+    descriptor.isTest(true);
+    Assertions.assertTrue(locationHintValue().startsWith("java:test:"));
+
+    descriptor.isTest(false);
+    Assertions.assertTrue(locationHintValue().startsWith("java:suite:"));
+  }
+
+  @Test
+  void locationHintValueForFileSource() {
+    myTestSource = new FileSource(Paths.get("/some/file.txt").toFile());
+
+    Assertions.assertEquals("file:///some/file.txt", locationHintValue());
+  }
+
+
+  @Test
+  void locationHintValueForFileSourceWithLineInformation() {
+    myTestSource = new FileSource(Paths.get("/some/file.txt").toFile(), new FilePosition(22, 7));
+
+    Assertions.assertEquals("file:///some/file.txt:22", locationHintValue());
+  }
+
+  @Test
+  void ignoreCompositeSourceWithoutAnySupportedTestSource() {
+    myTestSource = new CompositeTestSource(singletonList(anyUnsupportedTestSource()));
+
+    Assertions.assertEquals("", locationHint());
+  }
+
+  @Test
+  void locationHintValueForCompositeSourcePickTheFirstSupportedSourceInTheList() {
+    myTestSource = new CompositeTestSource(Arrays.asList(anyUnsupportedTestSource(), new ClassSource(String.class), new MethodSource("className", "methodName")));
+    String locationHintValue = locationHintValue();
+
+    Assertions.assertTrue(locationHintValue.startsWith("java:"), locationHintValue);
+    Assertions.assertTrue(locationHintValue.contains("://java.lang.String"), locationHintValue);
+  }
+
+  private String locationHint() {
+    descriptor.use(myTestSource);
+    TestIdentifier testIdentifier = TestIdentifier.from(descriptor);
+    return JUnit5TestExecutionListener.getLocationHint(testIdentifier);
+  }
+
+  private String locationHintValue() {
+    descriptor.use(myTestSource);
+    TestIdentifier testIdentifier = TestIdentifier.from(descriptor);
+    return JUnit5TestExecutionListener.getLocationHintValue(testIdentifier.getSource().orElseThrow(IllegalStateException::new), testIdentifier.isTest());
+  }
+
+  private static ClassSource anySupportedSource() {
+    return new ClassSource(String.class);
+  }
+
+  private static TestSource methodOrClassSource() {
+    return new ClassSource(String.class);
+  }
+
+  private static TestSource anyUnsupportedTestSource() {
+    return new TestSource() {
+    };
+  }
+
+  private static UniqueId anyUniqueId() {
+    return UniqueId.forEngine("stand in");
+  }
+
+  private static String anyDisplayName() {
+    return "stand in";
+  }
+
+  private static class ConfigurableTestDescriptor extends AbstractTestDescriptor {
+    private boolean myIsTest;
+
+    public ConfigurableTestDescriptor() {
+      super(JUnit5NavigationTest.anyUniqueId(), JUnit5NavigationTest.anyDisplayName());
+    }
+
+    public void use(TestSource testSource) {
+      if (null == testSource) {
+        return;
+      }
+      setSource(testSource);
+    }
+
+    @Override
+    public boolean isContainer() {
+      return false;
+    }
+
+    @Override
+    public boolean isTest() {
+      return myIsTest;
+    }
+
+    public void isTest(boolean isTest) {
+      myIsTest = isTest;
+    }
   }
 }


### PR DESCRIPTION
Currently Intellij only extracts locationHints from [MethodSource][MethodSource] and [ClassSource][ClassSource].
In cucumber there is a feature file ([FileSource][FileSource]) as well as a step implementation ([MethodSource][MethodSource]) you may want to navigate to from the test tree.
I report [both][junit-cucumber-engine] of them in a [CompositeTestSource][CompositeTestSource] in this order [FileSource, MethodSource].

This pull request adds support for:
1. Extract locationHint to a file from a [FileSource][FileSource].
1. Extract locationHint from the first supported TestSource in the list of a [CompositeTestSource][CompositeTestSource].
   If the current protocol supports multiple locationHints for a test tree item let me know and I'll adjust the pull request.

I already send a signed CLA for a [previous pull request][previous pull request] to intellij-plugins.

@akozlova can you have a look?

[MethodSource]: https://github.com/junit-team/junit5/blob/master/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
[ClassSource]: https://github.com/junit-team/junit5/blob/master/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
[FileSource]: https://github.com/junit-team/junit5/blob/master/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FileSource.java
[CompositeTestSource]:https://github.com/junit-team/junit5/blob/master/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/CompositeTestSource.java
[previous pull request]: https://github.com/JetBrains/intellij-plugins/pull/4
[junit-cucumber-engine]: https://github.com/signed/junit-cucumber-engine/blob/master/cucumber-engine/src/main/java/cucumber/runtime/junit/CucumberInsight.java#L57