### PR TITLE
Introduce ScratchFileLanguageProvider

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/scratch/ScratchFileActions.java
+++ b/platform/lang-impl/src/com/intellij/ide/scratch/ScratchFileActions.java
@@ -28,7 +28,6 @@ import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileTypes.FileType;
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Condition;
@@ -166,8 +165,7 @@ public class ScratchFileActions {
   static void doCreateNewScratch(@NotNull Project project, boolean buffer, @NotNull Language language, @NotNull String text) {
     FeatureUsageTracker.getInstance().triggerFeatureUsed("scratch");
 
-    LanguageFileType fileType = language.getAssociatedFileType();
-    String ext = buffer || fileType == null? "" : fileType.getDefaultExtension();
+    String ext = buffer ? "" : ScratchFileLanguageProvider.Companion.getDefaultFileExtension(language);
     String fileName = buffer ? "buffer" + nextBufferIndex() : "scratch";
     ScratchFileService.Option option = buffer ? ScratchFileService.Option.create_if_missing : ScratchFileService.Option.create_new_always;
     VirtualFile f = ScratchRootType.getInstance().createScratchFile(project, PathUtil.makeFileName(fileName, ext), language, text, option);

--- a/platform/lang-impl/src/com/intellij/ide/scratch/ScratchFileLanguageProvider.kt
+++ b/platform/lang-impl/src/com/intellij/ide/scratch/ScratchFileLanguageProvider.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+package com.intellij.ide.scratch
+
+import com.intellij.lang.Language
+import com.intellij.lang.LanguageExtension
+
+abstract class ScratchFileLanguageProvider {
+  abstract fun getDefaultExtension(): String?
+
+  companion object {
+    private val EXTENSION = LanguageExtension<ScratchFileLanguageProvider>("com.intellij.scratchFileLanguageProvider")
+
+    fun getDefaultFileExtension(language: Language): String {
+      return ScratchFileLanguageProvider.EXTENSION
+               .forLanguage(language)
+               .getDefaultExtension()
+               ?: language.associatedFileType?.defaultExtension
+               ?: ""
+    }
+  }
+}

--- a/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
+++ b/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
@@ -919,6 +919,10 @@
                     beanClass="com.intellij.openapi.fileTypes.FileTypeExtensionPoint">
       <with attribute="implementationClass" implements="com.intellij.psi.stubs.PrebuiltStubsProvider"/>
     </extensionPoint>
+
+    <extensionPoint name="scratchFileLanguageProvider" beanClass="com.intellij.lang.LanguageExtensionPoint">
+      <with attribute="implementationClass" implements="com.intellij.ide.scratch.ScratchFileLanguageProvider"/>
+    </extensionPoint>
   </extensionPoints>
 </idea-plugin>
 


### PR DESCRIPTION
It is needed for kotlin plugin to create scratch files with .kts extension instead of .kt.