### PR TITLE
Do not use a hard-coded color for active tool header

### DIFF
--- a/platform/util/src/com/intellij/util/ui/UIUtil.java
+++ b/platform/util/src/com/intellij/util/ui/UIUtil.java
@@ -1896,7 +1896,8 @@ public class UIUtil {
       g.fillRect(x, 0, width, height);
 
       if (active) {
-        g.setColor(new Color(100, 150, 230, toolWindow ? 50 : 30));
+        Color headerColor = ObjectUtils.notNull(ACTIVE_HEADER_COLOR, new Color(100, 150, 230, toolWindow ? 50 : 30)));
+        g.setColor(headerColor);
         g.fillRect(x, 0, width, height);
       }
       g.setColor(SystemInfo.isMac && isUnderIntelliJLaF() ? Gray.xC9 : Gray.x00.withAlpha(toolWindow ? 90 : 50));


### PR DESCRIPTION
It would be easier to theme this, like I'm doing with the Material Theme UI plugin