### PR TITLE
IDEA-190710 Add Gitlab Time Tracking integration

### DIFF
--- a/plugins/tasks/tasks-tests/intellij.tasks.tests.iml
+++ b/plugins/tasks/tasks-tests/intellij.tasks.tests.iml
@@ -26,5 +26,6 @@
     <orderEntry type="module" module-name="intellij.platform.tasks" scope="TEST" />
     <orderEntry type="module" module-name="intellij.platform.tasks.impl" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="http-client-3.1" level="project" />
+    <orderEntry type="library" name="http-client" level="project" />
   </component>
 </module>


### PR DESCRIPTION
This allows for GitLab Time Tracking through the Tasks plugin. GitLab already supports this feature, but never got support in the IDE.