### PR TITLE
Use same timeout for MultiProcessDebugger as for RemoteDebugger

### DIFF
--- a/python/src/com/jetbrains/python/debugger/PyDebugProcess.java
+++ b/python/src/com/jetbrains/python/debugger/PyDebugProcess.java
@@ -222,7 +222,7 @@ public class PyDebugProcess extends XDebugProcess implements IPyDebugProcess, Pr
   }
 
   private MultiProcessDebugger createMultiprocessDebugger(ServerSocket serverSocket) {
-    MultiProcessDebugger debugger = new MultiProcessDebugger(this, serverSocket, 10000);
+    MultiProcessDebugger debugger = new MultiProcessDebugger(this, serverSocket, getConnectTimeout());
     debugger.addOtherDebuggerCloseListener(new MultiProcessDebugger.DebuggerProcessListener() {
       @Override
       public void threadsClosed(Set<String> threadIds) {


### PR DESCRIPTION
Changed MultiProcessDebugger timeout to same timeout as RemoteDebugger. In our case sometimes it takes longer than 10000 to start process. If it is not okay to use same timeout as for RemoteDebugger I can change it to use value from IDEA registry or some where else. I just need to be able to override this value or be it as 60 000. Just let me know.