### PR TITLE
py/build: target the community plugin gant script

### DIFF
--- a/python/build.xml
+++ b/python/build.xml
@@ -34,7 +34,7 @@
   </target>
 
   <target name="plugin" depends="init">
-    <call_gant script="${python.home}/build/python_plugin_build.gant"/>
+    <call_gant script="${python.home}/build/python_community_plugin_build.gant"/>
   </target>
   <!--
   <target name="test" depends="init">


### PR DESCRIPTION
The only python plugin gant file in the repository is named `python_community_plugin_build.gant`.