### PR TITLE
fix NPE: PsiFile.getContainingDirectory can return null

### DIFF
--- a/python/src/com/jetbrains/python/findUsages/PyModuleFindUsagesHandler.java
+++ b/python/src/com/jetbrains/python/findUsages/PyModuleFindUsagesHandler.java
@@ -80,7 +80,9 @@ public class PyModuleFindUsagesHandler extends PyFindUsagesHandler {
     if (target instanceof PyFile && PyNames.INIT_DOT_PY.equals(((PyFile)target).getName())) {
       List<PsiReference> result = new ArrayList<>(super.findReferencesToHighlight(target, searchScope));
       PsiElement targetDir = PyUtil.turnInitIntoDir(target);
-      result.addAll(ReferencesSearch.search(targetDir, searchScope, false).findAll());
+      if (targetDir != null) {
+        result.addAll(ReferencesSearch.search(targetDir, searchScope, false).findAll());
+      }
       return result;
     }
     return super.findReferencesToHighlight(target, searchScope);

--- a/python/src/com/jetbrains/python/psi/PyUtil.java
+++ b/python/src/com/jetbrains/python/psi/PyUtil.java
@@ -1027,7 +1027,7 @@ public class PyUtil {
    * @param target PSI element to check
    * @return PsiDirectory or target unchanged
    */
-  @Contract("null -> null; !null -> !null")
+  @Contract("null -> null")
   @Nullable
   public static PsiElement turnInitIntoDir(@Nullable PsiElement target) {
     if (target instanceof PyFile && isPackage((PsiFile)target)) {


### PR DESCRIPTION
PyUtil.turnInitIntoDir can return null for not null values. In my case this problem caused the reference highlighter to throw an exception in the Diff Viewer.