### PR TITLE
Fix bug in resizing of DialogWrapper with large error label

### DIFF
--- a/platform/platform-api/src/com/intellij/openapi/ui/DialogWrapper.java
+++ b/platform/platform-api/src/com/intellij/openapi/ui/DialogWrapper.java
@@ -236,7 +236,7 @@ public abstract class DialogWrapper {
           if (!myResizeInProgress) {
             myActualSize = myPeer.getSize();
             if (myErrorText != null && myErrorText.isVisible()) {
-              myActualSize.height -= myErrorText.getMinimumHeight();
+              myActualSize.height -= myErrorText.getMinimumSize().height;
             }
           }
         }
@@ -1253,7 +1253,7 @@ public abstract class DialogWrapper {
         if (height != myHeight) {
           myHeight = height;
           myResizeInProgress = true;
-          myErrorText.setMinimumHeight(height);
+          myErrorText.setMinimumSize(new Dimension(0, height));
           JRootPane root = myPeer.getRootPane();
           if (root != null) {
             root.validate();
@@ -2168,14 +2168,6 @@ public abstract class DialogWrapper {
       } else {
         return false;
       }
-    }
-
-    public void setMinimumHeight(int height) {
-      setMinimumSize(new Dimension(0, height));
-    }
-
-    public int getMinimumHeight() {
-      return getMinimumSize().height;
     }
   }
 

--- a/platform/platform-api/src/com/intellij/openapi/ui/DialogWrapper.java
+++ b/platform/platform-api/src/com/intellij/openapi/ui/DialogWrapper.java
@@ -236,7 +236,7 @@ public abstract class DialogWrapper {
           if (!myResizeInProgress) {
             myActualSize = myPeer.getSize();
             if (myErrorText != null && myErrorText.isVisible()) {
-              myActualSize.height -= myErrorText.myLabel.getHeight();
+              myActualSize.height -= myErrorText.getMinimumHeight();
             }
           }
         }
@@ -1253,7 +1253,7 @@ public abstract class DialogWrapper {
         if (height != myHeight) {
           myHeight = height;
           myResizeInProgress = true;
-          myErrorText.setMinimumSize(new Dimension(0, height));
+          myErrorText.setMinimumHeight(height);
           JRootPane root = myPeer.getRootPane();
           if (root != null) {
             root.validate();
@@ -2168,6 +2168,14 @@ public abstract class DialogWrapper {
       } else {
         return false;
       }
+    }
+
+    public void setMinimumHeight(int height) {
+      setMinimumSize(new Dimension(0, height));
+    }
+
+    public int getMinimumHeight() {
+      return getMinimumSize().height;
     }
   }
 


### PR DESCRIPTION
If the error label in the DialogWrapper is displayed on multiple lines,
any update of the error message that keeps it on several lines will
cause the dialog window to shrink.