### PR TITLE
Improve operations for document listeners

### DIFF
--- a/platform/core-api/src/com/intellij/openapi/editor/Document.java
+++ b/platform/core-api/src/com/intellij/openapi/editor/Document.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 JetBrains s.r.o.
+ * Copyright 2000-2018 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,6 +217,14 @@ public interface Document extends UserDataHolder {
   default void addDocumentListener(@NotNull DocumentListener listener) {
   }
 
+  /**
+   * Adds a listener for receiving notifications about changes in the document content if a listener is not registered
+   *
+   * @param listener the listener instance.
+   */
+  default void addDocumentListenerIfNotExist(@NotNull DocumentListener listener) {
+  }
+
   default void addDocumentListener(@NotNull DocumentListener listener, @NotNull Disposable parentDisposable) {
   }
 
@@ -226,6 +234,14 @@ public interface Document extends UserDataHolder {
    * @param listener the listener instance.
    */
   default void removeDocumentListener(@NotNull DocumentListener listener) {
+  }
+
+  /**
+   * Removes a listener for receiving notifications about changes in the document content if a listener is registered
+   *
+   * @param listener the listener instance.
+   */
+  default void removeDocumentListenerIfExist(@NotNull DocumentListener listener) {
   }
 
   /**

--- a/platform/core-impl/src/com/intellij/openapi/editor/impl/DocumentImpl.java
+++ b/platform/core-impl/src/com/intellij/openapi/editor/impl/DocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 JetBrains s.r.o.
+ * Copyright 2000-2018 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -868,6 +868,13 @@ public class DocumentImpl extends UserDataHolderBase implements DocumentEx {
   }
 
   @Override
+  public void addDocumentListenerIfNotExist(@NotNull DocumentListener listener) {
+    if (!ArrayUtil.contains(listener, getListeners())) {
+      addDocumentListener(listener);
+    }
+  }
+
+  @Override
   public void addDocumentListener(@NotNull final DocumentListener listener, @NotNull Disposable parentDisposable) {
     addDocumentListener(listener);
     Disposer.register(parentDisposable, new DocumentListenerDisposable(myDocumentListeners, listener));
@@ -894,6 +901,13 @@ public class DocumentImpl extends UserDataHolderBase implements DocumentEx {
     boolean success = myDocumentListeners.remove(listener);
     if (!success) {
       LOG.error("Can't remove document listener (" + listener + "). Registered listeners: " + Arrays.toString(getListeners()));
+    }
+  }
+
+  @Override
+  public void removeDocumentListenerIfExist(@NotNull DocumentListener listener) {
+    if (ArrayUtil.contains(listener, getListeners())) {
+      removeDocumentListener(listener);
     }
   }
 


### PR DESCRIPTION
**Purpose**

1. I would like to add a listener to `DocumentImpl.myDocumentListeners` safety to avoid an error message if it exists.
2. I would like to remove a listener from `DocumentImpl.myDocumentListeners` safety to avoid an error message if it does not exist.

Currently access to `myDocumentListeners` is prohibited so I implemented 2 public methods in `DocumentImpl`.

Thanks.