### PR TITLE
IDEABKL-6449 Enable ISO-8601 date format via system property

### DIFF
--- a/platform/util/src/com/intellij/util/text/DateFormatUtil.java
+++ b/platform/util/src/com/intellij/util/text/DateFormatUtil.java
@@ -311,7 +311,15 @@ public class DateFormatUtil {
   private static SyncDateFormat[] getDateTimeFormats() {
     DateFormat[] formats = null;
     try {
-      if (SystemInfo.isMac && JnaLoader.isLoaded()) {
+      if (Boolean.parseBoolean(System.getProperty("date.iso8601"))) {
+        formats = new DateFormat[]{
+          new SimpleDateFormat("yyyy-MM-dd");
+          new SimpleDateFormat("HH:mm");
+          new SimpleDateFormat("HH:mm:ss");
+          new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        };
+      }
+      else if (SystemInfo.isMac && JnaLoader.isLoaded()) {
         formats = getMacFormats();
       }
       else if (SystemInfo.isUnix) {


### PR DESCRIPTION
Setting the system property `date.iso8601` to `true` (`java -Ddate.iso8601=true`), enables the ISO-8601 format in the `DateFormatUtil`.

This addresses https://youtrack.jetbrains.com/issue/IDEABKL-6449.

I'm not sure whether and how to test this contribution: programmatically setting the system property would have to be done prior to the first access of `DateFormatUtil` (in all variations of running the tests).