### PR TITLE
JPS: add extension to provide additional constant affection resolvers

### DIFF
--- a/jps/jps-builders/src/org/jetbrains/jps/builders/java/ConstantSearchProvider.java
+++ b/jps/jps-builders/src/org/jetbrains/jps/builders/java/ConstantSearchProvider.java
@@ -1,0 +1,17 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.jps.builders.java;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.jps.builders.java.dependencyView.Callbacks;
+import org.jetbrains.jps.incremental.CompileContext;
+
+/**
+ * Implement this interface to provide additional constant affection resolver that will be notified when a constant is changed.
+ * Implementations are registered as Java services, by creating a file
+ * META-INF/services/org.jetbrains.jps.builders.java.ConstantSearchProvider
+ * containing the qualified name of your implementation class.
+ */
+public interface ConstantSearchProvider {
+  @NotNull
+  Callbacks.ConstantAffectionResolver getConstantSearch(@NotNull CompileContext context);
+}


### PR DESCRIPTION
JVM languages such as Kotlin can inline constant values at use-site.
When a constant's value is changed, all use-sites must be recompiled.
Since values are inlined, there are no references in bytecode
so Java builder does not know when a Java constant is referenced in Kotlin.
Kotlin builder knows where each FQ-name is used, but does not know
when a Java constant is changed.

To fix KT-16091, Kotlin plugin needs to provide additional ConstantAffectionResolver,
so it would be notified when a constant value is changed.

In this commit ConstantSearchProvider class is added.
Additional instances of ConstantAffectionResolver provided by ConstantSearchProvider
implementations are used only when "main" ConstantAffectionResolver
(that searches using Intellij) is used (otherwise Java builder forces rebuild,
so it does not make sense).

// cc @chashnikov  