### PR TITLE
Take moved lines into account

### DIFF
--- a/plugins/git4idea/src/git4idea/annotate/GitAnnotationProvider.java
+++ b/plugins/git4idea/src/git4idea/annotate/GitAnnotationProvider.java
@@ -153,7 +153,7 @@ public class GitAnnotationProvider implements AnnotationProviderEx {
     VirtualFile root = GitUtil.getGitRoot(repositoryFilePath);
     GitSimpleHandler h = new GitSimpleHandler(myProject, root, GitCommand.BLAME);
     h.setStdoutSuppressed(true);
-    h.addParameters("--porcelain", "-l", "-t", "-w");
+    h.addParameters("--porcelain", "-l", "-t", "-w", "-M");
     h.addParameters("--encoding=UTF-8");
     if (revision == null) {
       h.addParameters("HEAD");


### PR DESCRIPTION
This option is useful after a global formatting of a project. At least in Java, as imports can be easily moved by a formatter. (Using the spotless plugin + google java format as an example).