### PR TITLE
Pasting mvn dependency with classifier to gradle

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/action/PasteMvnDependencyPreProcessor.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/action/PasteMvnDependencyPreProcessor.java
@@ -77,12 +77,14 @@ public class PasteMvnDependencyPreProcessor implements CopyPastePreProcessor {
     String artifactId = getArtifactId(document);
     String version = getVersion(document);
     String scope = getScope(document);
+    String classifier = getClassifier(document);
 
     if (groupId.isEmpty() || artifactId.isEmpty() || version.isEmpty()) {
       return null;
     }
+    String gradleClassifier = classifier.isEmpty() ? "" : ":" + classifier;
 
-    return scope + "'" + groupId + ":" + artifactId + ":" + version + "'";
+    return scope + "'" + groupId + ":" + artifactId + ":" + version + gradleClassifier + "'";
   }
 
   private static String getScope(@NotNull Document document) {
@@ -111,6 +113,10 @@ public class PasteMvnDependencyPreProcessor implements CopyPastePreProcessor {
 
   private static String getGroupId(@NotNull Document document) {
     return firstOrEmpty(document.getElementsByTagName("groupId"));
+  }
+
+  private static String getClassifier(@NotNull Document document) {
+    return firstOrEmpty(document.getElementsByTagName("classifier"));
   }
 
   private static String firstOrEmpty(@NotNull NodeList list) {

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/codeInsight/actions/MvnDependencyPasteTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/codeInsight/actions/MvnDependencyPasteTest.java
@@ -37,6 +37,18 @@ public class MvnDependencyPasteTest extends LightCodeInsightTestCase {
                       "    runtime 'group:artifact:1.0'\n" +
                       "}");
   }
+
+  public void testDependencyWithClassifier() throws Exception {
+    configureFromFileText("pom.xml", getDependency("group", "artifact", "1.0", "runtime", "jdk14"));
+    selectWholeFile();
+    performCut();
+
+    configureGradleFile();
+    performPaste();
+    checkResultByText("dependencies {\n" +
+                      "    runtime 'group:artifact:1.0:jdk14'\n" +
+                      "}");
+  }
   
   public void test_DoNotConvertIfCoordinatesNotClear() throws Exception {
     String noArtifact = getDependency("group", null, "1.0", "runtime", null);
@@ -77,7 +89,7 @@ public class MvnDependencyPasteTest extends LightCodeInsightTestCase {
                                       @Nullable String artifactId,
                                       @Nullable String version,
                                       @Nullable String scope,
-                                      @Nullable String type) {
+                                      @Nullable String classifier) {
     
     String dependency = "<dependency>\n";
     if (groupId != null) {
@@ -92,8 +104,8 @@ public class MvnDependencyPasteTest extends LightCodeInsightTestCase {
     if (scope != null) {
       dependency +=     "  <scope>" + scope + "</scope>\n";
     }
-    if (type != null) {
-      dependency +=     "  <type>" + type + "</type>\n";
+    if (classifier != null) {
+      dependency +=     "  <classifier>" + classifier + "</classifier>\n";
     }
     dependency += "</dependency>";
     return dependency;


### PR DESCRIPTION
Gradle supports maven classifiers https://docs.gradle.org/current/userguide/dependency_management.html#sub:classifiers. This change adds support for classifiers in `PasteMvnDependencyPreProcessor`. 

I've signed CLA. 