### PR TITLE
Support fetch for svn bridged repos

### DIFF
--- a/plugins/git4idea/src/git4idea/commands/Git.java
+++ b/plugins/git4idea/src/git4idea/commands/Git.java
@@ -173,6 +173,18 @@ public interface Git {
   GitCommandResult stashPop(@NotNull GitRepository repository, @NotNull GitLineHandlerListener... listeners);
 
   @NotNull
+  GitCommandResult svnRead(@NotNull GitRepository repository,
+                         @NotNull GitRemote remote,
+                         @NotNull List<GitLineHandlerListener> listeners,
+                         String... params);
+
+  @NotNull
+  GitCommandResult svnWrite(@NotNull GitRepository repository,
+                           @NotNull GitRemote remote,
+                           @NotNull List<GitLineHandlerListener> listeners,
+                           String... params);
+
+  @NotNull
   GitCommandResult fetch(@NotNull GitRepository repository,
                          @NotNull GitRemote remote,
                          @NotNull List<GitLineHandlerListener> listeners,

--- a/plugins/git4idea/src/git4idea/commands/GitCommand.java
+++ b/plugins/git4idea/src/git4idea/commands/GitCommand.java
@@ -40,12 +40,14 @@ public class GitCommand {
   public static final GitCommand CHECKOUT = write("checkout");
   public static final GitCommand CHECK_ATTR = read("check-attr");
   public static final GitCommand COMMIT = write("commit");
+  public static final GitCommand SVN_WRITE = write("svn");
   public static final GitCommand CONFIG = read("config");
   public static final GitCommand CHERRY = read("cherry");
   public static final GitCommand CHERRY_PICK = write("cherry-pick");
   public static final GitCommand CLONE = read("clone"); // write, but can't interfere with any other command => should be treated as read
   public static final GitCommand DIFF = read("diff");
   public static final GitCommand FETCH = read("fetch");  // fetch is a read-command, because it doesn't modify the index
+  public static final GitCommand SVN_READ = read("svn");
   public static final GitCommand INIT = write("init");
   public static final GitCommand LOG = read("log");
   public static final GitCommand LS_FILES = read("ls-files");

--- a/plugins/git4idea/src/git4idea/commands/GitImpl.java
+++ b/plugins/git4idea/src/git4idea/commands/GitImpl.java
@@ -489,6 +489,52 @@ public class GitImpl extends GitImplBase {
   }
 
   /**
+   * Write operation on git-svn bridge
+   * {@code git fetch <remote> <params>}
+   */
+  @Override
+  @NotNull
+  public GitCommandResult svnWrite(@NotNull final GitRepository repository,
+                                  @NotNull final GitRemote remote,
+                                  @NotNull final List<GitLineHandlerListener> listeners,
+                                  final String... params) {
+    return runCommand(() -> {
+      final GitLineHandler h = new GitLineHandler(repository.getProject(), repository.getRoot(), GitCommand.SVN_WRITE);
+      h.setSilent(false);
+      h.setStdoutSuppressed(false);
+      h.setUrls(remote.getUrls());
+      h.addParameters(remote.getName());
+      h.addParameters(params);
+      GitVcs vcs = GitVcs.getInstance(repository.getProject());
+      addListeners(h, listeners);
+      return h;
+    });
+  }
+
+  /**
+   * Read operation on git-svn bridge
+   * {@code git fetch <remote> <params>}
+   */
+  @Override
+  @NotNull
+  public GitCommandResult svnRead(@NotNull final GitRepository repository,
+                                @NotNull final GitRemote remote,
+                                @NotNull final List<GitLineHandlerListener> listeners,
+                                final String... params) {
+    return runCommand(() -> {
+      final GitLineHandler h = new GitLineHandler(repository.getProject(), repository.getRoot(), GitCommand.SVN_READ);
+      h.setSilent(false);
+      h.setStdoutSuppressed(false);
+      h.setUrls(remote.getUrls());
+      h.addParameters(remote.getName());
+      h.addParameters(params);
+      GitVcs vcs = GitVcs.getInstance(repository.getProject());
+      addListeners(h, listeners);
+      return h;
+    });
+  }
+
+  /**
    * Fetch remote branch
    * {@code git fetch <remote> <params>}
    */

--- a/plugins/git4idea/src/git4idea/repo/GitRemote.java
+++ b/plugins/git4idea/src/git4idea/repo/GitRemote.java
@@ -64,7 +64,7 @@ public final class GitRemote implements Comparable<GitRemote> {
    *   remote = .
    *   merge = refs/remotes/git-svn
    */
-  public static final GitRemote DOT = new GitRemote(".", Collections.singletonList("."), emptyList(), emptyList(), emptyList());
+  public static final GitRemote DOT = new GitRemote(".", Collections.singletonList("."), emptyList(), emptyList(), emptyList(), false);
 
   /**
    * Default remote name in Git is "origin".
@@ -77,14 +77,25 @@ public final class GitRemote implements Comparable<GitRemote> {
   @NotNull private final Collection<String> myPushUrls;
   @NotNull private final List<String> myFetchRefSpecs;
   @NotNull private final List<String> myPushRefSpecs;
+  @NotNull private final boolean myIsSvnBridge;
 
   public GitRemote(@NotNull String name, @NotNull List<String> urls, @NotNull Collection<String> pushUrls,
-                   @NotNull List<String> fetchRefSpecs, @NotNull List<String> pushRefSpecs) {
+                   @NotNull List<String> fetchRefSpecs, @NotNull List<String> pushRefSpecs, @NotNull boolean isSvnBridge) {
     myName = name;
     myUrls = urls;
     myPushUrls = pushUrls;
     myFetchRefSpecs = fetchRefSpecs;
     myPushRefSpecs = pushRefSpecs;
+    myIsSvnBridge = isSvnBridge;
+  }
+
+  /**
+   * Returns if remote represents a git-svn bridge
+   * @return
+   */
+  @NotNull
+  public boolean isSvnBridge() {
+    return myIsSvnBridge;
   }
 
   @NotNull

--- a/plugins/git4idea/src/git4idea/repo/GitRepositoryReader.java
+++ b/plugins/git4idea/src/git4idea/repo/GitRepositoryReader.java
@@ -297,7 +297,7 @@ class GitRepositoryReader {
       if (remote == null) {
         // user may remove the remote section from .git/config, but leave remote refs untouched in .git/refs/remotes
         LOG.debug(String.format("No remote found with the name [%s]. All remotes: %s", remoteName, remotes));
-        GitRemote fakeRemote = new GitRemote(remoteName, emptyList(), emptyList(), emptyList(), emptyList());
+        GitRemote fakeRemote = new GitRemote(remoteName, emptyList(), emptyList(), emptyList(), emptyList(), false);
         return new GitStandardRemoteBranch(fakeRemote, branchName);
       }
       return new GitStandardRemoteBranch(remote, branchName);

--- a/plugins/git4idea/src/git4idea/update/GitFetcher.java
+++ b/plugins/git4idea/src/git4idea/update/GitFetcher.java
@@ -41,10 +41,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static git4idea.GitBranch.REFS_HEADS_PREFIX;
 import static git4idea.GitBranch.REFS_REMOTES_PREFIX;
@@ -183,8 +185,17 @@ public class GitFetcher {
                                 ArrayUtil.EMPTY_STRING_ARRAY;
 
     GitFetchPruneDetector pruneDetector = new GitFetchPruneDetector();
-    GitCommandResult result = git.fetch(repository, remote,
-                                        Collections.singletonList(pruneDetector), additionalParams);
+    GitCommandResult result;
+    if (remote.isSvnBridge()) {
+      String[] command = new String[] {"fetch"};
+      String[] commandAndParams = Stream.concat(Arrays.stream(command), Arrays.stream(additionalParams))
+        .toArray(String[]::new);
+      result = git.svnRead(repository, remote,
+                         Collections.singletonList(pruneDetector), commandAndParams);
+    } else {
+      result = git.fetch(repository, remote,
+                         Collections.singletonList(pruneDetector), additionalParams);
+    }
 
     GitFetchResult fetchResult;
     if (result.success()) {

--- a/plugins/git4idea/tests/git4idea/push/GitPushResultNotificationTest.java
+++ b/plugins/git4idea/tests/git4idea/push/GitPushResultNotificationTest.java
@@ -205,7 +205,7 @@ public class GitPushResultNotificationTest extends GitPlatformTest {
   private static GitRemoteBranch to(String to) {
     int firstSlash = to.indexOf('/');
     GitRemote remote = new GitRemote(to.substring(0, firstSlash), Collections.emptyList(), Collections.emptyList(),
-                                     Collections.emptyList(), Collections.emptyList());
+                                     Collections.emptyList(), Collections.emptyList(), false);
     return new GitStandardRemoteBranch(remote, to.substring(firstSlash + 1));
   }
 

--- a/plugins/git4idea/tests/git4idea/repo/GitConfigTest.kt
+++ b/plugins/git4idea/tests/git4idea/repo/GitConfigTest.kt
@@ -232,7 +232,7 @@ class GitConfigTest : GitPlatformTest() {
   private fun getRemote(remoteString: String): GitRemote {
     val remoteInfo = remoteString.split(" ")
     return GitRemote(remoteInfo[0], getSingletonOrEmpty(remoteInfo, 1), getSingletonOrEmpty(remoteInfo, 2),
-                     getSingletonOrEmpty(remoteInfo, 3), getSingletonOrEmpty(remoteInfo, 4))
+                     getSingletonOrEmpty(remoteInfo, 3), getSingletonOrEmpty(remoteInfo, 4), false)
   }
 
   private fun readRemoteResults(resultFile: File): Set<GitRemote> {
@@ -248,7 +248,7 @@ class GitConfigTest : GitPlatformTest() {
       val pushUrls = info[2].split(" ")
       val fetchSpec = info[3].split(" ")
       val pushSpec = info[4].split(" ")
-      remotes.add(GitRemote(name, urls, pushUrls, fetchSpec, pushSpec))
+      remotes.add(GitRemote(name, urls, pushUrls, fetchSpec, pushSpec, false))
     }
     return remotes
   }


### PR DESCRIPTION
* Detect svn remotes on parse config
* Parse branches and tags section properties
* Add git svn commands (for read and write)
* Detect svn remotes on fetchAll to do it properly

This is related with [IDEA-26427](https://youtrack.jetbrains.com/issue/IDEA-26427)