### PR TITLE
Update settings-repository plugin's "more info" link

### DIFF
--- a/plugins/settings-repository/resources/META-INF/plugin.xml
+++ b/plugins/settings-repository/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
   <description><![CDATA[
   <p>Supports sharing settings between installations of IntelliJ Platform based products used by the same developer (or team) on different computers.</p>
   <p>Synchronization is performed automatically after successful completion of "Update Project" or "Push" actions. Also you can do sync using VCS -> Sync Settings.</p>
-  <p>See <a href="https://github.com/develar/settings-repository">project page</a> for more info.</p>]]></description>
+  <p>See the <a href="https://github.com/JetBrains/intellij-community/tree/master/plugins/settings-repository">README file</a> on Github for more info.</p>]]></description>
   <vendor>JetBrains</vendor>
 
   <!-- otherwise plugin will be not loaded in tests -->


### PR DESCRIPTION
The formerly independent `settings-repository` plugin is now bundled with IDEA, but the "more info" link in its plugin description still points to what is now a stale, archived GitHub repository. This change updates the link to the current location.

_Note that since it is no longer a GitHub project page being linked to, I've decided to link directly to the README.md file, rather than, say, linking to a directory deep within the IDEA source tree that happens to contain that README._