### PR TITLE
Remove usages and deprecate some obsolete StringUtil methods

### DIFF
--- a/jps/jps-builders/src/org/jetbrains/jps/builders/java/dependencyView/TypeRepr.java
+++ b/jps/jps-builders/src/org/jetbrains/jps/builders/java/dependencyView/TypeRepr.java
@@ -15,7 +15,6 @@
  */
 package org.jetbrains.jps.builders.java.dependencyView;
 
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.DataInputOutputUtil;
 import org.jetbrains.annotations.NotNull;
@@ -241,7 +240,7 @@ public class TypeRepr {
 
     switch (t.getSort()) {
       case Type.OBJECT:
-        return context.getType(new ClassType(context.get(StringUtil.replaceChar(t.getClassName(), '.', '/'))));
+        return context.getType(new ClassType(context.get(t.getClassName().replace('.', '/'))));
 
       case Type.ARRAY:
         return context.getType(new ArrayType(getType(context, t.getElementType())));

--- a/platform/analysis-impl/src/com/intellij/codeInspection/ProblemDescriptorUtil.java
+++ b/platform/analysis-impl/src/com/intellij/codeInspection/ProblemDescriptorUtil.java
@@ -55,7 +55,7 @@ public class ProblemDescriptorUtil {
         }
       }
     }
-    ref = StringUtil.replaceChar(ref, '\n', ' ').trim();
+    ref = ref.replace('\n', ' ').trim();
     ref = StringUtil.first(ref, 100, true);
     return ref.trim().replaceAll("\\s+", " ");
   }

--- a/platform/lang-impl/src/com/intellij/ide/macro/FileDirPathFromParentMacro.java
+++ b/platform/lang-impl/src/com/intellij/ide/macro/FileDirPathFromParentMacro.java
@@ -78,7 +78,7 @@ public class FileDirPathFromParentMacro extends Macro {
       boolean found = true;
       for (int j = 0; j < patternLength; j++) {
         if (ignoreCase) {
-          if (!StringUtil.charsEqualIgnoreCase(pattern.charAt(j), buffer.charAt(i + j))) {
+          if (!StringUtil.charsMatch(pattern.charAt(j), buffer.charAt(i + j), true)) {
             found = false;
             break;
           }

--- a/platform/platform-impl/src/com/intellij/ide/actions/ShowSettingsUtilImpl.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/ShowSettingsUtilImpl.java
@@ -28,7 +28,6 @@ import com.intellij.openapi.options.newEditor.SettingsDialogFactory;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.navigation.Place;
 import com.intellij.util.ui.update.Activatable;
 import com.intellij.util.ui.update.UiNotifyConnector;
@@ -244,7 +243,7 @@ public class ShowSettingsUtilImpl extends ShowSettingsUtil {
 
   @NotNull
   public static String createDimensionKey(@NotNull Configurable configurable) {
-    return '#' + StringUtil.replaceChar(StringUtil.replaceChar(configurable.getDisplayName(), '\n', '_'), ' ', '_');
+    return '#' + configurable.getDisplayName().replace('\n', '_').replace(' ', '_');
   }
 
   @Override

--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/FilePointerPartNode.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/FilePointerPartNode.java
@@ -309,7 +309,7 @@ class FilePointerPartNode {
     while (start1 < len1 && start2 < len2) {
       char c1 = s1.charAt(start1);
       char c2 = s2.charAt(start2);
-      if (!StringUtil.charsEqual(c1, c2, ignoreCase)) {
+      if (!StringUtil.charsMatch(c1, c2, ignoreCase)) {
         return start1;
       }
       start1++;

--- a/platform/platform-impl/src/com/intellij/ui/AppUIUtil.java
+++ b/platform/platform-impl/src/com/intellij/ui/AppUIUtil.java
@@ -33,7 +33,6 @@ import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.*;
@@ -135,7 +134,7 @@ public class AppUIUtil {
 
   public static String getFrameClass() {
     String name = ApplicationNamesInfo.getInstance().getProductName().toLowerCase(Locale.US);
-    String wmClass = VENDOR_PREFIX + StringUtil.replaceChar(name, ' ', '-');
+    String wmClass = VENDOR_PREFIX + name.replace(' ', '-');
     if ("true".equals(System.getProperty("idea.debug.mode"))) {
       wmClass += "-debug";
     }

--- a/platform/util/src/com/intellij/openapi/util/text/StringUtil.java
+++ b/platform/util/src/com/intellij/openapi/util/text/StringUtil.java
@@ -144,6 +144,7 @@ public class StringUtil extends StringUtilRt {
     }
   };
 
+  // Unlike String.replace(CharSequence,CharSequence) does not allocate intermediate objects on non-match
   @NotNull
   @Contract(pure = true)
   public static String replace(@NonNls @NotNull String text, @NonNls @NotNull String oldS, @NonNls @NotNull String newS) {
@@ -165,25 +166,14 @@ public class StringUtil extends StringUtilRt {
     }
   }
 
+  /**
+   * @deprecated Use {@link String#replace(char,char)} instead
+   */
   @NotNull
   @Contract(pure = true)
+  @Deprecated
   public static String replaceChar(@NotNull String buffer, char oldChar, char newChar) {
-    StringBuilder newBuffer = null;
-    for (int i = 0; i < buffer.length(); i++) {
-      char c = buffer.charAt(i);
-      if (c == oldChar) {
-        if (newBuffer == null) {
-          newBuffer = new StringBuilder(buffer.length());
-          newBuffer.append(buffer, 0, i);
-        }
-
-        newBuffer.append(newChar);
-      }
-      else if (newBuffer != null) {
-        newBuffer.append(c);
-      }
-    }
-    return newBuffer == null ? buffer : newBuffer.toString();
+    return buffer.replace(oldChar, newChar);
   }
 
   @Contract(pure = true)
@@ -244,15 +234,15 @@ public class StringUtil extends StringUtilRt {
 
     for (int i = fromIndex; i <= max; i++) {
       /* Look for first character. */
-      if (!charsEqualIgnoreCase(where.charAt(i), first)) {
-        while (++i <= max && !charsEqualIgnoreCase(where.charAt(i), first)) ;
+      if (!charsMatch(where.charAt(i), first, true)) {
+        while (++i <= max && !charsMatch(where.charAt(i), first, true)) ;
       }
 
       /* Found first character, now look at the rest of v2 */
       if (i <= max) {
         int j = i + 1;
         int end = j + targetCount - 1;
-        for (int k = 1; j < end && charsEqualIgnoreCase(where.charAt(j), what.charAt(k)); j++, k++) ;
+        for (int k = 1; j < end && charsMatch(where.charAt(j), what.charAt(k), true); j++, k++) ;
 
         if (j == end) {
           /* Found whole string. */
@@ -268,7 +258,7 @@ public class StringUtil extends StringUtilRt {
   public static int indexOfIgnoreCase(@NotNull String where, char what, int fromIndex) {
     int sourceCount = where.length();
     for (int i = Math.max(fromIndex, 0); i < sourceCount; i++) {
-      if (charsEqualIgnoreCase(where.charAt(i), what)) {
+      if (charsMatch(where.charAt(i), what, true)) {
         return i;
       }
     }
@@ -1148,10 +1138,10 @@ public class StringUtil extends StringUtilRt {
 
   @Contract(value = "null -> false", pure = true)
   public static boolean isNotEmpty(@Nullable String s) {
-    return s != null && !s.isEmpty();
+    return !isEmpty(s);
   }
 
-  @Contract(value = "null -> true", pure=true)
+  @Contract(value = "null -> true", pure = true)
   public static boolean isEmpty(@Nullable String s) {
     return s == null || s.isEmpty();
   }
@@ -2980,12 +2970,20 @@ public class StringUtil extends StringUtilRt {
     return shortenPathWithEllipsis(path, maxLength, false);
   }
 
+  /**
+   * @deprecated Use {@link #charsMatch(char, char, boolean)}
+   */
   @Contract(pure = true)
+  @Deprecated
   public static boolean charsEqual(char a, char b, boolean ignoreCase) {
-    return ignoreCase ? charsEqualIgnoreCase(a, b) : a == b;
+    return charsMatch(a, b, ignoreCase);
   }
 
+  /**
+   * @deprecated Use {@link #charsMatch(char, char, boolean)} which works more correctly
+   */
   @Contract(pure = true)
+  @Deprecated
   public static boolean charsEqualIgnoreCase(char a, char b) {
     return StringUtilRt.charsEqualIgnoreCase(a, b);
   }

--- a/platform/util/src/com/intellij/util/text/StringSearcher.java
+++ b/platform/util/src/com/intellij/util/text/StringSearcher.java
@@ -209,7 +209,7 @@ public class StringSearcher {
   private boolean isSameChar(char charInPattern, char charInText) {
     boolean sameChar = charInPattern == charInText;
     if (!sameChar && !myCaseSensitive) {
-      return StringUtil.charsEqualIgnoreCase(charInPattern, charInText);
+      return StringUtil.charsMatch(charInPattern, charInText, true);
     }
     return sameChar;
   }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/TestMethodGradleConfigurationProducer.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/test/runner/TestMethodGradleConfigurationProducer.java
@@ -190,6 +190,6 @@ public class TestMethodGradleConfigurationProducer extends GradleTestRunConfigur
   public static String createTestFilter(@Nullable String aClass, @Nullable String method) {
     if (aClass == null) return null;
     String testFilterPattern = aClass + (method == null ? "" : '.' + method);
-    return String.format("--tests \"%s\" ", StringUtil.replaceChar(testFilterPattern, '\"', '*'));
+    return String.format("--tests \"%s\" ", testFilterPattern.replace('\"', '*'));
   }
 }

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/annotator/GroovyAnnotator.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/annotator/GroovyAnnotator.java
@@ -1397,7 +1397,7 @@ public class GroovyAnnotator extends GroovyElementVisitor {
   @Override
   public void visitGStringInjection(@NotNull GrStringInjection injection) {
     if (((GrString)injection.getParent()).isPlainString()) {
-      if (StringUtil.indexOf(injection.getText(), '\n') != -1) {
+      if (injection.getText().indexOf('\n') != -1) {
         myHolder.createErrorAnnotation(injection, GroovyBundle.message("injection.should.not.contain.line.feeds"));
       }
     }

--- a/plugins/properties/src/com/intellij/lang/properties/ResourceBundleReference.java
+++ b/plugins/properties/src/com/intellij/lang/properties/ResourceBundleReference.java
@@ -21,7 +21,6 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.icons.AllIcons;
 import com.intellij.lang.properties.psi.PropertiesFile;
 import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.*;
 import com.intellij.util.Function;
 import com.intellij.util.IncorrectOperationException;
@@ -50,7 +49,7 @@ public class ResourceBundleReference extends PsiReferenceBase<PsiElement>
 
   public ResourceBundleReference(final PsiElement element, boolean soft) {
     super(element, soft);
-    myBundleName = StringUtil.replaceChar(getValue(), '/', '.');
+    myBundleName = getValue().replace('/', '.');
   }
 
   @Override
@@ -96,7 +95,7 @@ public class ResourceBundleReference extends PsiReferenceBase<PsiElement>
   }
 
   private char getPackageDelimiter() {
-    return StringUtil.indexOf(getValue(), '/') != -1 ? '/' : '.';
+    return getValue().indexOf('/') != -1 ? '/' : '.';
   }
 
   @Override

--- a/spellchecker/src/com/intellij/spellchecker/inspections/PlainTextSplitter.java
+++ b/spellchecker/src/com/intellij/spellchecker/inspections/PlainTextSplitter.java
@@ -50,11 +50,11 @@ public class PlainTextSplitter extends BaseSplitter {
 
   @Override
   public void split(@Nullable String text, @NotNull TextRange range, Consumer<TextRange> consumer) {
-    if (text == null || StringUtil.isEmpty(text)) {
+    if (StringUtil.isEmpty(text)) {
       return;
     }
 
-    final String substring = StringUtil.replaceChar(StringUtil.replaceChar(range.substring(text), '\b', '\n'), '\f', '\n');
+    final String substring = range.substring(text).replace('\b', '\n').replace('\f', '\n');
     if (Verifier.checkCharacterData(SPLIT_PATTERN.matcher(substring).replaceAll("")) != null) {
       return;
     }


### PR DESCRIPTION
Following the discussion here
https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000240144
I removed usages and deprecated some obsolete / duplicating methods in `com.intellij.openapi.util.text.StringUtil`.

Namely:
`replaceChar(String,char,char)` was replaced with `String.replace(char,char)`
`charsEqual(char,char,boolean)` was replaced with `charsMatch(char,char,boolean)`
`charsEqualIgnoreCase(char,char)` was replaced with `charsMatch(char,char,boolean)`

Also usages of `indexOf(CharSequence,char)` applied to `String` were replaced with `txt.indexOf(char)`.