### PR TITLE
Additional line number pattern matching for the Open File Dialog

### DIFF
--- a/java/java-tests/testSrc/com/intellij/navigation/ChooseByNameTest.groovy
+++ b/java/java-tests/testSrc/com/intellij/navigation/ChooseByNameTest.groovy
@@ -242,6 +242,7 @@ class Intf {
     assert getPopupElements(model, 'Bar at line 2') == [file]
     assert getPopupElements(model, 'Bar 2:39') == [file]
     assert getPopupElements(model, 'Bar#L2') == [file]
+    assert getPopupElements(model, 'Bar?l=2') == [file]
   }
 
   void "test dollar"() {

--- a/platform/lang-impl/src/com/intellij/ide/util/gotoByName/ChooseByNamePopup.java
+++ b/platform/lang-impl/src/com/intellij/ide/util/gotoByName/ChooseByNamePopup.java
@@ -340,7 +340,7 @@ public class ChooseByNamePopup extends ChooseByNameBase implements ChooseByNameP
   }
 
   private static final Pattern patternToDetectLinesAndColumns = Pattern.compile("(.+?)" + // name, non-greedy matching
-                                                                                "(?::|@|,| |#L| on line | at line |:?\\(|:?\\[)" + // separator
+                                                                                "(?::|@|,| |#|#L|\\?l=| on line | at line |:?\\(|:?\\[)" + // separator
                                                                                 "(\\d+)(?:(?:\\D)(\\d+)?)?" + // line + column
                                                                                 "[)\\]]?" // possible closing paren/brace
   );
@@ -355,7 +355,7 @@ public class ChooseByNamePopup extends ChooseByNameBase implements ChooseByNameP
 
   public static String getTransformedPattern(String pattern, ChooseByNameModel model) {
     Pattern regex = null;
-    if (StringUtil.containsAnyChar(pattern, ":,;@[( #") || pattern.contains(" line ")) { // quick test if reg exp should be used
+    if (StringUtil.containsAnyChar(pattern, ":,;@[( #") || pattern.contains(" line ") || pattern.contains("?l=")) { // quick test if reg exp should be used
       regex = patternToDetectLinesAndColumns;
     }
 


### PR DESCRIPTION
Additional line number pattern matching for the Open File Dialog (TreeFileChooserDialog), `#` and `?l=` are now matched covering web source code viewers such as

Chromium: https://cs.chromium.org/chromium/src/apps/app_restore_service_factory.cc?l=15

and

Android: https://android.googlesource.com/device/sample/+/master/apps/LeanbackCustomizer/src/com/google/android/leanbacklauncher/partnercustomizer/PartnerReceiver.java#100

Some more context/ additional improvement on: https://youtrack.jetbrains.com/issue/IDEA-162418