### PR TITLE
meta element tag closing fix in HTML file template

### DIFF
--- a/platform/platform-resources-en/src/fileTemplates/internal/HTML File.html.ft
+++ b/platform/platform-resources-en/src/fileTemplates/internal/HTML File.html.ft
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>#[[$Title$]]#</title>
 </head>
 <body>


### PR DESCRIPTION
`meta` tag closing is wrong in default HTML template file. Thymeleaf gives an error while processing.