### PR TITLE
Fix memory leak of StatusBar in IdeFrameImpl

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeFrameImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeFrameImpl.java
@@ -407,8 +407,9 @@ public class IdeFrameImpl extends JFrame implements IdeFrameEx, AccessibleContex
       if (ApplicationManager.getApplication().isUnitTestMode()) {
         myRootPane.removeNotify();
       }
-      myRootPane = null;
       setRootPane(new JRootPane());
+      Disposer.dispose(myRootPane);
+      myRootPane = null;
     }
     if (myFrameDecorator != null) {
       Disposer.dispose(myFrameDecorator);

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeRootPane.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/IdeRootPane.java
@@ -10,6 +10,7 @@ import com.intellij.ide.ui.UISettings;
 import com.intellij.ide.ui.UISettingsListener;
 import com.intellij.ide.ui.customization.CustomActionsSchema;
 import com.intellij.ide.ui.laf.darcula.ui.DarculaRootPaneUI;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx;
 import com.intellij.openapi.application.Application;
@@ -47,7 +48,7 @@ import java.util.List;
  * @author Anton Katilin
  * @author Vladimir Kondratyev
  */
-public class IdeRootPane extends JRootPane implements UISettingsListener {
+public class IdeRootPane extends JRootPane implements UISettingsListener, Disposable {
   /**
    * Toolbar and status bar.
    */
@@ -229,6 +230,7 @@ public class IdeRootPane extends JRootPane implements UISettingsListener {
 
   private void createStatusBar(IdeFrame frame) {
     myStatusBar = new IdeStatusBarImpl();
+    Disposer.register(this, myStatusBar);
     myStatusBar.install(frame);
 
     myMemoryWidget = new MemoryUsagePanel();
@@ -334,6 +336,10 @@ public class IdeRootPane extends JRootPane implements UISettingsListener {
     IdeFrame frame = UIUtil.getParentOfType(IdeFrame.class, this);
     BalloonLayout layout = frame != null ? frame.getBalloonLayout() : null;
     if (layout instanceof BalloonLayoutImpl) ((BalloonLayoutImpl)layout).queueRelayout();
+  }
+
+  @Override
+  public void dispose() {
   }
 
   private class MyRootLayout extends RootLayout {


### PR DESCRIPTION
IdeFrameImpl holds a IdeRootPane that holds a StatusBar.
When disposing of the IdeFrameImpl, one needs to first dispose of
the StatusBar.