### PR TITLE
Honor .mailmap

### DIFF
--- a/plugins/git4idea/src/git4idea/history/GitLogParser.java
+++ b/plugins/git4idea/src/git4idea/history/GitLogParser.java
@@ -228,7 +228,7 @@ public class GitLogParser {
    * These are the pieces of information about a commit which we want to get from 'git log'.
    */
   enum GitLogOption {
-    HASH("H"), TREE("T"), COMMIT_TIME("ct"), AUTHOR_NAME("an"), AUTHOR_TIME("at"), AUTHOR_EMAIL("ae"), COMMITTER_NAME("cn"),
+    HASH("H"), TREE("T"), COMMIT_TIME("ct"), AUTHOR_NAME("aN"), AUTHOR_TIME("at"), AUTHOR_EMAIL("ae"), COMMITTER_NAME("cn"),
     COMMITTER_EMAIL("ce"), SUBJECT("s"), BODY("b"), PARENTS("P"), REF_NAMES("d"), SHORT_REF_LOG_SELECTOR("gd"),
     RAW_BODY("B");
 


### PR DESCRIPTION
Using `%aN` instead of `%an` git log respects the mappings in .mailmap file

More details on https://git-scm.com/docs/git-log