### PR TITLE
Add missing package to pydev

### DIFF
--- a/python/helpers/pydev/setup.py
+++ b/python/helpers/pydev/setup.py
@@ -86,6 +86,7 @@ args = dict(
         '_pydev_runfiles',
         '_pydevd_bundle',
         'pydev_ipython',
+        '_pydevd_frame_eval',
 
         # 'pydev_sitecustomize', -- Not actually a package (not added)
 


### PR DESCRIPTION
Remote debugging with IntelliJ Ultimate fails unless the _pydevd_frame_eval package is included in the pydev helper.