### PR TITLE
IDEA-175089 Move updateHistoryEntry call

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorWindow.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorWindow.java
@@ -1194,7 +1194,11 @@ public class EditorWindow {
   }
 
   public void clear() {
+    Project project = getManager().getProject();
     for (EditorWithProviderComposite composite : getEditors()) {
+      if (!project.isDefault()) { // There's no EditorHistoryManager for default project (which is used in diff command-line application)
+        EditorHistoryManager.getInstance(project).updateHistoryEntry(composite.getFile(), false);
+      }
       Disposer.dispose(composite);
     }
     if (myTabbedPane == null) {

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/text/TextEditorComponent.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/text/TextEditorComponent.java
@@ -32,7 +32,6 @@ import com.intellij.openapi.editor.impl.EditorImpl;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.fileEditor.impl.EditorHistoryManager;
 import com.intellij.openapi.fileTypes.FileTypeEvent;
 import com.intellij.openapi.fileTypes.FileTypeListener;
 import com.intellij.openapi.fileTypes.FileTypeManager;
@@ -125,9 +124,6 @@ class TextEditorComponent extends JBLoadingPanel implements DataProvider, Dispos
    */
   @Override
   public void dispose(){
-    if (!myProject.isDefault()) { // There's no EditorHistoryManager for default project (which is used in diff command-line application)
-      EditorHistoryManager.getInstance(myProject).updateHistoryEntry(myFile, false);
-    }
     disposeEditor();
 
     myDisposed = true;


### PR DESCRIPTION
… from TextEditorComponent.dispose to EditorWindow.clear.

Calling this method updates the last used editor to the current editor.
In TextEditorComponent.dispose, the editor may already be removed from
an EditorWithProviderComposite, causing updateHistoryEntry to record the
wrong editor as most recent for the file.