### PR TITLE
collecting variables debugger hang fix

### DIFF
--- a/python/helpers/pydev/_pydevd_bundle/pydevd_xml.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_xml.py
@@ -210,7 +210,7 @@ def var_to_xml(val, name, doTrim=True, additionalInXml='', return_value=False, i
             if v.__class__ == frame_type:
                 value = pydevd_resolver.frameResolver.get_frame_name(v)
 
-            elif v.__class__ in (list, tuple):
+            elif v.__class__ in (list, tuple, set, frozenset, dict):
                 if len(v) > 300:
                     value = '%s: %s' % (str(v.__class__), '<Too big to print. Len: %s>' % (len(v),))
                 else:


### PR DESCRIPTION
For large dictionaries the debugger can freeze completely, this checks for dictionaries, sets, and frozensets to avoid that.