### PR TITLE
JavaDoc formatting refactor.

### DIFF
--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDClassComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDClassComment.java
@@ -40,16 +40,12 @@ public class JDClassComment extends JDParamListOwnerComment {
     if (!isNull(myAuthorsList)) {
       JDTag tag = JDTag.AUTHOR;
       for (String author : myAuthorsList) {
-        sb.append(prefix);
-        sb.append(tag.getWithEndWhitespace());
-        sb.append(myFormatter.getParser().formatJDTagDescription(author, tag.getDescriptionPrefix(prefix)));
+        sb.append(myFormatter.getParser().formatJDTagDescription(author, prefix + tag.getWithEndWhitespace(), prefix));
       }
     }
     if (!isNull(myVersion)) {
-      sb.append(prefix);
       JDTag tag = JDTag.VERSION;
-      sb.append(tag.getWithEndWhitespace());
-      sb.append(myFormatter.getParser().formatJDTagDescription(myVersion, tag.getDescriptionPrefix(prefix)));
+      sb.append(myFormatter.getParser().formatJDTagDescription(myVersion, prefix + tag.getWithEndWhitespace(), prefix));
     }
   }
 

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDComment.java
@@ -66,8 +66,7 @@ public class JDComment {
     int start = sb.length();
 
     if (!isNull(myDescription)) {
-      sb.append(prefix);
-      sb.append(myFormatter.getParser().formatJDTagDescription(myDescription, prefix, false));
+      sb.append(myFormatter.getParser().formatJDTagDescription(myDescription, prefix));
 
       if (myFormatter.getSettings().JD_ADD_BLANK_AFTER_DESCRIPTION) {
         sb.append(prefix);
@@ -79,7 +78,6 @@ public class JDComment {
 
     if (!isNull(myUnknownList) && myFormatter.getSettings().JD_KEEP_INVALID_TAGS) {
       for (String aUnknownList : myUnknownList) {
-        sb.append(prefix);
         sb.append(myFormatter.getParser().formatJDTagDescription(aUnknownList, prefix));
       }
     }
@@ -87,29 +85,23 @@ public class JDComment {
     if (!isNull(mySeeAlsoList)) {
       JDTag tag = JDTag.SEE;
       for (String aSeeAlsoList : mySeeAlsoList) {
-        sb.append(prefix);
-        sb.append(tag.getWithEndWhitespace());
         StringBuilder tagDescription = myFormatter.getParser()
-          .formatJDTagDescription(aSeeAlsoList, prefix, true, tag.getDescriptionPrefix(prefix).length());
+          .formatJDTagDescription(aSeeAlsoList, prefix + tag.getWithEndWhitespace(), prefix);
         sb.append(tagDescription);
       }
     }
 
     if (!isNull(mySince)) {
       JDTag tag = JDTag.SINCE;
-      sb.append(prefix);
-      sb.append(tag.getWithEndWhitespace());
       StringBuilder tagDescription = myFormatter.getParser()
-        .formatJDTagDescription(mySince, prefix, true, tag.getDescriptionPrefix(prefix).length());
+        .formatJDTagDescription(mySince, prefix + tag.getWithEndWhitespace(), prefix);
       sb.append(tagDescription);
     }
 
     if (myDeprecated != null) {
       JDTag tag = JDTag.DEPRECATED;
-      sb.append(prefix);
-      sb.append(tag.getWithEndWhitespace());
       StringBuilder tagDescription = myFormatter.getParser()
-        .formatJDTagDescription(myDeprecated, prefix, true, tag.getDescriptionPrefix(prefix).length());
+        .formatJDTagDescription(myDeprecated, prefix + tag.getWithEndWhitespace(), prefix);
       sb.append(tagDescription);
     }
 

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDMethodComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDMethodComment.java
@@ -41,9 +41,7 @@ public class JDMethodComment extends JDParamListOwnerComment {
     if (myReturnTag != null) {
       if (myFormatter.getSettings().JD_KEEP_EMPTY_RETURN || !myReturnTag.trim().isEmpty()) {
         JDTag tag = JDTag.RETURN;
-        sb.append(prefix);
-        sb.append(tag.getWithEndWhitespace());
-        sb.append(myFormatter.getParser().formatJDTagDescription(myReturnTag, prefix, true, tag.getDescriptionPrefix(prefix).length()));
+        sb.append(myFormatter.getParser().formatJDTagDescription(myReturnTag, prefix + tag.getWithEndWhitespace(), prefix));
         if (myFormatter.getSettings().JD_ADD_BLANK_AFTER_RETURN) {
           sb.append(prefix);
           sb.append('\n');

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDParamListOwnerComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDParamListOwnerComment.java
@@ -117,19 +117,15 @@ public class JDParamListOwnerComment extends JDComment {
       if (isNull(nd.desc) && !generate_empty_tags) continue;
       if (wrapDescription && !isNull(nd.desc)) {
         sb.append(prefix).append(tag).append(nd.name).append("\n");
-        sb.append(wrapParametersPrefix);
         sb.append(myFormatter.getParser().formatJDTagDescription(nd.desc, wrapParametersPrefix));
       }
       else if (align_comments) {
-        sb.append(prefix);
-        sb.append(tag);
-        sb.append(nd.name);
         int spacesNumber = max + 1 - nd.name.length();
-        StringUtil.repeatSymbol(sb, ' ', Math.max(0, spacesNumber));
-        sb.append(myFormatter.getParser().formatJDTagDescription(nd.desc, fill));
+        String spaces = StringUtil.repeatSymbol(' ', Math.max(0, spacesNumber));
+        String firstLinePrefix = prefix + tag + nd.name + spaces;
+        sb.append(myFormatter.getParser().formatJDTagDescription(nd.desc, firstLinePrefix, fill));
       }
       else {
-        sb.append(prefix);
         String description = (nd.desc == null) ? "" : nd.desc;
         sb.append(myFormatter.getParser().formatJDTagDescription(tag + nd.name + " " + description, prefix));
       }

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDTag.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDTag.java
@@ -15,7 +15,6 @@
  */
 package com.intellij.psi.impl.source.codeStyle.javadoc;
 
-import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,11 +39,6 @@ public enum JDTag {
 
   JDTag(@NotNull String tag) {
     this.myTag = tag;
-  }
-
-  @NotNull
-  public String getDescriptionPrefix(@NotNull String prefix) {
-    return prefix + StringUtil.repeatSymbol(' ', getWithEndWhitespace().length());
   }
 
   @NotNull


### PR DESCRIPTION
Fixes a couple issues along the way,

- Disabling "Preserve Line Feeds" has no affect on the JavaDoc description unless a line already exceeds the right margin. This is inconsistent with how tag blocks are handled (they are generally re-flowed regardless of if the right margin has been exceeded).
- A couple class-level tags (@author and @version) used inconsistent continuation indentation from other tags.

This was prep-work for another MR to fix [IDEA-23188](https://youtrack.jetbrains.com/issue/IDEA-23188)