### PR TITLE
Fix ThreeComponentsSplitter focus cycle

### DIFF
--- a/platform/platform-api/src/com/intellij/openapi/ui/ThreeComponentsSplitter.java
+++ b/platform/platform-api/src/com/intellij/openapi/ui/ThreeComponentsSplitter.java
@@ -72,75 +72,7 @@ public class ThreeComponentsSplitter extends JPanel implements Disposable {
 
   private boolean myShowDividerControls;
   private int myDividerZone;
-
-  private class MyFocusTraversalPolicy extends FocusTraversalPolicy {
-
-    @Override
-    public Component getComponentAfter(Container aContainer, Component aComponent) {
-      if (aComponent == myFirstComponent) {
-        return findChildToFocus(myInnerComponent);
-      }
-      if (aComponent == myInnerComponent) {
-        return findChildToFocus(myLastComponent);
-      }
-      return findChildToFocus(myFirstComponent);
-    }
-
-    @Override
-    public Component getComponentBefore(Container aContainer, Component aComponent) {
-      if (aComponent == myInnerComponent) {
-        return findChildToFocus(myFirstComponent);
-      }
-      if (aComponent == myLastComponent) {
-        return findChildToFocus(myInnerComponent);
-      }
-      return findChildToFocus(myFirstComponent);
-    }
-
-    @Override
-    public Component getFirstComponent(Container aContainer) {
-      return findChildToFocus(myFirstComponent);
-    }
-
-    @Override
-    public Component getLastComponent(Container aContainer) {
-      return findChildToFocus(myLastComponent);
-    }
-
-    @Override
-    public Component getDefaultComponent(Container aContainer) {
-      return findChildToFocus(myInnerComponent);
-    }
-
-    Component findChildToFocus (Component component) {
-      final Window ancestor = SwingUtilities.getWindowAncestor(ThreeComponentsSplitter.this);
-      if (ancestor != null) {
-        final Component mostRecentFocusOwner = ancestor.getMostRecentFocusOwner();
-        if (mostRecentFocusOwner != null && mostRecentFocusOwner.isShowing()) {
-          return mostRecentFocusOwner;
-        }
-      }
-      if (component instanceof JPanel) {
-        JPanel container = (JPanel)component;
-        final FocusTraversalPolicy policy = container.getFocusTraversalPolicy();
-
-        if (policy == null) {
-          return container;
-        }
-
-        final Component defaultComponent = policy.getDefaultComponent(container);
-        if (defaultComponent == null) {
-          return container;
-        }
-        return policy.getDefaultComponent(container);
-      }
-
-      return component;
-
-    }
-
-  }
-
+  
   /**
    * Creates horizontal split with proportion equals to .5f
    */
@@ -166,8 +98,8 @@ public class ThreeComponentsSplitter extends JPanel implements Disposable {
       myFirstDivider.setBackground(bg);
       myLastDivider.setBackground(bg);
     }
-    setFocusCycleRoot(true);
-    setFocusTraversalPolicy(new MyFocusTraversalPolicy());
+    setFocusTraversalPolicyProvider(true);
+    setFocusTraversalPolicy(new LayoutFocusTraversalPolicy());
     setOpaque(false);
     add(myFirstDivider);
     add(myLastDivider);

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/StripeButton.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/StripeButton.java
@@ -93,7 +93,7 @@ public final class StripeButton extends AnchoredButton implements ActionListener
   }
 
   private void init() {
-    setFocusable(false);
+    setFocusable(true);
     setBackground(ourBackgroundColor);
     final Border border = JBUI.Borders.empty(5, 5, 0, 5);
     setBorder(border);


### PR DESCRIPTION
Allow tab to navigate focus between the 3 panels of
ThreeComponentsSplitter by changing the traversal policy and removing
ThreeComponentsSplitter as the focus cycle root. This allows for users
of the component the control of the focus cycle instead.

Also allows for StripeButton to be focused.

JetBrains Contributor License Agreement signed under kelvinhanma@google.com 