### PR TITLE
JavaDoc fix at PsiTreeUtil.findChildrenOfAnyType()

### DIFF
--- a/platform/core-api/src/com/intellij/psi/util/PsiTreeUtil.java
+++ b/platform/core-api/src/com/intellij/psi/util/PsiTreeUtil.java
@@ -312,7 +312,7 @@ public class PsiTreeUtil {
    * @param strict  if false the {@code element} is also included in the search.
    * @param classes element types to search for.
    * @param <T>     type to cast found elements to.
-   * @return first found element, or {@code null} if nothing found.
+   * @return {@code Collection<T>} of all found elements, or empty {@code List<T>} if nothing found.
    */
   @SafeVarargs
   @NotNull


### PR DESCRIPTION
looks like copy-past typo from `findChildOfType()` JavaDoc.