### PR TITLE
Fix WideSelectionListUI for *_WRAP orientation

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/components/WideSelectionListUI.java
+++ b/platform/platform-api/src/com/intellij/ui/components/WideSelectionListUI.java
@@ -39,6 +39,13 @@ final class WideSelectionListUI extends BasicListUI {
                            ListModel model,
                            ListSelectionModel selectionModel,
                            int leadSelectionIndex) {
+    if (list.getLayoutOrientation() != JList.VERTICAL) {
+      // If the list layout orientation is VERTICAL_WRAP or HORIZONTAL_WRAP
+      // we don't want to paint anything outside the cell to avoid covering other cells on the same row
+      super.paintCell(g, row, rowBounds, renderer, model, selectionModel, leadSelectionIndex);
+      return;
+    }
+
     Rectangle paintBounds = myPaintBounds;
     if (paintBounds != null) {
       boolean selected = selectionModel.isSelectedIndex(row);


### PR DESCRIPTION
The WideSelectionListUI that fixes the bug
https://youtrack.jetbrains.com/issue/IDEA-160777
was causing another bug on Linux and Window where the background were
drawn over component on the left of the one selected in VERTICAL_WRAP
or HORIZONTAL_WRAP.

This change just skip the fix if the layout orientaion is not VERTICAL

Bug: https://youtrack.jetbrains.com/issue/IDEA-176759

Test: This fix a bug inside the paint() method and can't be
automatically tested.