### PR TITLE
Move 'dropSelf' to PyFunctionType

### DIFF
--- a/python/psi-api/src/com/jetbrains/python/psi/types/PyFunctionType.java
+++ b/python/psi-api/src/com/jetbrains/python/psi/types/PyFunctionType.java
@@ -31,5 +31,6 @@ public interface PyFunctionType extends PyCallableType {
   @NotNull
   PyCallable getCallable();
 
+  @NotNull
   PyFunctionType dropSelf(@NotNull TypeEvalContext context);
 }

--- a/python/psi-api/src/com/jetbrains/python/psi/types/PyFunctionType.java
+++ b/python/psi-api/src/com/jetbrains/python/psi/types/PyFunctionType.java
@@ -30,4 +30,6 @@ public interface PyFunctionType extends PyCallableType {
    */
   @NotNull
   PyCallable getCallable();
+
+  PyFunctionType dropSelf(@NotNull TypeEvalContext context);
 }

--- a/python/src/com/jetbrains/python/psi/impl/PyReferenceExpressionImpl.java
+++ b/python/src/com/jetbrains/python/psi/impl/PyReferenceExpressionImpl.java
@@ -509,7 +509,7 @@ public class PyReferenceExpressionImpl extends PyElementImpl implements PyRefere
       final PyFunctionType functionType = (PyFunctionType)type;
 
       if (qualifier != null && PyCallExpressionHelper.isQualifiedByInstance(functionType.getCallable(), qualifier, context)) {
-         return ((PyFunctionType)type).dropSelf(context);
+         return functionType.dropSelf(context);
       }
     }
 

--- a/python/src/com/jetbrains/python/psi/impl/PyReferenceExpressionImpl.java
+++ b/python/src/com/jetbrains/python/psi/impl/PyReferenceExpressionImpl.java
@@ -509,11 +509,7 @@ public class PyReferenceExpressionImpl extends PyElementImpl implements PyRefere
       final PyFunctionType functionType = (PyFunctionType)type;
 
       if (qualifier != null && PyCallExpressionHelper.isQualifiedByInstance(functionType.getCallable(), qualifier, context)) {
-        final List<PyCallableParameter> parameters = functionType.getParameters(context);
-
-        if (!ContainerUtil.isEmpty(parameters) && parameters.get(0).isSelf()) {
-          return new PyFunctionTypeImpl(functionType.getCallable(), ContainerUtil.subList(parameters, 1));
-        }
+         return ((PyFunctionType)type).dropSelf(context);
       }
     }
 

--- a/python/src/com/jetbrains/python/psi/types/PyFunctionTypeImpl.java
+++ b/python/src/com/jetbrains/python/psi/types/PyFunctionTypeImpl.java
@@ -172,6 +172,7 @@ public class PyFunctionTypeImpl implements PyFunctionType {
     return myCallable;
   }
 
+  @NotNull
   public PyFunctionType dropSelf(@NotNull TypeEvalContext context) {
     final List<PyCallableParameter> parameters = getParameters(context);
 

--- a/python/src/com/jetbrains/python/psi/types/PyFunctionTypeImpl.java
+++ b/python/src/com/jetbrains/python/psi/types/PyFunctionTypeImpl.java
@@ -171,4 +171,13 @@ public class PyFunctionTypeImpl implements PyFunctionType {
   public PyCallable getCallable() {
     return myCallable;
   }
+
+  public PyFunctionType dropSelf(@NotNull TypeEvalContext context) {
+    final List<PyCallableParameter> parameters = getParameters(context);
+
+    if (!ContainerUtil.isEmpty(parameters) && parameters.get(0).isSelf()) {
+      return new PyFunctionTypeImpl(myCallable, ContainerUtil.subList(parameters, 1));
+    }
+    return this;
+  }
 }


### PR DESCRIPTION
@sproshev  In our framework we have decorators that add certain attributes to the functions that they decorate. To handle these decorators my plugin returns a PyFunctionType from 'provider.getCallableType' that handles these extensions.  I do not want to return a simple 'PyCallableType' as it isn't handled as well as 'PyFunctionType' by the rest of PyCharm code. 

Anyways, these used to work in 2016.3. In 2017 the change '804354727e46f3c1f02b23faa264f6b1a80c4837' broke it because 'dropSelfForInstanceMethod' drops the concrete implementation of PyFunctionType always replacing it with 'PyFunctionTypeImpl'


This change delegates 'dropSelf' to PyFunctionType so that the concrete class can be preserved. 