### PR TITLE
terminal: quote shell variable when testing

### DIFF
--- a/plugins/terminal/resources/jediterm-bash.in
+++ b/plugins/terminal/resources/jediterm-bash.in
@@ -31,7 +31,7 @@ function load_interactive_configs {
   fi
 }
 
-if [ -n $LOGIN_SHELL ]; then
+if [ -n "$LOGIN_SHELL" ]; then
   load_login_configs
   unset LOGIN_SHELL
 fi


### PR DESCRIPTION
In the case LOGIN_SHELL is undefined, the test becomes:

if [ -n ]; then
...
fi

which will execute the block inside the if, when it shouldn't.