### PR TITLE
make EmptyList compatible with java.utilCollections.EmptyList

### DIFF
--- a/platform/util-rt/src/com/intellij/util/containers/ContainerUtilRt.java
+++ b/platform/util-rt/src/com/intellij/util/containers/ContainerUtilRt.java
@@ -314,6 +314,34 @@ public class ContainerUtilRt {
     public Iterator<T> iterator() {
       return EmptyIterator.getInstance();
     }
+
+    @NotNull
+    @Override
+    public ListIterator<T> listIterator() {
+      return EmptyListIterator.getInstance();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+      return c.isEmpty();
+    }
+
+    @Override
+    @Contract(pure = true)
+    public boolean isEmpty() {
+      return true;
+    }
+
+    @Override
+    @Contract(pure = true)
+    public boolean equals(Object o) {
+      return (o instanceof List) && ((List)o).isEmpty();
+    }
+
+    @Override
+    public int hashCode() {
+      return 1;
+    }
   }
 
   @NotNull


### PR DESCRIPTION
Current implementation of ContainerUtilRt.EmptyList invokes methods of java.util.AbstractList. As a result
- EmptyList.listIterator allocates new instance of ListIterator
- EmptyList.equals allocates two instances of ListIterator (for both compared lists)

These behaviour can be avoided by this patch.