### PR TITLE
Custom iterator for SmartList

### DIFF
--- a/platform/util/src/com/intellij/util/SmartList.java
+++ b/platform/util/src/com/intellij/util/SmartList.java
@@ -195,7 +195,58 @@ public class SmartList<E> extends AbstractList<E> implements RandomAccess {
     if (mySize == 1) {
       return new SingletonIterator();
     }
-    return super.iterator();
+    return new Itr();
+  }
+
+  private class Itr implements Iterator<E> {
+    int cursor = 0;
+    int lastRet = -1;
+    int expectedModCount = modCount;
+
+    public boolean hasNext() {
+      return cursor != mySize;
+    }
+
+    public E next() {
+      checkForComodification();
+      int i = cursor;
+      int size = mySize;
+      if (i >= size)
+        throw new NoSuchElementException();
+
+      if (size == 1) {
+        cursor = i + 1;
+        lastRet = i;
+        return (E) myElem;
+      } else {
+        Object[] elementData = (Object[])myElem;
+        if (i >= elementData.length)
+          throw new ConcurrentModificationException();
+        cursor = i + 1;
+        return (E) elementData[lastRet = i];
+      }
+    }
+
+    public void remove() {
+      if (lastRet < 0)
+        throw new IllegalStateException();
+      checkForComodification();
+
+      try {
+        SmartList.this.remove(lastRet);
+        if (lastRet < cursor)
+          cursor--;
+        lastRet = -1;
+        expectedModCount = modCount;
+      } catch (IndexOutOfBoundsException e) {
+        throw new ConcurrentModificationException();
+      }
+    }
+
+    final void checkForComodification() {
+      if (modCount != expectedModCount)
+        throw new ConcurrentModificationException();
+    }
   }
 
   private class SingletonIterator extends SingletonIteratorBase<E> {

--- a/platform/util/testSrc/com/intellij/util/SmartListIteratorTest.java
+++ b/platform/util/testSrc/com/intellij/util/SmartListIteratorTest.java
@@ -1,0 +1,268 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * @author stsypanov
+ */
+@RunWith(value = Parameterized.class)
+public class SmartListIteratorTest {
+
+  private String listType;
+
+  public SmartListIteratorTest(String listType) {
+    this.listType = listType;
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<String> data() {
+    return Arrays.asList("ArrayList", "SmartList");
+  }
+
+  @Test
+  public void testIterateOverAllItems() {
+    Integer[] ints = {1, 2};
+    Iterator<Integer> iterator = freshList(ints).iterator();
+
+    int itemsCount = 0;
+    while (iterator.hasNext()) {
+      iterator.next();
+      itemsCount++;
+    }
+
+    assertThat(itemsCount).isEqualTo(ints.length);
+
+    assertThat(iterator.hasNext()).isFalse();
+    try {
+      iterator.next();
+    } catch (NoSuchElementException e) {
+      return;
+    }
+    fail("NoSuchElementException must be thrown");
+  }
+
+  @Test
+  public void testCMEThrownWhenRemovingInLoop() {
+    Integer[] ints = {1, 2, 3};
+
+    List<Integer> smartList = freshList(ints);
+
+    try {
+      for (Integer integer : smartList) {
+        smartList.remove(integer);
+      }
+    } catch (ConcurrentModificationException e) {
+      return;
+    }
+    fail("CME must be thrown");
+  }
+
+  @Test
+  public void testRemoveAll_checkNSEEThrownCallingNextOnEmptyItr() {
+    Integer[] ints = {1, 2, 3};
+
+    Iterator<Integer> iterator = freshList(ints).iterator();
+
+    while (iterator.hasNext()) {
+      iterator.next();
+      iterator.remove();
+    }
+
+    assertThat(iterator.hasNext()).isFalse();
+    try {
+      iterator.next();
+    } catch (NoSuchElementException e) {
+      return;
+    }
+    fail("NoSuchElementException must be thrown");
+  }
+
+  @Test
+  public void testRemoveAll_checkISEThrownCallingRemoveOnEmptyItr() {
+    Integer[] ints = {1, 2, 3};
+
+    Iterator<Integer> iterator = freshList(ints).iterator();
+
+    while (iterator.hasNext()) {
+      iterator.next();
+      iterator.remove();
+    }
+
+    assertThat(iterator.hasNext()).isFalse();
+    try {
+      iterator.remove();
+    } catch (IllegalStateException e) {
+      return;
+    }
+    fail("NoSuchElementException must be thrown");
+  }
+
+  @Test
+  public void testRemoveOrder() {
+    final Integer first = 1;
+    final Integer second = 2;
+
+    Iterator<Integer> iterator = freshList(first, second).iterator();
+
+    iterator.next();
+    iterator.remove();
+
+    assertThat(iterator.hasNext()).isTrue();
+
+    Integer next = iterator.next();
+    assertThat(next).isEqualTo(second);
+
+    assertThat(iterator.hasNext()).isFalse();
+    try {
+      iterator.next();
+    } catch (NoSuchElementException e) {
+      return;
+    }
+    fail("NoSuchElementException must be thrown");
+  }
+
+  @Test
+  public void testCMEMustBeThrow_sourceListIsModified() {
+    List<Integer> integers = freshList(1, 2);
+
+    Iterator<Integer> iterator = integers.iterator();
+
+    integers.add(3);
+
+    assertThat(iterator.hasNext()).isTrue();
+
+    try {
+      iterator.next();
+    } catch (ConcurrentModificationException e) {
+      return;
+    }
+    fail("ConcurrentModificationException must be thrown");
+  }
+
+  @Test
+  public void testCMEMustBeThrow_sourceListIsModifiedAfterNextCalled() {
+    List<Integer> integers = freshList(1, 2);
+
+    Iterator<Integer> iterator = integers.iterator();
+
+    iterator.next();
+
+    integers.add(3);
+
+    assertThat(iterator.hasNext()).isTrue();
+
+    try {
+      iterator.next();
+    } catch (ConcurrentModificationException e) {
+      return;
+    }
+    fail("ConcurrentModificationException must be thrown");
+  }
+
+  @Test
+  public void testCMEMustBeThrow_sourceListIsModifiedAfterRemoveCalled() {
+    List<Integer> integers = freshList(1, 2);
+
+    Iterator<Integer> iterator = integers.iterator();
+
+    iterator.next();
+    iterator.remove();
+
+    integers.add(3);
+
+    assertThat(iterator.hasNext()).isTrue();
+
+    try {
+      iterator.next();
+    } catch (ConcurrentModificationException e) {
+      return;
+    }
+    fail("ConcurrentModificationException must be thrown");
+  }
+
+  @Test
+  public void testCMEMustBeThrow_removeIndexCalledInLoop() {
+    List<Integer> integers = freshList(1, 2);
+
+    Iterator<Integer> iterator = integers.iterator();
+
+    integers.remove(0);
+
+    try {
+      while (iterator.hasNext()) {
+        iterator.next();
+        integers.remove(0);
+        iterator.remove();
+      }
+    } catch (ConcurrentModificationException e) {
+      return;
+    }
+    fail("ConcurrentModificationException must be thrown");
+  }
+
+  @Test
+  public void testCMEMustBeThrow_clearCalledInLoopAfterCallingNext() {
+    List<Integer> integers = freshList(1, 2);
+
+    Iterator<Integer> iterator = integers.iterator();
+
+    try {
+      while (iterator.hasNext()) {
+        iterator.next();
+        integers.clear();
+        iterator.remove();
+      }
+    } catch (ConcurrentModificationException e) {
+      return;
+    }
+    fail("ConcurrentModificationException must be thrown");
+  }
+
+  @Test
+  public void testCMEMustBeThrow_clearCalledInLoopBeforeCallingNext() {
+    List<Integer> integers = freshList(1, 2);
+
+    Iterator<Integer> iterator = integers.iterator();
+
+    try {
+      while (iterator.hasNext()) {
+        integers.clear();
+        iterator.next();
+        iterator.remove();
+      }
+    } catch (ConcurrentModificationException e) {
+      return;
+    }
+    fail("ConcurrentModificationException must be thrown");
+  }
+
+  @Test
+  public void testCMEMustNotBeThrow_clearCalledInLoopAfterCallingNextAndRemove() {
+    List<Integer> integers = freshList(1, 2);
+
+    Iterator<Integer> iterator = integers.iterator();
+
+    while (iterator.hasNext()) {
+      iterator.next();
+      iterator.remove();
+      integers.clear();
+    }
+  }
+
+  @NotNull
+  private List<Integer> freshList(@NotNull Integer... ints) {
+    if ("ArrayList".equals(listType)) {
+      return new ArrayList<>(Arrays.asList(ints));
+    }
+    return new SmartList<>(ints);
+  }
+}


### PR DESCRIPTION
Current implementation of `SmartList` calls `super.iterator()` for size > 1 which means `AbstractList.Itr` is utilized. There's more effective implementation of `Iterator` provided in `ArrayList` so I used it as a prototype for this one (`SmartList` is also array-based for size > 1).

Effectiveness is measured with benchmark:

```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-XX:+UseParallelGC", "-Xms2g", "-Xmx2g"})
public class ArrayVsSmartListIterator {

    @Benchmark
    public void iterateOverArrayList(Lists lists, Blackhole bh) {
        ArrayList<Integer> list = lists.arrayList;
        for (Integer integer : list) {
            bh.consume(integer.intValue());
        }
    }

    @Benchmark
    public void iterateOverEnhancedSmartList(Lists lists, Blackhole bh) {
        SmartList<Integer> list = lists.smartList;
        for (Integer integer : list) {
            bh.consume(integer.intValue());
        }
    }

    @Benchmark
    public void iterateOverOriginalSmartList(Lists lists, Blackhole bh) {
        OriginalSmartList<Integer> list = lists.originalSmartList;
        for (Integer integer : list) {
            bh.consume(integer.intValue());
        }
    }

    @State(Scope.Benchmark)
    public static class Lists {
        ArrayList<Integer> arrayList;
        SmartList<Integer> smartList;
        OriginalSmartList<Integer> originalSmartList;

        @Param({"10", "100", "1000"})
        int size;

        @Setup
        public void setup() {
            List<Integer> ints = IntStream
                    .range(0, size)
                    .boxed()
                    .collect(Collectors.toList());
            arrayList = new ArrayList<>(ints);
            smartList = new SmartList<>(ints);
            originalSmartList = new OriginalSmartList<>(ints);
        }
    }
}
```

yielding this result:

```
Benchmark                     (size)  Mode  Cnt     Score    Error  Units
iterateOverArrayList              10  avgt  100    42,300 ±  0,400  ns/op
iterateOverEnhancedSmartList      10  avgt  100    44,697 ±  0,517  ns/op
iterateOverOriginalSmartList      10  avgt  100    49,251 ±  0,355  ns/op

iterateOverArrayList             100  avgt  100   414,039 ±  2,581  ns/op
iterateOverEnhancedSmartList     100  avgt  100   441,414 ±  4,917  ns/op
iterateOverOriginalSmartList     100  avgt  100   499,638 ±  6,275  ns/op

iterateOverArrayList            1000  avgt  100  4339,670 ± 57,336  ns/op
iterateOverEnhancedSmartList    1000  avgt  100  4324,626 ± 39,592  ns/op
iterateOverOriginalSmartList    1000  avgt  100  5001,817 ± 50,657  ns/op
```