### PR TITLE
Add Nullable for YAMLKeyValue::getParentMapping to sync it with YAMLKeyValueImpl

### DIFF
--- a/plugins/yaml/src/org/jetbrains/yaml/psi/YAMLKeyValue.java
+++ b/plugins/yaml/src/org/jetbrains/yaml/psi/YAMLKeyValue.java
@@ -27,6 +27,7 @@ public interface YAMLKeyValue extends YAMLPsiElement, PsiNamedElement, PomTarget
   @NotNull
   String getValueText();
   
+  @Nullable
   YAMLMapping getParentMapping();
 
   void setValue(@NotNull YAMLValue value);


### PR DESCRIPTION
npe issue because of not seeing nullable return value: https://github.com/Haehnchen/idea-php-symfony2-plugin/issues/942