### PR TITLE
Fixed incorrect handling of nested branch locations in SVN plugin

### DIFF
--- a/plugins/svn4idea/src/org/jetbrains/idea/svn/branchConfig/SvnBranchConfigurationNew.java
+++ b/plugins/svn4idea/src/org/jetbrains/idea/svn/branchConfig/SvnBranchConfigurationNew.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.jetbrains.idea.svn.branchConfig;
 
+import com.google.common.collect.Lists;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -68,7 +69,7 @@ public class SvnBranchConfigurationNew {
   public static String ensureEndSlash(String name) {
     return name.trim().endsWith("/") ? name : name + "/";
   }
-  
+
   private static String cutEndSlash(String name) {
     return name.endsWith("/") && name.length() > 0 ? name.substring(0, name.length() - 1) : name;
   }
@@ -112,7 +113,10 @@ public class SvnBranchConfigurationNew {
         return cutEndSlash(myTrunkUrl);
       }
     }
-    for(String branchUrl: myBranchMap.keySet()) {
+    //find the longest possible match to correctly handle cases when one branch location is a subdirectory of another
+    List<String> strings = Lists.newArrayList(myBranchMap.keySet());
+    Collections.sort(strings, Comparator.comparingInt(String::length).reversed());
+    for (String branchUrl : strings) {
       if (Url.isAncestor(branchUrl, url)) {
         String relativePath = Url.getRelative(branchUrl, url);
         int secondSlash = relativePath.indexOf("/");
@@ -166,7 +170,7 @@ public class SvnBranchConfigurationNew {
 
   // to retrieve mappings between existing in the project working copies and their URLs
   @Nullable
-  public Map<String,String> getUrl2FileMappings(final Project project, final VirtualFile root) {
+  public Map<String, String> getUrl2FileMappings(final Project project, final VirtualFile root) {
     try {
       final BranchRootSearcher searcher = new BranchRootSearcher(SvnVcs.getInstance(project), root);
       iterateUrls(searcher);

--- a/plugins/svn4idea/testSource/org/jetbrains/idea/svn/branchConfig/SvnBranchConfigurationNewTest.java
+++ b/plugins/svn4idea/testSource/org/jetbrains/idea/svn/branchConfig/SvnBranchConfigurationNewTest.java
@@ -1,0 +1,25 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.idea.svn.branchConfig;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class SvnBranchConfigurationNewTest {
+
+  public static final InfoStorage<List<SvnBranchItem>> EMPTY_INFO = new InfoStorage<>(new ArrayList<>(), InfoReliability.empty);
+
+  @Test
+  public void getRelativeUrlMatchesLongestPrefix() {
+    SvnBranchConfigurationNew branchConfig = new SvnBranchConfigurationNew();
+    branchConfig.setTrunkUrl("svn://example.com/trunk");
+    branchConfig.addBranches("svn://example.com/branches", EMPTY_INFO);
+    branchConfig.addBranches("svn://example.com/branches/subbranches", EMPTY_INFO);
+
+    assertThat(branchConfig.getRelativeUrl("svn://example.com/branches/subbranches/someBranch/dir"), is("/dir"));
+  }
+}


### PR DESCRIPTION
SVN plugin incorrectly handles cases when one branch location is a subdirectory or another. I.e. in a project I am working on, we extended the standard repository layout (trunk, branches, tags) with a subdirectory for each team inside branches.  For example, we might have the following branches in repo:
```
branches/GeneralBranch
branches/TeamA/AFeatureBranch1
branches/TeamA/AFeatureBranch2
branches/TeamB/BFeatureBranch1
```
and so on. When switching (or merging, or probably in some other cases too) from `AFeatureBranch1` to `AFeatureBranch2`, the URL incorrectly becomes:
```branches/TeamA/AFeatureBranch2/AFeatureBranch1```

This commit fixes this behaviour by considering the branch locations in order defined by their length, descending.