### PR TITLE
Fix hierarchy export to file indentation

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/hierarchy/ExporterToTextFileHierarchy.java
+++ b/platform/lang-impl/src/com/intellij/ide/hierarchy/ExporterToTextFileHierarchy.java
@@ -58,13 +58,12 @@ class ExporterToTextFileHierarchy implements ExporterToTextFile {
   }
 
   private void appendNode(StringBuilder buf, DefaultMutableTreeNode node, String lineSeparator, String indent) {
-    buf.append(indent);
     final String childIndent;
     if (node.getParent() != null) {
       childIndent = indent + "    ";
       final HierarchyNodeDescriptor descriptor = myHierarchyBrowserBase.getDescriptor(node);
       if (descriptor != null) {
-        buf.append(descriptor.getHighlightedText().getText()).append(lineSeparator);
+        buf.append(indent).append(descriptor.getHighlightedText().getText()).append(lineSeparator);
       }
     }
     else {


### PR DESCRIPTION
If a hierarchy node had a null descriptor, indentation
was still appended to the string builder, leading to
malformed indentation later on.

Originally a fix for a bug reported to Android Studio, now
submitting upstream. (For questions, email gharrma@google.com)