### PR TITLE
[PY-27594] disable debug when Python gets input from stdin

### DIFF
--- a/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
+++ b/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
@@ -177,7 +177,16 @@ def patch_args(args):
                 # Always insert at pos == 1 (i.e.: pydevd "--module" --multiprocess ...)
                 original.insert(1, '--module')
             else:
-                if args[i].startswith('-'):
+                if args[i] == '-':
+                    # this is the marker that input is going to be from stdin for Python
+                    # however pydevd only supports passing a file argument, so we would need to
+                    # write out the stdin to a file and pass that in for this to work;
+                    # but in this function we don't have access to it, because patching occurs at
+                    # Popen creation time, while stdin may be passed in later during communicate
+                    # solution: for now we just disable the debugging here, don't crash but is
+                    # not supported
+                    return args
+                elif args[i].startswith('-'):
                     new_args.append(args[i])
                 else:
                     break


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/PY-27594 for more details. Resolves https://github.com/fabioz/PyDev.Debugger/issues/103. 

Note this is a workaround, as it will have the effect of not breaking things (as it does now). However, it will not allow users to debug library calls from within the stdin content. 

If we could interpret the whole input, write it to a temp file, that would allow the user to debug. However, I think that will require a significant refactor of this monkey patching.