### PR TITLE
Improve the doc-comment on PsiNameIdentifierOwner

### DIFF
--- a/platform/core-api/src/com/intellij/psi/PsiNameIdentifierOwner.java
+++ b/platform/core-api/src/com/intellij/psi/PsiNameIdentifierOwner.java
@@ -18,6 +18,11 @@ package com.intellij.psi;
 import org.jetbrains.annotations.Nullable;
 
 /**
+ * A Psi element which has a name given by an identifier token in the Psi tree.
+ * <p/>
+ * Implementors should also override {@link PsiElement#getTextOffset()} to return
+ * the relative offset of the identifier token.
+ *
  * @author yole
  */
 public interface PsiNameIdentifierOwner extends PsiNamedElement {

--- a/platform/lang-impl/src/com/intellij/codeInsight/TargetElementUtil.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/TargetElementUtil.java
@@ -350,7 +350,7 @@ public class TargetElementUtil extends TargetElementUtilBase {
     if ((parent = PsiTreeUtil.getParentOfType(element, PsiNamedElement.class, false)) != null) {
       boolean isInjected = parent instanceof PsiFile
                            && InjectedLanguageManager.getInstance(parent.getProject()).isInjectedFragment((PsiFile)parent);
-      // A bit hacky depends on navigation offset correctly overridden
+      // A bit hacky: depends on the named element's text offset being overridden correctly
       if (!isInjected && parent.getTextOffset() == element.getTextRange().getStartOffset()) {
         if (evaluator == null || evaluator.isAcceptableNamedParent(parent)) {
           return parent;


### PR DESCRIPTION
While implementing reference resolve and rename in a custom language
plugin, I ran into a subtle bug caused by failing to override
`PsiElement#getTextOffset()`. I eventually figured it out by tracing
the code into `TargetElementUtil` and finding a useful comment about
the importance of overriding the text offset on named elements.