### PR TITLE
IDEA-140862 Changed the "Regex" checkbox ChangeListener to ItemListener

### DIFF
--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/CommittedChangesPanel.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/committed/CommittedChangesPanel.java
@@ -52,6 +52,8 @@ import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -102,10 +104,13 @@ public class CommittedChangesPanel extends JPanel implements TypeSafeDataProvide
     toolbarPanel.add(toolBar.getComponent());
     toolbarPanel.add(Box.createHorizontalGlue());
     myRegexCheckbox = new JCheckBox(VcsBundle.message("committed.changes.regex.title"));
+    // FIXME: take mnemonic from VcsBundle too ???
+    myRegexCheckbox.setMnemonic('g');		// same as in Editor > Find toolbar
     myRegexCheckbox.setSelected(false);
-    myRegexCheckbox.getModel().addChangeListener(new ChangeListener() {
+    myRegexCheckbox.getModel().addItemListener(new ItemListener() {
       @Override
-      public void stateChanged(ChangeEvent e) {
+      public void itemStateChanged(ItemEvent e) {
+        // TODO: no need to re-filter if the text field is empty anyway
         myFilterComponent.filter();
       }
     });


### PR DESCRIPTION
Checkbox `ChangeListener` is also triggered on mouse hover as focus gain / loss state changes. To listen to checkbox 'selected' state changes only you want `ItemListener` instead. The patch does exactly that.

This way the list selection is not reset when mouse is moved over "Regex" checkbox.
I also added a 'g' mnemonic so that regexp mode can be switched with Alt+G hotkey.