### PR TITLE
IDEA-146215 SILENT Install should use admin parameters, if installed …

### DIFF
--- a/build/conf/nsis/idea.nsi
+++ b/build/conf/nsis/idea.nsi
@@ -459,7 +459,12 @@ LicenseLangString myLicenseData ${LANG_JAPANESE} "${LICENSE_FILE}.txt"
 
 Function .onInit
   StrCpy $baseRegKey "HKCU"
-  IfSilent UAC_Done
+  IfSilent silent_install
+silent_install:
+  ;the user has admin rights?
+  UserInfo::GetAccountType
+  Pop $R2
+  StrCmp $R2 "Admin" UAC_Admin UAC_Done
 UAC_Elevate:
     !insertmacro UAC_RunElevated
     StrCmp 1223 $0 UAC_ElevationAborted ; UAC dialog aborted by user? - continue install under user


### PR DESCRIPTION
This will install the application silently with admin if the user has run the installer as an admin else it will do what it did previously and install as a normal user.