### PR TITLE
Added VC notification

### DIFF
--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/actions/VcsContextWrapper.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/actions/VcsContextWrapper.java
@@ -160,7 +160,7 @@ public class VcsContextWrapper implements VcsContext {
       stream(VcsDataKeys.FILE_PATH_ARRAY.getData(myContext)),
       getSelectedFilesStream().map(VcsUtil::getFilePath),
       stream(getSelectedIOFiles()).map(VcsUtil::getFilePath)
-    );
+    ).distinct();
   }
 
   @Nullable

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/UpdateRequestsQueue.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/UpdateRequestsQueue.java
@@ -204,22 +204,21 @@ public class UpdateRequestsQueue {
       }
     }
 
+    boolean stopped = myStopped;
     synchronized (myLock) {
-      if (! myStopped) {
+      if (!stopped) {
         myWaitingUpdateCompletionQueue.add(data.getCallback());
         schedule();
       }
     }
     // do not run under lock; stopped cannot be switched into not stopped - can check without lock
-    if (myStopped) {
+    if (stopped) {
       LOG.debug("invokeAfterUpdate: stopped, invoke right now for project: " + myProject.getName());
-      SwingUtilities.invokeLater(new Runnable() {
-        public void run() {
-          if (!myProject.isDisposed()) {
-            afterUpdate.run();
-          }
+      ApplicationManager.getApplication().invokeLater(() -> {
+        if (!myProject.isDisposed()) {
+          afterUpdate.run();
         }
-      });
+      }, state != null ? state : ModalityState.any());
       return;
     }
     // invoke progress if needed

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ui/CommitChangeListDialog.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ui/CommitChangeListDialog.java
@@ -488,7 +488,7 @@ public class CommitChangeListDialog extends DialogWrapper implements CheckinProj
 
     @Override
     public void actionPerformed(ActionEvent e) {
-      executeDefaultCommitSession();
+      executeDefaultCommitSession(null);
     }
 
     @NotNull
@@ -533,7 +533,7 @@ public class CommitChangeListDialog extends DialogWrapper implements CheckinProj
     return toObjectArray(result, Action.class);
   }
 
-  private void executeDefaultCommitSession() {
+  private void executeDefaultCommitSession(@Nullable CommitExecutor executor) {
     if (!myIsAlien && !addUnversionedFiles()) return;
     if (!saveDialogState()) return;
     saveComments(true);
@@ -541,7 +541,7 @@ public class CommitChangeListDialog extends DialogWrapper implements CheckinProj
     ensureDataIsActual(() -> {
       try {
         DefaultListCleaner defaultListCleaner = new DefaultListCleaner();
-        CheckinHandler.ReturnResult result = runBeforeCommitHandlers(null);
+        CheckinHandler.ReturnResult result = runBeforeCommitHandlers(executor);
         if (result == CheckinHandler.ReturnResult.COMMIT) {
           close(OK_EXIT_CODE);
           doCommit(myResultHandler);
@@ -558,7 +558,7 @@ public class CommitChangeListDialog extends DialogWrapper implements CheckinProj
   private void execute(@NotNull CommitExecutor commitExecutor) {
     CommitSession session = commitExecutor.createCommitSession();
     if (session == CommitSession.VCS_COMMIT) {
-      executeDefaultCommitSession();
+      executeDefaultCommitSession(commitExecutor);
       return;
     }
 

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/impl/ProjectLevelVcsManagerImpl.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/impl/ProjectLevelVcsManagerImpl.java
@@ -53,10 +53,7 @@ import com.intellij.openapi.vcs.ex.ProjectLevelVcsManagerEx;
 import com.intellij.openapi.vcs.history.VcsHistoryCache;
 import com.intellij.openapi.vcs.impl.projectlevelman.*;
 import com.intellij.openapi.vcs.roots.VcsRootScanner;
-import com.intellij.openapi.vcs.update.ActionInfo;
-import com.intellij.openapi.vcs.update.UpdateInfoTree;
-import com.intellij.openapi.vcs.update.UpdatedFiles;
-import com.intellij.openapi.vcs.update.UpdatedFilesListener;
+import com.intellij.openapi.vcs.update.*;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -494,8 +491,11 @@ public class ProjectLevelVcsManagerImpl extends ProjectLevelVcsManagerEx impleme
       return null;  // content manager is made null during dispose; flag is set later
     }
     final UpdateInfoTree updateInfoTree = new UpdateInfoTree(contentManager, myProject, updatedFiles, displayActionName, actionInfo);
-    ContentUtilEx.addTabbedContent(contentManager, updateInfoTree, "Update Info", DateFormatUtil.formatDateTime(System.currentTimeMillis()), true, updateInfoTree);
-    ToolWindowManager.getInstance(myProject).getToolWindow(ToolWindowId.VCS).activate(null);
+    boolean selectAndFocus = ActionInfoEx.activeToolWindowOnUpdate(actionInfo);
+    ContentUtilEx.addTabbedContent(contentManager, updateInfoTree, "Update Info", DateFormatUtil.formatDateTime(System.currentTimeMillis()), selectAndFocus, updateInfoTree);
+    if (selectAndFocus) {
+      ToolWindowManager.getInstance(myProject).getToolWindow(ToolWindowId.VCS).activate(null);
+    }
     updateInfoTree.expandRootChildren();
     return updateInfoTree;
   }

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/update/AbstractCommonUpdateAction.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/update/AbstractCommonUpdateAction.java
@@ -301,7 +301,7 @@ public abstract class AbstractCommonUpdateAction extends AbstractVcsAction {
     private LocalHistoryAction myLocalHistoryAction;
 
     public Updater(final Project project, final FilePath[] roots, final Map<AbstractVcs, Collection<FilePath>> vcsToVirtualFiles) {
-      super(project, getTemplatePresentation().getText(), true, VcsConfiguration.getInstance(project).getUpdateOption());
+      super(project, getTemplatePresentation().getText(), true, ActionInfoEx.maybeOverrideBackGroundOption(myActionInfo, VcsConfiguration.getInstance(project).getUpdateOption()));
       myProject = project;
       myProjectLevelVcsManager = ProjectLevelVcsManagerEx.getInstanceEx(project);
       myDirtyScopeManager = VcsDirtyScopeManager.getInstance(myProject);

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/update/ActionInfoEx.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/update/ActionInfoEx.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.vcs.update;
+
+import com.intellij.openapi.progress.PerformInBackgroundOption;
+
+/**
+ * Created by kirylch on 4/12/2017.
+ */
+public interface ActionInfoEx extends ActionInfo {
+  static boolean activeToolWindowOnUpdate(ActionInfo action) {
+    if(action instanceof ActionInfoEx) {
+      return ((ActionInfoEx)action).activeToolWindowOnUpdate();
+    }
+    return true;
+  }
+
+  static PerformInBackgroundOption maybeOverrideBackGroundOption(ActionInfo action, PerformInBackgroundOption option) {
+    if(action instanceof ActionInfoEx) {
+      return ((ActionInfoEx)action).maybeOverrideBackGroundOption(option);
+    }
+    return option;
+  }
+
+  boolean activeToolWindowOnUpdate();
+  PerformInBackgroundOption maybeOverrideBackGroundOption(PerformInBackgroundOption option);
+}


### PR DESCRIPTION
We have several actions that auto sync remote sources locally, I am guessing similar to AutoSVN updater. For this we inherit 'AbstractCommonUpdateAction'. Unfortunately we need a little bit more control of the action that 'AbstractCommonUpdateAction' offers, so we added some extensions. The other option would be not to inherit 'AbstractCommonUpdateAction' and instead copy the code. We'd really like to avoid doing this as 'AbstractCommonUpdateAction' implementation handles some very esoteric low level details and we'd like to ensure we receive any updates/bugfixes to it.

CommitChangeListDialog:
We need to be able to pass a parameter to CheckinEnvironment depending on the CommitExecutor. There is currently no way to do this cleanly. Passing the executor(not null) allows CheckinHandler to pass in a parameter to CheckinEnvironment