### PR TITLE
Make MethodData.methodBody() resilient to non–stub-based PsiMethod implementations, as intended

### DIFF
--- a/java/java-analysis-impl/src/com/intellij/codeInspection/dataFlow/inferenceResults.kt
+++ b/java/java-analysis-impl/src/com/intellij/codeInspection/dataFlow/inferenceResults.kt
@@ -123,7 +123,7 @@ data class MethodData(
     internal val bodyEnd: Int
 ) {
   fun methodBody(method: PsiMethod): () -> PsiCodeBlock = {
-    if ((method as StubBasedPsiElement<*>?)?.stub != null)
+    if ((method as? StubBasedPsiElement<*>)?.stub != null)
       CachedValuesManager.getCachedValue(method) { CachedValueProvider.Result(getDetachedBody(method), method) }
     else
       method.body!!


### PR DESCRIPTION

BEFORE: `(method as StubBasedPsiElement<*>?)?.stub != null`
This will throw a cast exception if not stub-based. And if it is stub-based, the `?` in `StubBasedPsiElement<*>?` has the effect of silently needlessly casting the known-to-be-non-null stub-based PSI element into a nullable one.

AFTER: `(method as? StubBasedPsiElement<*>)?.stub != null`
As I believe was probably intended, the parenthesized section in this version will not throw, but instead result in `null` if `method` is not a stub-based PSI element, allowing the surrounding if-else control flow to fallback to using ASTNode-based PSI (instead of throwing an exception).