### PR TITLE
[pycharm] [py.test] Issue py.test for multiple source roots [build 171.3780.115]

### DIFF
--- a/python/helpers/pycharm/_jb_runner_tools.py
+++ b/python/helpers/pycharm/_jb_runner_tools.py
@@ -357,16 +357,24 @@ def jb_patch_separator(targets, fs_glue, python_glue, fs_to_python_glue):
     """
     if not targets:
         return []
-
+    
+    import importlib # python>=2.7
+    
     def _patch_target(target):
         _jb_utils.VersionAgnosticUtils.is_py3k()
         splitter = _SymbolName3KSplitter() if _jb_utils.VersionAgnosticUtils.is_py3k() else _SymbolName2KSplitter()
 
         separator = "."
         parts = target.split(separator)
+        fs_part = ''
         for i in range(0, len(parts)):
             try:
+                # TODO: splitter may be return path to module
                 splitter.check_is_importable(parts, i, separator)
+                
+                module_to_import = separator.join(parts[:i + 1])
+                m = importlib.import_module(module_to_import)
+                fs_part = os.path.splitext(m.__file__)[0]
             except ImportError:
                 fs_part = fs_glue.join(parts[:i])
                 python_path = python_glue.join(parts[i:])

--- a/python/helpers/pycharm/_jb_runner_tools.py
+++ b/python/helpers/pycharm/_jb_runner_tools.py
@@ -371,12 +371,11 @@ def jb_patch_separator(targets, fs_glue, python_glue, fs_to_python_glue):
             try:
                 # TODO: splitter may be return path to module
                 splitter.check_is_importable(parts, i, separator)
-                
+
                 module_to_import = separator.join(parts[:i + 1])
                 m = importlib.import_module(module_to_import)
                 fs_part = os.path.splitext(m.__file__)[0]
             except ImportError:
-                fs_part = fs_glue.join(parts[:i])
                 python_path = python_glue.join(parts[i:])
                 return fs_part + fs_to_python_glue + python_path if python_path else fs_part
         return target


### PR DESCRIPTION
That fixes issue for project with multiple source roots

example structure

src [source root]
├── applications [source root]
│   └── example
│       ├── __init__.py
│       ├── models.py
│       ├── tests
│       │   ├── __init__.py
│       │   └── test_example.py`::TestExample::test_generic`
│       └── views.py
├── manage.py
├── pytest.ini
└── settings.py

When select run test_example.py file - it okay becasuse pass absolute path to pytest
and when select run class or method test case - py.test not found test, because pass no absolute path to p;
as example: `example/tests/test_example.py::TestExample::test_generic`
should be 
`applications/example/tests/test_example.py::TestExample::test_generic` or 
`/absolute/path/to/file/applications/example/tests/test_example.py::TestExample::test_generic`
