### PR TITLE
UAST: Fix receiverType for JavaUCallExpression

### DIFF
--- a/uast/uast-tests/java/Simple/ReceiverType.java
+++ b/uast/uast-tests/java/Simple/ReceiverType.java
@@ -1,0 +1,93 @@
+class TestBaseBase {
+    void bazBaseBase(int i) {
+
+    }
+}
+
+class TestBase extends TestBaseBase {
+    void fooBase(int i) {
+
+    }
+
+    void barBase(int i) {
+
+    }
+}
+
+class Test extends TestBase {
+    Test() {
+        foo(1);
+        fooBase(1);
+        this.barBase(1);
+        staticMethod(1);
+        bazBaseBase(1);
+    }
+
+    void foo(int i) {
+
+    }
+
+    static void staticMethod(int i) {
+
+    }
+
+
+    class InnerTest {
+        InnerTest() {
+            foo(2);
+            fooBase(2);
+            bar(2);
+            staticMethod(2);
+
+            TestBase t = new TestBase() {
+                void fooBase(int i) {
+                    bazBaseBase(7);
+                    bar(7);
+                    barBase(7);
+                }
+            };
+        }
+
+        void bar(int i) {
+
+        }
+
+        class InnerInnerTest {
+            InnerInnerTest() {
+                foo(3);
+                fooBase(3);
+                bar(3);
+                baz(3);
+                staticMethod(3);
+            }
+
+            void baz(int i) {
+
+            }
+        }
+    }
+
+    class InnerTest2 extends TestBase {
+        InnerTest2() {
+            foo(4);
+            fooBase(4);
+        }
+    }
+
+    static class StaticTest {
+        StaticTest() {
+            bar(5);
+            staticMethod(5);
+        }
+
+        void bar(int i) {
+
+        }
+
+        class InnerInStatic {
+            InnerInStatic() {
+                bar(6);
+            }
+        }
+    }
+}

--- a/uast/uast-tests/test/org/jetbrains/uast/test/java/JavaUastApiTest.kt
+++ b/uast/uast-tests/test/org/jetbrains/uast/test/java/JavaUastApiTest.kt
@@ -61,4 +61,37 @@ class JavaUastApiTest : AbstractJavaUastTest() {
                     "java.lang.Runnable")
         }
     }
+
+    @Test fun testReceiverType() {
+        doTest("Simple/ReceiverType.java") { name, file ->
+            assertEquals("Test", file.findElementByText<UCallExpression>("foo(1)").receiverType?.canonicalText)
+            assertEquals("Test", file.findElementByText<UCallExpression>("fooBase(1)").receiverType?.canonicalText)
+            assertEquals("Test", file.findElementByText<UCallExpression>("this.barBase(1)").receiverType?.canonicalText)
+            assertEquals("Test", file.findElementByText<UCallExpression>("bazBaseBase(1)").receiverType?.canonicalText)
+            assertNull(file.findElementByText<UCallExpression>("staticMethod(1)").receiverType)
+
+            assertEquals("Test", file.findElementByText<UCallExpression>("foo(2)").receiverType?.canonicalText)
+            assertEquals("Test", file.findElementByText<UCallExpression>("fooBase(2)").receiverType?.canonicalText)
+            assertEquals("Test.InnerTest", file.findElementByText<UCallExpression>("bar(2)").receiverType?.canonicalText)
+            assertNull(file.findElementByText<UCallExpression>("staticMethod(2)").receiverType)
+
+            assertEquals("Test", file.findElementByText<UCallExpression>("foo(3)").receiverType?.canonicalText)
+            assertEquals("Test", file.findElementByText<UCallExpression>("fooBase(3)").receiverType?.canonicalText)
+            assertEquals("Test.InnerTest", file.findElementByText<UCallExpression>("bar(3)").receiverType?.canonicalText)
+            assertEquals("Test.InnerTest.InnerInnerTest", file.findElementByText<UCallExpression>("baz(3)").receiverType?.canonicalText)
+            assertNull(file.findElementByText<UCallExpression>("staticMethod(3)").receiverType)
+
+            assertEquals("Test", file.findElementByText<UCallExpression>("foo(4)").receiverType?.canonicalText)
+            assertEquals("Test.InnerTest2", file.findElementByText<UCallExpression>("fooBase(4)").receiverType?.canonicalText)
+
+            assertEquals("Test.StaticTest", file.findElementByText<UCallExpression>("bar(5)").receiverType?.canonicalText)
+            assertNull(file.findElementByText<UCallExpression>("staticMethod(5)").receiverType)
+
+            assertEquals("Test.StaticTest", file.findElementByText<UCallExpression>("bar(6)").receiverType?.canonicalText)
+
+            assertEquals("TestBase", file.findElementByText<UCallExpression>("bazBaseBase(7)").receiverType?.canonicalText)
+            assertEquals("Test.InnerTest", file.findElementByText<UCallExpression>("bar(7)").receiverType?.canonicalText)
+            assertEquals("TestBase", file.findElementByText<UCallExpression>("barBase(7)").receiverType?.canonicalText)
+        }
+    }
 }


### PR DESCRIPTION
Return correct receiver class for a method call with implicit receiver instead of super class, when method defined in one of super classes

#IDEA-177417 Fixed