### PR TITLE
support atomic save

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/LocalFileSystemBase.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/LocalFileSystemBase.java
@@ -21,7 +21,6 @@ import com.intellij.util.PathUtilRt;
 import com.intellij.util.Processor;
 import com.intellij.util.ThrowableConsumer;
 import com.intellij.util.containers.ContainerUtil;
-import com.intellij.util.io.SafeFileOutputStream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -462,7 +461,7 @@ public abstract class LocalFileSystemBase extends LocalFileSystem {
     final File ioFile = convertToIOFileAndCheck(file);
     @SuppressWarnings("IOResourceOpenedButNotSafelyClosed")
     final OutputStream stream = shallUseSafeStream(requestor, file) ?
-                                new SafeFileOutputStream(ioFile, SystemInfo.isUnix) : new FileOutputStream(ioFile);
+                                new AtomicSafeFileOutputStream(ioFile, SystemInfo.isUnix) : new FileOutputStream(ioFile);
     return new BufferedOutputStream(stream) {
       @Override
       public void close() throws IOException {


### PR DESCRIPTION
@trespasserw @nicity 

Please accept this PR. It prevents many heisenbugs results from the file being temporarily deleted when saving. For example Git rescan sometimes picking up the deleted file. It is also safer and faster than the alternate save. 

Had to do some copy-paste reuse because the module with SafeOutputStream must support JDK 1.6 and this needs 1.7+.