### PR TITLE
Avoid logging passwords in GradleExecutionHelper

### DIFF
--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelperTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.plugins.gradle.service.execution;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class GradleExecutionHelperTest {
+
+  @Test
+  public void testPasswordObfuscation() throws Exception {
+    List<String> originalArgs = ImmutableList.of(
+      "--configure-on-demand",
+      "-Pandroid.injected.invoked.from.ide=true",
+      "-Pandroid.injected.signing.store.password=asdfghjkl;",
+      "-Pandroid.injected.signing.key.alias=testKey",
+      "-Pandroid.injected.signing.key.password=blabla",
+      "/tmp/asLocalRepo1004.gradle"
+    );
+
+    List<String> obfuscatedArgs = GradleExecutionHelper.obfuscatePasswordParameters(originalArgs);
+
+    List<String> expectedArgs = ImmutableList.of(
+      "--configure-on-demand",
+      "-Pandroid.injected.invoked.from.ide=true",
+      "-Pandroid.injected.signing.store.password=*********",
+      "-Pandroid.injected.signing.key.alias=testKey",
+      "-Pandroid.injected.signing.key.password=*********",
+      "/tmp/asLocalRepo1004.gradle"
+    );
+
+    assertEquals(obfuscatedArgs, expectedArgs);
+  }
+}


### PR DESCRIPTION
The GradleExecutionHelper was previously logging android keystore passwords.  This change will obfuscate the values of a parameter ending in '.password' within the `idea.log` file.