### PR TITLE
IDEA-154288 - Gradle import: Support jdkName property in IdeaModule

### DIFF
--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ModuleData.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ModuleData.java
@@ -32,6 +32,7 @@ public class ModuleData extends AbstractNamedData implements Named, ExternalConf
   @Nullable private String[] myIdeModuleGroup;
   @Nullable  private String mySourceCompatibility;
   @Nullable private String myTargetCompatibility;
+  @Nullable private String mySdkName;
   @Nullable private String myProductionModuleId;
 
   private boolean myInheritProjectCompileOutputPath = true;
@@ -202,6 +203,15 @@ public class ModuleData extends AbstractNamedData implements Named, ExternalConf
     myTargetCompatibility = targetCompatibility;
   }
 
+  @Nullable
+  public String getSdkName() {
+    return mySdkName;
+  }
+
+  public void setSdkName(@Nullable String sdkName) {
+    mySdkName = sdkName;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof ModuleData)) return false;
@@ -214,6 +224,7 @@ public class ModuleData extends AbstractNamedData implements Named, ExternalConf
     if (!myModuleTypeId.equals(that.myModuleTypeId)) return false;
     if (myVersion != null ? !myVersion.equals(that.myVersion) : that.myVersion != null) return false;
     if (myDescription != null ? !myDescription.equals(that.myDescription) : that.myDescription != null) return false;
+    if (mySdkName != null ? !mySdkName.equals(that.mySdkName) : that.mySdkName != null) return false;
 
     return true;
   }
@@ -226,6 +237,7 @@ public class ModuleData extends AbstractNamedData implements Named, ExternalConf
     result = 31 * result + (myGroup != null ? myGroup.hashCode() : 0);
     result = 31 * result + (myVersion != null ? myVersion.hashCode() : 0);
     result = 31 * result + (myDescription != null ? myDescription.hashCode() : 0);
+    result = 31 * result + (mySdkName != null ? mySdkName.hashCode() : 0);
     return result;
   }
 

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractModuleDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractModuleDataService.java
@@ -36,6 +36,9 @@ import com.intellij.openapi.module.ModifiableModuleModel;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.UnloadedModuleDescription;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.JavaSdk;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.*;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.util.Computable;
@@ -95,6 +98,7 @@ public abstract class AbstractModuleDataService<E extends ModuleData> extends Ab
         ModifiableRootModel modifiableRootModel = modelsProvider.getModifiableRootModel(module);
         syncPaths(module, modifiableRootModel, node.getData());
         setLanguageLevel(modifiableRootModel, node.getData());
+        setSdk(modifiableRootModel, node.getData());
       }
     }
 
@@ -395,6 +399,19 @@ public abstract class AbstractModuleDataService<E extends ModuleData> extends Ab
       }
       catch (IllegalArgumentException e) {
         LOG.debug(e);
+      }
+    }
+  }
+
+  private void setSdk(@NotNull ModifiableRootModel modifiableRootModel, E data) {
+    String skdName = data.getSdkName();
+    if (skdName != null) {
+      ProjectJdkTable projectJdkTable = ProjectJdkTable.getInstance();
+      Sdk sdk = projectJdkTable.findJdk(skdName);
+      if (sdk != null) {
+        modifiableRootModel.setSdk(sdk);
+      } else {
+        modifiableRootModel.setInvalidSdk(skdName, JavaSdk.getInstance().getName());
       }
     }
   }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
@@ -170,6 +170,7 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
     final ModuleData mainModuleData = mainModuleNode.getData();
     final String mainModuleConfigPath = mainModuleData.getLinkedExternalProjectPath();
     final String mainModuleFileDirectoryPath = mainModuleData.getModuleFileDirectoryPath();
+    final String jdkName = gradleModule.getJdkName();
 
     ExternalProject externalProject = resolverCtx.getExtraProject(gradleModule, ExternalProject.class);
     if (resolverCtx.isResolveModulePerSourceSet() && externalProject != null) {
@@ -195,6 +196,7 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
 
         sourceSetData.setSourceCompatibility(sourceSet.getSourceCompatibility());
         sourceSetData.setTargetCompatibility(sourceSet.getTargetCompatibility());
+        sourceSetData.setSdkName(jdkName);
 
         final Set<File> artifacts = ContainerUtil.newTroveSet(FileUtil.FILE_HASHING_STRATEGY);
         if ("main".equals(sourceSet.getName())) {
@@ -240,6 +242,7 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
             mainModuleData.setTargetCompatibility(languageSettings.getTargetBytecodeVersion().toString());
           }
         }
+        mainModuleData.setSdkName(jdkName);
       }
       catch (UnsupportedMethodException ignore) {
         // org.gradle.tooling.model.idea.IdeaModule.getJavaLanguageSettings method supported since Gradle 2.11

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
@@ -170,7 +170,7 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
     final ModuleData mainModuleData = mainModuleNode.getData();
     final String mainModuleConfigPath = mainModuleData.getLinkedExternalProjectPath();
     final String mainModuleFileDirectoryPath = mainModuleData.getModuleFileDirectoryPath();
-    final String jdkName = gradleModule.getJdkName();
+    final String jdkName = getJdkName(gradleModule);
 
     ExternalProject externalProject = resolverCtx.getExtraProject(gradleModule, ExternalProject.class);
     if (resolverCtx.isResolveModulePerSourceSet() && externalProject != null) {
@@ -256,6 +256,16 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
     }
 
     return mainModuleNode;
+  }
+
+  @Nullable
+  private static String getJdkName(@NotNull IdeaModule gradleModule) {
+    try {
+      return gradleModule.getJdkName();
+    }
+    catch (UnsupportedMethodException e) {
+      return null;
+    }
   }
 
   @Override

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleMiscImportingTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleMiscImportingTest.java
@@ -16,12 +16,16 @@
 package org.jetbrains.plugins.gradle.importing;
 
 import com.intellij.compiler.CompilerConfiguration;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.LanguageLevelModuleExtensionImpl;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.TestModuleProperties;
 import com.intellij.pom.java.LanguageLevel;
+import org.jetbrains.plugins.gradle.tooling.annotation.TargetVersions;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -121,6 +125,31 @@ public class GradleMiscImportingTest extends GradleImportingTestCase {
   }
 
   @Test
+  @TargetVersions("3.4+")
+  public void testJdkName() throws Exception {
+    Sdk myJdk = createJdk("MyJDK");
+    edt(() -> ApplicationManager.getApplication().runWriteAction(() -> ProjectJdkTable.getInstance().addJdk(myJdk)));
+    try {
+      importProject(
+        "apply plugin: 'java'\n" +
+        "apply plugin: 'idea'\n" +
+        "idea {\n" +
+        "  module {\n" +
+        "    jdkName = 'MyJDK'\n" +
+        "  }\n" +
+        "}\n"
+      );
+
+      assertModules("project", "project_main", "project_test");
+      assertTrue(getSdkForModule("project_main") == myJdk);
+      assertTrue(getSdkForModule("project_test") == myJdk);
+
+    } finally {
+      edt(() -> ApplicationManager.getApplication().runWriteAction(() -> ProjectJdkTable.getInstance().removeJdk(myJdk)));
+    }
+  }
+
+  @Test
   public void testUnloadedModuleImport() throws Exception {
     importProject(
       "apply plugin: 'java'"
@@ -140,5 +169,9 @@ public class GradleMiscImportingTest extends GradleImportingTestCase {
 
   private String getBytecodeTargetLevel(String moduleName) {
     return CompilerConfiguration.getInstance(myProject).getBytecodeTargetLevel(getModule(moduleName));
+  }
+
+  private Sdk getSdkForModule(final String moduleName) {
+    return ModuleRootManager.getInstance(getModule(moduleName)).getSdk();
   }
 }


### PR DESCRIPTION
In

https://github.com/gradle/gradle/commit/8e02bc268f6478773ca6daf49bea9aed14c5d1eb

support for this property was added to the Gradle tooling API, now
it can be used for the Gradle import in IDEA in order to correctly
select the JDK that was configured by the user in the gradle project.

This is important for projects that have modules with different
language levels.