### PR TITLE
improve contains() and containsAll() of SmartList and HashSet

### DIFF
--- a/platform/platform-tests/testSrc/com/intellij/util/containers/HashSetTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/util/containers/HashSetTest.java
@@ -1,0 +1,88 @@
+// Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.util.containers;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.*;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.runners.Parameterized.*;
+
+
+@RunWith(value = Parameterized.class)
+public class HashSetTest {
+  private String mapType;
+
+  public HashSetTest(String mapType) {
+    this.mapType = mapType;
+  }
+
+  @Parameters
+  public static Collection<String> data() {
+    return Arrays.asList("jdk", "idea");
+  }
+
+  @Test
+  public void contains() {
+    Set<Integer> set = freshSet();
+
+    assertFalse(set.contains(1));
+    assertFalse(set.contains(null));
+
+    set.add(1);
+    assertTrue(set.contains(1));
+
+
+    set.clear();
+    assertFalse(set.contains(1));
+    assertFalse(set.contains(null));
+  }
+
+  @Test
+  public void containsAll() {
+    Set<Integer> set = freshSet();
+
+    boolean contains = set.containsAll(Collections.emptyList());
+
+    assertTrue(contains);
+
+    contains = set.containsAll(new java.util.HashSet<>());
+
+    assertTrue(contains);
+
+    contains = set.containsAll(Collections.singleton(1));
+
+    assertFalse(contains);
+
+    contains = set.containsAll(Collections.singletonList(1));
+
+    assertFalse(contains);
+  }
+
+  @Test
+  public void clear() {
+    Set<Integer> set = freshSet();
+
+    set.clear();
+    assertThat(set).isEmpty();
+
+    set.add(1);
+    assertThat(set).isNotEmpty();
+
+    set.clear();
+    assertThat(set).isEmpty();
+  }
+
+  @NotNull
+  private Set<Integer> freshSet() {
+    if ("jdk".equals(mapType)) {
+      return new java.util.HashSet<>();
+    }
+    return new com.intellij.util.containers.HashSet<>();
+  }
+}

--- a/platform/util-rt/src/com/intellij/util/containers/HashSet.java
+++ b/platform/util-rt/src/com/intellij/util/containers/HashSet.java
@@ -15,6 +15,8 @@
  */
 package com.intellij.util.containers;
 
+import org.jetbrains.annotations.Contract;
+
 import java.util.Collection;
 
 @SuppressWarnings("ClassNameSameAsAncestorName")
@@ -33,6 +35,20 @@ public class HashSet<E> extends java.util.HashSet<E> {
     super(i);
   }
 
+  @Override
+  @Contract(pure = true)
+  public boolean contains(Object o) {
+    if (size() == 0) return false;
+    return super.contains(o);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    if (size() == 0) return c.isEmpty();
+    return super.containsAll(c);
+  }
+
+  @Override
   public void clear() {
     if (size() == 0) return; // optimization
     super.clear();

--- a/platform/util/src/com/intellij/util/SmartList.java
+++ b/platform/util/src/com/intellij/util/SmartList.java
@@ -380,4 +380,10 @@ public class SmartList<E> extends AbstractList<E> implements RandomAccess {
     }
     return true;
   }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    if (mySize == 0) return c.isEmpty();
+    return super.containsAll(c);
+  }
 }

--- a/platform/util/testSrc/com/intellij/util/SmartListTest.java
+++ b/platform/util/testSrc/com/intellij/util/SmartListTest.java
@@ -22,6 +22,10 @@ import org.junit.Test;
 
 import java.util.*;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -365,4 +369,99 @@ public class SmartListTest {
     assertThat(list).isNotEqualTo(new LinkedList<>(Arrays.asList(new Integer(1), new Integer(2), new Integer(3))));
     assertThat(list).isNotEqualTo(Arrays.asList(new Integer(1), new Integer(2), new Integer(3)));
   }
+
+  @Test
+  public void testContainsAllInEmptyList() {
+    List<Integer> emptyList = new SmartList<>();
+
+    boolean contains = emptyList.containsAll(singleton(1));
+    assertThat(contains).isFalse();
+
+    contains = emptyList.containsAll(emptyList());
+    assertThat(contains).isTrue();
+
+    contains = emptyList.containsAll(emptySet());
+    assertThat(contains).isTrue();
+
+    contains = emptyList.containsAll(new SmartList<>());
+    assertThat(contains).isTrue();
+
+    contains = emptyList.containsAll(new ArrayList<>());
+    assertThat(contains).isTrue();
+
+    contains = emptyList.containsAll(new LinkedList<>());
+    assertThat(contains).isTrue();
+  }
+
+  @Test
+  public void testContainsAllInNonEmptyList() {
+    List<Integer> list = new SmartList<>(1,2);
+
+    boolean contains = list.containsAll(Arrays.asList(1,2));
+    assertThat(contains).isTrue();
+
+    contains = list.containsAll(Arrays.asList(2,1));
+    assertThat(contains).isTrue();
+
+    contains = list.containsAll(emptyList());
+    assertThat(contains).isTrue();
+
+    contains = list.containsAll(emptySet());
+    assertThat(contains).isTrue();
+
+    contains = list.containsAll(new SmartList<>());
+    assertThat(contains).isTrue();
+
+    contains = list.containsAll(new ArrayList<>());
+    assertThat(contains).isTrue();
+
+    contains = list.containsAll(new LinkedList<>());
+    assertThat(contains).isTrue();
+  }
+
+  @Test
+  public void testContainsAll_ensureBehaviouralCompatibilityWithEmptyArrayList() {
+    List<Integer> emptySmartList = new SmartList<>();
+    List<Integer> emptyArrayList = new ArrayList<>();
+
+    boolean containsInSmartList = emptySmartList.containsAll(singletonList(1));
+    boolean containsInArrayList = emptyArrayList.containsAll(singletonList(1));
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+
+    containsInSmartList = emptySmartList.containsAll(emptyList());
+    containsInArrayList = emptyArrayList.containsAll(emptyList());
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+
+    containsInSmartList = emptySmartList.containsAll(emptySet());
+    containsInArrayList = emptyArrayList.containsAll(emptySet());
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+  }
+
+  @Test
+  public void testContainsAll_ensureBehaviouralCompatibilityWithNonEmptyArrayList() {
+    List<Integer> emptySmartList = new SmartList<>(Arrays.asList(1,2));
+    List<Integer> emptyArrayList = new ArrayList<>(Arrays.asList(1,2));
+
+    boolean containsInSmartList = emptySmartList.containsAll(singletonList(1));
+    boolean containsInArrayList = emptyArrayList.containsAll(singletonList(1));
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+
+    containsInSmartList = emptySmartList.containsAll(Arrays.asList(1,2));
+    containsInArrayList = emptyArrayList.containsAll(Arrays.asList(1,2));
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+
+    containsInSmartList = emptySmartList.containsAll(Arrays.asList(2,1));
+    containsInArrayList = emptyArrayList.containsAll(Arrays.asList(2,1));
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+
+
+    containsInSmartList = emptySmartList.containsAll(emptyList());
+    containsInArrayList = emptyArrayList.containsAll(emptyList());
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+
+    containsInSmartList = emptySmartList.containsAll(emptySet());
+    containsInArrayList = emptyArrayList.containsAll(emptySet());
+    assertThat(containsInSmartList).isEqualTo(containsInArrayList);
+  }
+
 }


### PR DESCRIPTION
I've made some measurements with benchmark [available here](https://github.com/stsypanov/logeek-night-benchmark/blob/master/benchmark-runners/src/main/java/com/luxoft/logeek/benchmark/contains/EnhancedCollectionsBenchmark.java) for both `com.intellij.util.containers.HashSet` and `com.intellij.util.SmartList` and got the following results:

Case 1: argument is collections/item of type `Integer` and value `1`
```
Benchmark                                                  (integer)  Mode  Cnt   Score    Error   Units
measureContainsAllInEmptyIdeaHashSet                               1  avgt  500   6,434 ±  0,421   ns/op
measureContainsAllInEmptyJdkHashSet                                1  avgt  500   9,995 ±  0,066   ns/op

measureContainsInEmptyIdeaHashSet                                  1  avgt  500   3,572 ±  0,041   ns/op
measureContainsInEmptyJdkHashSet                                   1  avgt  500   4,234 ±  0,034   ns/op

measureSmartListEnhancedContainsAll                                1  avgt  500   3,970 ±  0,033   ns/op
measureSmartListContainsAll                                        1  avgt  500   4,884 ±  0,040   ns/op
```

Case 2: argument is collections/item of type `Integer` and value `null`
```
Benchmark                                                  (integer)  Mode  Cnt   Score    Error   Units
measureContainsAllInEmptyIdeaHashSet                            null  avgt  500   4,610 ±  0,060   ns/op
measureContainsAllInEmptyJdkHashSet                             null  avgt  500   5,673 ±  0,045   ns/op

measureContainsInEmptyIdeaHashSet                               null  avgt  500   3,553 ±  0,036   ns/op
measureContainsInEmptyJdkHashSet                                null  avgt  500   4,116 ±  0,035   ns/op

measureSmartListEnhancedContainsAll                             null  avgt  500   3,931 ±  0,029   ns/op
measureSmartListContainsAll                                     null  avgt  500   4,870 ±  0,041   ns/op
```

Patch also prevents allocating iterator in case when argument collection does not support element access by index (e.g. `HashSet`) in `AbstractCollections.containsAll()`:

```java
public boolean containsAll(Collection<?> c) {
    for (Object e : c)
        if (!contains(e))
            return false;
    return true;
}
```