### PR TITLE
Scale should matter only if the type is NOT SVG

### DIFF
--- a/platform/util/src/com/intellij/util/ImageLoader.java
+++ b/platform/util/src/com/intellij/util/ImageLoader.java
@@ -107,7 +107,7 @@ public class ImageLoader implements Serializable {
       }
       if (stream == null) {
         if (useCache) {
-          cacheKey = path + (type == Type.SVG ? "_@" + scale + "x" : "");
+          cacheKey = path + (type != Type.SVG ? "_@" + scale + "x" : "");
           Image image = ourCache.get(cacheKey);
           if (image != null) return image;
         }


### PR DESCRIPTION
The following project use this loader with SVG format: https://github.com/davidsommer/IconViewer/blob/master/src/ch/dasoft/iconviewer/ImageIconProvider.java

All icons are well displayed except SVG.

My inspection lead me to this ImageLoader class and I try to see what's wrong with SVG.