### PR TITLE
PY-26863 Support 3dsmaxpy.exe

### DIFF
--- a/python/src/META-INF/python-core-common.xml
+++ b/python/src/META-INF/python-core-common.xml
@@ -774,6 +774,7 @@
                    implementationClass="com.jetbrains.python.codeInsight.functionTypeComments.PyFunctionTypeAnnotationVisitorFilter"/>
 
     <pythonFlavorProvider implementation="com.jetbrains.python.sdk.flavors.MayaFlavorProvider"/>
+    <pythonFlavorProvider implementation="com.jetbrains.python.sdk.flavors.MaxFlavorProvider"/>
     <pyPregeneratedSkeletonsProvider id="default" implementation="com.jetbrains.python.sdk.skeletons.DefaultPregeneratedSkeletonsProvider"/>
   </extensions>
 

--- a/python/src/com/jetbrains/python/sdk/flavors/MaxPythonSdkFlavor.kt
+++ b/python/src/com/jetbrains/python/sdk/flavors/MaxPythonSdkFlavor.kt
@@ -1,0 +1,44 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python.sdk.flavors
+
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VirtualFile
+import icons.PythonIcons
+import java.io.File
+import javax.swing.Icon
+
+class MaxSdkFlavor private constructor() : PythonSdkFlavor() {
+  override fun isValidSdkHome(path: String?): Boolean {
+    val file = File(path)
+    return file.isFile && isValidSdkPath(file)
+  }
+
+  override fun isValidSdkPath(file: File): Boolean {
+    val name = FileUtil.getNameWithoutExtension(file).toLowerCase()
+    return name.startsWith("3dsmaxpy")
+  }
+
+  override fun getVersionOption(): String {
+    return "--version"
+  }
+
+  override fun getName(): String {
+    return "3dsMaxPy"
+  }
+
+  override fun getIcon(): Icon {
+    return PythonIcons.Python.Python
+  }
+
+  override fun getSdkPath(path: VirtualFile): VirtualFile? {
+    return path
+  }
+
+  companion object {
+    var INSTANCE = MaxSdkFlavor()
+  }
+}
+
+class MaxFlavorProvider : PythonFlavorProvider {
+  override fun getFlavor(platformIndependent: Boolean) = MaxSdkFlavor.INSTANCE
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/PY-26863

Simply support to allow PyCharm to recognize 3ds Max's `3dsmaxpy.exe`, this approach is based on the PythonSdk flavor approach that was used to make PyCharm work with Maya's `mayapy`.