### PR TITLE
FernFlower: Rename classes whose filenames will exceed 255 characters

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/renamer/ConverterHelper.java
@@ -42,7 +42,7 @@ public class ConverterHelper implements IIdentifierRenamer {
   public boolean toBeRenamed(Type elementType, String className, String element, String descriptor) {
     String value = elementType == Type.ELEMENT_CLASS ? className : element;
     return value == null || value.length() == 0 || value.length() <= 2 || KEYWORDS.contains(value) || Character.isDigit(value.charAt(0))
-      || elementType == Type.ELEMENT_CLASS && RESERVED_WINDOWS_NAMESPACE.contains(value.toLowerCase());
+      || elementType == Type.ELEMENT_CLASS && (RESERVED_WINDOWS_NAMESPACE.contains(value.toLowerCase()) || value.length() > 255 - ".class".length());
   }
 
   // TODO: consider possible conflicts with not renamed classes, fields and methods!


### PR DESCRIPTION
An obfuscated application I'm reversing has a class called "OoOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO" in it (256 characters long). This decompiles fine into a JAR, but if I want to unpack the JAR in order to refactor code and/or recompile it, I quickly run in to filesystem filename length limits ([almost all filesystems](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits) top out at 255 characters).

This patch renames classes that would exceed 255 characters in length once ".class" is added to the name.