### PR TITLE
Leak hunter sometimes uses stale roots

### DIFF
--- a/platform/testFramework/src/com/intellij/testFramework/LeakHunter.java
+++ b/platform/testFramework/src/com/intellij/testFramework/LeakHunter.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import javax.swing.*;
 import java.util.*;
+import java.util.function.Supplier;
 
 public class LeakHunter {
   @TestOnly
@@ -57,10 +58,10 @@ public class LeakHunter {
    * Checks if there is a memory leak if an object of type {@code suspectClass} is strongly accessible via references from the {@code root} object.
    */
   @TestOnly
-  public static <T> void checkLeak(@NotNull Map<Object, String> roots,
+  public static <T> void checkLeak(@NotNull Supplier<Map<Object, String>> rootsSupplier,
                                    @NotNull Class<T> suspectClass,
                                    @Nullable final Condition<? super T> isReallyLeak) throws AssertionError {
-    processLeaks(roots, suspectClass, isReallyLeak, (leaked, backLink)->{
+    processLeaks(rootsSupplier, suspectClass, isReallyLeak, (leaked, backLink)->{
       String place = leaked instanceof Project ? PlatformTestCase.getCreationPlace((Project)leaked) : "";
       String message ="Found leaked "+leaked.getClass() + ": "+leaked +
                       "; hash: " + System.identityHashCode(leaked) + "; place: " + place + "\n" +
@@ -77,7 +78,7 @@ public class LeakHunter {
    * Checks if there is a memory leak if an object of type {@code suspectClass} is strongly accessible via references from the {@code root} object.
    */
   @TestOnly
-  static <T> void processLeaks(@NotNull Map<Object, String> roots,
+  static <T> void processLeaks(@NotNull Supplier<Map<Object, String>> rootsSupplier,
                                @NotNull Class<T> suspectClass,
                                @Nullable final Condition<? super T> isReallyLeak,
                                @NotNull final PairProcessor<? super T, Object> processor) throws AssertionError {
@@ -88,10 +89,9 @@ public class LeakHunter {
       UIUtil.pump();
     }
     PersistentEnumeratorBase.clearCacheForTests();
-    LaterInvocator.purgeExpiredItems();
     ApplicationManager.getApplication().runReadAction(() -> {
       try (AccessToken ignored = ProhibitAWTEvents.start("checking for leaks")) {
-        DebugReflectionUtil.walkObjects(10000, roots, suspectClass, Conditions.alwaysTrue(), (value, backLink) -> {
+        DebugReflectionUtil.walkObjects(10000, rootsSupplier.get(), suspectClass, Conditions.alwaysTrue(), (value, backLink) -> {
           @SuppressWarnings("unchecked")
           T leaked = (T)value;
           if (isReallyLeak == null || isReallyLeak.value(leaked)) {
@@ -108,22 +108,27 @@ public class LeakHunter {
    */
   @TestOnly
   public static <T> void checkLeak(@NotNull Object root, @NotNull Class<T> suspectClass, @Nullable final Condition<? super T> isReallyLeak) throws AssertionError {
-    checkLeak(Collections.singletonMap(root, "Root object"), suspectClass, isReallyLeak);
+    checkLeak(() -> Collections.singletonMap(root, "Root object"), suspectClass, isReallyLeak);
   }
 
   @NotNull
-  public static Map<Object, String> allRoots() {
-    ClassLoader classLoader = LeakHunter.class.getClassLoader();
-    // inspect static fields of all loaded classes
-    Vector allLoadedClasses = ReflectionUtil.getField(classLoader.getClass(), classLoader, Vector.class, "classes");
+  public static Supplier<Map<Object, String>> allRoots() {
+    return () -> {
+      ClassLoader classLoader = LeakHunter.class.getClassLoader();
+      // inspect static fields of all loaded classes
+      Vector allLoadedClasses = ReflectionUtil.getField(classLoader.getClass(), classLoader, Vector.class, "classes");
 
-    Map<Object, String> result = new IdentityHashMap<>();
-    result.put(ApplicationManager.getApplication(), "ApplicationManager.getApplication()");
-    result.put(Disposer.getTree(), "Disposer.getTree()");
-    result.put(IdeEventQueue.getInstance(), "IdeEventQueue.getInstance()");
-    result.put(LaterInvocator.getLaterInvocatorQueue(), "LaterInvocator.getLaterInvocatorQueue()");
-    result.put(ThreadTracker.getThreads(), "all live threads");
-    result.put(allLoadedClasses, "all loaded classes statics");
-    return result;
+      // Remove expired invocations, so they are not used as object roots.
+      LaterInvocator.purgeExpiredItems();
+
+      Map<Object, String> result = new IdentityHashMap<>();
+      result.put(ApplicationManager.getApplication(), "ApplicationManager.getApplication()");
+      result.put(Disposer.getTree(), "Disposer.getTree()");
+      result.put(IdeEventQueue.getInstance(), "IdeEventQueue.getInstance()");
+      result.put(LaterInvocator.getLaterInvocatorQueue(), "LaterInvocator.getLaterInvocatorQueue()");
+      result.put(ThreadTracker.getThreads(), "all live threads");
+      result.put(allLoadedClasses, "all loaded classes statics");
+      return result;
+    };
   }
 }


### PR DESCRIPTION
LeakHunter.processLeaks() gets a list of root objects, typically a result
of LeakHunter.allRoots() call. As a part of leak search, LeakHunter will
flush all outstanding tasks in AWT EventQueue, which should also include
all tasks schedules with LaterInvocator.

allRoots() call gets all LaterInvocator tasks and uses them as roots for
leaks search. This list will become stale (i.e. will include runnables that
were already executed and removed from the LaterInvocator queue) after
processLeaks() flushes all events. To fix this the list of roots should be
computed after all event flushing is completed.

Fix: processLeaks() now takes a supplier for roots collection, so the set
of root objects can be computed after all events are flushed.

This fix has already been applied in Android Studio source tree as some 
test runs intermittently reported failures because of these timing issues.