### PR TITLE
python: Remove import that's not needed and absent

### DIFF
--- a/python/testSrc/com/jetbrains/env/PyExecutionFixtureTestTask.java
+++ b/python/testSrc/com/jetbrains/env/PyExecutionFixtureTestTask.java
@@ -20,7 +20,6 @@ import com.intellij.testFramework.builders.ModuleFixtureBuilder;
 import com.intellij.testFramework.fixtures.*;
 import com.intellij.testFramework.fixtures.impl.ModuleFixtureBuilderImpl;
 import com.intellij.testFramework.fixtures.impl.ModuleFixtureImpl;
-import com.jetbrains.django.util.VirtualFileUtil;
 import com.jetbrains.extensions.ModuleExtKt;
 import com.jetbrains.python.PythonModuleTypeBase;
 import com.jetbrains.python.PythonTestUtil;


### PR DESCRIPTION
The import causes builds to fail (it's missing), but it seems to be unnecessary.