### PR TITLE
Make set next statement work properly for frame eval debugger

### DIFF
--- a/python/helpers/pydev/_pydevd_bundle/pydevd_frame.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_frame.py
@@ -560,7 +560,7 @@ class PyDBFrame:
                     breakpoint = breakpoints_for_file[line]
                     new_frame = frame
                     stop = True
-                    if step_cmd == CMD_STEP_OVER and stop_frame is frame and (is_line or is_return):
+                    if (step_cmd == CMD_STEP_OVER  or step_cmd == CMD_SET_NEXT_STATEMENT) and stop_frame is frame and (is_line or is_return):
                         stop = False #we don't stop on breakpoint if we have to stop by step-over (it will be processed later)
                 elif plugin_manager is not None and main_debugger.has_plugin_line_breaks:
                     result = plugin_manager.get_breakpoint(main_debugger, self, frame, event, self._args)

--- a/python/helpers/pydev/_pydevd_frame_eval/pydevd_frame_tracing.py
+++ b/python/helpers/pydev/_pydevd_frame_eval/pydevd_frame_tracing.py
@@ -1,12 +1,14 @@
+from types import CodeType
+
 import sys
 
 from _pydev_bundle import pydev_log
 from _pydev_imps._pydev_saved_modules import threading
-from _pydevd_bundle.pydevd_comm import get_global_debugger, CMD_SET_BREAK
+from _pydevd_bundle.pydevd_comm import get_global_debugger, CMD_SET_BREAK, CMD_SET_NEXT_STATEMENT
 from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame, NORM_PATHS_AND_BASE_CONTAINER
 from _pydevd_bundle.pydevd_frame import handle_breakpoint_condition, handle_breakpoint_expression
 
-
+import opcode
 class DummyTracingHolder:
     dummy_trace_func = None
 
@@ -54,7 +56,7 @@ def _pydev_stop_at_break():
     frame = sys._getframe(1)
     t = threading.currentThread()
     if t.additional_info.is_tracing:
-        return
+        return False
 
     if t.additional_info.pydev_step_cmd == -1 and frame.f_trace in (None, dummy_tracing_holder.dummy_trace_func):
         # do not handle breakpoints while stepping, because they're handled by old tracing function
@@ -74,16 +76,40 @@ def _pydev_stop_at_break():
         except KeyError:
             pydev_log.debug("Couldn't find breakpoint in the file {} on line {}".format(frame.f_code.co_filename, line))
             t.additional_info.is_tracing = False
-            return
+            return False
         if breakpoint and handle_breakpoint(frame, t, debugger, breakpoint):
             pydev_log.debug("Suspending at breakpoint in file: {} on line {}".format(frame.f_code.co_filename, line))
             debugger.set_suspend(t, CMD_SET_BREAK)
             debugger.do_wait_suspend(t, frame, 'line', None, "frame_eval")
-
         t.additional_info.is_tracing = False
+        return t.additional_info.pydev_step_cmd == CMD_SET_NEXT_STATEMENT
+    return False
 
 
 def pydev_trace_code_wrapper():
     # import this module again, because it's inserted inside user's code
     global _pydev_stop_at_break
-    _pydev_stop_at_break()
+    return _pydev_stop_at_break()
+
+
+
+def create_code_wrapper(offset):
+    co = pydev_trace_code_wrapper.__code__
+    # 0 + offset LOAD_GLOBAL              0 (_pydev_stop_at_break)
+    # 2 + offset CALL_FUNCTION            0
+    # 4 + offset POP_JUMP_IF_TRUE         offset
+    byte_code = [116, 0, 131, 0]
+    if offset > 0xFF:
+        byte_code += [opcode.EXTENDED_ARG, offset >> 8]
+    byte_code += [115, offset & 0xFF]
+
+    #below code is just function trailer and gets removed
+    byte_code += [100, 0, 83, 0]
+    return CodeType(
+        co.co_argcount, co.co_kwonlyargcount, co.co_nlocals,
+        co.co_stacksize,
+        co.co_flags,
+        bytes(byte_code),
+        co.co_consts, co.co_names, co.co_varnames, co.co_filename,
+        co.co_name, co.co_firstlineno, co.co_lnotab, co.co_freevars,
+        co.co_cellvars)


### PR DESCRIPTION
@Elizaveta239 The CPython interpreter invokes the line trace function under two conditions. 
1) If the line number change (which we don't want)
2) If the instruction number decreases. 
See `maybe_call_line_trace` at https://github.com/python/cpython/blob/13a6c098c215921e35004f9d3a9b70f601e56500/Python/ceval.c 

The secret sauce here is the conditional jump back instruction after calling `_pydev_stop_at_break`. This allows us to pass control to the line trace function while staying on the same line. 

You may also consider using this trick to pass control to the line trace function when `_pydev_stop_at_break` encounters a breakpoint. So instead of calling `debugger.do_wait_suspend` from `_pydev_stop_at_break` set _f_trace on the frame and then pass control to the line trace function. This would allow making the frame eval trace and the rest of the debugger completely orthogonal.