### PR TITLE
Simplify logging output options to three, matching the options availa…

### DIFF
--- a/plugins/maven/maven30-server-impl/src/org/jetbrains/idea/maven/server/Maven30ServerEmbedderImpl.java
+++ b/plugins/maven/maven30-server-impl/src/org/jetbrains/idea/maven/server/Maven30ServerEmbedderImpl.java
@@ -169,14 +169,6 @@ public class Maven30ServerEmbedderImpl extends Maven3ServerEmbedder {
         commandLineOptions.add("-D" + each.getKey() + "=" + each.getValue());
       }
 
-      if (settings.getLoggingLevel() == MavenServerConsole.LEVEL_DEBUG) {
-        commandLineOptions.add("-X");
-        commandLineOptions.add("-e");
-      }
-      else if (settings.getLoggingLevel() == MavenServerConsole.LEVEL_DISABLED) {
-        commandLineOptions.add("-q");
-      }
-
       String mavenEmbedderCliOptions = System.getProperty(MavenServerEmbedder.MAVEN_EMBEDDER_CLI_ADDITIONAL_ARGS);
       if (mavenEmbedderCliOptions != null) {
         commandLineOptions.addAll(StringUtil.splitHonorQuotes(mavenEmbedderCliOptions, ' '));

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenExecutionOptions.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenExecutionOptions.java
@@ -22,10 +22,7 @@ public class MavenExecutionOptions {
   public enum LoggingLevel {
     DEBUG("Debug", MavenServerConsole.LEVEL_DEBUG),
     INFO("Info", MavenServerConsole.LEVEL_INFO),
-    WARN("Warn", MavenServerConsole.LEVEL_WARN),
-    ERROR("Error", MavenServerConsole.LEVEL_ERROR),
-    FATAL("Fatal", MavenServerConsole.LEVEL_FATAL),
-    DISABLED("Disabled", MavenServerConsole.LEVEL_DISABLED);
+    WARN("Warn", MavenServerConsole.LEVEL_WARN);
 
     private final String myDisplayString;
     private final int myLevel;

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenExternalParameters.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenExternalParameters.java
@@ -527,6 +527,11 @@ public class MavenExternalParameters {
     if (coreSettings.getOutputLevel() == MavenExecutionOptions.LoggingLevel.DEBUG) {
       cmdList.add("--debug");
     }
+    if (coreSettings.getOutputLevel() == MavenExecutionOptions.LoggingLevel.WARN) {
+      cmdList.add("--quiet");
+    }
+
+
     if (coreSettings.isNonRecursive()) {
       cmdList.add("--non-recursive");
     }

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/NullMavenConsole.java
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/NullMavenConsole.java
@@ -21,7 +21,7 @@ import org.jetbrains.idea.maven.project.MavenConsole;
 
 public class NullMavenConsole extends MavenConsole {
   public NullMavenConsole() {
-    super(MavenExecutionOptions.LoggingLevel.DISABLED, false);
+    super(MavenExecutionOptions.LoggingLevel.WARN, false);
   }
 
   @Override

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/execution/MavenRunConfigurationTest.java
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/execution/MavenRunConfigurationTest.java
@@ -51,7 +51,7 @@ public class MavenRunConfigurationTest extends IdeaTestCase {
     s.myGeneralSettings = new MavenGeneralSettings();
     s.myGeneralSettings.setChecksumPolicy(MavenExecutionOptions.ChecksumPolicy.WARN);
     s.myGeneralSettings.setFailureBehavior(MavenExecutionOptions.FailureMode.AT_END);
-    s.myGeneralSettings.setOutputLevel(MavenExecutionOptions.LoggingLevel.FATAL);
+    s.myGeneralSettings.setOutputLevel(MavenExecutionOptions.LoggingLevel.WARN);
     s.myGeneralSettings.setThreads("1.5C");
 
     s.myRunnerSettings = new MavenRunnerSettings();


### PR DESCRIPTION
Signed-off-by: Arvind Ranganathan <arvindanekal@gmail.com>

This fix constrains the output options to just three (debug, info and warn) matching the options available in apache maven (--debug, --quiet and for no option, everything). This avoids ambiguity and makes the UI simpler. Existing tests work fine and no new tests were needed.

This credits for the idea of the fix goes to Timothy Basanov (https://github.com/timothybasanov)