### PR TITLE
Adds new macro expansion $MODULE_CONTENT_ROOT$

### DIFF
--- a/jps/model-serialization/src/org/jetbrains/jps/model/serialization/PathMacroUtil.java
+++ b/jps/model-serialization/src/org/jetbrains/jps/model/serialization/PathMacroUtil.java
@@ -35,6 +35,7 @@ import static com.intellij.openapi.util.io.FileUtilRt.toSystemIndependentName;
 public class PathMacroUtil {
   @NonNls public static final String PROJECT_DIR_MACRO_NAME = "PROJECT_DIR";
   @NonNls public static final String MODULE_DIR_MACRO_NAME = "MODULE_DIR";
+  @NonNls public static final String MODULE_CONTENT_ROOT_MACRO_NAME = "MODULE_ROOT";
   @NonNls public static final String DIRECTORY_STORE_NAME = ".idea";
   @NonNls public static final String APPLICATION_HOME_DIR = "APPLICATION_HOME_DIR";
   @NonNls public static final String APPLICATION_CONFIG_DIR = "APPLICATION_CONFIG_DIR";
@@ -81,5 +82,22 @@ public class PathMacroUtil {
   @Nullable
   public static String getGlobalSystemMacroValue(String name) {
     return ourGlobalMacros.get(name);
+  }
+
+  public static String getModuleContentRoot(String moduleContentRootPath) {
+    String moduleContentRoot = PathUtilRt.getParentPath(moduleContentRootPath);
+    if (StringUtil.isEmpty(moduleContentRoot)) {
+      return null;
+    }
+
+    // hack so that, if a module is stored inside the .idea directory, the base directory
+    // rather than the .idea directory itself is considered the module root
+    // (so that a Ruby IDE project doesn't break if its directory is moved together with the .idea directory)
+
+    moduleContentRoot = toSystemIndependentName(moduleContentRoot);
+    if (moduleContentRoot.endsWith(":/")) {
+      moduleContentRoot = moduleContentRoot.substring(0, moduleContentRoot.length() - 1);
+    }
+    return moduleContentRoot;
   }
 }

--- a/platform/projectModel-impl/src/com/intellij/openapi/components/impl/ModulePathMacroManager.java
+++ b/platform/projectModel-impl/src/com/intellij/openapi/components/impl/ModulePathMacroManager.java
@@ -19,6 +19,8 @@ import com.intellij.application.options.ReplacePathToMacroMap;
 import com.intellij.openapi.application.PathMacros;
 import com.intellij.openapi.components.ExpandMacroToPathMap;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jps.model.serialization.PathMacroUtil;
 
@@ -36,6 +38,10 @@ public class ModulePathMacroManager extends BasePathMacroManager {
   public ExpandMacroToPathMap getExpandMacroMap() {
     ExpandMacroToPathMap result = super.getExpandMacroMap();
     addFileHierarchyReplacements(result, PathMacroUtil.MODULE_DIR_MACRO_NAME, PathMacroUtil.getModuleDir(myModule.getModuleFilePath()));
+    VirtualFile[] roots = ModuleRootManager.getInstance(myModule).getContentRoots();
+    if(roots.length==1) {
+      addFileHierarchyReplacements(result, PathMacroUtil.MODULE_CONTENT_ROOT_MACRO_NAME, PathMacroUtil.getModuleContentRoot(roots[0].getCanonicalPath()));
+    }
     return result;
   }
 


### PR DESCRIPTION
This new macro is expanded to the current module's content root when a
the module only has one content root.
I have never seen a case were a module has multiple content roots, and
am therefore unable to decide what to do in these cases.
When a project uses the file based project descriptor (`*.iml`), this
should be strictly equivalent to `$MODULE_DIR$`
When a project uses the directory based project description (`.idea/*`),
this macro points to the content root instead of the parent directory of
the module file.

I am unfamiliar with the codebase and was unable to find a test which
exercises the code path I changed. I tried writing one based on
`PathMacroManagerTest` but was unable to make it work as it seems to
requires a lot of setup which goes beyond the setup already provided. 
Given guidance I am willing to try and add a test for it. Running the IDE 
seemed to resolve it well enough.

Please consider including this since it opens a way to fixing:

https://youtrack.jetbrains.com/issue/IDEA-152227
https://youtrack.jetbrains.com/issue/SCL-9296
https://youtrack.jetbrains.com/issue/IDEA-121819
https://youtrack.jetbrains.com/issue/IDEA-153852
And probably a few more `$MODULE_DIR$` related issues
