### PR TITLE
IDEA-172832. Support long module names in Find in Path.

### DIFF
--- a/platform/lang-impl/src/com/intellij/find/impl/FindDialog.java
+++ b/platform/lang-impl/src/com/intellij/find/impl/FindDialog.java
@@ -1128,7 +1128,8 @@ public class FindDialog extends DialogWrapper implements FindUI {
     }
 
     Arrays.sort(names,String.CASE_INSENSITIVE_ORDER);
-    myModuleComboBox = new ComboBox(names);
+    int preferredWidth = Collections.max(Arrays.asList(names), Comparator.comparing(String::length)).length();
+    myModuleComboBox = new ComboBox(names, preferredWidth);
     myModuleComboBox.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
Sets the preferredWidth to the length of the longest module name in the selected project.