### PR TITLE
IDEA-163705: Add option to not log error on missing jars in JarLoader

### DIFF
--- a/platform/util/src/com/intellij/util/lang/ClassPath.java
+++ b/platform/util/src/com/intellij/util/lang/ClassPath.java
@@ -54,6 +54,7 @@ public class ClassPath {
   private final boolean myCanHavePersistentIndex;
   @Nullable private final CachePoolImpl myCachePool;
   @Nullable private final UrlClassLoader.CachingCondition myCachingCondition;
+  private final boolean myLogErrorOnMissingJar;
 
   public ClassPath(List<URL> urls,
                    boolean canLockJars,
@@ -62,7 +63,8 @@ public class ClassPath {
                    boolean preloadJarContents,
                    boolean canHavePersistentIndex,
                    @Nullable CachePoolImpl cachePool,
-                   @Nullable UrlClassLoader.CachingCondition cachingCondition) {
+                   @Nullable UrlClassLoader.CachingCondition cachingCondition,
+                   boolean logErrorOnMissingJar) {
     myCanLockJars = canLockJars;
     myCanUseCache = canUseCache;
     myAcceptUnescapedUrls = acceptUnescapedUrls;
@@ -70,6 +72,7 @@ public class ClassPath {
     myCachePool = cachePool;
     myCachingCondition = cachingCondition;
     myCanHavePersistentIndex = canHavePersistentIndex;
+    myLogErrorOnMissingJar = logErrorOnMissingJar;
     push(urls);
   }
 
@@ -199,7 +202,7 @@ public class ClassPath {
       return new FileLoader(url, index, myCanHavePersistentIndex);
     }
     if (file.isFile()) {
-      Loader loader = new JarLoader(url, myCanLockJars, index, myPreloadJarContents, this);
+      Loader loader = new JarLoader(url, myCanLockJars, index, myPreloadJarContents, this, myLogErrorOnMissingJar);
       if (processRecursively) {
         String[] referencedJars = loadManifestClasspath((JarLoader)loader);
         if (referencedJars != null) {

--- a/platform/util/src/com/intellij/util/lang/JarLoader.java
+++ b/platform/util/src/com/intellij/util/lang/JarLoader.java
@@ -45,16 +45,18 @@ class JarLoader extends Loader {
 
   private final String myFilePath;
   private final boolean myCanLockJar; // true implies that the .jar file will not be modified in the lifetime of the JarLoader
+  private final boolean myLogError;
   private SoftReference<JarMemoryLoader> myMemoryLoader;
   private volatile SoftReference<ZipFile> myZipFileSoftReference; // Used only when myCanLockJar==true
   private final Map<Resource.Attribute, String> myAttributes;
   private volatile SoftReference<Attributes> myCachedManifestAttributes;
 
-  JarLoader(URL url, boolean canLockJar, int index, boolean preloadJarContents, ClassPath classPath) throws IOException {
+  JarLoader(URL url, boolean canLockJar, int index, boolean preloadJarContents, ClassPath classPath, boolean logError) throws IOException {
     super(new URL("jar", "", -1, url + "!/"), index);
 
     myFilePath = urlToFilePath(url);
     myCanLockJar = canLockJar;
+    myLogError = logError;
 
     ZipFile zipFile = getZipFile(); // IOException from opening is propagated to caller if zip file isn't valid,
     try {
@@ -211,7 +213,12 @@ class JarLoader extends Loader {
   }
 
   protected void error(String message, Throwable t) {
-    Logger.getInstance(JarLoader.class).error(message, t);
+    if (myLogError) {
+      Logger.getInstance(JarLoader.class).error(message, t);
+    }
+    else {
+      Logger.getInstance(JarLoader.class).warn(message, t);
+    }
   }
 
   private static final Object ourLock = new Object();

--- a/platform/util/src/com/intellij/util/lang/UrlClassLoader.java
+++ b/platform/util/src/com/intellij/util/lang/UrlClassLoader.java
@@ -108,6 +108,7 @@ public class UrlClassLoader extends ClassLoader {
     private boolean myAllowBootstrapResources;
     @Nullable private CachePoolImpl myCachePool;
     @Nullable private CachingCondition myCachingCondition;
+    private boolean myErrorOnMissingJar = true;
 
     private Builder() { }
 
@@ -151,6 +152,7 @@ public class UrlClassLoader extends ClassLoader {
     public Builder allowUnescaped() { myAcceptUnescaped = true; return this; }
     public Builder noPreload() { myPreload = false; return this; }
     public Builder allowBootstrapResources() { myAllowBootstrapResources = true; return this; }
+    public Builder setLogErrorOnMissingJar(boolean log) {myErrorOnMissingJar = log; return this; }
 
     /** @deprecated use {@link #allowUnescaped()} (to be removed in IDEA 2018) */
     public Builder allowUnescaped(boolean acceptUnescaped) { myAcceptUnescaped = acceptUnescaped; return this; }
@@ -191,7 +193,8 @@ public class UrlClassLoader extends ClassLoader {
   @NotNull
   protected final ClassPath createClassPath(@NotNull Builder builder) {
     return new ClassPath(myURLs, builder.myLockJars, builder.myUseCache, builder.myAcceptUnescaped, builder.myPreload,
-                                builder.myUsePersistentClasspathIndex, builder.myCachePool, builder.myCachingCondition);
+                                builder.myUsePersistentClasspathIndex, builder.myCachePool, builder.myCachingCondition,
+                                builder.myErrorOnMissingJar);
   }
 
   public static URL internProtocol(@NotNull URL url) {


### PR DESCRIPTION
Android Studio preview makes use of the UrlClassLoader to load
classes that are part of the project. In some cases, like when building,
some classes might be temporarily missing.
The preview handles that case correctly but the JarLoader logs an error
that shows the error notification.
This change adds an option that its used from Android Studio to disable
that behaviour in the preview.