### PR TITLE
Fix sporadic exceptions in AbstractTreeUi.

### DIFF
--- a/platform/platform-api/src/com/intellij/ide/util/treeView/AbstractTreeUi.java
+++ b/platform/platform-api/src/com/intellij/ide/util/treeView/AbstractTreeUi.java
@@ -1008,7 +1008,7 @@ public class AbstractTreeUi {
       DefaultMutableTreeNode nodeToUpdate = null;
       boolean updateElementStructure = updateStructure;
       for (Object element = fromElement; element != null; element = getTreeStructure().getParentElement(element)) {
-        final DefaultMutableTreeNode node = getNodeForElement(element, false);
+        final DefaultMutableTreeNode node = getFirstNode(element);
         if (node != null) {
           nodeToUpdate = node;
           break;


### PR DESCRIPTION
AbstractTreeUi has been sporadically failing in different places and
most often at

    assert descriptor != null;

in sortChildren().

The other manifistation of the problem was "null" nodes sometimes
appearing in the tree (nodes that visually appear with text "null").

The root cause of the problem is getNodeForElement() which disposes
any node that is not in the tree. However, because of async nature of
queued updates a node which is being dosposed can be already scheduled
for addition to the tree.

Here is the original comment from the commit from 2008 thad added
diposing:

IDEADEV-29853 - invalid nodes, found by custom builders are disposed

This CL replaces the getNodeForElement() with the equiavalent code that
does not dispose any nodes.
Attn: @vladsoroka 

Test: "null" node does not appear visually. makeSimpleApplication() UI
      test passes.
Bug: IDEA-181904
Change-Id: I837f2f4d3ab7a235d8b9ec6cb1afb215b4c230e4