### PR TITLE
Date: remove usage of deprecated API

### DIFF
--- a/platform/util/src/com/intellij/util/io/zip/DosTime.java
+++ b/platform/util/src/com/intellij/util/io/zip/DosTime.java
@@ -19,7 +19,7 @@
  */
 package com.intellij.util.io.zip;
 
-import java.util.Date;
+import java.util.Calendar;
 
 public class DosTime {
   private DosTime() {
@@ -29,25 +29,28 @@ public class DosTime {
    * Converts DOS time to Java time (number of milliseconds since epoch).
    */
   public static long dosToJavaTime(long dtime) {
-    Date d = new Date((int)(((dtime >> 25) & 0x7f) + 80), (int)(((dtime >> 21) & 0x0f) - 1), (int)((dtime >> 16) & 0x1f),
-                      (int)((dtime >> 11) & 0x1f), (int)((dtime >> 5) & 0x3f), (int)((dtime << 1) & 0x3e));
-    return d.getTime();
+    Calendar cal = Calendar.getInstance();
+    cal.set((int)(((dtime >> 25) & 0x7f) + 1980), (int)(((dtime >> 21) & 0x0f) - 1), (int)((dtime >> 16) & 0x1f),
+            (int)((dtime >> 11) & 0x1f), (int)((dtime >> 5) & 0x3f), (int)((dtime << 1) & 0x3e));
+    cal.clear(Calendar.MILLISECOND);
+    return cal.getTimeInMillis();
   }
 
   /*
    * Converts Java time to DOS time.
    */
   public static long javaToDosTime(long time) {
-    Date d = new Date(time);
-    int year = d.getYear() + 1900;
+    Calendar cal = Calendar.getInstance();
+    cal.setTimeInMillis(time);
+    int year = cal.get(Calendar.YEAR);
     if (year < 1980) {
       return (1 << 21) | (1 << 16);
     }
-    return (year - 1980) << 25 |
-           (d.getMonth() + 1) << 21 |
-           d.getDate() << 16 |
-           d.getHours() << 11 |
-           d.getMinutes() << 5 |
-           d.getSeconds() >> 1;
+    return (year - 1980) << 25
+           | (cal.get(Calendar.MONTH) + 1) << 21
+           | cal.get(Calendar.DAY_OF_MONTH) << 16
+           | cal.get(Calendar.HOUR_OF_DAY) << 11
+           | cal.get(Calendar.MINUTE) << 5
+           | cal.get(Calendar.SECOND) >> 1;
   }
 }


### PR DESCRIPTION
Replaced Date for Calendar.
Two implementation notes:
- On "dosToJavaTime" method, I clear the millisecond field to maintain what the Date implementation would return.
- On both "javaToDosTime" and "dosToJavaTime", I handle the year "gap" (Calendar uses the real value while Date uses the year minus 1900).
