### PR TITLE
Add an onStart method to ExternalProjectRefreshCallback

### DIFF
--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/service/project/ExternalProjectRefreshCallback.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/service/project/ExternalProjectRefreshCallback.java
@@ -29,6 +29,13 @@ import org.jetbrains.annotations.Nullable;
 */
 public interface ExternalProjectRefreshCallback {
 
+  default void onStart(@NotNull ExternalSystemTaskId externalTaskId) {
+    onStart();
+  }
+
+  default void onStart() {
+  }
+
   /**
    * Is expected to be called when
    * {@link ExternalSystemProjectResolver#resolveProjectInfo(ExternalSystemTaskId, String, boolean, ExternalSystemExecutionSettings, ExternalSystemTaskNotificationListener)}

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
@@ -537,6 +537,9 @@ public class ExternalSystemUtil {
             }
           }
         };
+        if (callback != null) {
+          callback.onStart(myTask.getId());
+        }
         myTask.execute(indicator, ArrayUtil.prepend(taskListener, ExternalSystemTaskNotificationListener.EP_NAME.getExtensions()));
         if (project.isDisposed()) return;
 


### PR DESCRIPTION
When ExternalSystemUtil#refreshProject is called, a rerun import action is
created and attached to the build view. This action is called when the
"Refresh" button is pressed and what it does is simply call refreshProject
again with the same parameters. For Android Studio, we do some setup
before calling refreshProject, but since this rerun action calls
refreshProject directly, we cannot do this inicial setup.

This CL adds an onStart method to ExternalProjectRefreshCallback which
allows any setup steps to be done before starting project refresh,
causing those steps to be repeated when the refresh button is pressed.