### PR TITLE
Add copy URL to clipboard for Gist creation dialog in GitHub plugin

### DIFF
--- a/plugins/github/src/org/jetbrains/plugins/github/GithubCreateGistAction.java
+++ b/plugins/github/src/org/jetbrains/plugins/github/GithubCreateGistAction.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.DumbAwareAction;
@@ -40,8 +41,6 @@ import org.jetbrains.plugins.github.api.requests.GithubGistRequest.FileContent;
 import org.jetbrains.plugins.github.ui.GithubCreateGistDialog;
 import org.jetbrains.plugins.github.util.*;
 
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -135,8 +134,7 @@ public class GithubCreateGistAction extends DumbAwareAction {
         if (dialog.isCopyURLToClipboard()) {
           StringSelection stringSelection = new StringSelection(url.get());
 
-          Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-          clipboard.setContents(stringSelection, null);
+          CopyPasteManager.getInstance().setContents(stringSelection);
         }
         else {
           GithubNotifications.showInfoURL(project, "Gist Created Successfully", "Your gist url", url.get());

--- a/plugins/github/src/org/jetbrains/plugins/github/GithubCreateGistAction.java
+++ b/plugins/github/src/org/jetbrains/plugins/github/GithubCreateGistAction.java
@@ -40,6 +40,9 @@ import org.jetbrains.plugins.github.api.requests.GithubGistRequest.FileContent;
 import org.jetbrains.plugins.github.ui.GithubCreateGistDialog;
 import org.jetbrains.plugins.github.util.*;
 
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -128,6 +131,12 @@ public class GithubCreateGistAction extends DumbAwareAction {
         }
         if (dialog.isOpenInBrowser()) {
           BrowserUtil.browse(url.get());
+        }
+        if (dialog.isCopyURLToClipboard()) {
+          StringSelection stringSelection = new StringSelection(url.get());
+
+          Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+          clipboard.setContents(stringSelection, null);
         }
         else {
           GithubNotifications.showInfoURL(project, "Gist Created Successfully", "Your gist url", url.get());

--- a/plugins/github/src/org/jetbrains/plugins/github/ui/GithubCreateGistDialog.java
+++ b/plugins/github/src/org/jetbrains/plugins/github/ui/GithubCreateGistDialog.java
@@ -40,6 +40,7 @@ public class GithubCreateGistDialog extends DialogWrapper {
     myGithubCreateGistPanel.setAnonymous(settings.isAnonymousGist());
     myGithubCreateGistPanel.setPrivate(settings.isPrivateGist());
     myGithubCreateGistPanel.setOpenInBrowser(settings.isOpenInBrowserGist());
+    myGithubCreateGistPanel.setCopyURLToClipboard(settings.isCopyURLToClipboardGist());
 
     if (editor != null) {
       if (file != null) {
@@ -83,6 +84,7 @@ public class GithubCreateGistDialog extends DialogWrapper {
     final GithubSettings settings = GithubSettings.getInstance();
     settings.setAnonymousGist(myGithubCreateGistPanel.isAnonymous());
     settings.setOpenInBrowserGist(myGithubCreateGistPanel.isOpenInBrowser());
+    settings.setCopyURLToClipboardGist(myGithubCreateGistPanel.isCopyURLToClipboard());
     settings.setPrivateGist(myGithubCreateGistPanel.isPrivate());
     super.doOKAction();
   }
@@ -112,5 +114,9 @@ public class GithubCreateGistDialog extends DialogWrapper {
 
   public boolean isOpenInBrowser() {
     return myGithubCreateGistPanel.isOpenInBrowser();
+  }
+
+  public boolean isCopyURLToClipboard() {
+    return myGithubCreateGistPanel.isCopyURLToClipboard();
   }
 }

--- a/plugins/github/src/org/jetbrains/plugins/github/ui/GithubCreateGistPanel.form
+++ b/plugins/github/src/org/jetbrains/plugins/github/ui/GithubCreateGistPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.jetbrains.plugins.github.ui.GithubCreateGistPanel">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="4" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="4" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -36,7 +36,7 @@
       </component>
       <scrollpane id="6c5d2" class="com.intellij.ui.components.JBScrollPane">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="4" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="5" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <minimum-size width="150" height="50"/>
             <preferred-size width="150" height="50"/>
           </grid>
@@ -76,9 +76,17 @@
       </component>
       <hspacer id="192a4">
         <constraints>
-          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
+      <component id="71436" class="javax.swing.JCheckBox" binding="myCopyURLToClipboardCheckBox">
+        <constraints>
+          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Copy URL to clipboard"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/plugins/github/src/org/jetbrains/plugins/github/ui/GithubCreateGistPanel.java
+++ b/plugins/github/src/org/jetbrains/plugins/github/ui/GithubCreateGistPanel.java
@@ -29,6 +29,7 @@ public class GithubCreateGistPanel {
   private JPanel myPanel;
   private JCheckBox myAnonymousCheckBox;
   private JCheckBox myOpenInBrowserCheckBox;
+  private JCheckBox myCopyURLToClipboardCheckBox;
   private JTextField myFileNameField;
   private JLabel myFileNameLabel;
 
@@ -50,6 +51,10 @@ public class GithubCreateGistPanel {
     return myOpenInBrowserCheckBox.isSelected();
   }
 
+  public boolean isCopyURLToClipboard() {
+    return myCopyURLToClipboardCheckBox.isSelected();
+  }
+
   public void setPrivate(final boolean isPrivate){
     myPrivateCheckBox.setSelected(isPrivate);
   }
@@ -60,6 +65,10 @@ public class GithubCreateGistPanel {
 
   public void setOpenInBrowser(final boolean openInBrowser) {
     myOpenInBrowserCheckBox.setSelected(openInBrowser);
+  }
+
+  public void setCopyURLToClipboard(final boolean copyURLToClipboard) {
+    myCopyURLToClipboardCheckBox.setSelected(copyURLToClipboard);
   }
 
   public void showFileNameField(@NotNull String filename) {

--- a/plugins/github/src/org/jetbrains/plugins/github/util/GithubSettings.java
+++ b/plugins/github/src/org/jetbrains/plugins/github/util/GithubSettings.java
@@ -52,6 +52,7 @@ public class GithubSettings implements PersistentStateComponent<GithubSettings.S
     @NotNull public AuthType AUTH_TYPE = AuthType.ANONYMOUS;
     public boolean ANONYMOUS_GIST = false;
     public boolean OPEN_IN_BROWSER_GIST = true;
+    public boolean COPY_URL_TO_CLIPBOARD = false;
     public boolean PRIVATE_GIST = true;
     public boolean SAVE_PASSWORD = true;
     public int CONNECTION_TIMEOUT = 5000;
@@ -111,6 +112,10 @@ public class GithubSettings implements PersistentStateComponent<GithubSettings.S
     return myState.OPEN_IN_BROWSER_GIST;
   }
 
+  public boolean isCopyURLToClipboardGist() {
+    return myState.COPY_URL_TO_CLIPBOARD;
+  }
+
   public boolean isPrivateGist() {
     return myState.PRIVATE_GIST;
   }
@@ -158,6 +163,10 @@ public class GithubSettings implements PersistentStateComponent<GithubSettings.S
 
   public void setOpenInBrowserGist(final boolean openInBrowserGist) {
     myState.OPEN_IN_BROWSER_GIST = openInBrowserGist;
+  }
+
+  public void setCopyURLToClipboardGist(final boolean copyURLToClipboardGist) {
+    myState.COPY_URL_TO_CLIPBOARD = copyURLToClipboardGist;
   }
 
   public void setCloneGitUsingSsh(boolean value) {


### PR DESCRIPTION
Adds an additional check box in the Create Gist dialog to copy the URL to clipboard.
![image](https://user-images.githubusercontent.com/12993584/29917806-12aca3e2-8e11-11e7-9197-aa0306661495.png)