### PR TITLE
Remove  the  `usleep` in fsNotifier main loop

### DIFF
--- a/native/fsNotifier/linux/main.c
+++ b/native/fsNotifier/linux/main.c
@@ -225,7 +225,6 @@ static bool main_loop() {
   struct timeval timeout;
 
   while (true) {
-    usleep(50000);
 
     FD_ZERO(&rfds);
     FD_SET(input_fd, &rfds);


### PR DESCRIPTION
The loop is already throttled by `select`. It seems that `usleep` was added to facilitate batch processing of inotify events [here](https://github.com/JetBrains/intellij-community/commit/f19adbd5ab5f0230a93835c233d4ba2241cee9d0).

The `usleep` can have a real performance hit. For example, if one has to re-register watchable roots up to hundreds of times in relatively short timeframe.

If removal of the `usleep` is not feasible then either reducing the value passed to `usleep` or moving the `usleep` directly before processing inotify events would also help with the use case described.