### PR TITLE
Fix an error when the HEAD is detached

### DIFF
--- a/plugins/git4idea/src/git4idea/ui/branch/GitBranchPopupActions.java
+++ b/plugins/git4idea/src/git4idea/ui/branch/GitBranchPopupActions.java
@@ -623,7 +623,10 @@ class GitBranchPopupActions {
   @Nullable
   private static String getCurrentBranchPresentation(@NotNull Collection<GitRepository> repositories) {
     Set<String> currentBranches = map2Set(repositories, Repository::getCurrentBranchName);
-    if (currentBranches.size() == 1) return getBranchPresentation(currentBranches.iterator().next());
+    if (currentBranches.size() == 1) {
+      String branch = currentBranches.iterator().next();
+      return branch == null ? "detached head" : getBranchPresentation(branch);
+    }
     return "current branch";
   }
 


### PR DESCRIPTION
The error occurred when there is no current branch (e.g. a commit is checked out).

Fixed by checking if the parameter is null before passing it to `getBranchPresentation()` method.

### How to reproduce error
* Checkout a previous commit that is not on top of a branch.
* Try to change the branch from the bottom right branches list.