### PR TITLE
Fix the type reported in completion dialog for field based Geb page content

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/geb/GebUtil.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/geb/GebUtil.java
@@ -112,10 +112,16 @@ public class GebUtil {
                                                  @NotNull GrExpression invokedExpression,
                                                  @NotNull GrClosableBlock block) {
     GrLightField field = new GrLightField(pageOrModuleClass, name, objectType, invokedExpression) {
-
       @Override
-      public PsiType getTypeGroovy() {
-        return block.getReturnType();
+      @NotNull
+      public PsiType getType() {
+        PsiType type = block.getReturnType();
+
+        if (type == null) {
+          return super.myType;
+        }
+
+        return type;
       }
 
       @Override

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/geb/GebTestsTest.groovy
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/geb/GebTestsTest.groovy
@@ -95,6 +95,24 @@ class PageWithContent extends geb.Page {
     TestUtils.checkCompletionContains(myFixture, "button", "formField()")
   }
 
+  void testContentElementsCompletionType() {
+    myFixture.configureByText("PageWithContent.groovy", """
+class PageWithContent extends geb.Page {
+  static content = {
+    button { \$('button') }
+    formField { String name -> \$('input', name: name) }
+  }
+  
+  def someMethod() {
+    <caret>
+  }
+}
+""")
+
+    TestUtils.checkCompletionType(myFixture, "button", "geb.navigator.Navigator")
+    TestUtils.checkCompletionType(myFixture, "formField", "geb.navigator.Navigator")
+  }
+
   void testContentMethodReturnType() {
     myFixture.configureByText("PageWithContent.groovy", """
 class PageWithContent extends geb.Page {

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/util/TestUtils.java
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/util/TestUtils.java
@@ -206,6 +206,31 @@ public abstract class TestUtils {
     }
   }
 
+  public static void checkCompletionType(JavaCodeInsightTestFixture fixture, String lookupString, String expectedTypeCanonicalText) {
+    LookupElement[] lookupElements = fixture.completeBasic();
+    PsiType type = null;
+
+    for (LookupElement lookupElement : lookupElements) {
+      if (lookupElement.getLookupString().equals(lookupString)) {
+        PsiElement element = lookupElement.getPsiElement();
+        if (element instanceof PsiField) {
+          type = ((PsiField)element).getType();
+          break;
+        }
+        if (element instanceof PsiMethod) {
+          type = ((PsiMethod)element).getReturnType();
+          break;
+        }
+      }
+    }
+
+    if (type == null) {
+      Assert.fail("No field or method called '" + lookupString + "' found in completion lookup elements");
+    }
+
+    Assert.assertEquals(expectedTypeCanonicalText, type.getCanonicalText());
+  }
+
   public static void checkResolve(PsiFile file, final String ... expectedUnresolved) {
     final List<String> actualUnresolved = new ArrayList<>();
 


### PR DESCRIPTION
As previously mentioned to @dovchinnikov, this is another PR around support for Geb.

I've noticed that in recent versions of IntelliJ the return type for field based Geb page content always comes up on the completion dialog as `Object` even though the right type seems to be known and used when completing symbols on the field itself. 

This fixes the above issue. 