### PR TITLE
Resize myOriginalDocument to a message boundary

### DIFF
--- a/platform/lang-impl/src/com/intellij/diagnostic/logging/LogConsoleBase.java
+++ b/platform/lang-impl/src/com/intellij/diagnostic/logging/LogConsoleBase.java
@@ -380,7 +380,13 @@ public abstract class LogConsoleBase extends AdditionalTabComponent implements L
       if (ConsoleBuffer.useCycleBuffer()) {
         final int toRemove = myOriginalDocument.length() - ConsoleBuffer.getCycleBufferSize();
         if (toRemove > 0) {
-          myOriginalDocument.delete(0, toRemove);
+          final int indexOfNewline = myOriginalDocument.indexOf("\n", toRemove);
+
+          if (indexOfNewline == -1) {
+            myOriginalDocument.delete(0, toRemove);
+          } else {
+            myOriginalDocument.delete(0, indexOfNewline + 1);
+          }
         }
       }
     }


### PR DESCRIPTION
Android Studio overrides LogConsoleBase.getOriginalDocument to work around
the referenced issue. The override deletes additional characters up to and
including the next newline so the Studio logcat message parsers don't break.

Bug: https://issuetracker.google.com/77876440