### PR TITLE
Enhance Java builder completion for superclasses and generics

### DIFF
--- a/java/java-impl/src/com/intellij/psi/filters/getters/BuilderCompletion.kt
+++ b/java/java-impl/src/com/intellij/psi/filters/getters/BuilderCompletion.kt
@@ -44,10 +44,11 @@ internal class BuilderCompletion(private val expectedType: PsiClassType, private
   }
 
   private fun methodsReturning(containingClass: PsiClass, returnedClass: PsiClass, isStatic: Boolean): Collection<List<PsiMethod>> {
-    return containingClass.methods
-      .filter { it.hasModifierProperty(PsiModifier.STATIC) == isStatic &&
-                returnedClass == PsiUtil.resolveClassInClassTypeOnly(it.returnType) &&
-                PsiUtil.isAccessible(it, place, null) }
+    return containingClass.allMethodsAndTheirSubstitutors
+      .filter { it.first.hasModifierProperty(PsiModifier.STATIC) == isStatic &&
+                returnedClass == PsiUtil.resolveClassInClassTypeOnly(it.second.substitute(it.first.returnType)) &&
+                PsiUtil.isAccessible(it.first, place, null) }
+      .map { it.first }
       .groupBy { it.name }
       .values
   }

--- a/java/java-tests/testData/codeInsight/completion/smartType/StaticBuilderWithInterfaceAndGenerics-out.java
+++ b/java/java-tests/testData/codeInsight/completion/smartType/StaticBuilderWithInterfaceAndGenerics-out.java
@@ -1,0 +1,23 @@
+public class S {
+
+  {
+    Map m = Map.build()<caret>.get();
+  }
+
+}
+
+class Map {
+  static MapBuilder build() {}
+
+  interface BaseBuilder<T> {
+    T get();
+  }
+
+  interface MapBuilder extends BaseBuilder<Map> {
+
+  }
+
+  static class Builder implements MapBuilder {
+    Map get() {}
+  }
+}

--- a/java/java-tests/testData/codeInsight/completion/smartType/StaticBuilderWithInterfaceAndGenerics.java
+++ b/java/java-tests/testData/codeInsight/completion/smartType/StaticBuilderWithInterfaceAndGenerics.java
@@ -1,0 +1,23 @@
+public class S {
+
+  {
+    Map m = bui<caret>
+  }
+
+}
+
+class Map {
+  static MapBuilder build() {}
+
+  interface BaseBuilder<T> {
+    T get();
+  }
+
+  interface MapBuilder extends BaseBuilder<Map> {
+
+  }
+
+  static class Builder implements MapBuilder {
+    Map get() {}
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/completion/SmartTypeCompletionTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/completion/SmartTypeCompletionTest.java
@@ -1249,6 +1249,7 @@ public class SmartTypeCompletionTest extends LightFixtureCompletionTestCase {
 
   public void testStaticBuilder() { doTest(); }
   public void testStaticBuilderWithArguments() { doTest(); }
+  public void testStaticBuilderWithInterfaceAndGenerics() { doTest(); }
 
   public void testStaticBuilderWithGenerics() {
     configureByTestName();


### PR DESCRIPTION
Adding the ability for builder completion to understand when the `build` method is defined in an interface, and also enabling it to handle generic types. Tested on the following sample code: 

A base-builder defined in an interface: 

```java 
public interface BaseBuilder<T> { 
    T build(); 
} 
``` 

An implementation as follows: 

```java 
public class MyObject { 

    static Builder builder() { 
        return newDefaultBuilder(); 
    } 

    public interface Builder extends BaseBuilder<MyObject> { 
    } 

    static class DefaultBuilder implements Builder { 

        @Override 
        public MyObject build() { 
            return new MyObject(); 
        } 
    } 
} 
``` 

The builders in V2 of the AWS Java SDK are structured in this way, see [interface](https://github.com/aws/aws-sdk-java-v2/blob/shorea-netty-default-thread-factory/utils/src/main/java/software/amazon/awssdk/utils/builder/SdkBuilder.java) and [example implementation](https://github.com/aws/aws-sdk-java-v2/blob/shorea-netty-default-thread-factory/core/src/main/java/software/amazon/awssdk/client/builder/ClientHttpConfiguration.java#L93).