### PR TITLE
IJSDK-299 Fix stack overflow in EditorTextField.requestFocus()

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/EditorTextField.java
+++ b/platform/platform-impl/src/com/intellij/ui/EditorTextField.java
@@ -721,7 +721,7 @@ public class EditorTextField extends NonOpaquePanel implements DocumentListener,
     }
     else {
       IdeFocusManager.getGlobalInstance().doWhenFocusSettlesDown(() -> {
-        requestFocus();
+        super.requestFocus();
       });
     }
   }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IJSDK-299.

It seems "super." was just accidentally removed in 556290b4063aae9c2d9fc107b9f3c65f6cd0839b