### PR TITLE
generate hashCode: prefer HashCodeBuilder with default constructor

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/generation/apacheHashCodeBuilder.vm
+++ b/java/java-impl/src/com/intellij/codeInsight/generation/apacheHashCodeBuilder.vm
@@ -1,5 +1,5 @@
 public int hashCode() {
-  return new org.apache.commons.lang.builder.HashCodeBuilder(17, 37)
+  return new org.apache.commons.lang.builder.HashCodeBuilder()
   #if($superHasHashCode)
     .appendSuper(super.hashCode())
   #end

--- a/java/java-impl/src/com/intellij/codeInsight/generation/apacheHashCodeBuilder3.vm
+++ b/java/java-impl/src/com/intellij/codeInsight/generation/apacheHashCodeBuilder3.vm
@@ -1,5 +1,5 @@
 public int hashCode() {
-  return new org.apache.commons.lang3.builder.HashCodeBuilder(17, 37)
+  return new org.apache.commons.lang3.builder.HashCodeBuilder()
   #if($superHasHashCode)
     .appendSuper(super.hashCode())
   #end


### PR DESCRIPTION
Hi,
hashCode generator uses template with builder class with two parameters constructors. There is default constructor with same constants as in current template. It should be handy not to duplicate this constants and use default constructor instead. Second point of view could be that when you have hard-coded constants many of static code analysis tools marks them as magic numbers.
Is it this change ok for you?
Thx,
Ivos