### PR TITLE
Let unused TypeEvalContext instances be gc-ed

### DIFF
--- a/python/psi-api/src/com/jetbrains/python/psi/types/TypeEvalContext.java
+++ b/python/psi-api/src/com/jetbrains/python/psi/types/TypeEvalContext.java
@@ -47,18 +47,8 @@ public class TypeEvalContext {
 
   private final Map<PyTypedElement, PyType> myEvaluated = new HashMap<>();
   private final Map<PyCallable, PyType> myEvaluatedReturn = new HashMap<>();
-  private final ThreadLocal<Set<PyTypedElement>> myEvaluating = new ThreadLocal<Set<PyTypedElement>>() {
-    @Override
-    protected Set<PyTypedElement> initialValue() {
-      return new HashSet<>();
-    }
-  };
-  private final ThreadLocal<Set<PyCallable>> myEvaluatingReturn = new ThreadLocal<Set<PyCallable>>() {
-    @Override
-    protected Set<PyCallable> initialValue() {
-      return new HashSet<>();
-    }
-  };
+  private final ThreadLocal<Set<PyTypedElement>> myEvaluating = ThreadLocal.withInitial(HashSet::new);
+  private final ThreadLocal<Set<PyCallable>> myEvaluatingReturn = ThreadLocal.withInitial(HashSet::new);
 
   private TypeEvalContext(boolean allowDataFlow, boolean allowStubToAST, boolean allowCallContext, @Nullable PsiFile origin) {
     myConstraints = new TypeEvalConstraints(allowDataFlow, allowStubToAST, allowCallContext, origin);
@@ -254,7 +244,7 @@ public class TypeEvalContext {
   }
 
   /**
-   * @return context constraints (see {@link com.jetbrains.python.psi.types.TypeEvalConstraints}
+   * @return context constraints (see {@link TypeEvalConstraints}
    */
   @NotNull
   TypeEvalConstraints getConstraints() {


### PR DESCRIPTION
The problem here is that while the map holding cached values is softly referenced , the values themselves are not. This means the GC can either collect the entire map or none of it. Since the collector uses an LRU policy to collect soft refs and the reference to the map is usually 'recently used' it does not get collected until the memory situation becomes critical.  This becomes a problem when running inspections in batch mode on a large enough workload. 

This patch makes the cached values themselves softly referenced so that the gc can collect TypeEvalContext instances that have no been recently used.