### PR TITLE
Make isImplicitReturnStatement public

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitor.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitor.java
@@ -17,6 +17,7 @@ import org.jetbrains.plugins.groovy.annotator.GrHighlightUtil;
 import org.jetbrains.plugins.groovy.codeInspection.BaseInspectionVisitor;
 import org.jetbrains.plugins.groovy.codeInspection.GroovyInspectionBundle;
 import org.jetbrains.plugins.groovy.codeInspection.assignment.*;
+import org.jetbrains.plugins.groovy.codeInspection.utils.ControlFlowUtils;
 import org.jetbrains.plugins.groovy.config.GroovyConfigUtils;
 import org.jetbrains.plugins.groovy.extensions.GroovyNamedArgumentProvider;
 import org.jetbrains.plugins.groovy.extensions.NamedArgumentDescriptor;
@@ -732,7 +733,7 @@ public class GroovyTypeCheckVisitor extends BaseInspectionVisitor {
   @Override
   public void visitExpression(@NotNull GrExpression expression) {
     super.visitExpression(expression);
-    if (isImplicitReturnStatement(expression)) {
+    if (ControlFlowUtils.isImplicitReturnStatement(expression)) {
       processReturnValue(expression, expression, expression);
     }
   }

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitorHelper.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/type/GroovyTypeCheckVisitorHelper.java
@@ -274,12 +274,4 @@ public class GroovyTypeCheckVisitorHelper {
     }
     return args;
   }
-
-  static boolean isImplicitReturnStatement(@NotNull GrExpression expression) {
-    GrControlFlowOwner flowOwner = ControlFlowUtils.findControlFlowOwner(expression);
-    return flowOwner != null &&
-        PsiUtil.isExpressionStatement(expression) &&
-        ControlFlowUtils.isReturnValue(expression, flowOwner) &&
-        !PsiUtil.isVoidMethodCall(expression);
-  }
 }

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/utils/ControlFlowUtils.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/codeInspection/utils/ControlFlowUtils.java
@@ -524,6 +524,14 @@ public class ControlFlowUtils {
     return applicable.get(0);
   }
 
+  public static boolean isImplicitReturnStatement(@NotNull GrExpression expression) {
+    GrControlFlowOwner flowOwner = findControlFlowOwner(expression);
+    return flowOwner != null &&
+           PsiUtil.isExpressionStatement(expression) &&
+           isReturnValue(expression, flowOwner) &&
+           !PsiUtil.isVoidMethodCall(expression);
+  }
+
   private static class ReturnFinder extends GroovyRecursiveElementVisitor {
     private boolean m_found = false;
 


### PR DESCRIPTION
Call me a [crazy liberal](http://steve-yegge.blogspot.com/2010/07/wikileaks-to-leak-5000-open-source-java.html), but is there any reason this method shouldn't be public like the others in this helper class?

I ended up wanting this method for a custom Annotator, and had to just re-implement it inside my plugin. Yay open source, but why not just let people use it where it is, and thus get updates to the code as well?