### PR TITLE
Simplify Arrays.asList().sublist().toArray()

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/resolve/ProcessCandidateParameterTypeInferencePolicy.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/resolve/ProcessCandidateParameterTypeInferencePolicy.java
@@ -15,7 +15,6 @@
  */
 package com.intellij.psi.impl.source.resolve;
 
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Pair;
 import com.intellij.pom.java.LanguageLevel;
 import com.intellij.psi.*;
@@ -28,7 +27,6 @@ import com.intellij.util.ArrayUtilRt;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
-import java.util.List;
 
 public class ProcessCandidateParameterTypeInferencePolicy extends DefaultParameterTypeInferencePolicy {
   public static final ProcessCandidateParameterTypeInferencePolicy INSTANCE = new ProcessCandidateParameterTypeInferencePolicy();
@@ -54,7 +52,7 @@ public class ProcessCandidateParameterTypeInferencePolicy extends DefaultParamet
       final PsiType innerReturnType = owner.getReturnType();
       for (final JavaResolveResult result : results) {
         if (result == null) continue;
-        final PsiSubstitutor substitutor = getSubstitutor(contextCall, expressions, i, result);
+        final PsiSubstitutor substitutor = getSubstitutor(expressions, i, result);
         final Pair<PsiType, ConstraintType> constraint = inferConstraint(typeParameter, innerMethodCall, i, innerReturnType, result, substitutor);
         if (constraint != null) return constraint;
       }
@@ -66,18 +64,18 @@ public class ProcessCandidateParameterTypeInferencePolicy extends DefaultParamet
     return null;
   }
 
-  protected PsiSubstitutor getSubstitutor(PsiCallExpression contextCall, PsiExpression[] expressions, int i, JavaResolveResult result) {
+  protected PsiSubstitutor getSubstitutor(PsiExpression[] expressions, int i, JavaResolveResult result) {
     if (result instanceof MethodCandidateInfo) {
-      List<PsiExpression> leftArgs = getExpressions(expressions, i);
-      return ((MethodCandidateInfo)result).inferSubstitutorFromArgs(this, leftArgs.toArray(new PsiExpression[leftArgs.size()]));
+      PsiExpression[] leftArgs = getExpressions(expressions, i);
+      return ((MethodCandidateInfo)result).inferSubstitutorFromArgs(this, leftArgs);
     }
     else {
       return result.getSubstitutor();
     }
   }
 
-  protected List<PsiExpression> getExpressions(PsiExpression[] expressions, int i) {
-    return Arrays.asList(expressions).subList(0, i);
+  protected PsiExpression[] getExpressions(PsiExpression[] expressions, int i) {
+    return Arrays.copyOf(expressions, i);
   }
 
   protected static Pair<PsiType, ConstraintType> inferConstraint(PsiTypeParameter typeParameter,

--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/resolve/ProcessCandidateParameterTypeInferencePolicy.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/resolve/ProcessCandidateParameterTypeInferencePolicy.java
@@ -27,6 +27,7 @@ import com.intellij.util.ArrayUtilRt;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class ProcessCandidateParameterTypeInferencePolicy extends DefaultParameterTypeInferencePolicy {
   public static final ProcessCandidateParameterTypeInferencePolicy INSTANCE = new ProcessCandidateParameterTypeInferencePolicy();
@@ -52,7 +53,7 @@ public class ProcessCandidateParameterTypeInferencePolicy extends DefaultParamet
       final PsiType innerReturnType = owner.getReturnType();
       for (final JavaResolveResult result : results) {
         if (result == null) continue;
-        final PsiSubstitutor substitutor = getSubstitutor(expressions, i, result);
+        final PsiSubstitutor substitutor = getSubstitutor(contextCall, expressions, i, result);
         final Pair<PsiType, ConstraintType> constraint = inferConstraint(typeParameter, innerMethodCall, i, innerReturnType, result, substitutor);
         if (constraint != null) return constraint;
       }
@@ -64,18 +65,18 @@ public class ProcessCandidateParameterTypeInferencePolicy extends DefaultParamet
     return null;
   }
 
-  protected PsiSubstitutor getSubstitutor(PsiExpression[] expressions, int i, JavaResolveResult result) {
+  protected PsiSubstitutor getSubstitutor(PsiCallExpression contextCall, PsiExpression[] expressions, int i, JavaResolveResult result) {
     if (result instanceof MethodCandidateInfo) {
-      PsiExpression[] leftArgs = getExpressions(expressions, i);
-      return ((MethodCandidateInfo)result).inferSubstitutorFromArgs(this, leftArgs);
+      List<PsiExpression> leftArgs = getExpressions(expressions, i);
+      return ((MethodCandidateInfo)result).inferSubstitutorFromArgs(this, leftArgs.toArray(new PsiExpression[leftArgs.size()]));
     }
     else {
       return result.getSubstitutor();
     }
   }
 
-  protected PsiExpression[] getExpressions(PsiExpression[] expressions, int i) {
-    return Arrays.copyOf(expressions, i);
+  protected List<PsiExpression> getExpressions(PsiExpression[] expressions, int i) {
+    return Arrays.asList(expressions).subList(0, i);
   }
 
   protected static Pair<PsiType, ConstraintType> inferConstraint(PsiTypeParameter typeParameter,

--- a/platform/util/src/com/intellij/util/ExceptionUtil.java
+++ b/platform/util/src/com/intellij/util/ExceptionUtil.java
@@ -54,7 +54,7 @@ public class ExceptionUtil {
     for (int i=0, len = Math.min(trace.length, rootTrace.length); i < len; i++) {
       if (trace[trace.length - i - 1].equals(rootTrace[rootTrace.length - i - 1])) continue;
       int newDepth = trace.length - i;
-      th.setStackTrace(Arrays.asList(trace).subList(0, newDepth).toArray(new StackTraceElement[newDepth]));
+      th.setStackTrace(Arrays.copyOf(trace, newDepth));
       break;
     }
     return th;


### PR DESCRIPTION
Expression 
```java
Arrays.asList(T...).sublist(0, to).toArray(T[])
```
can be simplified to
```java
Arrays.copyOf(T[], to)
```
giving both performance enhancement and code simplicity.
See inspection request: https://youtrack.jetbrains.com/issue/IDEA-182206