### PR TITLE
Disable rerunImportAction when it is performed on refreshProject

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
@@ -489,6 +489,8 @@ public class ExternalSystemUtil {
 
               @Override
               public void actionPerformed(AnActionEvent e) {
+                Presentation p = e.getPresentation();
+                p.setEnabled(false);
                 refreshProject(externalProjectPath, importSpec);
               }
             };


### PR DESCRIPTION
There is a "Refresh Project" button on the Build view, when this button
is pressed, the rerunImportAction action inside
ExternalSystemUtil#refreshProject is performed, but if you double click
this button, this action is performed twice.

This button is not disabled until the update method is called and inside it,
processHadles.isProcessTerminated() returns false. This causes a small
time window in wich this button can be cliicked multiple times.

This change disables this button when this action is performed instead
of waiting for update and isProcessTerminated to catch up.