### PR TITLE
PY-25655: Store super classes text in stub

### DIFF
--- a/python/psi-api/src/com/jetbrains/python/psi/stubs/PyClassStub.java
+++ b/python/psi-api/src/com/jetbrains/python/psi/stubs/PyClassStub.java
@@ -43,6 +43,7 @@ public interface PyClassStub extends NamedStub<PyClass> {
   @NotNull
   List<String> getSubscriptedSuperClasses();
 
+
   @Nullable
   QualifiedName getMetaClass();
 
@@ -51,4 +52,9 @@ public interface PyClassStub extends NamedStub<PyClass> {
 
   @Nullable
   String getDocString();
+
+  @Nullable // Made nullable for compatibility
+  default List<String> getSuperClassesText() {
+    return null;
+  }
 }

--- a/python/psi-api/src/com/jetbrains/python/psi/stubs/PyClassStub.java
+++ b/python/psi-api/src/com/jetbrains/python/psi/stubs/PyClassStub.java
@@ -25,6 +25,7 @@ import com.jetbrains.python.psi.PyClass;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -53,8 +54,8 @@ public interface PyClassStub extends NamedStub<PyClass> {
   @Nullable
   String getDocString();
 
-  @Nullable // Made nullable for compatibility
+  @NotNull
   default List<String> getSuperClassesText() {
-    return null;
+    return Collections.emptyList();
   }
 }

--- a/python/src/com/jetbrains/python/psi/PyFileElementType.java
+++ b/python/src/com/jetbrains/python/psi/PyFileElementType.java
@@ -62,7 +62,7 @@ public class PyFileElementType extends IStubFileElementType<PyFileStub> {
   @Override
   public int getStubVersion() {
     // Don't forget to update versions of indexes that use the updated stub-based elements
-    return 65;
+    return 66;
   }
 
   @Nullable

--- a/python/src/com/jetbrains/python/psi/impl/PyClassImpl.java
+++ b/python/src/com/jetbrains/python/psi/impl/PyClassImpl.java
@@ -29,8 +29,8 @@ import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.tree.TokenSet;
-import com.intellij.psi.util.*;
 import com.intellij.psi.util.CachedValueProvider.Result;
+import com.intellij.psi.util.*;
 import com.intellij.util.*;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.python.PyElementTypes;
@@ -356,18 +356,25 @@ public class PyClassImpl extends PyBaseElementImpl<PyClassStub> implements PyCla
       public String getPresentableText() {
         PyPsiUtils.assertValid(PyClassImpl.this);
         final StringBuilder result = new StringBuilder(notNullize(getName(), PyNames.UNNAMED_ELEMENT));
-        final PyExpression[] superClassExpressions = getSuperClassExpressions();
-        if (superClassExpressions.length > 0) {
+        final List<String> superClassesText = getSuperClassesText();
+        if (superClassesText.size() > 0) {
           result.append("(");
-          result.append(join(Arrays.asList(superClassExpressions), expr -> {
-            String name = expr.getText();
-            return notNullize(name, PyNames.UNNAMED_ELEMENT);
-          }, ", "));
+          result.append(join(superClassesText, expr -> notNullize(expr, PyNames.UNNAMED_ELEMENT), ", "));
           result.append(")");
         }
         return result.toString();
       }
     };
+  }
+
+  private List<String> getSuperClassesText() {
+    PyClassStub stub = getGreenStub();
+    if (stub == null || stub.getSuperClassesText() == null) {
+      return ContainerUtil.map(getSuperClassExpressions(), exp -> exp.getText());
+    }
+    else {
+      return stub.getSuperClassesText();
+    }
   }
 
   @NotNull

--- a/python/src/com/jetbrains/python/psi/impl/stubs/PyClassStubImpl.java
+++ b/python/src/com/jetbrains/python/psi/impl/stubs/PyClassStubImpl.java
@@ -37,7 +37,7 @@ public class PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
 
   @NotNull
   private final Map<QualifiedName, QualifiedName> mySuperClasses;
-  private final List<String> mySuperClassesText;
+  private final List<String> mySubscriptedSuperClassesText;
 
   @Nullable
   private final QualifiedName myMetaClass;
@@ -48,17 +48,34 @@ public class PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
   @Nullable
   private final String myDocString;
 
+  @Nullable
+  private final List<String> mySuperClassesText;
+
   public PyClassStubImpl(@Nullable String name,
                          @Nullable StubElement parentStub,
                          @NotNull Map<QualifiedName, QualifiedName> superClasses,
-                         @NotNull List<String> superClassesText,
+                         @NotNull List<String> subscriptedSuperClassesText,
                          @Nullable QualifiedName metaClass,
                          @Nullable List<String> slots,
                          @Nullable String docString,
                          @NotNull IStubElementType stubElementType) {
+    this(name, parentStub, superClasses, subscriptedSuperClassesText, null, metaClass, slots, docString, stubElementType);
+  }
+
+  public PyClassStubImpl(
+    @Nullable String name,
+    @Nullable StubElement parentStub,
+    @NotNull Map<QualifiedName, QualifiedName> superClasses,
+    @NotNull List<String> subscriptedSuperClassesText,
+    @Nullable List<String> superClassesText,
+    @Nullable QualifiedName metaClass,
+    @Nullable List<String> slots,
+    @Nullable String docString,
+    @NotNull IStubElementType stubElementType) {
     super(parentStub, stubElementType);
     myName = name;
     mySuperClasses = superClasses;
+    mySubscriptedSuperClassesText = subscriptedSuperClassesText;
     mySuperClassesText = superClassesText;
     myMetaClass = metaClass;
     mySlots = slots;
@@ -78,7 +95,7 @@ public class PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
   @NotNull
   @Override
   public List<String> getSubscriptedSuperClasses() {
-    return mySuperClassesText;
+    return mySubscriptedSuperClassesText;
   }
 
   @Nullable
@@ -97,6 +114,12 @@ public class PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
   @Override
   public String getDocString() {
     return myDocString;
+  }
+
+  @Nullable
+  @Override
+  public List<String> getSuperClassesText() {
+    return mySuperClassesText;
   }
 
   @Override

--- a/python/src/com/jetbrains/python/psi/impl/stubs/PyClassStubImpl.java
+++ b/python/src/com/jetbrains/python/psi/impl/stubs/PyClassStubImpl.java
@@ -30,7 +30,8 @@ import java.util.Map;
 /**
  * @author max
  */
-public class PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
+public class
+PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
 
   @Nullable
   private final String myName;
@@ -62,16 +63,15 @@ public class PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
     this(name, parentStub, superClasses, subscriptedSuperClassesText, null, metaClass, slots, docString, stubElementType);
   }
 
-  public PyClassStubImpl(
-    @Nullable String name,
-    @Nullable StubElement parentStub,
-    @NotNull Map<QualifiedName, QualifiedName> superClasses,
-    @NotNull List<String> subscriptedSuperClassesText,
-    @Nullable List<String> superClassesText,
-    @Nullable QualifiedName metaClass,
-    @Nullable List<String> slots,
-    @Nullable String docString,
-    @NotNull IStubElementType stubElementType) {
+  public PyClassStubImpl(@Nullable String name,
+                         @Nullable StubElement parentStub,
+                         @NotNull Map<QualifiedName, QualifiedName> superClasses,
+                         @NotNull List<String> subscriptedSuperClassesText,
+                         @Nullable List<String> superClassesText,
+                         @Nullable QualifiedName metaClass,
+                         @Nullable List<String> slots,
+                         @Nullable String docString,
+                         @NotNull IStubElementType stubElementType) {
     super(parentStub, stubElementType);
     myName = name;
     mySuperClasses = superClasses;
@@ -116,7 +116,7 @@ public class PyClassStubImpl extends StubBase<PyClass> implements PyClassStub {
     return myDocString;
   }
 
-  @Nullable
+  @NotNull
   @Override
   public List<String> getSuperClassesText() {
     return mySuperClassesText;

--- a/python/testData/stubs/BaseClassText.py
+++ b/python/testData/stubs/BaseClassText.py
@@ -1,0 +1,8 @@
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+V = TypeVar('V')
+
+
+class Class(Generic[T, V], BaseClass1, SomeModule.SomeClass):
+    pass

--- a/python/testSrc/com/jetbrains/python/PyStubsTest.java
+++ b/python/testSrc/com/jetbrains/python/PyStubsTest.java
@@ -843,6 +843,17 @@ public class PyStubsTest extends PyTestCase {
     assertNotParsed(file);
   }
 
+  // PY-25655
+  public void testBaseClassText() {
+    final PyFile file = getTestFile();
+    final PyClass pyClass = file.findTopLevelClass("Class");
+    final PyClassStub stub = pyClass.getStub();
+    assertNotNull(stub);
+    final List<String> genericBases = stub.getSuperClassesText();
+    assertContainsOrdered(genericBases, "Generic[T, V]", "BaseClass1", "SomeModule.SomeClass");
+    assertNotParsed(file);
+  }
+
   // PY-18816
   public void testComplexGenericType() {
     runWithLanguageLevel(LanguageLevel.PYTHON30, () -> {


### PR DESCRIPTION
@vlasovskikh Wanted to get this in because it involves stub changes so it's only possible to get it in before a major release. Implementation is slightly strange to preserve compatibility.