### PR TITLE
Add option for JavaDoc continuation indent.

### DIFF
--- a/java/java-impl/src/com/intellij/application/options/JavaDocFormattingPanel.java
+++ b/java/java-impl/src/com/intellij/application/options/JavaDocFormattingPanel.java
@@ -99,6 +99,8 @@ public class JavaDocFormattingPanel extends OptionTreeWithPreviewPanel {
     initBooleanField("JD_DO_NOT_WRAP_ONE_LINE_COMMENTS", ApplicationBundle.message("checkbox.do.not.wrap.one.line.comments"), OTHER_GROUP);
     initBooleanField("JD_PRESERVE_LINE_FEEDS", ApplicationBundle.message("checkbox.preserve.line.feeds"), OTHER_GROUP);
     initBooleanField("JD_PARAM_DESCRIPTION_ON_NEW_LINE", ApplicationBundle.message("checkbox.param.description.on.new.line"), OTHER_GROUP);
+
+    initBooleanField("JD_INDENT_ON_CONTINUATION", ApplicationBundle.message("checkbox.param.indent.on.continuation"), OTHER_GROUP);
   }
 
   protected int getRightMargin() {

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDClassComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDClassComment.java
@@ -37,15 +37,20 @@ public class JDClassComment extends JDParamListOwnerComment {
   @Override
   protected void generateSpecial(@NotNull String prefix, @NotNull StringBuilder sb) {
     super.generateSpecial(prefix, sb);
+    String continuationPrefix = getContinuationPrefix(prefix);
     if (!isNull(myAuthorsList)) {
       JDTag tag = JDTag.AUTHOR;
       for (String author : myAuthorsList) {
-        sb.append(myFormatter.getParser().formatJDTagDescription(author, prefix + tag.getWithEndWhitespace(), prefix));
+        sb.append(myFormatter.getParser().formatJDTagDescription(author,
+                                                                 prefix + tag.getWithEndWhitespace(),
+                                                                 continuationPrefix));
       }
     }
     if (!isNull(myVersion)) {
       JDTag tag = JDTag.VERSION;
-      sb.append(myFormatter.getParser().formatJDTagDescription(myVersion, prefix + tag.getWithEndWhitespace(), prefix));
+      sb.append(myFormatter.getParser().formatJDTagDescription(myVersion,
+                                                               prefix + tag.getWithEndWhitespace(),
+                                                               continuationPrefix));
     }
   }
 

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDClassComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDClassComment.java
@@ -40,16 +40,12 @@ public class JDClassComment extends JDParamListOwnerComment {
     if (!isNull(myAuthorsList)) {
       JDTag tag = JDTag.AUTHOR;
       for (String author : myAuthorsList) {
-        sb.append(prefix);
-        sb.append(tag.getWithEndWhitespace());
-        sb.append(myFormatter.getParser().formatJDTagDescription(author, tag.getDescriptionPrefix(prefix)));
+        sb.append(myFormatter.getParser().formatJDTagDescription(author, prefix + tag.getWithEndWhitespace(), prefix));
       }
     }
     if (!isNull(myVersion)) {
-      sb.append(prefix);
       JDTag tag = JDTag.VERSION;
-      sb.append(tag.getWithEndWhitespace());
-      sb.append(myFormatter.getParser().formatJDTagDescription(myVersion, tag.getDescriptionPrefix(prefix)));
+      sb.append(myFormatter.getParser().formatJDTagDescription(myVersion, prefix + tag.getWithEndWhitespace(), prefix));
     }
   }
 

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDComment.java
@@ -15,6 +15,10 @@
  */
 package com.intellij.psi.impl.source.codeStyle.javadoc;
 
+import com.intellij.formatting.IndentInfo;
+import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.util.containers.ContainerUtilRt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -52,6 +56,20 @@ public class JDComment {
     myMultiLineComment = value;
   }
 
+  protected String getContinuationIndent() {
+    CodeStyleSettings settings = myFormatter.getSettings();
+    CommonCodeStyleSettings.IndentOptions indentOptions = settings.getIndentOptions(JavaFileType.INSTANCE);
+    return new IndentInfo(0, indentOptions.CONTINUATION_INDENT_SIZE, 0).generateNewWhiteSpace(indentOptions);
+  }
+
+  protected String getContinuationPrefix(String prefix) {
+    if (myFormatter.getSettings().JD_INDENT_ON_CONTINUATION) {
+      return prefix + getContinuationIndent();
+    } else {
+      return prefix;
+    }
+  }
+
   @Nullable
   public String generate(@NotNull String indent) {
     final String prefix;
@@ -76,9 +94,11 @@ public class JDComment {
 
     generateSpecial(prefix, sb);
 
+    final String continuationPrefix = getContinuationPrefix(prefix);
+
     if (!isNull(myUnknownList) && myFormatter.getSettings().JD_KEEP_INVALID_TAGS) {
       for (String aUnknownList : myUnknownList) {
-        sb.append(myFormatter.getParser().formatJDTagDescription(aUnknownList, prefix));
+        sb.append(myFormatter.getParser().formatJDTagDescription(aUnknownList, prefix, continuationPrefix));
       }
     }
 
@@ -86,7 +106,7 @@ public class JDComment {
       JDTag tag = JDTag.SEE;
       for (String aSeeAlsoList : mySeeAlsoList) {
         StringBuilder tagDescription = myFormatter.getParser()
-          .formatJDTagDescription(aSeeAlsoList, prefix + tag.getWithEndWhitespace(), prefix);
+          .formatJDTagDescription(aSeeAlsoList, prefix + tag.getWithEndWhitespace(), continuationPrefix);
         sb.append(tagDescription);
       }
     }
@@ -94,14 +114,14 @@ public class JDComment {
     if (!isNull(mySince)) {
       JDTag tag = JDTag.SINCE;
       StringBuilder tagDescription = myFormatter.getParser()
-        .formatJDTagDescription(mySince, prefix + tag.getWithEndWhitespace(), prefix);
+        .formatJDTagDescription(mySince, prefix + tag.getWithEndWhitespace(), continuationPrefix);
       sb.append(tagDescription);
     }
 
     if (myDeprecated != null) {
       JDTag tag = JDTag.DEPRECATED;
       StringBuilder tagDescription = myFormatter.getParser()
-        .formatJDTagDescription(myDeprecated, prefix + tag.getWithEndWhitespace(), prefix);
+        .formatJDTagDescription(myDeprecated, prefix + tag.getWithEndWhitespace(), continuationPrefix);
       sb.append(tagDescription);
     }
 

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDComment.java
@@ -66,8 +66,7 @@ public class JDComment {
     int start = sb.length();
 
     if (!isNull(myDescription)) {
-      sb.append(prefix);
-      sb.append(myFormatter.getParser().formatJDTagDescription(myDescription, prefix, false));
+      sb.append(myFormatter.getParser().formatJDTagDescription(myDescription, prefix));
 
       if (myFormatter.getSettings().JD_ADD_BLANK_AFTER_DESCRIPTION) {
         sb.append(prefix);
@@ -79,7 +78,6 @@ public class JDComment {
 
     if (!isNull(myUnknownList) && myFormatter.getSettings().JD_KEEP_INVALID_TAGS) {
       for (String aUnknownList : myUnknownList) {
-        sb.append(prefix);
         sb.append(myFormatter.getParser().formatJDTagDescription(aUnknownList, prefix));
       }
     }
@@ -87,29 +85,23 @@ public class JDComment {
     if (!isNull(mySeeAlsoList)) {
       JDTag tag = JDTag.SEE;
       for (String aSeeAlsoList : mySeeAlsoList) {
-        sb.append(prefix);
-        sb.append(tag.getWithEndWhitespace());
         StringBuilder tagDescription = myFormatter.getParser()
-          .formatJDTagDescription(aSeeAlsoList, prefix, true, tag.getDescriptionPrefix(prefix).length());
+          .formatJDTagDescription(aSeeAlsoList, prefix + tag.getWithEndWhitespace(), prefix);
         sb.append(tagDescription);
       }
     }
 
     if (!isNull(mySince)) {
       JDTag tag = JDTag.SINCE;
-      sb.append(prefix);
-      sb.append(tag.getWithEndWhitespace());
       StringBuilder tagDescription = myFormatter.getParser()
-        .formatJDTagDescription(mySince, prefix, true, tag.getDescriptionPrefix(prefix).length());
+        .formatJDTagDescription(mySince, prefix + tag.getWithEndWhitespace(), prefix);
       sb.append(tagDescription);
     }
 
     if (myDeprecated != null) {
       JDTag tag = JDTag.DEPRECATED;
-      sb.append(prefix);
-      sb.append(tag.getWithEndWhitespace());
       StringBuilder tagDescription = myFormatter.getParser()
-        .formatJDTagDescription(myDeprecated, prefix, true, tag.getDescriptionPrefix(prefix).length());
+        .formatJDTagDescription(myDeprecated, prefix + tag.getWithEndWhitespace(), prefix);
       sb.append(tagDescription);
     }
 

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDMethodComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDMethodComment.java
@@ -41,9 +41,7 @@ public class JDMethodComment extends JDParamListOwnerComment {
     if (myReturnTag != null) {
       if (myFormatter.getSettings().JD_KEEP_EMPTY_RETURN || !myReturnTag.trim().isEmpty()) {
         JDTag tag = JDTag.RETURN;
-        sb.append(prefix);
-        sb.append(tag.getWithEndWhitespace());
-        sb.append(myFormatter.getParser().formatJDTagDescription(myReturnTag, prefix, true, tag.getDescriptionPrefix(prefix).length()));
+        sb.append(myFormatter.getParser().formatJDTagDescription(myReturnTag, prefix + tag.getWithEndWhitespace(), prefix));
         if (myFormatter.getSettings().JD_ADD_BLANK_AFTER_RETURN) {
           sb.append(prefix);
           sb.append('\n');

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDMethodComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDMethodComment.java
@@ -41,7 +41,9 @@ public class JDMethodComment extends JDParamListOwnerComment {
     if (myReturnTag != null) {
       if (myFormatter.getSettings().JD_KEEP_EMPTY_RETURN || !myReturnTag.trim().isEmpty()) {
         JDTag tag = JDTag.RETURN;
-        sb.append(myFormatter.getParser().formatJDTagDescription(myReturnTag, prefix + tag.getWithEndWhitespace(), prefix));
+        sb.append(myFormatter.getParser().formatJDTagDescription(myReturnTag,
+                                                                 prefix + tag.getWithEndWhitespace(),
+                                                                 getContinuationPrefix(prefix)));
         if (myFormatter.getSettings().JD_ADD_BLANK_AFTER_RETURN) {
           sb.append(prefix);
           sb.append('\n');

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDParamListOwnerComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDParamListOwnerComment.java
@@ -20,11 +20,7 @@
  */
 package com.intellij.psi.impl.source.codeStyle.javadoc;
 
-import com.intellij.formatting.IndentInfo;
-import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.psi.codeStyle.CodeStyleSettings;
-import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.util.containers.ContainerUtilRt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -91,10 +87,6 @@ public class JDParamListOwnerComment extends JDComment {
                               boolean generate_empty_tags,
                               boolean wrapDescription)
   {
-    CodeStyleSettings settings = myFormatter.getSettings();
-    CommonCodeStyleSettings.IndentOptions indentOptions = settings.getIndentOptions(JavaFileType.INSTANCE);
-    String continuationIndent = new IndentInfo(0, indentOptions.CONTINUATION_INDENT_SIZE, 0).generateNewWhiteSpace(indentOptions);
-
     int max = 0;
 
     if (align_comments && !wrapDescription) {
@@ -112,7 +104,7 @@ public class JDParamListOwnerComment extends JDComment {
     fill.append(prefix);
     StringUtil.repeatSymbol(fill, ' ', max + 1 + tag.length());
 
-    String wrapParametersPrefix = prefix + continuationIndent;
+    String wrapParametersPrefix = prefix + getContinuationIndent();
     for (NameDesc nd : list) {
       if (isNull(nd.desc) && !generate_empty_tags) continue;
       if (wrapDescription && !isNull(nd.desc)) {
@@ -127,7 +119,9 @@ public class JDParamListOwnerComment extends JDComment {
       }
       else {
         String description = (nd.desc == null) ? "" : nd.desc;
-        sb.append(myFormatter.getParser().formatJDTagDescription(tag + nd.name + " " + description, prefix));
+        sb.append(myFormatter.getParser().formatJDTagDescription(tag + nd.name + " " + description,
+                                                                 prefix,
+                                                                 getContinuationPrefix(prefix)));
       }
     }
   }

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDParamListOwnerComment.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDParamListOwnerComment.java
@@ -117,19 +117,15 @@ public class JDParamListOwnerComment extends JDComment {
       if (isNull(nd.desc) && !generate_empty_tags) continue;
       if (wrapDescription && !isNull(nd.desc)) {
         sb.append(prefix).append(tag).append(nd.name).append("\n");
-        sb.append(wrapParametersPrefix);
         sb.append(myFormatter.getParser().formatJDTagDescription(nd.desc, wrapParametersPrefix));
       }
       else if (align_comments) {
-        sb.append(prefix);
-        sb.append(tag);
-        sb.append(nd.name);
         int spacesNumber = max + 1 - nd.name.length();
-        StringUtil.repeatSymbol(sb, ' ', Math.max(0, spacesNumber));
-        sb.append(myFormatter.getParser().formatJDTagDescription(nd.desc, fill));
+        String spaces = StringUtil.repeatSymbol(' ', Math.max(0, spacesNumber));
+        String firstLinePrefix = prefix + tag + nd.name + spaces;
+        sb.append(myFormatter.getParser().formatJDTagDescription(nd.desc, firstLinePrefix, fill));
       }
       else {
-        sb.append(prefix);
         String description = (nd.desc == null) ? "" : nd.desc;
         sb.append(myFormatter.getParser().formatJDTagDescription(tag + nd.name + " " + description, prefix));
       }

--- a/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDTag.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/codeStyle/javadoc/JDTag.java
@@ -15,7 +15,6 @@
  */
 package com.intellij.psi.impl.source.codeStyle.javadoc;
 
-import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,11 +39,6 @@ public enum JDTag {
 
   JDTag(@NotNull String tag) {
     this.myTag = tag;
-  }
-
-  @NotNull
-  public String getDescriptionPrefix(@NotNull String prefix) {
-    return prefix + StringUtil.repeatSymbol(' ', getWithEndWhitespace().length());
   }
 
   @NotNull

--- a/platform/lang-api/src/com/intellij/psi/codeStyle/CodeStyleSettings.java
+++ b/platform/lang-api/src/com/intellij/psi/codeStyle/CodeStyleSettings.java
@@ -409,9 +409,10 @@ public class CodeStyleSettings extends CommonCodeStyleSettings implements Clonea
 
 
   public boolean JD_LEADING_ASTERISKS_ARE_ENABLED = true;
-  
   public boolean JD_PRESERVE_LINE_FEEDS;
   public boolean JD_PARAM_DESCRIPTION_ON_NEW_LINE;
+
+  public boolean JD_INDENT_ON_CONTINUATION = false;
 
 // endregion
 

--- a/platform/platform-resources-en/src/messages/ApplicationBundle.properties
+++ b/platform/platform-resources-en/src/messages/ApplicationBundle.properties
@@ -499,6 +499,7 @@ checkbox.keep.empty.lines=Keep empty lines
 checkbox.do.not.wrap.one.line.comments=Do not wrap one line comments
 checkbox.preserve.line.feeds=Preserve line feeds
 checkbox.param.description.on.new.line=Parameter descriptions on new line
+checkbox.param.indent.on.continuation=Indent continuation lines
 title.javadoc=JavaDoc
 option.table.sizing.text=Chop down if long.
 title.choose.code.style.scheme=Choose Code Style Scheme


### PR DESCRIPTION
This fixes https://youtrack.jetbrains.com/issue/IDEA-23188

This change is based on #526 so the first commit can be ignored.