### PR TITLE
Add elements into collection directly

### DIFF
--- a/java/compiler/impl/src/com/intellij/compiler/options/ValidationConfigurable.java
+++ b/java/compiler/impl/src/com/intellij/compiler/options/ValidationConfigurable.java
@@ -36,6 +36,7 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.util.NullableFunction;
+import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
 import gnu.trove.THashSet;
 import gnu.trove.TObjectHashingStrategy;
@@ -148,8 +149,7 @@ public class ValidationConfigurable implements SearchableConfigurable, Configura
 
   private List<Compiler> getValidators() {
     final CompilerManager compilerManager = CompilerManager.getInstance(myProject);
-    final List<Compiler> validators = new ArrayList<>();
-    validators.addAll(Arrays.asList(compilerManager.getCompilers(Validator.class)));
+    final List<Compiler> validators = new SmartList<>(compilerManager.getCompilers(Validator.class));
     for (GenericCompiler compiler : compilerManager.getCompilers(GenericCompiler.class)) {
       if (compiler.getOrderPlace() == GenericCompiler.CompileOrderPlace.VALIDATING) {
         validators.add(compiler);

--- a/java/idea-ui/src/com/intellij/ide/util/newProjectWizard/StepSequence.java
+++ b/java/idea-ui/src/com/intellij/ide/util/newProjectWizard/StepSequence.java
@@ -22,6 +22,7 @@ import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.openapi.util.Pair;
+import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.MultiMap;
 import org.jetbrains.annotations.NonNls;
@@ -31,14 +32,14 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class StepSequence {
-  private final List<ModuleWizardStep> myCommonSteps = new ArrayList<>();
+  private final List<ModuleWizardStep> myCommonSteps;
   private final List<Pair<ModuleWizardStep, Set<String>>> myCommonFinishingSteps = new ArrayList<>();
   private final MultiMap<String, ModuleWizardStep> mySpecificSteps = new MultiMap<>();
   @NonNls private List<String> myTypes = new ArrayList<>();
   private List<ModuleWizardStep> mySelectedSteps;
 
   public StepSequence(ModuleWizardStep... commonSteps) {
-    myCommonSteps.addAll(Arrays.asList(commonSteps));
+    myCommonSteps = new SmartList<>(commonSteps);
   }
 
   public void addCommonStep(@NotNull ModuleWizardStep step){

--- a/java/java-impl/src/com/intellij/codeInsight/generation/GenerateDelegateHandler.java
+++ b/java/java-impl/src/com/intellij/codeInsight/generation/GenerateDelegateHandler.java
@@ -33,6 +33,7 @@ import com.intellij.psi.scope.processor.VariablesProcessor;
 import com.intellij.psi.scope.util.PsiScopesUtil;
 import com.intellij.psi.util.*;
 import com.intellij.util.IncorrectOperationException;
+import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.HashMap;
 import com.intellij.util.containers.HashSet;
 import org.jetbrains.annotations.NonNls;
@@ -233,7 +234,7 @@ public class GenerateDelegateHandler implements LanguageCodeInsightActionHandler
     if (targetClass instanceof PsiTypeParameter) {
       LinkedHashSet<PsiMethod> meths = new LinkedHashSet<>();
       for (PsiClass superClass : targetClass.getSupers()) {
-        meths.addAll(Arrays.asList(superClass.getAllMethods()));
+        ContainerUtil.addAll(meths, superClass.getAllMethods());
       }
       allMethods = meths.toArray(new PsiMethod[meths.size()]);
     }

--- a/java/java-impl/src/com/intellij/psi/impl/source/resolve/reference/impl/providers/PsiPackageReference.java
+++ b/java/java-impl/src/com/intellij/psi/impl/source/resolve/reference/impl/providers/PsiPackageReference.java
@@ -20,6 +20,7 @@ import com.intellij.codeInsight.daemon.JavaErrorMessages;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.util.IncorrectOperationException;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -52,7 +53,7 @@ public class PsiPackageReference extends PsiPolyVariantReferenceBase<PsiElement>
   public Object[] getVariants() {
     Set<PsiPackage> subPackages = new HashSet<>();
     for (PsiPackage psiPackage : getContext()) {
-      subPackages.addAll(Arrays.asList(psiPackage.getSubPackages(myReferenceSet.getResolveScope())));
+      ContainerUtil.addAll(subPackages, psiPackage.getSubPackages(myReferenceSet.getResolveScope()));
     }
     return subPackages.toArray();
   }

--- a/java/java-impl/src/com/intellij/testIntegration/createTest/CreateTestDialog.java
+++ b/java/java-impl/src/com/intellij/testIntegration/createTest/CreateTestDialog.java
@@ -59,6 +59,7 @@ import com.intellij.testIntegration.TestFramework;
 import com.intellij.testIntegration.TestIntegrationUtils;
 import com.intellij.ui.*;
 import com.intellij.util.IncorrectOperationException;
+import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
@@ -355,8 +356,7 @@ public class CreateTestDialog extends DialogWrapper {
 
     final DefaultComboBoxModel model = (DefaultComboBoxModel)myLibrariesCombo.getModel();
 
-    final List<TestFramework> descriptors = new ArrayList<>();
-    descriptors.addAll(Arrays.asList(Extensions.getExtensions(TestFramework.EXTENSION_NAME)));
+    final List<TestFramework> descriptors = new SmartList<>(Extensions.getExtensions(TestFramework.EXTENSION_NAME));
     descriptors.sort((d1, d2) -> Comparing.compare(d1.getName(), d2.getName()));
 
     for (final TestFramework descriptor : descriptors) {

--- a/platform/lang-api/src/com/intellij/facet/frameworks/LibrariesDownloadAssistant.java
+++ b/platform/lang-api/src/com/intellij/facet/frameworks/LibrariesDownloadAssistant.java
@@ -6,9 +6,7 @@ import com.intellij.facet.frameworks.beans.Artifacts;
 import com.intellij.facet.ui.libraries.LibraryInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.HashSet;
 import com.intellij.util.net.HttpConfigurable;
@@ -79,7 +77,7 @@ public class LibrariesDownloadAssistant {
       if (allArtifacts != null) {
         final Artifact[] vers = allArtifacts.getArtifacts();
         if (vers != null) {
-          versions.addAll(Arrays.asList(vers));
+          ContainerUtil.addAll(versions, Arrays.asList(vers));
         }
       }
     }

--- a/platform/lang-api/src/com/intellij/facet/frameworks/ui/LibrariesDownloadUiUtil.java
+++ b/platform/lang-api/src/com/intellij/facet/frameworks/ui/LibrariesDownloadUiUtil.java
@@ -19,6 +19,7 @@ import com.intellij.facet.frameworks.LibrariesDownloadAssistant;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.ui.CollectionComboBoxModel;
+import com.intellij.util.SmartList;
 import com.intellij.util.ui.update.Activatable;
 import com.intellij.util.ui.update.UiNotifyConnector;
 import org.jetbrains.annotations.NotNull;
@@ -26,7 +27,6 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -73,8 +73,7 @@ public class LibrariesDownloadUiUtil {
                                 final URL... localUrls) {
     final ModalityState state = ModalityState.current();
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      final List<Object> newItems = new ArrayList<>();
-      newItems.addAll(Arrays.asList(LibrariesDownloadAssistant.getVersions(groupId, localUrls)));
+      final List<Object> newItems = new SmartList<>(LibrariesDownloadAssistant.getVersions(groupId, localUrls));
 
       ApplicationManager.getApplication().invokeLater(() -> {
         items.clear();

--- a/platform/lang-impl/src/com/intellij/codeInsight/completion/FilePathCompletionContributor.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/completion/FilePathCompletionContributor.java
@@ -48,6 +48,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.ProjectScope;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.ProcessingContext;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -218,7 +219,7 @@ public class FilePathCompletionContributor extends CompletionContributor {
     final ChooseByNameContributor[] nameContributors = ChooseByNameContributor.FILE_EP_NAME.getExtensions();
     for (final ChooseByNameContributor contributor : nameContributors) {
       try {
-        names.addAll(Arrays.asList(contributor.getNames(project, false)));
+        ContainerUtil.addAll(names, contributor.getNames(project, false));
       }
       catch (ProcessCanceledException ex) {
         // index corruption detected, ignore

--- a/platform/lang-impl/src/com/intellij/ide/util/StructureViewCompositeModel.java
+++ b/platform/lang-impl/src/com/intellij/ide/util/StructureViewCompositeModel.java
@@ -26,6 +26,7 @@ import com.intellij.ide.util.treeView.smartTree.TreeElement;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.openapi.Disposable;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -102,7 +103,7 @@ public class StructureViewCompositeModel extends StructureViewModelBase implemen
     final HashSet<Filter> filters = new HashSet<>();
     for (StructureViewComposite.StructureViewDescriptor view : myViews) {
       final StructureViewModel model = view.structureView.getTreeModel();
-      filters.addAll(Arrays.asList(model.getFilters()));
+      ContainerUtil.addAll(filters, model.getFilters());
     }
     return filters.toArray(new Filter[filters.size()]);
   }

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.java
@@ -196,7 +196,7 @@ public class FileEditorManagerImpl extends FileEditorManagerEx implements Persis
       Set<FileEditorProvider> providers = new HashSet<>();
       List<EditorWithProviderComposite> composites = getEditorComposites(file);
       for (EditorWithProviderComposite composite : composites) {
-        providers.addAll(Arrays.asList(composite.getProviders()));
+        ContainerUtil.addAll(providers, composite.getProviders());
       }
       FileEditorProvider[] newProviders = FileEditorProviderManager.getInstance().getProviders(project, file);
       if (newProviders.length > providers.size()) {
@@ -1216,7 +1216,7 @@ public class FileEditorManagerImpl extends FileEditorManagerEx implements Persis
   public VirtualFile[] getOpenFiles() {
     Set<VirtualFile> openFiles = new THashSet<>();
     for (EditorsSplitters each : getAllSplitters()) {
-      openFiles.addAll(Arrays.asList(each.getOpenFiles()));
+      ContainerUtil.addAll(openFiles, each.getOpenFiles());
     }
     return VfsUtilCore.toVirtualFileArray(openFiles);
   }
@@ -1229,7 +1229,7 @@ public class FileEditorManagerImpl extends FileEditorManagerEx implements Persis
     selectedFiles.addAll(Arrays.asList(activeSplitters.getSelectedFiles()));
     for (EditorsSplitters each : getAllSplitters()) {
       if (each != activeSplitters) {
-        selectedFiles.addAll(Arrays.asList(each.getSelectedFiles()));
+        ContainerUtil.addAll(selectedFiles, each.getSelectedFiles());
       }
     }
     return VfsUtilCore.toVirtualFileArray(selectedFiles);

--- a/plugins/git4idea/src/git4idea/history/GitLogRecordCollector.java
+++ b/plugins/git4idea/src/git4idea/history/GitLogRecordCollector.java
@@ -130,7 +130,7 @@ abstract class GitLogRecordCollector implements Consumer<GitLogRecord> {
 
     for (GitLogRecord r : records) {
       hashes.add(r.getHash());
-      hashes.addAll(Arrays.asList(r.getParentsHashes()));
+      ContainerUtil.addAll(hashes, r.getParentsHashes());
     }
 
     GitSimpleHandler handler = new GitSimpleHandler(myProject, myRoot, GitCommand.LOG);

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/transformations/TransformationContextImpl.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/transformations/TransformationContextImpl.java
@@ -128,7 +128,7 @@ public class TransformationContextImpl implements TransformationContext {
     for (PsiClassType type: superTypes) {
       PsiClass psiClass = type.resolve();
       if (psiClass != null) {
-        fields.addAll(Arrays.asList(psiClass.getAllFields()));
+        ContainerUtil.addAll(fields, psiClass.getAllFields());
       }
     }
     return fields;


### PR DESCRIPTION
Direct adding of elements into collection by the means of `ContainerUtil.addAll` and `new SmartList(T...)` allows to reduce amount of garbage instances produced by `Arrays.asList`

See [https://youtrack.jetbrains.com/issue/IDEA-178648](https://youtrack.jetbrains.com/issue/IDEA-178648)