### PR TITLE
Minor pydev changes/fixes

### DIFF
--- a/python/helpers/pydev/_pydev_bundle/pydev_ipython_console_011.py
+++ b/python/helpers/pydev/_pydev_bundle/pydev_ipython_console_011.py
@@ -16,7 +16,9 @@
 from __future__ import print_function
 
 import os
+import sys
 import codeop
+import traceback
 
 from IPython.core.error import UsageError
 from IPython.core.completer import IPCompleter
@@ -139,14 +141,24 @@ class PyDevTerminalInteractiveShell(TerminalInteractiveShell):
     # Things related to exceptions
     #-------------------------------------------------------------------------
 
-    def showtraceback(self, *args, **kwargs):
+    def showtraceback(self, exc_tuple=None, **kwargs):
         # IPython does a lot of clever stuff with Exceptions. However mostly
         # it is related to IPython running in a terminal instead of an IDE.
         # (e.g. it prints out snippets of code around the stack trace)
         # PyDev does a lot of clever stuff too, so leave exception handling
         # with default print_exc that PyDev can parse and do its clever stuff
         # with (e.g. it puts links back to the original source code)
-        import traceback;traceback.print_exc()
+        try:
+            if exc_tuple is None:
+                etype, value, tb = sys.exc_info()
+            else:
+                etype, value, tb = exc_tuple
+        except ValueError:
+            return
+
+        if tb is not None:
+            traceback.print_exception(etype, value, tb)
+
 
 
     #-------------------------------------------------------------------------

--- a/python/helpers/pydev/_pydevd_bundle/pydevd_comm.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_comm.py
@@ -1031,7 +1031,9 @@ class InternalGetVariable(InternalThreadCommand):
                 val_dict = {}
 
             keys = dict_keys(val_dict)
-            if _typeName != "OrderedDict" and not IS_PY36_OR_GREATER:
+            # assume properly ordered if resolver returns 'OrderedDict'
+            # check type as string to support OrderedDict backport for older Python
+            if not (_typeName == "OrderedDict" or val_dict.__class__.__name__ == "OrderedDict" or IS_PY36_OR_GREATER):
                 keys.sort(key=compare_object_attrs_key)
 
             for k in keys:


### PR DESCRIPTION
@Elizaveta239  Please take a look. One commit allows the typeResolve to decide on the order of columns by returning OrderedDict. The other commit handles cases where frameswork call sys.excepthook directly. 