### PR TITLE
Add name ID for usage tree component

### DIFF
--- a/platform/usageView/src/com/intellij/usages/impl/UsageViewImpl.java
+++ b/platform/usageView/src/com/intellij/usages/impl/UsageViewImpl.java
@@ -231,6 +231,7 @@ public class UsageViewImpl implements UsageView {
               return expandingAll ? EmptyEnumeration.getInstance() : super.getExpandedDescendants(parent);
             }
           };
+          myTree.setName("UsageViewTree");
 
           myRootPanel = new MyPanel(myTree);
           Disposer.register(this, myRootPanel);


### PR DESCRIPTION
UI tests benefit from having an identifier set on
the view components, since programming UI tests
to locate a UI component is much easier when using
an identifier.