### PR TITLE
Add versionDetailsProvider extension point to the platform.

### DIFF
--- a/platform/platform-api/src/com/intellij/openapi/application/VersionDetailsProvider.java
+++ b/platform/platform-api/src/com/intellij/openapi/application/VersionDetailsProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.application;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public interface VersionDetailsProvider {
+  ExtensionPointName<VersionDetailsProvider> EP_NAME = new ExtensionPointName<>("com.intellij.versionDetailsProvider");
+
+  @NotNull
+  Map<String, String> getVersionDetails(@Nullable Project project);
+}

--- a/platform/platform-resources/src/META-INF/PlatformExtensionPoints.xml
+++ b/platform/platform-resources/src/META-INF/PlatformExtensionPoints.xml
@@ -307,5 +307,6 @@
     <extensionPoint qualifiedName="com.intellij.tree.CustomLanguageASTComparator" beanClass="com.intellij.lang.LanguageExtensionPoint">
       <with attribute="implementationClass" implements="com.intellij.psi.tree.CustomLanguageASTComparator"/>
     </extensionPoint>
+    <extensionPoint name="versionDetailsProvider" interface="com.intellij.openapi.application.VersionDetailsProvider"/>
   </extensionPoints>
 </idea-plugin>


### PR DESCRIPTION
This extension point allows the extensions to supply
application-specific version details in addition to the platform,
system and JDK information always populated by the platform by
default.

For example, Android Studio would provide additional details like
Gradle and Android Gradle Plugin versions, as well as versions
of some Android SDK components.

This is going to make it easier for users to collect version
information when they file bugs, which apart from the general
UX improvement would also reduce turnaround time as it'll be
less likely that a necessary detail might need to be requested
from the user additionally.

This CL also makes the relevant changes to SendFeedbackAction
and AboutPopup, which are the two sources of the version
information used by people when filing bugs.