### PR TITLE
Remove current name from the suggestion list when renaming

### DIFF
--- a/platform/lang-impl/src/com/intellij/refactoring/rename/RenameDialog.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/rename/RenameDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2016 JetBrains s.r.o.
+ * Copyright 2000-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.codeStyle.SuggestedNameInfo;
 import com.intellij.psi.util.PsiUtilCore;
 import com.intellij.refactoring.RefactoringBundle;
@@ -187,6 +188,10 @@ public class RenameDialog extends RefactoringDialog {
         mySuggestedNameInfo = info;
         if (provider instanceof PreferrableNameSuggestionProvider && !((PreferrableNameSuggestionProvider)provider).shouldCheckOthers()) break;
       }
+    }
+    // avoid suggesting the same name when renaming
+    if (myPsiElement instanceof PsiNamedElement) {
+      result.remove(((PsiNamedElement)myPsiElement).getName());
     }
     return ArrayUtil.toStringArray(result);
   }

--- a/platform/lang-impl/src/com/intellij/refactoring/rename/inplace/MyLookupExpression.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/rename/inplace/MyLookupExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2012 JetBrains s.r.o.
+ * Copyright 2000-2017 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,8 @@ public class MyLookupExpression extends Expression {
           break;
         }
       }
+      // avoid suggesting the same name when renaming
+      names.remove(elementToRename.getName());
     }
     final LookupElement[] lookupElements = new LookupElement[names.size()];
     final Iterator<String> iterator = names.iterator();


### PR DESCRIPTION
This patch removes the element current name from the suggestions list when renaming.
(as mentioned in IDEA-171082)