### PR TITLE
Ini4j replaced by custom parser for .git/config.

### DIFF
--- a/plugins/git4idea/testData/config/remote/r12_pushurl_lowercase/r12_config.txt
+++ b/plugins/git4idea/testData/config/remote/r12_pushurl_lowercase/r12_config.txt
@@ -1,0 +1,13 @@
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	ignorecase = true
+[remote "origin"]
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	url = git://github.com/JetBrains/intellij-community.git
+	pushurl = https://github.com/JetBrains/intellij-community.git
+[branch "master"]
+	remote = origin
+	merge = refs/heads/master

--- a/plugins/git4idea/testData/config/remote/r12_pushurl_lowercase/r12_desc.txt
+++ b/plugins/git4idea/testData/config/remote/r12_pushurl_lowercase/r12_desc.txt
@@ -1,0 +1,1 @@
+r12 Remote with pushurl all lowercase

--- a/plugins/git4idea/testData/config/remote/r12_pushurl_lowercase/r12_result.txt
+++ b/plugins/git4idea/testData/config/remote/r12_pushurl_lowercase/r12_result.txt
@@ -1,0 +1,6 @@
+REMOTE
+origin
+git://github.com/JetBrains/intellij-community.git
+https://github.com/JetBrains/intellij-community.git
++refs/heads/*:refs/remotes/origin/*
++refs/heads/*:refs/remotes/origin/*


### PR DESCRIPTION
Looking at [IDEA-81364](https://youtrack.jetbrains.com/issue/IDEA-81364) and the possibility to patch ini4j to allow case insensitivity in parameter names in .git/config I found that ini4j was a very generic library. That could of course be very nice but it seems very hard to patch and change. I guess the age of IDEA-81364 testifies to this. Since the format of .git/config is pretty straight forward and the current Intellij parsing of it only covers some parts it seems to me that it would be simpler way to replace it. I've here tried to replace it with a small custom parser. It doesn't cover everything, for example it doesn't handle quoted special characters etc, but it passes all the old test and one I added.

A review would be welcome and I could use some ideas of what tests to add to avoid unwanted consequences. I've made sure to only change the inner workings of GitConfig and therefore there are some ugly solution with private static inner classes etc. Could possibly be refactored to a better structure.