### PR TITLE
Splice side effect from String concatenation

### DIFF
--- a/java/compiler/impl/src/com/intellij/packaging/impl/elements/PackagingElementFactoryImpl.java
+++ b/java/compiler/impl/src/com/intellij/packaging/impl/elements/PackagingElementFactoryImpl.java
@@ -253,7 +253,8 @@ public class PackagingElementFactoryImpl extends PackagingElementFactory {
     String name = prefix + suffix;
     int i = 2;
     while (findArchiveOrDirectoryByName(parent, name) != null) {
-      name = prefix + i++ + suffix;
+      int index = i++;
+      name = prefix + index + suffix;
     }
     return name;
   }

--- a/platform/platform-impl/src/com/intellij/notification/EventLog.java
+++ b/platform/platform-impl/src/com/intellij/notification/EventLog.java
@@ -167,7 +167,8 @@ public class EventLog {
 
         @Override
         public String fun(AnAction action) {
-          return "<a href=\"" + index++ + "\">" + action.getTemplatePresentation().getText() + "</a>";
+          int incrementedIndex = index++;
+          return "<a href=\"" + incrementedIndex + "\">" + action.getTemplatePresentation().getText() + "</a>";
         }
       }, isLongLine(actions) ? "<br>" : "&nbsp;") + "</p>";
       Notification n = new Notification("", "", ".", NotificationType.INFORMATION, new NotificationListener() {

--- a/platform/platform-tests/testSrc/com/intellij/openapi/editor/colors/EditorColorPaletteTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/editor/colors/EditorColorPaletteTest.java
@@ -101,7 +101,8 @@ public class EditorColorPaletteTest extends LightPlatformTestCase {
         break;
       } 
       else {
-        assertTrue(i++ + ": " + testColor + " vs " + color,
+        int index = i++;
+        assertTrue(index + ": " + testColor + " vs " + color,
                    RainbowHighlighter.colorDistance01(testColor, color) >= minimalColorDistance);
       }
     }

--- a/platform/projectModel-api/src/com/intellij/openapi/roots/libraries/LibraryUtil.java
+++ b/platform/projectModel-api/src/com/intellij/openapi/roots/libraries/LibraryUtil.java
@@ -93,7 +93,8 @@ public class LibraryUtil {
     String name = baseName;
     int count = 2;
     while (libraryTable.getLibraryByName(name) != null) {
-      name = baseName + " (" + count++ + ")";
+      int index = count++;
+      name = baseName + " (" + index + ")";
     }
     return libraryTable.createLibrary(name);
   }


### PR DESCRIPTION
According to https://bugs.openjdk.java.net/browse/JDK-8043677 
```java
new StringBuilder().append(counter++).toString()
```
is slower than 
```java
int cnt = counter++; 
new StringBuilder().append(cnt).toString();
```
I've created a feature request https://youtrack.jetbrains.com/issue/IDEA-181103 (wtih measurement results) to have IDEA detecting such cases automatically and replaced them in the code of CE.