### PR TITLE
Add a way to skip git pre-commit and pre-push hooks (IDEA-115914)

### DIFF
--- a/plugins/git4idea/src/git4idea/branch/GitDeleteRemoteBranchOperation.java
+++ b/plugins/git4idea/src/git4idea/branch/GitDeleteRemoteBranchOperation.java
@@ -162,7 +162,7 @@ class GitDeleteRemoteBranchOperation extends GitBranchOperation {
 
   @NotNull
   private GitCommandResult pushDeletion(@NotNull GitRepository repository, @NotNull GitRemote remote, @NotNull String branchName) {
-    return myGit.push(repository, remote, ":" + branchName, false, false, null);
+    return myGit.push(repository, remote, ":" + branchName, false, false, false, null);
   }
 
   @Nullable

--- a/plugins/git4idea/src/git4idea/commands/Git.java
+++ b/plugins/git4idea/src/git4idea/commands/Git.java
@@ -137,6 +137,7 @@ public interface Git {
                         @NotNull String spec,
                         boolean force,
                         boolean updateTracking,
+                        boolean skipHook,
                         @Nullable String tagMode,
                         GitLineHandlerListener... listeners);
 

--- a/plugins/git4idea/src/git4idea/commands/GitImpl.java
+++ b/plugins/git4idea/src/git4idea/commands/GitImpl.java
@@ -404,7 +404,7 @@ public class GitImpl implements Git {
                                @NotNull String spec,
                                boolean updateTracking,
                                @NotNull GitLineHandlerListener... listeners) {
-    return doPush(repository, remote, singleton(url), spec, false, updateTracking, null, listeners);
+    return doPush(repository, remote, singleton(url), spec, false, updateTracking, false, null, listeners);
   }
 
   @Override
@@ -414,9 +414,10 @@ public class GitImpl implements Git {
                                @NotNull String spec,
                                boolean force,
                                boolean updateTracking,
+                               boolean skipHook,
                                @Nullable String tagMode,
                                GitLineHandlerListener... listeners) {
-    return doPush(repository, remote.getName(), remote.getPushUrls(), spec, force, updateTracking, tagMode, listeners);
+    return doPush(repository, remote.getName(), remote.getPushUrls(), spec, force, updateTracking, skipHook, tagMode, listeners);
   }
 
   @NotNull
@@ -426,6 +427,7 @@ public class GitImpl implements Git {
                                   @NotNull final String spec,
                                   final boolean force,
                                   final boolean updateTracking,
+                                  final boolean skipHook,
                                   @Nullable final String tagMode,
                                   @NotNull final GitLineHandlerListener... listeners) {
     return runCommand(new Computable<GitLineHandler>() {
@@ -448,6 +450,9 @@ public class GitImpl implements Git {
         }
         if (tagMode != null) {
           h.addParameters(tagMode);
+        }
+        if (skipHook) {
+          h.addParameters("--no-verify");
         }
         return h;
       }

--- a/plugins/git4idea/src/git4idea/config/GitVersionSpecialty.java
+++ b/plugins/git4idea/src/git4idea/config/GitVersionSpecialty.java
@@ -150,9 +150,20 @@ public enum GitVersionSpecialty {
   },
 
   KNOWS_SET_UPSTREAM_TO { // in Git 1.8.0 --set-upstream-to was introduced as a replacement of --set-upstream which became deprecated
+
     @Override
     public boolean existsIn(@NotNull GitVersion version) {
       return version.isLaterOrEqual(new GitVersion(1, 8, 0, 0));
+    }
+  },
+
+  /**
+   * Git pre-push hook is supported since version 1.8.2.
+   */
+  PRE_PUSH_HOOK {
+    @Override
+    public boolean existsIn(@NotNull GitVersion version) {
+      return version.isLaterOrEqual(new GitVersion(1, 8, 2, 0));
     }
   };
 

--- a/plugins/git4idea/src/git4idea/i18n/GitBundle.properties
+++ b/plugins/git4idea/src/git4idea/i18n/GitBundle.properties
@@ -43,6 +43,8 @@ commit.author.tooltip=<html>Specify a commit author here if it is different from
 commit.author=&Author:
 commit.amend.tooltip=<html>Merge this commit with the previous one</html>
 commit.amend=Amend commit
+commit.hook.skip=Skip hook
+commit.hook.skip.tooltip=<html>Skip git hook with "no-verify" parameter</html>
 commit.partial.merge.message=Partial commit during a {0} is not allowed.\n\
   The following files are not included in commit.\n\
   Perform commit with all files included?

--- a/plugins/git4idea/src/git4idea/push/GitPushOperation.java
+++ b/plugins/git4idea/src/git4idea/push/GitPushOperation.java
@@ -79,6 +79,7 @@ public class GitPushOperation {
   private final Map<GitRepository, PushSpec<GitPushSource, GitPushTarget>> myPushSpecs;
   @Nullable private final GitPushTagMode myTagMode;
   private final boolean myForce;
+  private final boolean mySkipHook;
   private final Git myGit;
   private final ProgressIndicator myProgressIndicator;
   private final GitVcsSettings mySettings;
@@ -88,12 +89,14 @@ public class GitPushOperation {
                           @NotNull GitPushSupport pushSupport,
                           @NotNull Map<GitRepository, PushSpec<GitPushSource, GitPushTarget>> pushSpecs,
                           @Nullable GitPushTagMode tagMode,
-                          boolean force) {
+                          boolean force,
+                          boolean skipHook) {
     myProject = project;
     myPushSupport = pushSupport;
     myPushSpecs = pushSpecs;
     myTagMode = tagMode;
     myForce = force;
+    mySkipHook = skipHook;
     myGit = Git.getInstance();
     myProgressIndicator = ObjectUtils.notNull(ProgressManager.getInstance().getProgressIndicator(), new EmptyProgressIndicator());
     mySettings = GitVcsSettings.getInstance(myProject);
@@ -370,7 +373,8 @@ public class GitPushOperation {
     String tagMode = myTagMode == null ? null : myTagMode.getArgument();
 
     String spec = sourceBranch.getFullName() + ":" + targetBranch.getNameForRemoteOperations();
-    GitCommandResult res = myGit.push(repository, targetBranch.getRemote(), spec, myForce, setUpstream, tagMode, progressListener);
+    GitCommandResult res =
+      myGit.push(repository, targetBranch.getRemote(), spec, myForce, setUpstream, mySkipHook, tagMode, progressListener);
     return new ResultWithOutput(res);
   }
 

--- a/plugins/git4idea/src/git4idea/push/GitPushOptionsPanel.java
+++ b/plugins/git4idea/src/git4idea/push/GitPushOptionsPanel.java
@@ -27,13 +27,17 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 
-public class GitPushTagPanel extends VcsPushOptionsPanel {
+public class GitPushOptionsPanel extends VcsPushOptionsPanel {
 
   private final ComboBox myCombobox;
   private final JBCheckBox myCheckBox;
+  private final JBCheckBox mySkipHook;
 
-  public GitPushTagPanel(@Nullable GitPushTagMode defaultMode, boolean followTagsSupported) {
+  public GitPushOptionsPanel(@Nullable GitPushTagMode defaultMode,
+                             boolean followTagsSupported,
+                             boolean showSkipHookOption) {
     String checkboxText = "Push Tags";
     if (followTagsSupported) {
       checkboxText += ": ";
@@ -70,12 +74,19 @@ public class GitPushTagPanel extends VcsPushOptionsPanel {
       myCombobox = null;
     }
 
+    mySkipHook = new JBCheckBox("Skip hook");
+    mySkipHook.setMnemonic(KeyEvent.VK_H);
+    mySkipHook.setVisible(showSkipHookOption);
+
+    add(mySkipHook, BorderLayout.EAST);
   }
 
   @Nullable
   @Override
   public VcsPushOptionValue getValue() {
-    return myCheckBox.isSelected() ? myCombobox == null ? GitPushTagMode.ALL : (VcsPushOptionValue)myCombobox.getSelectedItem() : null;
+    GitPushTagMode selectedTagMode = myCombobox == null ? GitPushTagMode.ALL : (GitPushTagMode)myCombobox.getSelectedItem();
+    GitPushTagMode tagMode = myCheckBox.isSelected() ? selectedTagMode : null;
+    return new GitVcsPushOptionValue(tagMode, mySkipHook.isVisible() && mySkipHook.isSelected());
   }
 
 }

--- a/plugins/git4idea/src/git4idea/push/GitPushSupport.java
+++ b/plugins/git4idea/src/git4idea/push/GitPushSupport.java
@@ -26,10 +26,7 @@ import git4idea.branch.GitBranchUtil;
 import git4idea.config.GitSharedSettings;
 import git4idea.config.GitVcsSettings;
 import git4idea.config.GitVersionSpecialty;
-import git4idea.repo.GitBranchTrackInfo;
-import git4idea.repo.GitRemote;
-import git4idea.repo.GitRepository;
-import git4idea.repo.GitRepositoryManager;
+import git4idea.repo.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -172,7 +169,18 @@ public class GitPushSupport extends PushSupport<GitRepository, GitPushSource, Gi
   @Nullable
   @Override
   public VcsPushOptionsPanel createOptionsPanel() {
-    return new GitPushTagPanel(mySettings.getPushTagMode(), GitVersionSpecialty.SUPPORTS_FOLLOW_TAGS.existsIn(myVcs.getVersion()));
+    return new GitPushOptionsPanel(mySettings.getPushTagMode(),
+                                   GitVersionSpecialty.SUPPORTS_FOLLOW_TAGS.existsIn(myVcs.getVersion()),
+                                   shouldShowSkipHookOption());
+  }
+
+  private boolean shouldShowSkipHookOption() {
+    return GitVersionSpecialty.PRE_PUSH_HOOK.existsIn(myVcs.getVersion()) &&
+           getRepositoryManager()
+             .getRepositories()
+             .stream()
+             .map(e -> e.getInfo().getHooksInfo())
+             .anyMatch(GitHooksInfo::isPrePushHookAvailable);
   }
 
   @Override

--- a/plugins/git4idea/src/git4idea/push/GitPushTagMode.java
+++ b/plugins/git4idea/src/git4idea/push/GitPushTagMode.java
@@ -15,12 +15,11 @@
  */
 package git4idea.push;
 
-import com.intellij.dvcs.push.VcsPushOptionValue;
 import org.jetbrains.annotations.NotNull;
 
 /**
  */
-public final class GitPushTagMode implements VcsPushOptionValue {
+public final class GitPushTagMode {
 
   public static final GitPushTagMode ALL = new GitPushTagMode("All", "--tags");
   public static final GitPushTagMode FOLLOW = new GitPushTagMode("Current Branch", "--follow-tags");

--- a/plugins/git4idea/src/git4idea/push/GitPusher.java
+++ b/plugins/git4idea/src/git4idea/push/GitPusher.java
@@ -48,8 +48,10 @@ class GitPusher extends Pusher<GitRepository, GitPushSource, GitPushTarget> {
   public void push(@NotNull Map<GitRepository, PushSpec<GitPushSource, GitPushTarget>> pushSpecs,
                    @Nullable VcsPushOptionValue optionValue, boolean force) {
     expireExistingErrorsAndWarnings();
-    GitPushTagMode pushTagMode = (GitPushTagMode)optionValue;
-    GitPushResult result = new GitPushOperation(myProject, myPushSupport, pushSpecs, pushTagMode, force).execute();
+    GitVcsPushOptionValue value = optionValue != null ? (GitVcsPushOptionValue)optionValue : GitVcsPushOptionValue.UNDEFINED;
+    GitPushTagMode pushTagMode = value.getPushTagMode();
+    boolean skipHook = value.shouldSkipHook();
+    GitPushResult result = new GitPushOperation(myProject, myPushSupport, pushSpecs, pushTagMode, force, skipHook).execute();
     GitPushResultNotification notification = GitPushResultNotification.create(myProject, result, myRepositoryManager.moreThanOneRoot());
     notification.notify(myProject);
     mySettings.setPushTagMode(pushTagMode);

--- a/plugins/git4idea/src/git4idea/push/GitVcsPushOptionValue.java
+++ b/plugins/git4idea/src/git4idea/push/GitVcsPushOptionValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package git4idea.push;
+
+import com.intellij.dvcs.push.VcsPushOptionValue;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * @author Aliaksandr Jeihala
+ */
+public final class GitVcsPushOptionValue implements VcsPushOptionValue {
+
+  public static final GitVcsPushOptionValue UNDEFINED = new GitVcsPushOptionValue(null, false);
+
+  @Nullable private final GitPushTagMode myPushTagMode;
+  private final boolean skipHook;
+
+  public GitVcsPushOptionValue(@Nullable GitPushTagMode pushTagMode, boolean skipHook) {
+    myPushTagMode = pushTagMode;
+    this.skipHook = skipHook;
+  }
+
+  @Nullable
+  public GitPushTagMode getPushTagMode() {
+    return myPushTagMode;
+  }
+
+  public boolean shouldSkipHook() {
+    return skipHook;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GitVcsPushOptionValue value = (GitVcsPushOptionValue)o;
+    return skipHook == value.skipHook &&
+           Objects.equals(myPushTagMode, value.myPushTagMode);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(myPushTagMode, skipHook);
+  }
+}

--- a/plugins/git4idea/src/git4idea/repo/GitHooksInfo.java
+++ b/plugins/git4idea/src/git4idea/repo/GitHooksInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package git4idea.repo;
+
+import java.util.Objects;
+
+/**
+ * @author Aliaksandr Jeihala
+ */
+public class GitHooksInfo {
+
+  private final boolean myPreCommitHookAvailable;
+  private final boolean myPrePushHookAvailable;
+
+  public GitHooksInfo(boolean preCommitHookAvailable, boolean prePushHookAvailable) {
+    myPreCommitHookAvailable = preCommitHookAvailable;
+    myPrePushHookAvailable = prePushHookAvailable;
+  }
+
+  public boolean isPreCommitHookAvailable() {
+    return myPreCommitHookAvailable;
+  }
+
+  public boolean isPrePushHookAvailable() {
+    return myPrePushHookAvailable;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GitHooksInfo hooksInfo = (GitHooksInfo)o;
+    return myPreCommitHookAvailable == hooksInfo.myPreCommitHookAvailable &&
+           myPrePushHookAvailable == hooksInfo.myPrePushHookAvailable;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(myPreCommitHookAvailable, myPrePushHookAvailable);
+  }
+}

--- a/plugins/git4idea/src/git4idea/repo/GitRepoInfo.java
+++ b/plugins/git4idea/src/git4idea/repo/GitRepoInfo.java
@@ -39,6 +39,7 @@ public class GitRepoInfo {
   @NotNull private final Map<GitLocalBranch, Hash> myLocalBranches;
   @NotNull private final Map<GitRemoteBranch, Hash> myRemoteBranches;
   @NotNull private final Set<GitBranchTrackInfo> myBranchTrackInfos;
+  @NotNull private final GitHooksInfo myHooksInfo;
 
   public GitRepoInfo(@Nullable GitLocalBranch currentBranch,
                      @Nullable String currentRevision,
@@ -46,7 +47,8 @@ public class GitRepoInfo {
                      @NotNull Collection<GitRemote> remotes,
                      @NotNull Map<GitLocalBranch, Hash> localBranches,
                      @NotNull Map<GitRemoteBranch, Hash> remoteBranches,
-                     @NotNull Collection<GitBranchTrackInfo> branchTrackInfos) {
+                     @NotNull Collection<GitBranchTrackInfo> branchTrackInfos,
+                     @NotNull GitHooksInfo hooksInfo) {
     myCurrentBranch = currentBranch;
     myCurrentRevision = currentRevision;
     myState = state;
@@ -54,6 +56,7 @@ public class GitRepoInfo {
     myLocalBranches = new LinkedHashMap<>(localBranches);
     myRemoteBranches = new LinkedHashMap<>(remoteBranches);
     myBranchTrackInfos = new LinkedHashSet<>(branchTrackInfos);
+    myHooksInfo = hooksInfo;
   }
 
   @Nullable
@@ -97,6 +100,11 @@ public class GitRepoInfo {
     return myState;
   }
 
+  @NotNull
+  public GitHooksInfo getHooksInfo() {
+    return myHooksInfo;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -111,6 +119,7 @@ public class GitRepoInfo {
     if (!myBranchTrackInfos.equals(info.myBranchTrackInfos)) return false;
     if (!areEqual(myLocalBranches, info.myLocalBranches)) return false;
     if (!areEqual(myRemoteBranches, info.myRemoteBranches)) return false;
+    if (!myHooksInfo.equals(info.myHooksInfo)) return false;
 
     return true;
   }
@@ -124,6 +133,7 @@ public class GitRepoInfo {
     result = 31 * result + myLocalBranches.hashCode();
     result = 31 * result + myRemoteBranches.hashCode();
     result = 31 * result + myBranchTrackInfos.hashCode();
+    result = 31 * result + myHooksInfo.hashCode();
     return result;
   }
 

--- a/plugins/git4idea/src/git4idea/repo/GitRepositoryFiles.java
+++ b/plugins/git4idea/src/git4idea/repo/GitRepositoryFiles.java
@@ -56,6 +56,9 @@ public class GitRepositoryFiles {
   private static final String TAGS = "tags";
   private static final String REMOTES = "remotes";
   private static final String SQUASH_MSG = "SQUASH_MSG";
+  private static final String HOOKS = "hooks";
+  private static final String PRE_COMMIT_HOOK = "pre-commit";
+  private static final String PRE_PUSH_HOOK = "pre-push";
 
   private final VirtualFile myMainDir;
   private final VirtualFile myWorktreeDir;
@@ -77,6 +80,7 @@ public class GitRepositoryFiles {
   private final String myMergeSquashPath;
   private final String myInfoDirPath;
   private final String myExcludePath;
+  private final String myHooksDirPath;
 
   private GitRepositoryFiles(@NotNull VirtualFile mainDir, @NotNull VirtualFile worktreeDir) {
     myMainDir = mainDir;
@@ -91,6 +95,7 @@ public class GitRepositoryFiles {
     myRefsRemotesDirPath = refsPath + slash(REMOTES);
     myInfoDirPath = mainPath + slash(INFO);
     myExcludePath = mainPath + slash(INFO_EXCLUDE);
+    myHooksDirPath = mainPath + slash(HOOKS);
 
     String worktreePath = myWorktreeDir.getPath();
     myHeadFilePath = worktreePath + slash(HEAD);
@@ -148,7 +153,7 @@ public class GitRepositoryFiles {
    */
   @NotNull
   Collection<String> getDirsToWatch() {
-    return Arrays.asList(myRefsHeadsDirPath, myRefsRemotesDirPath, myRefsTagsPath, myInfoDirPath);
+    return Arrays.asList(myRefsHeadsDirPath, myRefsRemotesDirPath, myRefsTagsPath, myInfoDirPath, myHooksDirPath);
   }
 
   @NotNull
@@ -209,6 +214,16 @@ public class GitRepositoryFiles {
   @NotNull
   public File getSquashMessageFile() {
     return file(myMergeSquashPath);
+  }
+
+  @NotNull
+  public File getPreCommitHookFile() {
+    return file(myHooksDirPath + slash(PRE_COMMIT_HOOK));
+  }
+
+  @NotNull
+  public File getPrePushHookFile() {
+    return file(myHooksDirPath + slash(PRE_PUSH_HOOK));
   }
 
   @NotNull

--- a/plugins/git4idea/src/git4idea/repo/GitRepositoryImpl.java
+++ b/plugins/git4idea/src/git4idea/repo/GitRepositoryImpl.java
@@ -200,8 +200,9 @@ public class GitRepositoryImpl extends RepositoryImpl implements GitRepository {
     Collection<GitRemote> remotes = config.parseRemotes();
     GitBranchState state = myReader.readState(remotes);
     Collection<GitBranchTrackInfo> trackInfos = config.parseTrackInfos(state.getLocalBranches().keySet(), state.getRemoteBranches().keySet());
+    GitHooksInfo hooksInfo = myReader.readHooksInfo();
     return new GitRepoInfo(state.getCurrentBranch(), state.getCurrentRevision(), state.getState(), remotes,
-                           state.getLocalBranches(), state.getRemoteBranches(), trackInfos);
+                           state.getLocalBranches(), state.getRemoteBranches(), trackInfos, hooksInfo);
   }
 
   private static void notifyIfRepoChanged(@NotNull final GitRepository repository, @NotNull GitRepoInfo previousInfo, @NotNull GitRepoInfo info) {

--- a/plugins/git4idea/src/git4idea/repo/GitRepositoryReader.java
+++ b/plugins/git4idea/src/git4idea/repo/GitRepositoryReader.java
@@ -108,6 +108,16 @@ class GitRepositoryReader {
     return new GitBranchState(currentRevision, currentBranch, state, localBranches, branches.second);
   }
 
+  @NotNull
+  GitHooksInfo readHooksInfo() {
+    return new GitHooksInfo(isExistingExecutableFile(myGitFiles.getPreCommitHookFile()),
+                            isExistingExecutableFile(myGitFiles.getPrePushHookFile()));
+  }
+
+  private static boolean isExistingExecutableFile(@NotNull File file) {
+    return file.exists() && file.canExecute();
+  }
+
   @Nullable
   private static String getCurrentRevision(@NotNull HeadInfo headInfo, @Nullable Hash currentBranchHash) {
     String currentRevision;

--- a/plugins/git4idea/tests/git4idea/push/GitPushOperationMultiRepoTest.kt
+++ b/plugins/git4idea/tests/git4idea/push/GitPushOperationMultiRepoTest.kt
@@ -73,7 +73,7 @@ class GitPushOperationMultiRepoTest : GitPushOperationBaseTest() {
     val map = ContainerUtil.newHashMap<GitRepository, PushSpec<GitPushSource, GitPushTarget>>()
     map.put(myRepository, spec1)
     map.put(myCommunity, spec2)
-    val result = GitPushOperation(myProject, myPushSupport, map, null, false).execute()
+    val result = GitPushOperation(myProject, myPushSupport, map, null, false, false).execute()
 
     val result1 = result.results[myRepository]!!
     val result2 = result.results[myCommunity]!!
@@ -97,7 +97,7 @@ class GitPushOperationMultiRepoTest : GitPushOperationBaseTest() {
     val mainSpec = makePushSpec(myRepository, "master", "origin/master")
     agreeToUpdate(GitRejectedPushUpdateDialog.MERGE_EXIT_CODE) // auto-update-all-roots is selected by default
     val result = GitPushOperation(myProject, myPushSupport,
-        Collections.singletonMap<GitRepository, PushSpec<GitPushSource, GitPushTarget>>(myRepository, mainSpec), null, false).execute()
+        Collections.singletonMap<GitRepository, PushSpec<GitPushSource, GitPushTarget>>(myRepository, mainSpec), null, false, false).execute()
 
     val result1 = result.results[myRepository]!!
     val result2 = result.results[myCommunity]

--- a/plugins/git4idea/tests/git4idea/push/GitPushOperationSingleRepoTest.kt
+++ b/plugins/git4idea/tests/git4idea/push/GitPushOperationSingleRepoTest.kt
@@ -27,14 +27,15 @@ import com.intellij.openapi.vcs.update.UpdatedFiles
 import com.intellij.testFramework.UsefulTestCase
 import com.intellij.util.Function
 import com.intellij.util.containers.ContainerUtil
+import git4idea.GitUtil
 import git4idea.branch.GitBranchUtil
 import git4idea.config.UpdateMethod
 import git4idea.push.GitPushRepoResult.Type.*
 import git4idea.repo.GitRepository
 import git4idea.test.*
-import git4idea.test.makeCommit
 import git4idea.update.GitRebaseOverMergeProblem
 import git4idea.update.GitUpdateResult
+import junit.framework.TestCase
 import java.io.File
 import java.io.IOException
 import java.util.Collections.singletonMap
@@ -142,7 +143,7 @@ class GitPushOperationSingleRepoTest : GitPushOperationBaseTest() {
     updateRepositories()
     val pushSpec = makePushSpec(myRepository, "master", "origin/master")
 
-    val result = object : GitPushOperation(myProject, myPushSupport, singletonMap(myRepository, pushSpec), null, false) {
+    val result = object : GitPushOperation(myProject, myPushSupport, singletonMap(myRepository, pushSpec), null, false, false) {
       override fun update(rootsToUpdate: Collection<GitRepository>,
                           updateMethod: UpdateMethod,
                           checkForRebaseOverMergeProblem: Boolean): GitUpdateResult {
@@ -174,7 +175,7 @@ class GitPushOperationSingleRepoTest : GitPushOperationBaseTest() {
     updateRepositories()
     val pushSpec = makePushSpec(myRepository, "master", "origin/master")
 
-    val result = object : GitPushOperation(myProject, myPushSupport, singletonMap(myRepository, pushSpec), null, false) {
+    val result = object : GitPushOperation(myProject, myPushSupport, singletonMap(myRepository, pushSpec), null, false, false) {
       internal var updateHappened: Boolean = false
 
       override fun update(rootsToUpdate: Collection<GitRepository>,
@@ -254,7 +255,7 @@ class GitPushOperationSingleRepoTest : GitPushOperationBaseTest() {
     makeCommit("anyfile.txt")
 
     val map = singletonMap(myRepository, makePushSpec(myRepository, "master", "origin/master"))
-    val result = GitPushOperation(myProject, myPushSupport, map, null, true).execute()
+    val result = GitPushOperation(myProject, myPushSupport, map, null, true, false).execute()
     return Pair.create(pushedHash, result)
   }
 
@@ -331,11 +332,28 @@ class GitPushOperationSingleRepoTest : GitPushOperationBaseTest() {
     updateRepositories()
     val spec = makePushSpec(myRepository, "master", "origin/master")
     val pushResult = GitPushOperation(myProject, myPushSupport, singletonMap(myRepository, spec),
-        GitPushTagMode.ALL, false).execute()
+        GitPushTagMode.ALL, false, false).execute()
     val result = pushResult.results[myRepository]!!
     val pushedTags = result.pushedTags
     assertEquals(1, pushedTags.size)
     assertEquals("refs/tags/v1", pushedTags[0])
+  }
+
+  fun test_skip_pre_push_hook() {
+    cd(myRepository)
+    val hash = makeCommit("file.txt")
+
+    val rejectHook = """
+      exit 1
+      """.trimIndent()
+    val gitDir = GitUtil.findGitDir(File(myRepository.root.path))
+    TestCase.assertNotNull(gitDir)
+    installHook(gitDir as File, "pre-push", rejectHook)
+
+    val result = push("master", "origin/master", false, true)
+
+    assertResult(SUCCESS, 1, "master", "origin/master", result)
+    assertPushed(hash, "master")
   }
 
   fun test_warn_if_rebasing_over_merge() {
@@ -443,10 +461,10 @@ class GitPushOperationSingleRepoTest : GitPushOperationBaseTest() {
     git("merge branch1")
   }
 
-  private fun push(from: String, to: String, force: Boolean = false): GitPushResult {
+  private fun push(from: String, to: String, force: Boolean = false, skipHook: Boolean = false): GitPushResult {
     updateRepositories()
     val spec = makePushSpec(myRepository, from, to)
-    return GitPushOperation(myProject, myPushSupport, singletonMap(myRepository, spec), null, force).execute()
+    return GitPushOperation(myProject, myPushSupport, singletonMap(myRepository, spec), null, force, skipHook).execute()
   }
 
   private fun pushCommitFromBro(): String {

--- a/plugins/git4idea/tests/git4idea/test/TestGit.kt
+++ b/plugins/git4idea/tests/git4idea/test/TestGit.kt
@@ -52,10 +52,11 @@ class TestGitImpl : GitImpl() {
                     spec: String,
                     force: Boolean,
                     updateTracking: Boolean,
+                    skipHook: Boolean,
                     tagMode: String?,
                     vararg listeners: GitLineHandlerListener): GitCommandResult {
     return myPushHandler(repository) ?:
-        super.push(repository, remote, spec, force, updateTracking, tagMode, *listeners)
+        super.push(repository, remote, spec, force, updateTracking, skipHook, tagMode, *listeners)
   }
 
   override fun branchDelete(repository: GitRepository,


### PR DESCRIPTION
Git supports a `pre-commit` and `pre-push` hooks that are executed
after a commit or a push accordingly (https://git-scm.com/docs/githooks).
Sometimes it's needed to skip the hooks and bypass the checks for them.
For that purpose git supports a parameter `no-verify`.
With that commit inside the git commit dialog a checkbox "Skip hook" will be
available if any of the repositories have a `pre-commit` hook installed.
Similar way in the push dialog it will be possible to bypass the
`pre-push` hook.
Options are not visible and not used when there's no such hooks installed.

Currently only local hooks (inside .git/hooks folder) are supported.
It doesn't support a new git configuration variable `core.hooksPath`
that allows customizing where the hook directory is (since git 2.9.0).