### PR TITLE
Add support for Geb content definition based methods

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/geb/GebContentDeclarationSearcher.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/geb/GebContentDeclarationSearcher.java
@@ -17,10 +17,7 @@ package org.jetbrains.plugins.groovy.geb;
 
 import com.intellij.pom.PomDeclarationSearcher;
 import com.intellij.pom.PomTarget;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiModifier;
+import com.intellij.psi.*;
 import com.intellij.psi.util.InheritanceUtil;
 import com.intellij.util.Consumer;
 import org.jetbrains.annotations.NotNull;
@@ -52,11 +49,11 @@ public class GebContentDeclarationSearcher extends PomDeclarationSearcher {
     if (!InheritanceUtil.isInheritor(containingClass, "geb.Page")
         && !InheritanceUtil.isInheritor(containingClass, "geb.Module")) return;
 
-    Map<String, PsiField> elements = GebUtil.getContentElements(containingClass);
+    Map<String, PsiMember> contentElements = GebUtil.getContentElements(containingClass);
 
-    for (PsiField f : elements.values()) {
-      if (f.getNavigationElement() == element) {
-        consumer.consume(f);
+    for (PsiMember contentElement : contentElements.values()) {
+      if (contentElement.getNavigationElement() == element) {
+        consumer.consume(contentElement);
         return;
       }
     }

--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/geb/GebPageMemberContributor.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/geb/GebPageMemberContributor.java
@@ -54,10 +54,10 @@ public class GebPageMemberContributor extends NonCodeMembersContributor {
         if (contentField instanceof GrField) {
           GrField f = (GrField)contentField;
           if ("content".equals(f.getName()) && f.hasModifierProperty(PsiModifier.STATIC) && f.getContainingClass() == aClass) {
-            Map<String, PsiField> elements = GebUtil.getContentElements(aClass);
-            for (PsiField field : elements.values()) {
-              if (field.getNavigationElement() == place) {
-                return; // Don't resolve variable definition.
+            Map<String, PsiMember> elements = GebUtil.getContentElements(aClass);
+            for (PsiMember element : elements.values()) {
+              if (element.getNavigationElement() == place) {
+                return; // Don't resolve definition.
               }
             }
           }
@@ -65,27 +65,27 @@ public class GebPageMemberContributor extends NonCodeMembersContributor {
       }
     }
 
-    processPageFields(processor, aClass, state);
+    processPageElements(processor, aClass, state);
   }
 
-  public static boolean processPageFields(PsiScopeProcessor processor,
-                                          @NotNull PsiClass pageClass,
-                                          ResolveState state) {
+  public static boolean processPageElements(PsiScopeProcessor processor,
+                                            @NotNull PsiClass pageClass,
+                                            ResolveState state) {
     Map<String, PsiClass> supers = ClassUtil.getSuperClassesWithCache(pageClass);
     String nameHint = ResolveUtil.getNameHint(processor);
 
     for (PsiClass psiClass : supers.values()) {
-      Map<String, PsiField> contentFields = GebUtil.getContentElements(psiClass);
+      Map<String, PsiMember> contentElements = GebUtil.getContentElements(psiClass);
 
       if (nameHint == null) {
-        for (Map.Entry<String, PsiField> entry : contentFields.entrySet()) {
+        for (Map.Entry<String, PsiMember> entry : contentElements.entrySet()) {
           if (!processor.execute(entry.getValue(), state)) return false;
         }
       }
       else {
-        PsiField field = contentFields.get(nameHint);
-        if (field != null) {
-          return processor.execute(field, state);
+        PsiMember element = contentElements.get(nameHint);
+        if (element != null) {
+          return processor.execute(element, state);
         }
       }
     }

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/geb/GebTestsTest.groovy
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/geb/GebTestsTest.groovy
@@ -92,6 +92,39 @@ class ParentClass extends geb.Page {
     TestUtils.checkCompletionContains(myFixture, "allElements()", "add()", "firstElement()")
   }
 
+  void testResolveContentFieldsAndMethods() {
+    myFixture.configureByText("PageWithContent.groovy", """
+class PageWithContent extends geb.Page {
+  static content = {
+    button { \$('button') }
+    formField { String name -> \$('input', name: name) }
+  }
+  
+  def someMethod() {
+    <caret>
+  }
+}
+""")
+
+    TestUtils.checkCompletionContains(myFixture, "button", "formField()")
+  }
+
+  void testContentMethodReturnType() {
+    myFixture.configureByText("PageWithContent.groovy", """
+class PageWithContent extends geb.Page {
+  static content = {
+    formField { String name -> \$('input', name: name) }
+  }
+  
+  def someMethod() {
+    formField('username').<caret>
+  }
+}
+""")
+
+    TestUtils.checkCompletionContains(myFixture, "allElements()", "add()", "firstElement()")
+  }
+
   void testCheckHighlighting() {
     myFixture.enableInspections(GroovyAssignabilityCheckInspection)
 


### PR DESCRIPTION
This PR adds support for Geb's content definition based methods (as documented in [this chapter](http://gebish.org/manual/current/#content-dsl) in `TemplatedPageWithDiv` example and implemented [here](https://github.com/geb/geb/blob/f1294846366e7c28f7d8d04ba14c95319cd2adad/module/geb-core/src/main/groovy/geb/content/PageContentSupport.groovy#L31)) to complement the current support of content definition based fields. 

Do not hesitate to let me know if this PR needs more work before it can be merged. I'll happily apply any necessary changes to it.

Please note that I have signed the CLA.

Given that this contribution is related to Groovy, I believe that the best person to review it is @dovchinnikov.