### PR TITLE
Ensure '_latest_subtest_result' is set.

### DIFF
--- a/python/helpers/pycharm/_jb_runner_tools.py
+++ b/python/helpers/pycharm/_jb_runner_tools.py
@@ -154,6 +154,8 @@ PARSE_FUNC = None
 
 
 class NewTeamcityServiceMessages(_old_service_messages):
+    _latest_subtest_result = None
+    
     def message(self, messageName, **properties):
         # Intellij may fail to process message if it has char just before it.
         # Space before message has no visible affect, but saves from such cases


### PR DESCRIPTION
Prevent AttributeError: 'NewTeamcityServiceMessages' object has no attribute '_latest_subtest_result'