### PR TITLE
IDEA-73669 Allow branch to have longer name in status bar

### DIFF
--- a/platform/dvcs-impl/src/com/intellij/dvcs/ui/DvcsStatusWidget.java
+++ b/platform/dvcs-impl/src/com/intellij/dvcs/ui/DvcsStatusWidget.java
@@ -42,7 +42,7 @@ public abstract class DvcsStatusWidget<T extends Repository> extends EditorBased
   implements StatusBarWidget.MultipleTextValuesPresentation, StatusBarWidget.Multiframe
 {
   protected static final Logger LOG = Logger.getInstance(DvcsStatusWidget.class);
-  private static final String MAX_STRING = "VCS: Rebasing feature-12345";
+  private static final String MAX_STRING = "VCS: Rebasing feature-12345 in custom development branch";
 
   @NotNull private final String myPrefix;
 


### PR DESCRIPTION
This change allows to have a much longer branch name in status bar.
This is not perfect but working solution.