### PR TITLE
Changes to show sync issues messages on build view.

### DIFF
--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/importing/ImportSpecBuilder.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/importing/ImportSpecBuilder.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId;
 import com.intellij.openapi.externalSystem.service.execution.ProgressExecutionMode;
 import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
 import com.intellij.openapi.externalSystem.service.project.ProjectDataManager;
@@ -119,7 +120,8 @@ public class ImportSpecBuilder {
     if (myUseDefaultCallback) {
       mySpec.setCallback(new ExternalProjectRefreshCallback() {
         @Override
-        public void onSuccess(@Nullable final DataNode<ProjectData> externalProject) {
+        public void onSuccess(@NotNull ExternalSystemTaskId id,
+                              @Nullable final DataNode<ProjectData> externalProject) {
           if (externalProject == null) {
             return;
           }

--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/service/project/ExternalProjectRefreshCallback.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/service/project/ExternalProjectRefreshCallback.java
@@ -34,9 +34,10 @@ public interface ExternalProjectRefreshCallback {
    * {@link ExternalSystemProjectResolver#resolveProjectInfo(ExternalSystemTaskId, String, boolean, ExternalSystemExecutionSettings, ExternalSystemTaskNotificationListener)}
    * returns without exception.
    *
+   * @param externalTaskId id of task being called (to use when reporting issues)
    * @param externalProject  target external project (if available)
    */
-  void onSuccess(@Nullable DataNode<ProjectData> externalProject);
+  void onSuccess(@NotNull ExternalSystemTaskId externalTaskId, @Nullable DataNode<ProjectData> externalProject);
 
   void onFailure(@NotNull String errorMessage, @Nullable String errorDetails);
 }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/autoimport/ExternalSystemProjectsWatcherImpl.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/autoimport/ExternalSystemProjectsWatcherImpl.java
@@ -434,7 +434,8 @@ public class ExternalSystemProjectsWatcherImpl extends ExternalSystemTaskNotific
     ExternalSystemUtil.refreshProject(
       project, systemId, projectPath, new ExternalProjectRefreshCallback() {
         @Override
-        public void onSuccess(@Nullable final DataNode<ProjectData> externalProject) {
+        public void onSuccess(@NotNull ExternalSystemTaskId id,
+                              @Nullable final DataNode<ProjectData> externalProject) {
           if (externalProject != null) {
             ServiceManager.getService(ProjectDataManager.class).importData(externalProject, project, true);
           }
@@ -444,7 +445,7 @@ public class ExternalSystemProjectsWatcherImpl extends ExternalSystemTaskNotific
         public void onFailure(@NotNull String errorMessage, @Nullable String errorDetails) {
           // Do nothing.
         }
-      }, false, ProgressExecutionMode.IN_BACKGROUND_ASYNC, reportRefreshError);
+      }, ProgressExecutionMode.IN_BACKGROUND_ASYNC, ExternalSystemUtil.ShowFinishMessage.YES, false, reportRefreshError);
   }
 
   private static void makeUserAware(final MergingUpdateQueue mergingUpdateQueue, final Project project) {

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ExternalProjectsManagerImpl.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ExternalProjectsManagerImpl.java
@@ -179,7 +179,7 @@ public class ExternalProjectsManagerImpl implements ExternalProjectsManager, Per
 
   @Override
   public void refreshProject(@NotNull final String externalProjectPath, @NotNull final ImportSpec importSpec) {
-    ExternalSystemUtil.refreshProject(externalProjectPath, importSpec);
+    ExternalSystemUtil.refreshProject(externalProjectPath, importSpec, ExternalSystemUtil.ShowFinishMessage.YES);
   }
 
   @Override

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/wizard/AbstractExternalProjectImportBuilder.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/wizard/AbstractExternalProjectImportBuilder.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.externalSystem.model.ExternalSystemDataKeys;
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.intellij.openapi.externalSystem.model.internal.InternalExternalProjectInfo;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId;
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil;
 import com.intellij.openapi.externalSystem.service.execution.ProgressExecutionMode;
 import com.intellij.openapi.externalSystem.service.project.*;
@@ -229,7 +230,9 @@ public abstract class AbstractExternalProjectImportBuilder<C extends AbstractImp
     // resolve dependencies
     final Runnable resolveDependenciesTask = () -> ExternalSystemUtil.refreshProject(
       project, myExternalSystemId, projectSettings.getExternalProjectPath(),
-      createFinalImportCallback(project, projectSettings), false, ProgressExecutionMode.IN_BACKGROUND_ASYNC, true);
+      createFinalImportCallback(project, projectSettings), ProgressExecutionMode.IN_BACKGROUND_ASYNC,
+      ExternalSystemUtil.ShowFinishMessage.YES, false, true
+    );
     if (!isFromUI) {
       resolveDependenciesTask.run();
     }
@@ -248,7 +251,8 @@ public abstract class AbstractExternalProjectImportBuilder<C extends AbstractImp
                                                                      @NotNull ExternalProjectSettings projectSettings) {
     return new ExternalProjectRefreshCallback() {
       @Override
-      public void onSuccess(@Nullable final DataNode<ProjectData> externalProject) {
+      public void onSuccess(@NotNull ExternalSystemTaskId id,
+                            @Nullable final DataNode<ProjectData> externalProject) {
         if (externalProject == null) {
           return;
         }
@@ -296,7 +300,8 @@ public abstract class AbstractExternalProjectImportBuilder<C extends AbstractImp
     final Ref<ConfigurationException> error = new Ref<>();
     final ExternalProjectRefreshCallback callback = new ExternalProjectRefreshCallback() {
       @Override
-      public void onSuccess(@Nullable DataNode<ProjectData> externalProject) {
+      public void onSuccess(@NotNull ExternalSystemTaskId id,
+                            @Nullable DataNode<ProjectData> externalProject) {
         myExternalProjectNode = externalProject;
       }
 

--- a/platform/external-system-impl/testSrc/com/intellij/openapi/externalSystem/test/ExternalSystemImportingTestCase.java
+++ b/platform/external-system-impl/testSrc/com/intellij/openapi/externalSystem/test/ExternalSystemImportingTestCase.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.ExternalProjectInfo;
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId;
 import com.intellij.openapi.externalSystem.service.execution.ProgressExecutionMode;
 import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
 import com.intellij.openapi.externalSystem.service.project.ProjectDataManager;
@@ -434,7 +435,8 @@ public abstract class ExternalSystemImportingTestCase extends ExternalSystemTest
         .use(ProgressExecutionMode.MODAL_SYNC)
         .callback(new ExternalProjectRefreshCallback() {
           @Override
-          public void onSuccess(@Nullable final DataNode<ProjectData> externalProject) {
+          public void onSuccess(@NotNull ExternalSystemTaskId id,
+                                @Nullable final DataNode<ProjectData> externalProject) {
             if (externalProject == null) {
               System.err.println("Got null External project after import");
               return;
@@ -470,6 +472,7 @@ public abstract class ExternalSystemImportingTestCase extends ExternalSystemTest
     }
   }
 
+  @Override
   protected Sdk setupJdkForModule(final String moduleName) {
     final Sdk sdk = true ? JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk() : createJdk("Java 1.5");
     ModuleRootModificationUtil.setModuleSdk(getModule(moduleName), sdk);

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/action/GradleRefreshProjectDependenciesAction.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/action/GradleRefreshProjectDependenciesAction.java
@@ -35,6 +35,8 @@ import org.jetbrains.plugins.gradle.util.GradleConstants;
 
 import java.util.List;
 
+import static com.intellij.openapi.externalSystem.util.ExternalSystemUtil.ShowFinishMessage;
+
 /**
  * @author Vladislav.Soroka
  * @since 3/1/2017
@@ -87,6 +89,6 @@ public class GradleRefreshProjectDependenciesAction extends RefreshExternalProje
                                         .useDefaultCallback()
                                         .use(ProgressExecutionMode.IN_BACKGROUND_ASYNC)
                                         .withArguments("--refresh-dependencies")
-                                        .build());
+                                        .build(), ShowFinishMessage.YES);
   }
 }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/filters/ReRunSyncFilter.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/filters/ReRunSyncFilter.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+import static com.intellij.openapi.externalSystem.util.ExternalSystemUtil.*;
+
 /**
  * @author Vladislav.Soroka
  */
@@ -46,7 +48,7 @@ public class ReRunSyncFilter extends GradleReRunBuildFilter {
       ImportSpec importSpec = new ImportSpecBuilder(myProject, myTask.getExternalSystemId())
         .withArguments(StringUtil.join(options, " "))
         .build();
-      ExternalSystemUtil.refreshProject(myTask.getExternalProjectPath(), importSpec);
+      refreshProject(myTask.getExternalProjectPath(), importSpec, ShowFinishMessage.YES);
     };
   }
 }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/wizard/GradleModuleBuilder.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/wizard/GradleModuleBuilder.java
@@ -63,6 +63,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.intellij.openapi.externalSystem.util.ExternalSystemUtil.ShowFinishMessage;
+
 /**
  * @author Denis Zhdanov
  * @since 6/26/13 11:10 AM
@@ -249,7 +251,7 @@ public class GradleModuleBuilder extends AbstractExternalModuleBuilder<GradlePro
           .createDirectoriesForEmptyContentRoots()
           .useDefaultCallback()
           .build();
-        ExternalSystemUtil.refreshProject(rootProjectPath, importSpec);
+        ExternalSystemUtil.refreshProject(rootProjectPath, importSpec, ShowFinishMessage.YES);
 
         final PsiFile psiFile;
         if (finalBuildScriptFile != null) {

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/wizard/GradleProjectImportBuilder.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/wizard/GradleProjectImportBuilder.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.internal.InternalExternalProjectInfo;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId;
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil;
 import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
 import com.intellij.openapi.externalSystem.service.project.ProjectDataManager;
@@ -126,7 +127,8 @@ public class GradleProjectImportBuilder extends AbstractExternalProjectImportBui
                                                                      @NotNull ExternalProjectSettings projectSettings) {
     return new ExternalProjectRefreshCallback() {
       @Override
-      public void onSuccess(@Nullable final DataNode<ProjectData> externalProject) {
+      public void onSuccess(@NotNull ExternalSystemTaskId id,
+                            @Nullable final DataNode<ProjectData> externalProject) {
         if (externalProject == null) return;
         Runnable selectDataTask = () -> {
           ExternalProjectDataSelectorDialog dialog = new ExternalProjectDataSelectorDialog(


### PR DESCRIPTION
1.- Add a ExternalSystemTaskId parameter to
ExternalProjectRefreshCallback#onSucess

2.- Add a new parameter (showFinishMessage) to
ExternalSystemUtil#refreshProject to indicate if a FinishBuildEvent
should be generated when sync has finished.