### PR TITLE
Git4idea: pushurl without capital u

### DIFF
--- a/plugins/git4idea/src/git4idea/repo/GitConfig.java
+++ b/plugins/git4idea/src/git4idea/repo/GitConfig.java
@@ -376,7 +376,7 @@ public class GitConfig {
 
     @NotNull
     private Collection<String> getPushUrls() {
-      return nonNullCollection(myRemoteBean.getPushUrl());
+      return nonNullCollection(myRemoteBean.getPushurl());
     }
 
     @NotNull
@@ -396,7 +396,7 @@ public class GitConfig {
     @Nullable String[] getFetch();
     @Nullable String[] getPush();
     @Nullable String[] getUrl();
-    @Nullable String[] getPushUrl();
+    @Nullable String[] getPushurl();
   }
 
   private static class Url {

--- a/plugins/git4idea/testData/config/remote/r3_pushurl/r3_config.txt
+++ b/plugins/git4idea/testData/config/remote/r3_pushurl/r3_config.txt
@@ -7,7 +7,7 @@
 [remote "origin"]
 	fetch = +refs/heads/*:refs/remotes/origin/*
 	url = git://github.com/JetBrains/intellij-community.git
-	pushUrl = https://github.com/JetBrains/intellij-community.git
+	pushurl = https://github.com/JetBrains/intellij-community.git
 [branch "master"]
 	remote = origin
 	merge = refs/heads/master

--- a/plugins/git4idea/testData/config/remote/r5_pushinsteadof/r5_config.txt
+++ b/plugins/git4idea/testData/config/remote/r5_pushinsteadof/r5_config.txt
@@ -8,11 +8,11 @@ ignorecase = true
   [remote "origin"]
 fetch = +refs/heads/*:refs/remotes/origin/*
 url = anygithub/JetBrains/intellij-community.git
-pushUrl = git@github.com:JetBrains/intellij-community.git
+pushurl = git@github.com:JetBrains/intellij-community.git
   [remote "jps"]
 fetch = +refs/heads/*:refs/remotes/jps/*
 url = git://github.com/JetBrains/JPS.git
-pushUrl = git@github.com:JetBrains/JPS.git
+pushurl = git@github.com:JetBrains/JPS.git
 
   [url "https://github.com/"]
 insteadOf = anygithub/

--- a/plugins/git4idea/testData/config/remote/r6_two_urls/r6_config.txt
+++ b/plugins/git4idea/testData/config/remote/r6_two_urls/r6_config.txt
@@ -8,8 +8,8 @@
 	fetch = +refs/heads/*:refs/remotes/origin/*
 	url = git://github.com/JetBrains/intellij-community.git
 	url = git://jetbrains.com/intellij-community.git
-	pushUrl = https://github.com/JetBrains/intellij-community.git
-	pushUrl = https://jetbrains.com/intellij-community.git
+	pushurl = https://github.com/JetBrains/intellij-community.git
+	pushurl = https://jetbrains.com/intellij-community.git
 [branch "master"]
 	remote = origin
 	merge = refs/heads/master

--- a/plugins/git4idea/testData/config/remote/r8_insteadof_pushurl/r8_config.txt
+++ b/plugins/git4idea/testData/config/remote/r8_insteadof_pushurl/r8_config.txt
@@ -8,11 +8,11 @@ ignorecase = true
 [remote "origin"]
   fetch = +refs/heads/*:refs/remotes/origin/*
   url = github.com/JetBrains/intellij-community.git
-  pushUrl = jetbrains.com/JetBrains/intellij-community.git
+  pushurl = jetbrains.com/JetBrains/intellij-community.git
 [remote "jps"]
   fetch = +refs/heads/*:refs/remotes/jps/*
   url = github.com/JetBrains/JPS.git
-  pushUrl = jetbrains.com/JetBrains/JPS.git
+  pushurl = jetbrains.com/JetBrains/JPS.git
 
 [url "https://"]
   insteadOf =


### PR DESCRIPTION
In .git/config the remote parameter 'pushurl' is not written in camel case (although other git parameters are) and therefore the pushurl parameter is never loaded properly. As it defaults to the url value and the tests didn't cover this it has not yet been detected. The tests had faults in the test data and also used the equals() method in GitRemote which only compares the name so this was not covered by the tests.

A fix in the gerrit plugin,
https://github.com/uwolfer/gerrit-intellij-plugin/commit/d464a7aab689fccfd83654cdfab68048b59bcb9f ,
is dependent on this change to work properly.