### PR TITLE
Speedup gradle test output XML processing

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleManager.java
@@ -26,9 +26,7 @@ import com.intellij.execution.testframework.sm.runner.SMTestProxy;
 import com.intellij.execution.testframework.sm.runner.states.TestStateInfo;
 import com.intellij.execution.testframework.sm.runner.ui.SMRootTestProxyFormatter;
 import com.intellij.execution.testframework.sm.runner.ui.TestTreeRenderer;
-import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.execution.ExternalSystemExecutionConsoleManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.ExternalProjectInfo;
@@ -46,12 +44,10 @@ import com.intellij.util.ObjectUtils;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.action.GradleRerunFailedTestsAction;
-import org.jetbrains.plugins.gradle.execution.test.runner.events.*;
 import org.jetbrains.plugins.gradle.service.project.GradleProjectResolverUtil;
 import org.jetbrains.plugins.gradle.service.resolve.GradleCommonClassNames;
 import org.jetbrains.plugins.gradle.util.GradleBundle;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 /**
  * @author Vladislav.Soroka
@@ -59,7 +55,6 @@ import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
  */
 public class GradleTestsExecutionConsoleManager
   implements ExternalSystemExecutionConsoleManager<ExternalSystemRunConfiguration, GradleTestsExecutionConsole, ProcessHandler> {
-  private static final Logger LOG = Logger.getInstance(GradleTestsExecutionConsoleManager.class);
 
   @NotNull
   @Override
@@ -125,61 +120,7 @@ public class GradleTestsExecutionConsoleManager
                        @NotNull ProcessHandler processHandler,
                        @NotNull String text,
                        @NotNull Key processOutputType) {
-    final StringBuilder consoleBuffer = executionConsole.getBuffer();
-    if (StringUtil.endsWith(text, "<ijLogEol/>\n")) {
-      consoleBuffer.append(StringUtil.trimEnd(text, "<ijLogEol/>\n")).append('\n');
-      return;
-    }
-    else {
-      consoleBuffer.append(text);
-    }
-
-    String trimmedText = consoleBuffer.toString().trim();
-    consoleBuffer.setLength(0);
-
-    if (!StringUtil.startsWith(trimmedText, "<ijLog>") || !StringUtil.endsWith(trimmedText, "</ijLog>")) {
-      if (text.trim().isEmpty()) return;
-      executionConsole.print(text, ConsoleViewContentType.getConsoleViewType(processOutputType));
-      return;
-    }
-
-    try {
-      final XmlXpathHelper xml = new XmlXpathHelper(trimmedText);
-
-      final TestEventType eventType = TestEventType.fromValue(xml.queryXml("/ijLog/event/@type"));
-      TestEvent testEvent = null;
-      switch (eventType) {
-        case CONFIGURATION_ERROR:
-          testEvent = new ConfigurationErrorEvent(executionConsole);
-          break;
-        case REPORT_LOCATION:
-          testEvent = new ReportLocationEvent(executionConsole);
-          break;
-        case BEFORE_TEST:
-          testEvent = new BeforeTestEvent(executionConsole);
-          break;
-        case ON_OUTPUT:
-          testEvent = new OnOutputEvent(executionConsole);
-          break;
-        case AFTER_TEST:
-          testEvent = new AfterTestEvent(executionConsole);
-          break;
-        case BEFORE_SUITE:
-          testEvent = new BeforeSuiteEvent(executionConsole);
-          break;
-        case AFTER_SUITE:
-          testEvent = new AfterSuiteEvent(executionConsole);
-          break;
-        case UNKNOWN_EVENT:
-          break;
-      }
-      if (testEvent != null) {
-        testEvent.process(xml);
-      }
-    }
-    catch (XmlXpathHelper.XmlParserException e) {
-      LOG.error("Gradle test events parser error", e);
-    }
+    GradleTestsExecutionConsoleOutputProcessor.onOutput(executionConsole, text, processOutputType);
   }
 
   @Override

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
@@ -51,7 +51,7 @@ public class GradleTestsExecutionConsoleOutputProcessor {
     }
 
     try {
-      final TestEventXmlView xml = new TestEventXmlXPathView(trimmedText);
+      final TestEventXmlView xml = new TestEventXPPXmlView(trimmedText);
 
       final TestEventType eventType = TestEventType.fromValue(xml.getTestEventType());
       TestEvent testEvent = null;

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.gradle.execution.test.runner;
+
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.*;
+import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
+
+/**
+ * Created by eugene.petrenko@gmail.com
+ */
+public class GradleTestsExecutionConsoleOutputProcessor {
+  private static final Logger LOG = Logger.getInstance(GradleTestsExecutionConsoleOutputProcessor.class);
+
+  public static void onOutput(@NotNull GradleTestsExecutionConsole executionConsole,
+                              @NotNull String text,
+                              @NotNull Key processOutputType) {
+    final StringBuilder consoleBuffer = executionConsole.getBuffer();
+    if (StringUtil.endsWith(text, "<ijLogEol/>\n")) {
+      consoleBuffer.append(StringUtil.trimEnd(text, "<ijLogEol/>\n")).append('\n');
+      return;
+    }
+    else {
+      consoleBuffer.append(text);
+    }
+
+    String trimmedText = consoleBuffer.toString().trim();
+    consoleBuffer.setLength(0);
+
+    if (!StringUtil.startsWith(trimmedText, "<ijLog>") || !StringUtil.endsWith(trimmedText, "</ijLog>")) {
+      if (text.trim().isEmpty()) return;
+      executionConsole.print(text, ConsoleViewContentType.getConsoleViewType(processOutputType));
+      return;
+    }
+
+    try {
+      final XmlXpathHelper xml = new XmlXpathHelper(trimmedText);
+
+      final TestEventType eventType = TestEventType.fromValue(xml.queryXml("/ijLog/event/@type"));
+      TestEvent testEvent = null;
+      switch (eventType) {
+        case CONFIGURATION_ERROR:
+          testEvent = new ConfigurationErrorEvent(executionConsole);
+          break;
+        case REPORT_LOCATION:
+          testEvent = new ReportLocationEvent(executionConsole);
+          break;
+        case BEFORE_TEST:
+          testEvent = new BeforeTestEvent(executionConsole);
+          break;
+        case ON_OUTPUT:
+          testEvent = new OnOutputEvent(executionConsole);
+          break;
+        case AFTER_TEST:
+          testEvent = new AfterTestEvent(executionConsole);
+          break;
+        case BEFORE_SUITE:
+          testEvent = new BeforeSuiteEvent(executionConsole);
+          break;
+        case AFTER_SUITE:
+          testEvent = new AfterSuiteEvent(executionConsole);
+          break;
+        case UNKNOWN_EVENT:
+          break;
+      }
+      if (testEvent != null) {
+        testEvent.process(xml);
+      }
+    }
+    catch (XmlXpathHelper.XmlParserException e) {
+      LOG.error("Gradle test events parser error", e);
+    }
+  }
+}

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
@@ -21,7 +21,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.events.*;
-import org.jetbrains.plugins.gradle.execution.test.runner.events.XmlXpathHelper;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.TestEventXmlXPathView;
 
 /**
  * Created by eugene.petrenko@gmail.com
@@ -51,7 +51,7 @@ public class GradleTestsExecutionConsoleOutputProcessor {
     }
 
     try {
-      final XmlXpathHelper xml = new XmlXpathHelper(trimmedText);
+      final TestEventXmlView xml = new TestEventXmlXPathView(trimmedText);
 
       final TestEventType eventType = TestEventType.fromValue(xml.getTestEventType());
       TestEvent testEvent = null;
@@ -84,7 +84,7 @@ public class GradleTestsExecutionConsoleOutputProcessor {
         testEvent.process(xml);
       }
     }
-    catch (XmlXpathHelper.XmlParserException e) {
+    catch (TestEventXmlXPathView.XmlParserException e) {
       LOG.error("Gradle test events parser error", e);
     }
   }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
@@ -21,7 +21,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.events.*;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.XmlXpathHelper;
 
 /**
  * Created by eugene.petrenko@gmail.com

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/GradleTestsExecutionConsoleOutputProcessor.java
@@ -53,7 +53,7 @@ public class GradleTestsExecutionConsoleOutputProcessor {
     try {
       final XmlXpathHelper xml = new XmlXpathHelper(trimmedText);
 
-      final TestEventType eventType = TestEventType.fromValue(xml.queryXml("/ijLog/event/@type"));
+      final TestEventType eventType = TestEventType.fromValue(xml.getTestEventType());
       TestEvent testEvent = null;
       switch (eventType) {
         case CONFIGURATION_ERROR:

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AbstractTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AbstractTestEvent.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.execution.GradleRunnerUtil;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleConsoleProperties;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -59,26 +58,6 @@ public abstract class AbstractTestEvent implements TestEvent {
   @NotNull
   protected String findLocationUrl(@Nullable String name, @NotNull String fqClassName) {
     return GradleRunnerUtil.getTestLocationUrl(name, fqClassName);
-  }
-
-  protected String getTestName(@NotNull XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    return eventXml.queryXml("/ijLog/event/test/descriptor/@name");
-  }
-
-  protected String getParentTestId(@NotNull XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    return eventXml.queryXml("/ijLog/event/test/@parentId");
-  }
-
-  protected String getTestId(@NotNull XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    return eventXml.queryXml("/ijLog/event/test/@id");
-  }
-
-  protected String getTestClassName(@NotNull XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    return eventXml.queryXml("/ijLog/event/test/descriptor/@className");
-  }
-
-  protected TestEventResult getTestEventResultType(@NotNull XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    return TestEventResult.fromValue(eventXml.queryXml("/ijLog/event/test/result/@resultType"));
   }
 
   protected void addToInvokeLater(final Runnable runnable) {

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterSuiteEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterSuiteEvent.java
@@ -16,6 +16,7 @@
 package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
 
 /**
@@ -28,7 +29,7 @@ public class AfterSuiteEvent extends AbstractTestEvent {
   }
 
   @Override
-  public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
+  public void process(@NotNull TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
     final String testId = eventXml.getTestId();
     final TestEventResult result = TestEventResult.fromValue(eventXml.getTestEventResultType());
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterSuiteEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterSuiteEvent.java
@@ -17,7 +17,6 @@ package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 /**
  * @author Vladislav.Soroka

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterSuiteEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterSuiteEvent.java
@@ -30,8 +30,8 @@ public class AfterSuiteEvent extends AbstractTestEvent {
 
   @Override
   public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    final String testId = getTestId(eventXml);
-    final TestEventResult result = getTestEventResultType(eventXml);
+    final String testId = eventXml.getTestId();
+    final TestEventResult result = TestEventResult.fromValue(eventXml.getTestEventResultType());
 
     addToInvokeLater(() -> {
       final SMTestProxy testProxy = findTestProxy(testId);

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterTestEvent.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Couple;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.ObjectUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
 
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ public class AfterTestEvent extends AbstractTestEvent {
   }
 
   @Override
-  public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
+  public void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
 
     final String testId = eventXml.getTestId();
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterTestEvent.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.util.Couple;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.ObjectUtils;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 import java.util.ArrayList;
 import java.util.regex.Matcher;

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/AfterTestEvent.java
@@ -39,12 +39,12 @@ public class AfterTestEvent extends AbstractTestEvent {
   @Override
   public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
 
-    final String testId = getTestId(eventXml);
+    final String testId = eventXml.getTestId();
 
-    final String startTime = eventXml.queryXml("/ijLog/event/test/result/@startTime");
-    final String endTime = eventXml.queryXml("/ijLog/event/test/result/@endTime");
-    final String exceptionMsg = decode(eventXml.queryXml("/ijLog/event/test/result/errorMsg"));
-    final String stackTrace = decode(eventXml.queryXml("/ijLog/event/test/result/stackTrace"));
+    final String startTime = eventXml.getEventTestResultStartTime();
+    final String endTime = eventXml.getEventTestResultEndTime();
+    final String exceptionMsg = decode(eventXml.getEventTestResultErrorMsg());
+    final String stackTrace = decode(eventXml.getEventTestResultStackTrace());
 
     final SMTestProxy testProxy = findTestProxy(testId);
     if (testProxy == null) return;
@@ -56,20 +56,20 @@ public class AfterTestEvent extends AbstractTestEvent {
     }
 
     final CompositeRunnable runInEdt = new CompositeRunnable();
-    final TestEventResult result = getTestEventResultType(eventXml);
+    final TestEventResult result = TestEventResult.fromValue(eventXml.getTestEventResultType());
     switch (result) {
       case SUCCESS:
         runInEdt.add(testProxy::setFinished);
         break;
       case FAILURE:
-        final String failureType = eventXml.queryXml("/ijLog/event/test/result/failureType");
+        final String failureType = eventXml.getEventTestResultFailureType();
         if ("comparison".equals(failureType)) {
-          String actualText = decode(eventXml.queryXml("/ijLog/event/test/result/actual"));
-          String expectedText = decode(eventXml.queryXml("/ijLog/event/test/result/expected"));
+          String actualText = decode(eventXml.getEventTestResultActual());
+          String expectedText = decode(eventXml.getEventTestResultExpected());
           final Condition<String> emptyString = StringUtil::isEmpty;
-          String filePath = ObjectUtils.nullizeByCondition(decode(eventXml.queryXml("/ijLog/event/test/result/filePath")), emptyString);
+          String filePath = ObjectUtils.nullizeByCondition(decode(eventXml.getEventTestResultFilePath()), emptyString);
           String actualFilePath = ObjectUtils.nullizeByCondition(
-            decode(eventXml.queryXml("/ijLog/event/test/result/actualFilePath")), emptyString);
+            decode(eventXml.getEventTestResultActualFilePath()), emptyString);
           testProxy.setTestComparisonFailed(exceptionMsg, stackTrace, actualText, expectedText, filePath, actualFilePath);
         }
         else {

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
@@ -16,6 +16,7 @@
 package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
 import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleSMTestProxy;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
 
@@ -29,7 +30,7 @@ public class BeforeSuiteEvent extends AbstractTestEvent {
   }
 
   @Override
-  public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
+  public void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
     final String testId = eventXml.getTestId();
     final String parentTestId = eventXml.getParentTestId();
     final String name = eventXml.getTestName();

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
@@ -18,7 +18,6 @@ package org.jetbrains.plugins.gradle.execution.test.runner.events;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleSMTestProxy;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 /**
  * @author Vladislav.Soroka

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
@@ -31,10 +31,10 @@ public class BeforeSuiteEvent extends AbstractTestEvent {
 
   @Override
   public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    final String testId = getTestId(eventXml);
-    final String parentTestId = getParentTestId(eventXml);
-    final String name = getTestName(eventXml);
-    final String fqClassName = getTestClassName(eventXml);
+    final String testId = eventXml.getTestId();
+    final String parentTestId = eventXml.getParentTestId();
+    final String name = eventXml.getTestName();
+    final String fqClassName = eventXml.getTestClassName();
 
     if (StringUtil.isEmpty(parentTestId)) {
       registerTestProxy(testId, getResultsViewer().getTestsRootNode());

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeSuiteEvent.java
@@ -32,7 +32,7 @@ public class BeforeSuiteEvent extends AbstractTestEvent {
   @Override
   public void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
     final String testId = eventXml.getTestId();
-    final String parentTestId = eventXml.getParentTestId();
+    final String parentTestId = eventXml.getTestParentId();
     final String name = eventXml.getTestName();
     final String fqClassName = eventXml.getTestClassName();
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleSMTestProxy;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 import java.util.List;
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
@@ -18,6 +18,7 @@ package org.jetbrains.plugins.gradle.execution.test.runner.events;
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleSMTestProxy;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
 
@@ -34,7 +35,7 @@ public class BeforeTestEvent extends AbstractTestEvent {
   }
 
   @Override
-  public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
+  public void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
     final String testId = eventXml.getTestId();
     final String parentTestId = eventXml.getParentTestId();
     final String name = eventXml.getTestName();

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
@@ -37,7 +37,7 @@ public class BeforeTestEvent extends AbstractTestEvent {
   @Override
   public void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
     final String testId = eventXml.getTestId();
-    final String parentTestId = eventXml.getParentTestId();
+    final String parentTestId = eventXml.getTestParentId();
     final String name = eventXml.getTestName();
     final String fqClassName = eventXml.getTestClassName();
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/BeforeTestEvent.java
@@ -36,10 +36,10 @@ public class BeforeTestEvent extends AbstractTestEvent {
 
   @Override
   public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    final String testId = getTestId(eventXml);
-    final String parentTestId = getParentTestId(eventXml);
-    final String name = getTestName(eventXml);
-    final String fqClassName = getTestClassName(eventXml);
+    final String testId = eventXml.getTestId();
+    final String parentTestId = eventXml.getParentTestId();
+    final String name = eventXml.getTestName();
+    final String fqClassName = eventXml.getTestClassName();
 
     String locationUrl = findLocationUrl(name, fqClassName);
     final GradleSMTestProxy testProxy = new GradleSMTestProxy(name, false, locationUrl, fqClassName);

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
@@ -29,7 +29,6 @@ import org.jetbrains.plugins.gradle.GradleManager;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
 import org.jetbrains.plugins.gradle.service.project.GradleNotification;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 import javax.swing.event.HyperlinkEvent;
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
@@ -43,11 +43,9 @@ public class ConfigurationErrorEvent extends AbstractTestEvent {
   }
 
   @Override
-  public void process(XmlXpathHelper xml) throws XmlXpathHelper.XmlParserException {
+  public void process(@NotNull final TestEventXmlView xml) throws TestEventXmlView.XmlParserException {
     final String errorTitle = xml.getEventTitle();
-    assert errorTitle != null;
     final String configurationErrorMsg = xml.getEventMessage();
-    assert configurationErrorMsg != null;
     final boolean openSettings = Boolean.valueOf(xml.isEventOpenSettings());
     final Project project = getProject();
     assert project != null;

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
@@ -45,11 +45,11 @@ public class ConfigurationErrorEvent extends AbstractTestEvent {
 
   @Override
   public void process(XmlXpathHelper xml) throws XmlXpathHelper.XmlParserException {
-    final String errorTitle = xml.queryXml("/ijLog/event/title");
+    final String errorTitle = xml.getEventTitle();
     assert errorTitle != null;
-    final String configurationErrorMsg = xml.queryXml("/ijLog/event/message");
+    final String configurationErrorMsg = xml.getEventMessage();
     assert configurationErrorMsg != null;
-    final boolean openSettings = Boolean.valueOf(xml.queryXml("/ijLog/event/@openSettings"));
+    final boolean openSettings = Boolean.valueOf(xml.isEventOpenSettings());
     final Project project = getProject();
     assert project != null;
     final String message =

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ConfigurationErrorEvent.java
@@ -46,7 +46,7 @@ public class ConfigurationErrorEvent extends AbstractTestEvent {
   public void process(@NotNull final TestEventXmlView xml) throws TestEventXmlView.XmlParserException {
     final String errorTitle = xml.getEventTitle();
     final String configurationErrorMsg = xml.getEventMessage();
-    final boolean openSettings = Boolean.valueOf(xml.isEventOpenSettings());
+    final boolean openSettings = xml.isEventOpenSettings();
     final Project project = getProject();
     assert project != null;
     final String message =

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/OnOutputEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/OnOutputEvent.java
@@ -32,9 +32,9 @@ public class OnOutputEvent extends AbstractTestEvent {
 
   @Override
   public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    final String testId = getTestId(eventXml);
-    final String destination = eventXml.queryXml("/ijLog/event/test/event/@destination");
-    final String output = decode(eventXml.queryXml("/ijLog/event/test/event"));
+    final String testId = eventXml.getTestId();
+    final String destination = eventXml.getTestEventTestDescription();
+    final String output = decode(eventXml.getTestEventTest());
 
     SMTestProxy testProxy = findTestProxy(testId);
     if (testProxy == null) return;

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/OnOutputEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/OnOutputEvent.java
@@ -17,6 +17,7 @@ package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
 
 /**
@@ -30,7 +31,7 @@ public class OnOutputEvent extends AbstractTestEvent {
   }
 
   @Override
-  public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
+  public void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
     final String testId = eventXml.getTestId();
     final String destination = eventXml.getTestEventTestDescription();
     final String output = decode(eventXml.getTestEventTest());

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/OnOutputEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/OnOutputEvent.java
@@ -18,7 +18,6 @@ package org.jetbrains.plugins.gradle.execution.test.runner.events;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 /**
  * @author Vladislav.Soroka

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ReportLocationEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ReportLocationEvent.java
@@ -16,7 +16,6 @@
 package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
 
 import java.io.File;
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ReportLocationEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ReportLocationEvent.java
@@ -15,6 +15,7 @@
  */
 package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.execution.test.runner.GradleTestsExecutionConsole;
 
 import java.io.File;
@@ -30,9 +31,8 @@ public class ReportLocationEvent extends AbstractTestEvent {
   }
 
   @Override
-  public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
+  public void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException {
     final String testReport = eventXml.getEventTestReport();
-    assert testReport != null;
     getProperties().setGradleTestReport(new File(testReport));
   }
 }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ReportLocationEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/ReportLocationEvent.java
@@ -32,7 +32,7 @@ public class ReportLocationEvent extends AbstractTestEvent {
 
   @Override
   public void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException {
-    final String testReport = eventXml.queryXml("/ijLog/event/@testReport");
+    final String testReport = eventXml.getEventTestReport();
     assert testReport != null;
     getProperties().setGradleTestReport(new File(testReport));
   }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEvent.java
@@ -15,10 +15,12 @@
  */
 package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * @author Vladislav.Soroka
  * @since 2/28/14
  */
 public interface TestEvent {
-  void process(XmlXpathHelper eventXml) throws XmlXpathHelper.XmlParserException;
+  void process(@NotNull final TestEventXmlView eventXml) throws TestEventXmlView.XmlParserException;
 }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEvent.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEvent.java
@@ -15,8 +15,6 @@
  */
 package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
-import org.jetbrains.plugins.gradle.util.XmlXpathHelper;
-
 /**
  * @author Vladislav.Soroka
  * @since 2/28/14

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXPPXmlView.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXPPXmlView.java
@@ -47,7 +47,7 @@ public class TestEventXPPXmlView implements TestEventXmlView {
   private String myEventTestResultStartTime;
   private String myTestName;
 
-  public TestEventXPPXmlView(@NotNull final String xml) throws Exception {
+  public TestEventXPPXmlView(@NotNull final String xml) throws XmlParserException {
     final HierarchicalStreamReader parser = DRIVER.createReader(new StringReader(xml));
 
     if (!"ijLog".equals(parser.getNodeName())) throw new RuntimeException("root element must be 'ijLog'");

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXPPXmlView.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXPPXmlView.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.gradle.execution.test.runner.events;
+
+import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.xml.XppDriver;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.StringReader;
+
+public class TestEventXPPXmlView implements TestEventXmlView {
+  private static final HierarchicalStreamDriver DRIVER = new XppDriver();
+
+  private String myTestEventType;
+  private String myTestParentId;
+  private String myTestId;
+  private String myTestClassName;
+  private String myTestEventResultType;
+  private String myEventTitle;
+  private String myEventOpenSettings;
+  private String myEventMessage;
+  private String myTestEventTest;
+  private String myTestEventTestDescription;
+  private String myEventTestReport;
+  private String myEventTestResultActionFilePath;
+  private String myEventTestResultFilePath;
+  private String myEventTestResultExpected;
+  private String myEventTestResultActual;
+  private String myEventTestResultFailureType;
+  private String myEventTestResultStackTrace;
+  private String myEventTestResultErrorMsg;
+  private String myEventTestResultEndTime;
+  private String myEventTestResultStartTime;
+  private String myTestName;
+
+  public TestEventXPPXmlView(@NotNull final String xml) throws Exception {
+    final HierarchicalStreamReader parser = DRIVER.createReader(new StringReader(xml));
+
+    if (!"ijLog".equals(parser.getNodeName())) throw new RuntimeException("root element must be 'ijLog'");
+
+    while(parser.hasMoreChildren()) {
+      parser.moveDown();
+
+      if ("event".equals(parser.getNodeName())) {
+        myTestEventType = parser.getAttribute("type");                //queryXml("/ijLog/event/@type");
+        myEventOpenSettings = parser.getAttribute("openSettings");    //queryXml("/ijLog/event/@openSettings");
+        myEventTestReport = parser.getAttribute("testReport");        //queryXml("/ijLog/event/@testReport");
+
+        while (parser.hasMoreChildren()) {
+          parser.moveDown();
+
+          if ("title".equals(parser.getNodeName())) {
+            myEventTitle = parser.getValue();                               //queryXml("/ijLog/event/title");
+          } else if ("message".equals(parser.getNodeName())) {
+            myEventMessage = parser.getValue();                             //queryXml("/ijLog/event/message");
+          } else if ("test".equals(parser.getNodeName())) {
+            myTestParentId = parser.getAttribute("parentId");        //queryXml("/ijLog/event/test/@parentId");
+            myTestId = parser.getAttribute("id");                    //queryXml("/ijLog/event/test/@id");
+
+            while (parser.hasMoreChildren()) {
+              parser.moveDown();
+
+              if ("descriptor".equals(parser.getNodeName())) {
+                myTestName = parser.getAttribute("name");            //queryXml("/ijLog/event/test/descriptor/@name");
+                myTestClassName = parser.getAttribute("className");  //queryXml("/ijLog/event/test/descriptor/@className");
+              } else if ("event".equals(parser.getNodeName())) {
+                myTestEventTestDescription = parser.getAttribute("destination"); //queryXml("/ijLog/event/test/event/@destination");
+                myTestEventTest = parser.getValue();                                    //queryXml("/ijLog/event/test/event");
+              } else if ("result".equals(parser.getNodeName())) {
+                myTestEventResultType = parser.getAttribute("resultType");       //queryXml("/ijLog/event/test/result/@resultType");
+                myEventTestResultEndTime = parser.getAttribute("endTime");       //queryXml("/ijLog/event/test/result/@endTime");
+                myEventTestResultStartTime = parser.getAttribute("startTime");   //queryXml("/ijLog/event/test/result/@startTime");
+
+                while(parser.hasMoreChildren()) {
+                  parser.moveDown();
+
+                  if ("actualFilePath".equals(parser.getNodeName())){
+                    myEventTestResultActionFilePath = parser.getValue();             //queryXml("/ijLog/event/test/result/actualFilePath");
+                  } else if ("filePath".equals(parser.getNodeName())){
+                    myEventTestResultFilePath = parser.getValue();                   //queryXml("/ijLog/event/test/result/filePath");
+                  } else if ("expected".equals(parser.getNodeName())){
+                    myEventTestResultExpected = parser.getValue();                   //queryXml("/ijLog/event/test/result/expected");
+                  } else if ("actual".equals(parser.getNodeName())){
+                    myEventTestResultActual = parser.getValue();                     //queryXml("/ijLog/event/test/result/actual");
+                  } else if ("failureType".equals(parser.getNodeName())){
+                    myEventTestResultFailureType = parser.getValue();                //queryXml("/ijLog/event/test/result/failureType");
+                  } else if ("stackTrace".equals(parser.getNodeName())){
+                    myEventTestResultStackTrace = parser.getValue();                 //queryXml("/ijLog/event/test/result/stackTrace");
+                  } else if ("errorMsg".equals(parser.getNodeName())){
+                    myEventTestResultErrorMsg = parser.getValue();                   //queryXml("/ijLog/event/test/result/errorMsg");
+                  }
+                  parser.moveUp();
+                }
+              }
+
+              parser.moveUp();
+            }
+          }
+
+          parser.moveUp();
+        }
+      }
+
+      parser.moveUp();
+    }
+  }
+
+  @NotNull
+  @Override
+  public String getTestEventType() {
+    return myTestEventType == null ? "" : myTestEventType;
+  }
+
+  @NotNull
+  @Override
+  public String getTestName() {
+    return myTestName == null ? "" : myTestName;
+  }
+
+  @NotNull
+  @Override
+  public String getTestParentId() {
+    return myTestParentId == null ? "" : myTestParentId;
+  }
+
+  @NotNull
+  @Override
+  public String getTestId() {
+    return myTestId == null ? "" : myTestId;
+  }
+
+  @NotNull
+  @Override
+  public String getTestClassName() {
+    return myTestClassName == null ? "" : myTestClassName;
+  }
+
+  @NotNull
+  @Override
+  public String getTestEventResultType() {
+    return myTestEventResultType == null ? "" : myTestEventResultType;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTitle() {
+    return myEventTitle == null ? "" : myEventTitle;
+  }
+
+  @Override
+  public boolean isEventOpenSettings() {
+    return Boolean.parseBoolean(myEventOpenSettings == null ? "" : myEventOpenSettings);
+  }
+
+  @NotNull
+  @Override
+  public String getEventMessage() {
+    return myEventMessage == null ? "" : myEventMessage;
+  }
+
+  @NotNull
+  @Override
+  public String getTestEventTest() {
+    return myTestEventTest == null ? "" : myTestEventTest;
+  }
+
+  @NotNull
+  @Override
+  public String getTestEventTestDescription() {
+    return myTestEventTestDescription == null ? "" : myTestEventTestDescription;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestReport() {
+    return myEventTestReport == null ? "" : myEventTestReport;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultActualFilePath() {
+    return myEventTestResultActionFilePath == null ? "" : myEventTestResultActionFilePath;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultFilePath() {
+    return myEventTestResultFilePath == null ? "" : myEventTestResultFilePath;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultExpected() {
+    return myEventTestResultExpected == null ? "" : myEventTestResultExpected;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultActual() {
+    return myEventTestResultActual == null ? "" : myEventTestResultActual;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultFailureType() {
+    return myEventTestResultFailureType == null ? "" : myEventTestResultFailureType;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultStackTrace() {
+    return myEventTestResultStackTrace == null ? "" : myEventTestResultStackTrace;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultErrorMsg() {
+    return myEventTestResultErrorMsg == null ? "" : myEventTestResultErrorMsg;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultEndTime() {
+    return myEventTestResultEndTime == null ? "" : myEventTestResultEndTime;
+  }
+
+  @NotNull
+  @Override
+  public String getEventTestResultStartTime() {
+    return myEventTestResultStartTime == null ? "" : myEventTestResultStartTime;
+  }
+}

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlView.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlView.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.gradle.execution.test.runner.events;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by eugene.petrenko@gmail.com
+ */
+public interface TestEventXmlView {
+  @NotNull
+  String getTestEventType() throws XmlParserException;
+
+  @NotNull
+  String getTestName() throws XmlParserException;
+
+  @NotNull
+  String getParentTestId() throws XmlParserException;
+
+  @NotNull
+  String getTestId() throws XmlParserException;
+
+  @NotNull
+  String getTestClassName() throws XmlParserException;
+
+  @NotNull
+  String getTestEventResultType() throws XmlParserException;
+
+  @NotNull
+  String getEventTitle() throws XmlParserException;
+
+  @NotNull
+  String isEventOpenSettings() throws XmlParserException;
+
+  @NotNull
+  String getEventMessage() throws XmlParserException;
+
+  @NotNull
+  String getTestEventTest() throws XmlParserException;
+
+  @NotNull
+  String getTestEventTestDescription() throws XmlParserException;
+
+  @NotNull
+  String getEventTestReport() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultActualFilePath() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultFilePath() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultExpected() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultActual() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultFailureType() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultStackTrace() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultErrorMsg() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultEndTime() throws XmlParserException;
+
+  @NotNull
+  String getEventTestResultStartTime() throws XmlParserException;
+
+  /**
+   * {@link XmlParserException} indicates errors during xml processing.
+   */
+  public static class XmlParserException extends Exception {
+    public XmlParserException(final Throwable cause) {
+      super(cause);
+    }
+
+    public XmlParserException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+
+    public XmlParserException(final String message) {
+      super(message);
+    }
+  }
+}

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlView.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlView.java
@@ -28,7 +28,7 @@ public interface TestEventXmlView {
   String getTestName() throws XmlParserException;
 
   @NotNull
-  String getParentTestId() throws XmlParserException;
+  String getTestParentId() throws XmlParserException;
 
   @NotNull
   String getTestId() throws XmlParserException;
@@ -42,8 +42,7 @@ public interface TestEventXmlView {
   @NotNull
   String getEventTitle() throws XmlParserException;
 
-  @NotNull
-  String isEventOpenSettings() throws XmlParserException;
+  boolean isEventOpenSettings() throws XmlParserException;
 
   @NotNull
   String getEventMessage() throws XmlParserException;

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlXPathView.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlXPathView.java
@@ -70,7 +70,7 @@ public class TestEventXmlXPathView implements TestEventXmlView {
 
   @NotNull
   @Override
-  public String getParentTestId() throws XmlParserException {
+  public String getTestParentId() throws XmlParserException {
     return queryXml("/ijLog/event/test/@parentId");
   }
 
@@ -98,10 +98,9 @@ public class TestEventXmlXPathView implements TestEventXmlView {
     return queryXml("/ijLog/event/title");
   }
 
-  @NotNull
   @Override
-  public String isEventOpenSettings() throws XmlParserException {
-    return queryXml("/ijLog/event/@openSettings");
+  public boolean isEventOpenSettings() throws XmlParserException {
+    return Boolean.parseBoolean(queryXml("/ijLog/event/@openSettings"));
   }
 
   @NotNull

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlXPathView.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/TestEventXmlXPathView.java
@@ -26,12 +26,12 @@ import javax.xml.xpath.XPathFactory;
 import java.io.StringReader;
 
 /**
- * {@link XmlXpathHelper} utility class for query of XML using XPath expressions.
+ * {@link TestEventXmlXPathView} utility class for query of XML using XPath expressions.
  *
  * @author Vladislav.Soroka
  * @since 2/20/14
  */
-public class XmlXpathHelper {
+public class TestEventXmlXPathView implements TestEventXmlView {
   private final XPath xpath;
   private Document xmlDocument;
 
@@ -42,7 +42,7 @@ public class XmlXpathHelper {
    * @param xml            the XML content to be parsed (must be well formed)
    * @throws XmlParserException
    */
-  public XmlXpathHelper(String xml) throws XmlParserException {
+  public TestEventXmlXPathView(String xml) throws XmlParserException {
     xpath = XPathFactory.newInstance().newXPath();
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -57,114 +57,138 @@ public class XmlXpathHelper {
   }
 
   @NotNull
-  public String getTestEventType() throws XmlXpathHelper.XmlParserException {
+  @Override
+  public String getTestEventType() throws TestEventXmlXPathView.XmlParserException {
     return queryXml("/ijLog/event/@type");
   }
 
+  @NotNull
+  @Override
   public String getTestName() throws XmlParserException {
     return queryXml("/ijLog/event/test/descriptor/@name");
   }
 
+  @NotNull
+  @Override
   public String getParentTestId() throws XmlParserException {
     return queryXml("/ijLog/event/test/@parentId");
   }
 
+  @NotNull
+  @Override
   public String getTestId() throws XmlParserException {
     return queryXml("/ijLog/event/test/@id");
   }
 
+  @NotNull
+  @Override
   public String getTestClassName() throws XmlParserException {
     return queryXml("/ijLog/event/test/descriptor/@className");
   }
 
   @NotNull
+  @Override
   public String getTestEventResultType() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/@resultType");
   }
 
+  @NotNull
+  @Override
   public String getEventTitle() throws XmlParserException {
     return queryXml("/ijLog/event/title");
   }
 
+  @NotNull
+  @Override
   public String isEventOpenSettings() throws XmlParserException {
     return queryXml("/ijLog/event/@openSettings");
   }
 
+  @NotNull
+  @Override
   public String getEventMessage() throws XmlParserException {
     return queryXml("/ijLog/event/message");
   }
 
+  @NotNull
+  @Override
   public String getTestEventTest() throws XmlParserException {
     return queryXml("/ijLog/event/test/event");
   }
 
+  @NotNull
+  @Override
   public String getTestEventTestDescription() throws XmlParserException {
     return queryXml("/ijLog/event/test/event/@destination");
   }
 
+  @NotNull
+  @Override
   public String getEventTestReport() throws XmlParserException {
     return queryXml("/ijLog/event/@testReport");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultActualFilePath() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/actualFilePath");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultFilePath() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/filePath");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultExpected() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/expected");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultActual() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/actual");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultFailureType() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/failureType");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultStackTrace() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/stackTrace");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultErrorMsg() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/errorMsg");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultEndTime() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/@endTime");
   }
 
+  @NotNull
+  @Override
   public String getEventTestResultStartTime() throws XmlParserException {
     return queryXml("/ijLog/event/test/result/@startTime");
   }
 
+  @NotNull
   private String queryXml(final String xpathExpr) throws XmlParserException {
     try {
       return xmlDocument == null ? "" : xpath.evaluate(xpathExpr, xmlDocument);
     }
     catch (XPathExpressionException ex) {
       throw new XmlParserException(ex);
-    }
-  }
-
-  /**
-   * {@link XmlParserException} indicates errors during xml processing.
-   */
-  public static class XmlParserException extends Exception {
-    public XmlParserException(final Throwable cause) {
-      super(cause);
-    }
-
-    public XmlParserException(final String message, final Throwable cause) {
-      super(message, cause);
-    }
-
-    public XmlParserException(final String message) {
-      super(message);
     }
   }
 }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/XmlXpathHelper.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/events/XmlXpathHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2014 JetBrains s.r.o.
+ * Copyright 2000-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jetbrains.plugins.gradle.util;
+package org.jetbrains.plugins.gradle.execution.test.runner.events;
 
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/util/XmlXpathHelper.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/util/XmlXpathHelper.java
@@ -16,7 +16,6 @@
 package org.jetbrains.plugins.gradle.util;
 
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -40,46 +39,25 @@ public class XmlXpathHelper {
    * validate, and is namespace aware.
    *
    * @param xml            the XML content to be parsed (must be well formed)
-   * @param namespaceAware whether the parser is namespace aware
    * @throws XmlParserException
    */
-  public XmlXpathHelper(String xml, boolean namespaceAware) throws XmlParserException {
+  public XmlXpathHelper(String xml) throws XmlParserException {
     xpath = XPathFactory.newInstance().newXPath();
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       InputSource is = new InputSource(new StringReader(xml));
-      factory.setNamespaceAware(namespaceAware);
+      factory.setNamespaceAware(false);
       factory.setValidating(false);
       xmlDocument = factory.newDocumentBuilder().parse(is);
     }
     catch (Exception ex) {
       throw new XmlParserException(ex);
-    }
-  }
-
-  public XmlXpathHelper(String xml) throws XmlParserException {
-    this(xml, false);
+    };
   }
 
   public String queryXml(final String xpathExpr) throws XmlParserException {
     try {
       return xmlDocument == null ? "" : xpath.evaluate(xpathExpr, xmlDocument);
-    }
-    catch (XPathExpressionException ex) {
-      throw new XmlParserException(ex);
-    }
-  }
-
-  /**
-   * Extracts the String value for the given expression.
-   *
-   * @param node
-   * @param expr
-   * @return
-   */
-  public String getValue(Node node, String expr) throws XmlParserException {
-    try {
-      return xpath.compile(expr).evaluate(node);
     }
     catch (XPathExpressionException ex) {
       throw new XmlParserException(ex);

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/util/XmlXpathHelper.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/util/XmlXpathHelper.java
@@ -15,6 +15,7 @@
  */
 package org.jetbrains.plugins.gradle.util;
 
+import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -55,7 +56,93 @@ public class XmlXpathHelper {
     };
   }
 
-  public String queryXml(final String xpathExpr) throws XmlParserException {
+  @NotNull
+  public String getTestEventType() throws XmlXpathHelper.XmlParserException {
+    return queryXml("/ijLog/event/@type");
+  }
+
+  public String getTestName() throws XmlParserException {
+    return queryXml("/ijLog/event/test/descriptor/@name");
+  }
+
+  public String getParentTestId() throws XmlParserException {
+    return queryXml("/ijLog/event/test/@parentId");
+  }
+
+  public String getTestId() throws XmlParserException {
+    return queryXml("/ijLog/event/test/@id");
+  }
+
+  public String getTestClassName() throws XmlParserException {
+    return queryXml("/ijLog/event/test/descriptor/@className");
+  }
+
+  @NotNull
+  public String getTestEventResultType() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/@resultType");
+  }
+
+  public String getEventTitle() throws XmlParserException {
+    return queryXml("/ijLog/event/title");
+  }
+
+  public String isEventOpenSettings() throws XmlParserException {
+    return queryXml("/ijLog/event/@openSettings");
+  }
+
+  public String getEventMessage() throws XmlParserException {
+    return queryXml("/ijLog/event/message");
+  }
+
+  public String getTestEventTest() throws XmlParserException {
+    return queryXml("/ijLog/event/test/event");
+  }
+
+  public String getTestEventTestDescription() throws XmlParserException {
+    return queryXml("/ijLog/event/test/event/@destination");
+  }
+
+  public String getEventTestReport() throws XmlParserException {
+    return queryXml("/ijLog/event/@testReport");
+  }
+
+  public String getEventTestResultActualFilePath() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/actualFilePath");
+  }
+
+  public String getEventTestResultFilePath() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/filePath");
+  }
+
+  public String getEventTestResultExpected() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/expected");
+  }
+
+  public String getEventTestResultActual() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/actual");
+  }
+
+  public String getEventTestResultFailureType() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/failureType");
+  }
+
+  public String getEventTestResultStackTrace() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/stackTrace");
+  }
+
+  public String getEventTestResultErrorMsg() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/errorMsg");
+  }
+
+  public String getEventTestResultEndTime() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/@endTime");
+  }
+
+  public String getEventTestResultStartTime() throws XmlParserException {
+    return queryXml("/ijLog/event/test/result/@startTime");
+  }
+
+  private String queryXml(final String xpathExpr) throws XmlParserException {
     try {
       return xmlDocument == null ? "" : xpath.evaluate(xpathExpr, xmlDocument);
     }

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/TestEventXPPXmlViewTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/TestEventXPPXmlViewTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.gradle.execution;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.TestEventXPPXmlView;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.TestEventXmlView;
+
+public class TestEventXPPXmlViewTest extends TestEventXmlViewTestCase {
+  @NotNull
+  @Override
+  protected TestEventXmlView load(@NotNull final String xml) throws Exception {
+    return new TestEventXPPXmlView(xml);
+  }
+}

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/TestEventXmlViewTestCase.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/TestEventXmlViewTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.gradle.execution;
+
+import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.TestEventXmlView;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Base64;
+
+public abstract class TestEventXmlViewTestCase {
+
+  @NotNull
+  protected abstract TestEventXmlView load(@NotNull @Language("XML") final String xml) throws Exception;
+
+  @Test(expected = Exception.class)
+  public void test_empty_xml() throws Exception {
+    load("");
+  }
+
+  @Test
+  public void test_ijLog_empty() throws Exception {
+    load("<ijLog/>");
+  }
+
+  @Test
+  public void test_ijLog_event() throws Exception {
+    load("<ijLog><event/></ijLog>");
+  }
+
+  @Test
+  public void test_ijLog_event_id() throws Exception {
+    final TestEventXmlView helper = load("<ijLog><event type='fpp'/></ijLog>");
+    Assert.assertEquals("fpp", helper.getTestEventType());
+  }
+
+  @Test
+  public void test_ijLog_event_test_ids() throws Exception {
+    final TestEventXmlView helper = load("<ijLog><event><test id='aaa' parentId='bbb'/></event></ijLog>");
+    Assert.assertEquals("aaa", helper.getTestId());
+    Assert.assertEquals("bbb", helper.getTestParentId());
+  }
+
+  @Test
+  public void test_ijLog_event_test_result_actualFile() throws Exception {
+    final TestEventXmlView helper = load("<ijLog><event><test><result><actualFilePath>PAAATH</actualFilePath></result></test></event></ijLog>");
+    Assert.assertEquals("PAAATH", helper.getEventTestResultActualFilePath());
+  }
+
+  @Test
+  public void test_ijLog_event_test_result_actualCDATA() throws Exception {
+    final TestEventXmlView helper = load("<ijLog><event><test><result><actual><![CDATA[PAAATH]]></actual></result></test></event></ijLog>");
+    Assert.assertEquals("PAAATH", helper.getEventTestResultActual());
+  }
+
+  @Test
+  public void performance_huge_message() throws Exception {
+    final String outputMessage = Base64.getEncoder().encodeToString(new byte[256*1024]);
+
+    @Language("XML") final String text =
+      "<ijLog><event><test id='aaa' parentId='bbb'><event destination='2222'>" + outputMessage + "</event></test></event></ijLog>";
+
+    parseSeveralTimes(text, 100);
+  }
+
+  @Test
+  public void performance_small_message() throws Exception {
+    @Language("XML") final String text =
+      "<ijLog><event><test id='aaa' parentId='bbb'><event destination='2222'>intellijIdeaRulezzz!</event></test></event></ijLog>";
+
+    parseSeveralTimes(text, 2000);
+  }
+
+  private void parseSeveralTimes(@NotNull final @Language("XML") String text, int tries) throws Exception {
+    for(int i = 0; i < tries; i++) {
+      final TestEventXmlView helper = load(text);
+      Assert.assertTrue(helper.getTestId().length() > 0);
+      Assert.assertTrue(helper.getTestEventTestDescription().length() > 0);
+      Assert.assertTrue(helper.getTestEventTest().length() > 0);
+    }
+  }
+}

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/TestEventXmlXPathViewTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/TestEventXmlXPathViewTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.gradle.execution;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.TestEventXmlView;
+import org.jetbrains.plugins.gradle.execution.test.runner.events.TestEventXmlXPathView;
+
+public class TestEventXmlXPathViewTest extends TestEventXmlViewTestCase {
+  @NotNull
+  @Override
+  protected TestEventXmlView load(@NotNull final String xml) throws Exception {
+    return new TestEventXmlXPathView(xml);
+  }
+}


### PR DESCRIPTION
As discussed in the https://youtrack.jetbrains.com/issue/IDEA-167449 issue I decided to implement faster XML processing for Gradle plugin that would avoid my most pain point for tests with heavy output flow. 

Before the fix, IDEA UI was too overloaded. According to Activity Monitor IDEA process was eating even more CPU than tests worker process. You may find snapshot in the issue. 

After the fix I see It consumes less CPU wither by IDEA UI responsiveness or by fresh CPU profiling.

Current implementation I use XStreams (it was included in classpath) Hierarchical parser that uses KXML pull parser implementation. The whole processing is done within one class.

Unfortunately, I was not able to implement integration tests to measure performance boost more technically as well as to make sure performance will not be lost again. Also, it looks like there are NO tests for test runner integration at all. Just let me know if you have some correct snippet to implement more test.  