### PR TITLE
解决使用nosetest执行用例时，用例注释为中文unicode时的乱码问题。

### DIFF
--- a/python/helpers/pycharm/_jb_runner_tools.py
+++ b/python/helpers/pycharm/_jb_runner_tools.py
@@ -179,7 +179,7 @@ class NewTeamcityServiceMessages(_old_service_messages):
             loc = possible_location.find("(")
             if loc > 0:
                 possible_location = possible_location[:loc].strip()
-            properties["locationHint"] = "python<{0}>://{1}".format(PROJECT_DIR, possible_location)
+            properties["locationHint"] = u"python<{0}>://{1}".format(PROJECT_DIR, possible_location)
         except KeyError:
             # If message does not have name, then it is not test
             # Simply pass it
@@ -188,7 +188,7 @@ class NewTeamcityServiceMessages(_old_service_messages):
 
         # Shortcut for name
         try:
-            properties["name"] = str(properties["name"]).split(".")[-1]
+            properties["name"] = properties["name"].split(".")[-1]
         except IndexError:
             pass
 


### PR DESCRIPTION
如果`testcase`的注释为中文Unicode时，如：
```
def test_mysite(self):
    u"""这里是用例的注释""" 
    pass
```
这种形式，那么运行`nosetest`时，会报异常：
`UnicodeEncodeError: 'ascii' codec can't encode characters in position 1-11: ordinal not in range(128)`