### PR TITLE
Revert commit 8608f6e

### DIFF
--- a/platform/util/util.iml
+++ b/platform/util/util.iml
@@ -25,7 +25,6 @@
     <orderEntry type="library" name="xmlgraphics-commons" level="project" />
     <orderEntry type="library" name="batik" level="project" />
     <orderEntry type="library" name="lz4-java" level="project" />
-    <orderEntry type="library" name="xml-apis-ext" level="project" />
     <orderEntry type="library" name="commons-compress" level="project" />
   </component>
   <component name="copyright">


### PR DESCRIPTION
This dependency caused Project Structure Problems to show
“Module util: invalid item 'xml-apis-ext' in the dependencies list”
because xml-apis-ext was removed by commit 1c6369f.