### PR TITLE
Fix new line indent when alignment is enabled (IDEA-173208)

### DIFF
--- a/java/java-tests/testSrc/com/intellij/psi/formatter/java/JavaEnterActionTest.java
+++ b/java/java-tests/testSrc/com/intellij/psi/formatter/java/JavaEnterActionTest.java
@@ -195,7 +195,43 @@ public class JavaEnterActionTest extends AbstractEnterActionTestCase {
                "    }\n" +
                "}");
   }
-  
-  
-  
+
+  public void testEnter_NewArgumentWithTabs() throws IOException {
+    CodeStyleSettings settings = getCodeStyleSettings();
+    CommonCodeStyleSettings javaCommon = settings.getCommonSettings(JavaLanguage.INSTANCE);
+    javaCommon.getIndentOptions().USE_TAB_CHARACTER = true;
+    javaCommon.getIndentOptions().SMART_TABS = true;
+    setCodeStyleSettings(settings);
+
+    doTextTest("java",
+               "class T {\n" +
+               "\tvoid test(\n" +
+               "\t\t\tint a,<caret>\n" +
+               ") {}",
+               "class T {\n" +
+               "\tvoid test(\n" +
+               "\t\t\tint a,\n" +
+               "\t\t\t<caret>\n" +
+               ") {}");
+  }
+
+  public void testEnter_NewArgumentWithTabsNoAlign() throws IOException {
+    CodeStyleSettings settings = getCodeStyleSettings();
+    CommonCodeStyleSettings javaCommon = settings.getCommonSettings(JavaLanguage.INSTANCE);
+    javaCommon.getIndentOptions().USE_TAB_CHARACTER = true;
+    javaCommon.getIndentOptions().SMART_TABS = true;
+    javaCommon.ALIGN_MULTILINE_PARAMETERS = false;
+    setCodeStyleSettings(settings);
+
+    doTextTest("java",
+               "class T {\n" +
+               "\tvoid test(\n" +
+               "\t\t\tint a,<caret>\n" +
+               ") {}",
+               "class T {\n" +
+               "\tvoid test(\n" +
+               "\t\t\tint a,\n" +
+               "\t\t\t<caret>\n" +
+               ") {}");
+  }
 }

--- a/platform/lang-impl/src/com/intellij/formatting/engine/IndentAdjuster.java
+++ b/platform/lang-impl/src/com/intellij/formatting/engine/IndentAdjuster.java
@@ -17,6 +17,7 @@ package com.intellij.formatting.engine;
 
 import com.intellij.formatting.*;
 import com.intellij.formatting.FormatProcessor;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import org.jetbrains.annotations.Nullable;
 
@@ -104,40 +105,64 @@ public class IndentAdjuster {
     }
   }
 
-  public IndentInfo adjustLineIndent(LeafBlockWrapper currentBlock, FormatProcessor.ChildAttributesInfo info) {
+  @Deprecated
+  public IndentInfo adjustLineIndent(@SuppressWarnings("unused") LeafBlockWrapper currentBlock, FormatProcessor.ChildAttributesInfo info) {
+    return adjustLineIndent(info);
+  }
+
+  public IndentInfo adjustLineIndent(FormatProcessor.ChildAttributesInfo info) {
     AbstractBlockWrapper parent = info.parent;
     ChildAttributes childAttributes = info.attributes;
     int index = info.index;
 
-    int alignOffset = getAlignOffsetBefore(childAttributes.getAlignment(), null);
-    if (alignOffset == -1) {
+    AlignWhiteSpace alignWhiteSpace = getAlignOffsetBefore(childAttributes.getAlignment());
+    if (alignWhiteSpace == null) {
       return parent.calculateChildOffset(myBlockIndentOptions.getIndentOptions(parent), childAttributes, index).createIndentInfo();
     }
     else {
-      AbstractBlockWrapper indentedParentBlock = CoreFormatterUtil.getIndentedParentBlock(currentBlock);
-      if (indentedParentBlock == null) {
-        return new IndentInfo(0, 0, alignOffset);
-      }
-      else {
-        int indentOffset = indentedParentBlock.getWhiteSpace().getIndentOffset();
-        if (indentOffset > alignOffset) {
-          return new IndentInfo(0, 0, alignOffset);
-        }
-        else {
-          return new IndentInfo(0, indentOffset, alignOffset - indentOffset);
-        }
-      }
+      return new IndentInfo(0, alignWhiteSpace.indentSpaces, alignWhiteSpace.alignSpaces);
     }
   }
 
-  private static int getAlignOffsetBefore(@Nullable final Alignment alignment, @Nullable final LeafBlockWrapper blockAfter) {
-    if (alignment == null) return -1;
-    final LeafBlockWrapper alignRespBlock = ((AlignmentImpl)alignment).getOffsetRespBlockBefore(blockAfter);
+  private static class AlignWhiteSpace {
+    int indentSpaces = 0;
+    int alignSpaces = 0;
+  }
+
+  private static AlignWhiteSpace getAlignOffsetBefore(@Nullable final Alignment alignment) {
+    if (alignment == null) return null;
+    final LeafBlockWrapper alignRespBlock = ((AlignmentImpl)alignment).getOffsetRespBlockBefore(null);
     if (alignRespBlock != null) {
-      return CoreFormatterUtil.getStartColumn(alignRespBlock);
+      return getStartColumn(alignRespBlock);
     }
     else {
-      return -1;
+      return null;
+    }
+  }
+
+  private static AlignWhiteSpace getStartColumn(@Nullable LeafBlockWrapper block) {
+    if (block != null) {
+      AlignWhiteSpace alignWhitespace = new AlignWhiteSpace();
+      while (true) {
+        final WhiteSpace whiteSpace = block.getWhiteSpace();
+        alignWhitespace.alignSpaces += whiteSpace.getSpaces();
+
+        if (whiteSpace.containsLineFeeds()) {
+          alignWhitespace.indentSpaces += whiteSpace.getIndentSpaces();
+          return alignWhitespace;
+        }
+        else {
+          alignWhitespace.alignSpaces += whiteSpace.getIndentSpaces();
+        }
+
+        block = block.getPreviousBlock();
+        if (alignWhitespace.alignSpaces > CodeStyleSettings.MAX_RIGHT_MARGIN || block == null) return alignWhitespace;
+        alignWhitespace.alignSpaces += block.getSymbolsAtTheLastLine();
+        if (block.containsLineFeeds()) return alignWhitespace;
+      }
+    }
+    else {
+      return null;
     }
   }
 }


### PR DESCRIPTION
Reuse indentation from previous block when alignment is present (IDEA-173208)

Previous version didn't consider child attributes for indentation during
reconstruction from parent.

 #IDEA-173208 Fixed