### PR TITLE
UI: allow customizing the TabsUtil constants through PropertiesComponent

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/tabs/TabsUtil.java
+++ b/platform/platform-api/src/com/intellij/ui/tabs/TabsUtil.java
@@ -15,16 +15,18 @@
  */
 package com.intellij.ui.tabs;
 
+import com.intellij.ide.util.PropertiesComponent;
+
 import javax.swing.*;
 
 /**
  * @author pegov
  */
 public class TabsUtil {
-  public static final int TAB_VERTICAL_PADDING = 2;
-  public static final int TABS_BORDER = 1;
+  public static final int TAB_VERTICAL_PADDING = PropertiesComponent.getInstance().getInt("TAB_VERTICAL_PADDING", 2);
+  public static final int TABS_BORDER = PropertiesComponent.getInstance().getInt("TABS_BORDER", 1);
   
-  public static final int ACTIVE_TAB_UNDERLINE_HEIGHT = 4;
+  public static final int ACTIVE_TAB_UNDERLINE_HEIGHT = PropertiesComponent.getInstance().getInt("ACTIVE_TAB_UNDERLINE_HEIGHT", 4);
 
   private TabsUtil() {
   }


### PR DESCRIPTION
It would be useful for plugin makers to be able to customize the tab vertical padding, border and underline height using the PropertiesComponent instead of hard-coded fixed values.