### PR TITLE
Dispose of the IdeRootPanel when disposing of the IdeFrame

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeFrameImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeFrameImpl.java
@@ -407,8 +407,9 @@ public class IdeFrameImpl extends JFrame implements IdeFrameEx, AccessibleContex
       if (ApplicationManager.getApplication().isUnitTestMode()) {
         myRootPane.removeNotify();
       }
-      myRootPane = null;
       setRootPane(new JRootPane());
+      Disposer.dispose(myRootPane);
+      myRootPane = null;
     }
     if (myFrameDecorator != null) {
       Disposer.dispose(myFrameDecorator);


### PR DESCRIPTION
Avoid memory leaks by disposing of the IdeRootPane when about to dispose of the IdeFrame