### PR TITLE
Provide API for extending Create Field/Method from Usage

### DIFF
--- a/java/java-analysis-api/src/com/intellij/codeInsight/intention/JvmCommonIntentionActionsFactory.kt
+++ b/java/java-analysis-api/src/com/intellij/codeInsight/intention/JvmCommonIntentionActionsFactory.kt
@@ -46,6 +46,8 @@ abstract class JvmCommonIntentionActionsFactory {
 
   open fun createAddCallableMemberActions(info: MethodInsertionInfo): List<IntentionAction> = emptyList()
 
+  open fun createGenerateFieldFromUsageActions(info: CreateFromUsage.FieldInfo): List<IntentionAction> = emptyList()
+
   open fun createAddBeanPropertyActions(psiClass: @JvmCommon PsiClass,
                                         propertyName: String,
                                         @PsiModifier.ModifierConstant visibilityModifier: String,
@@ -77,6 +79,20 @@ abstract class JvmCommonIntentionActionsFactory {
                                         getterRequired: Boolean): List<IntentionAction> = emptyList()
 
 
+}
+
+@ApiStatus.Experimental
+object CreateFromUsage {
+  // type constraint is a language-specific object (e.g. ExpectedTypeInfo for Java)
+  class TypeInfo(val typeConstraints: List<Any>)
+
+  class FieldInfo(
+      val targetClass: @JvmCommon PsiClass,
+      val name: String,
+      @PsiModifier.ModifierConstant
+      val modifiers: List<String> = emptyList(),
+      val returnType: TypeInfo
+  )
 }
 
 @ApiStatus.Experimental

--- a/java/java-analysis-api/src/com/intellij/codeInsight/intention/JvmCommonIntentionActionsFactory.kt
+++ b/java/java-analysis-api/src/com/intellij/codeInsight/intention/JvmCommonIntentionActionsFactory.kt
@@ -48,6 +48,7 @@ abstract class JvmCommonIntentionActionsFactory {
 
   open fun createGenerateFieldFromUsageActions(info: CreateFromUsage.FieldInfo): List<IntentionAction> = emptyList()
   open fun createGenerateMethodFromUsageActions(info: CreateFromUsage.MethodInfo): List<IntentionAction> = emptyList()
+  open fun createGenerateConstructorFromUsageActions(info: CreateFromUsage.ConstructorInfo): List<IntentionAction> = emptyList()
 
   open fun createAddBeanPropertyActions(psiClass: @JvmCommon PsiClass,
                                         propertyName: String,
@@ -91,27 +92,32 @@ object CreateFromUsage {
 
   abstract class MemberInfo(
       val targetClass: @JvmCommon PsiClass,
-      val name: String,
-      @PsiModifier.ModifierConstant
-      val modifiers: List<String> = emptyList()
+      @PsiModifier.ModifierConstant val modifiers: List<String> = emptyList()
   )
 
   class FieldInfo(
       targetClass: @JvmCommon PsiClass,
-      name: String,
+      val name: String,
       @PsiModifier.ModifierConstant
       modifiers: List<String> = emptyList(),
       val returnType: TypeInfo
-  ) : MemberInfo(targetClass, name, modifiers)
+  ) : MemberInfo(targetClass, modifiers)
 
   class MethodInfo(
       targetClass: @JvmCommon PsiClass,
-      name: String,
+      val name: String,
       @PsiModifier.ModifierConstant
       modifiers: List<String> = emptyList(),
       val returnType: TypeInfo,
       val parameters: List<ParameterInfo>
-  ) : MemberInfo(targetClass, name, modifiers)
+  ) : MemberInfo(targetClass, modifiers)
+
+  class ConstructorInfo(
+      targetClass: @JvmCommon PsiClass,
+      @PsiModifier.ModifierConstant
+      modifiers: List<String> = emptyList(),
+      val parameters: List<ParameterInfo>
+  ) : MemberInfo(targetClass, modifiers)
 }
 
 @ApiStatus.Experimental

--- a/java/java-analysis-api/src/com/intellij/codeInsight/intention/JvmCommonIntentionActionsFactory.kt
+++ b/java/java-analysis-api/src/com/intellij/codeInsight/intention/JvmCommonIntentionActionsFactory.kt
@@ -47,6 +47,7 @@ abstract class JvmCommonIntentionActionsFactory {
   open fun createAddCallableMemberActions(info: MethodInsertionInfo): List<IntentionAction> = emptyList()
 
   open fun createGenerateFieldFromUsageActions(info: CreateFromUsage.FieldInfo): List<IntentionAction> = emptyList()
+  open fun createGenerateMethodFromUsageActions(info: CreateFromUsage.MethodInfo): List<IntentionAction> = emptyList()
 
   open fun createAddBeanPropertyActions(psiClass: @JvmCommon PsiClass,
                                         propertyName: String,
@@ -86,13 +87,31 @@ object CreateFromUsage {
   // type constraint is a language-specific object (e.g. ExpectedTypeInfo for Java)
   class TypeInfo(val typeConstraints: List<Any>)
 
-  class FieldInfo(
+  class ParameterInfo(val typeInfo: TypeInfo, val suggestedNames: List<String>)
+
+  abstract class MemberInfo(
       val targetClass: @JvmCommon PsiClass,
       val name: String,
       @PsiModifier.ModifierConstant
-      val modifiers: List<String> = emptyList(),
-      val returnType: TypeInfo
+      val modifiers: List<String> = emptyList()
   )
+
+  class FieldInfo(
+      targetClass: @JvmCommon PsiClass,
+      name: String,
+      @PsiModifier.ModifierConstant
+      modifiers: List<String> = emptyList(),
+      val returnType: TypeInfo
+  ) : MemberInfo(targetClass, name, modifiers)
+
+  class MethodInfo(
+      targetClass: @JvmCommon PsiClass,
+      name: String,
+      @PsiModifier.ModifierConstant
+      modifiers: List<String> = emptyList(),
+      val returnType: TypeInfo,
+      val parameters: List<ParameterInfo>
+  ) : MemberInfo(targetClass, name, modifiers)
 }
 
 @ApiStatus.Experimental

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateConstructorFromThisOrSuperFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateConstructorFromThisOrSuperFix.java
@@ -18,6 +18,9 @@ package com.intellij.codeInsight.daemon.impl.quickfix;
 import com.intellij.codeInsight.CodeInsightUtil;
 import com.intellij.codeInsight.CodeInsightUtilCore;
 import com.intellij.codeInsight.daemon.QuickFixBundle;
+import com.intellij.codeInsight.intention.CreateFromUsage;
+import com.intellij.codeInsight.intention.JvmCommonIntentionActionsFactory;
+import com.intellij.codeInsight.intention.impl.JavaCommonIntentionActionsFactory;
 import com.intellij.codeInsight.template.Template;
 import com.intellij.codeInsight.template.TemplateBuilderImpl;
 import com.intellij.codeInsight.template.TemplateEditingAdapter;
@@ -28,12 +31,15 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.RangeMarker;
 import com.intellij.openapi.fileEditor.ex.IdeDocumentHistory;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NonNls;
 
+import java.util.Collections;
 import java.util.List;
 
 public abstract class CreateConstructorFromThisOrSuperFix extends CreateFromUsageBaseFix {
@@ -76,6 +82,19 @@ public abstract class CreateConstructorFromThisOrSuperFix extends CreateFromUsag
     IdeDocumentHistory.getInstance(project).includeCurrentPlaceAsChangePlace();
 
     try {
+      JvmCommonIntentionActionsFactory actionsFactory = JvmCommonIntentionActionsFactory.forLanguage(targetClass.getLanguage());
+      if (actionsFactory != null && !(actionsFactory instanceof JavaCommonIntentionActionsFactory)) {
+        PsiExpression[] arguments = myMethodCall.getArgumentList().getExpressions();
+        CreateFromUsage.ConstructorInfo constructorInfo = new CreateFromUsage.ConstructorInfo(
+          targetClass,
+          Collections.emptyList(),
+          CreateFromUsageUtils.getParameterInfos(targetClass, ContainerUtil.map2List(arguments, Pair.createFunction(null)))
+        );
+        CreateFromUsageUtils.invokeActionInTargetEditor(targetClass,
+                                                        () -> actionsFactory.createGenerateConstructorFromUsageActions(constructorInfo));
+        return;
+      }
+
       PsiMethod constructor = elementFactory.createConstructor();
       constructor = (PsiMethod)targetClass.add(constructor);
 

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateFieldFromUsageFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateFieldFromUsageFix.java
@@ -18,12 +18,10 @@ package com.intellij.codeInsight.daemon.impl.quickfix;
 import com.intellij.codeInsight.ExpectedTypeInfo;
 import com.intellij.codeInsight.daemon.QuickFixBundle;
 import com.intellij.codeInsight.intention.CreateFromUsage;
-import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.codeInsight.intention.JvmCommonIntentionActionsFactory;
 import com.intellij.codeInsight.intention.impl.JavaCommonIntentionActionsFactory;
 import com.intellij.codeInsight.template.Template;
 import com.intellij.codeInsight.template.TemplateEditingAdapter;
-import com.intellij.ide.util.EditorHelper;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -32,7 +30,6 @@ import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import kotlin.collections.ArraysKt;
-import kotlin.collections.CollectionsKt;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -118,13 +115,7 @@ public class CreateFieldFromUsageFix extends CreateVarFromUsageFix {
         ArraysKt.filter(PsiModifier.MODIFIERS, (modifier) -> field.getModifierList().hasModifierProperty(modifier)),
         new CreateFromUsage.TypeInfo(ArraysKt.toList(expectedTypes))
       );
-
-      IntentionAction action = CollectionsKt.firstOrNull(actionsFactory.createGenerateFieldFromUsageActions(fieldInfo));
-      if (action == null) return;
-
-      Editor targetEditor = EditorHelper.openInEditor(targetClass);
-      action.invoke(project, targetEditor, targetClass.getContainingFile());
-
+      CreateFromUsageUtils.invokeActionInTargetEditor(targetClass, () -> actionsFactory.createGenerateFieldFromUsageActions(fieldInfo));
       return;
     }
 

--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateMethodFromMethodReferenceFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/CreateMethodFromMethodReferenceFix.java
@@ -19,6 +19,9 @@ import com.intellij.codeInsight.ExpectedTypeInfo;
 import com.intellij.codeInsight.ExpectedTypeInfoImpl;
 import com.intellij.codeInsight.TailType;
 import com.intellij.codeInsight.daemon.QuickFixBundle;
+import com.intellij.codeInsight.intention.CreateFromUsage;
+import com.intellij.codeInsight.intention.JvmCommonIntentionActionsFactory;
+import com.intellij.codeInsight.intention.impl.JavaCommonIntentionActionsFactory;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
@@ -27,9 +30,11 @@ import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import com.intellij.util.containers.ContainerUtil;
+import kotlin.collections.ArraysKt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,7 +52,7 @@ public class CreateMethodFromMethodReferenceFix extends CreateFromUsageBaseFix {
     final PsiMethodReferenceExpression call = getMethodReference();
     if (call == null || !call.isValid()) return false;
     final PsiType functionalInterfaceType = getFunctionalExpressionType(call);
-    if (functionalInterfaceType == null || 
+    if (functionalInterfaceType == null ||
         LambdaUtil.getFunctionalInterfaceMethod(functionalInterfaceType) == null){
       return false;
     }
@@ -102,12 +107,66 @@ public class CreateMethodFromMethodReferenceFix extends CreateFromUsageBaseFix {
     String methodName = expression.getReferenceName();
     LOG.assertTrue(methodName != null);
 
+    boolean shouldBeAbstract = false;
+    boolean shouldBeStatic = false;
+    if (!expression.isConstructor()) {
+      if (shouldCreateStaticMember(expression, targetClass)) {
+        shouldBeStatic = true;
+      }
+      else if (targetClass.isInterface()) {
+        shouldBeAbstract = true;
+      }
+    }
+
+    final PsiType functionalInterfaceType = getFunctionalExpressionType(expression);
+    final PsiClassType.ClassResolveResult classResolveResult = PsiUtil.resolveGenericsClassInType(functionalInterfaceType);
+    final PsiMethod interfaceMethod = LambdaUtil.getFunctionalInterfaceMethod(classResolveResult);
+    LOG.assertTrue(interfaceMethod != null);
+
+    final PsiType interfaceReturnType = LambdaUtil.getFunctionalInterfaceReturnType(functionalInterfaceType);
+    LOG.assertTrue(interfaceReturnType != null);
+
+    final PsiSubstitutor substitutor = LambdaUtil.getSubstitutor(interfaceMethod, classResolveResult);
+    final ExpectedTypeInfo[] expectedTypes = {
+      new ExpectedTypeInfoImpl(interfaceReturnType,
+                               ExpectedTypeInfo.TYPE_OR_SUBTYPE,
+                               interfaceReturnType,
+                               TailType.NONE,
+                               null,
+                               ExpectedTypeInfoImpl.NULL)
+    };
+
+    List<Pair<PsiExpression, PsiType>> argument2Type =
+      ContainerUtil.map2List(interfaceMethod.getParameterList().getParameters(),
+                             parameter -> Pair.create(null, substitutor.substitute(parameter.getType())));
 
     final Project project = targetClass.getProject();
+
+    JvmCommonIntentionActionsFactory actionsFactory = JvmCommonIntentionActionsFactory.forLanguage(targetClass.getLanguage());
+    if (actionsFactory != null && !(actionsFactory instanceof JavaCommonIntentionActionsFactory)) {
+      List<String> modifiers = new ArrayList<>(2);
+      if (shouldBeAbstract) {
+        modifiers.add(PsiModifier.ABSTRACT);
+      }
+      if (shouldBeStatic) {
+        modifiers.add(PsiModifier.STATIC);
+      }
+
+      CreateFromUsage.MethodInfo methodInfo = new CreateFromUsage.MethodInfo(
+        targetClass,
+        methodName,
+        modifiers,
+        new CreateFromUsage.TypeInfo(ArraysKt.toList(expectedTypes)),
+        CreateFromUsageUtils.getParameterInfos(targetClass, argument2Type)
+      );
+      CreateFromUsageUtils.invokeActionInTargetEditor(targetClass, () -> actionsFactory.createGenerateMethodFromUsageActions(methodInfo));
+      return;
+    }
+
     JVMElementFactory elementFactory = JVMElementFactories.getFactory(targetClass.getLanguage(), project);
     if (elementFactory == null) elementFactory = JavaPsiFacade.getElementFactory(project);
 
-    PsiMethod method = expression.isConstructor() ? (PsiMethod)targetClass.add(elementFactory.createConstructor()) 
+    PsiMethod method = expression.isConstructor() ? (PsiMethod)targetClass.add(elementFactory.createConstructor())
                                                   : CreateMethodFromUsageFix.createMethod(targetClass, parentClass, enclosingContext, methodName);
     if (method == null) {
       return;
@@ -120,33 +179,20 @@ public class CreateMethodFromMethodReferenceFix extends CreateFromUsageBaseFix {
     expression = getMethodReference();
     LOG.assertTrue(expression.isValid());
 
-    boolean shouldBeAbstract = false;
-    if (!expression.isConstructor()) {
-      if (shouldCreateStaticMember(expression, targetClass)) {
-        PsiUtil.setModifierProperty(method, PsiModifier.STATIC, true);
-      }
-      else if (targetClass.isInterface()) {
-        shouldBeAbstract = true;
-        PsiCodeBlock body = method.getBody();
-        assert body != null;
-        body.delete();
-      }
+    if (shouldBeAbstract) {
+      PsiCodeBlock body = method.getBody();
+      assert body != null;
+      body.delete();
+    }
+
+    if (shouldBeStatic) {
+      PsiUtil.setModifierProperty(method, PsiModifier.STATIC, true);
     }
 
     final PsiElement context = PsiTreeUtil.getParentOfType(expression, PsiClass.class, PsiMethod.class);
 
-    final PsiType functionalInterfaceType = getFunctionalExpressionType(expression);
-    final PsiClassType.ClassResolveResult classResolveResult = PsiUtil.resolveGenericsClassInType(functionalInterfaceType);
-    final PsiMethod interfaceMethod = LambdaUtil.getFunctionalInterfaceMethod(classResolveResult);
-    LOG.assertTrue(interfaceMethod != null);
-
-    final PsiType interfaceReturnType = LambdaUtil.getFunctionalInterfaceReturnType(functionalInterfaceType);
-    LOG.assertTrue(interfaceReturnType != null);
-
-    final PsiSubstitutor substitutor = LambdaUtil.getSubstitutor(interfaceMethod, classResolveResult);
-    final ExpectedTypeInfo[] expectedTypes = {new ExpectedTypeInfoImpl(interfaceReturnType, ExpectedTypeInfo.TYPE_OR_SUBTYPE, interfaceReturnType, TailType.NONE, null, ExpectedTypeInfoImpl.NULL)};
     CreateMethodFromUsageFix.doCreate(targetClass, method, shouldBeAbstract,
-                                      ContainerUtil.map2List(interfaceMethod.getParameterList().getParameters(), parameter -> Pair.create(null, substitutor.substitute(parameter.getType()))),
+                                      argument2Type,
                                       PsiSubstitutor.EMPTY,
                                       expectedTypes, context);
   }


### PR DESCRIPTION
The goal is to support cross-language "Create from Usage" (see, for example, https://youtrack.jetbrains.com/issue/KT-7641 for Java->Kotlin case)