### PR TITLE
Duplicate entries in RESERVED_WINDOWS_NAMESPACE and absense of `con`

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -29,7 +29,7 @@ public class ConverterHelper implements IIdentifierRenamer {
     "final", "interface", "short", "true", "char", "finally", "long", "static", "try", "class", "float", "native", "strictfp", "void",
     "const", "for", "new", "super", "volatile", "continue", "goto", "null", "switch", "while", "default", "assert", "enum"));
   private static final Set<String> RESERVED_WINDOWS_NAMESPACE = new HashSet<>(Arrays.asList(
-    "aux", "prn", "aux", "nul",
+    "con", "prn", "aux", "nul",
     "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
     "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"));
 


### PR DESCRIPTION
RESERVED_WINDOWS_NAMESPACE contains duplicate entries of `aux` and doesn't contain `con` which is reserved name too.