### PR TITLE
Symmetric start and end points for init ProgressIndicator

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/Splash.java
+++ b/platform/platform-impl/src/com/intellij/ui/Splash.java
@@ -128,7 +128,7 @@ public class Splash extends JDialog implements StartupProgress {
       mySplashIsVisible = true;
     }
 
-    int totalWidth = myImage.getIconWidth() - getProgressX();
+    int totalWidth = myImage.getIconWidth() - 2 * getProgressX();
     if (Registry.is("ide.new.about")) {
       totalWidth +=3;
     }


### PR DESCRIPTION
Fixed with changing total width value.

Before (Now):
![Before](https://user-images.githubusercontent.com/8865056/37488643-641e1c8a-28a6-11e8-93c8-6120a4406236.png)
After:
![After](https://user-images.githubusercontent.com/8865056/37488648-67914324-28a6-11e8-89ae-239769eb58b1.png)
