### PR TITLE
IDEA-193199 Split ExportHTMLAction into specific implementations, all…

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/InspectionResultsView.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/InspectionResultsView.java
@@ -12,7 +12,7 @@ import com.intellij.codeInspection.ex.*;
 import com.intellij.codeInspection.offlineViewer.OfflineInspectionRVContentProvider;
 import com.intellij.codeInspection.reference.RefElement;
 import com.intellij.codeInspection.reference.RefEntity;
-import com.intellij.codeInspection.ui.actions.ExportHTMLAction;
+import com.intellij.codeInspection.ui.actions.ExportAction;
 import com.intellij.codeInspection.ui.actions.InvokeQuickFixAction;
 import com.intellij.diff.util.DiffUtil;
 import com.intellij.ide.*;
@@ -298,7 +298,7 @@ public class InspectionResultsView extends JPanel implements Disposable, DataPro
     specialGroup.add(myGlobalInspectionContext.getUIOptions().createGroupByDirectoryAction(this));
     specialGroup.add(myGlobalInspectionContext.getUIOptions().createFilterResolvedItemsAction(this));
     specialGroup.add(myGlobalInspectionContext.createToggleAutoscrollAction());
-    specialGroup.add(new ExportHTMLAction(this));
+    specialGroup.add(new ExportAction(this));
     specialGroup.add(ActionManager.getInstance().getAction("EditInspectionSettings"));
     specialGroup.add(new InvokeQuickFixAction(this));
     return createToolbar(specialGroup);

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportAction.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportAction.java
@@ -1,0 +1,81 @@
+// Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+package com.intellij.codeInspection.ui.actions;
+
+import com.intellij.codeEditor.printing.ExportToHTMLSettings;
+import com.intellij.codeInspection.InspectionsBundle;
+import com.intellij.codeInspection.export.ExportToHTMLDialog;
+import com.intellij.codeInspection.ui.InspectionResultsView;
+import com.intellij.codeInspection.ui.actions.export.ExportActionBase;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.ui.popup.ListPopup;
+import com.intellij.openapi.ui.popup.PopupStep;
+import com.intellij.openapi.ui.popup.util.BaseListPopupStep;
+import org.jetbrains.annotations.NonNls;
+
+import java.io.File;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.intellij.util.containers.ContainerUtilRt.newArrayList;
+
+public class ExportAction extends AnAction implements DumbAware {
+  @NonNls private static final String CODE_INSPECTION_EXPORT_PREFIX = "CodeInspectionExport";
+  private final InspectionResultsView myView;
+  private final Map<String, ExportActionBase> myExportActions;
+
+  public ExportAction(final InspectionResultsView view) {
+    super(InspectionsBundle.message("inspection.action.export.html"), null, AllIcons.ToolbarDecorator.Export);
+    myView = view;
+    myExportActions = getExportActions();
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final ListPopup popup = JBPopupFactory.getInstance().createListPopup(
+      new BaseListPopupStep<String>(InspectionsBundle.message("inspection.action.export.popup.title"), newArrayList(myExportActions.keySet())) {
+        @Override
+        public PopupStep onChosen(final String selectedValue, final boolean finalChoice) {
+          return doFinalStep(() -> export(selectedValue));
+        }
+      });
+    InspectionResultsView.showPopup(e, popup);
+  }
+
+  protected Map<String, ExportActionBase> getExportActions() {
+    Map<String, ExportActionBase> exportActions = new TreeMap<>();
+    String[] ids = ActionManager.getInstance().getActionIds(CODE_INSPECTION_EXPORT_PREFIX);
+    for (String actionId: ids) {
+      ExportActionBase action = (ExportActionBase)ActionManager.getInstance().getAction(actionId);
+      if (action.isVisible(myView)) {
+        exportActions.put(action.getTemplatePresentation().getText(), action);
+      }
+    }
+    return exportActions;
+  }
+
+  private void export(final String selectedValue) {
+    ExportActionBase exportAction = myExportActions.get(selectedValue);
+    ExportToHTMLDialog exportToHTMLDialog = new ExportToHTMLDialog(myView.getProject(), exportAction.isExportToHTML());
+    final ExportToHTMLSettings exportToHTMLSettings = ExportToHTMLSettings.getInstance(myView.getProject());
+    if (exportToHTMLSettings.OUTPUT_DIRECTORY == null) {
+      exportToHTMLSettings.OUTPUT_DIRECTORY = PathManager.getHomePath() + File.separator + "inspections";
+    }
+    exportToHTMLDialog.reset();
+    if (!exportToHTMLDialog.showAndGet()) {
+      return;
+    }
+    exportToHTMLDialog.apply();
+
+    final String outputDirectoryName = exportToHTMLSettings.OUTPUT_DIRECTORY;
+
+    exportAction.actionPerformed(myView, outputDirectoryName, exportToHTMLSettings);
+  }
+
+}

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/export/ExportActionBase.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/export/ExportActionBase.java
@@ -1,0 +1,52 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.codeInspection.ui.actions.export;
+
+import com.intellij.codeEditor.printing.ExportToHTMLSettings;
+import com.intellij.codeInspection.ui.InspectionResultsView;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.DumbAware;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+/**
+ *  Every code inspection export action has to inherit this class. Register your implementation with "CodeInspectionExport" id prefix.
+ *  i.e.<action id="CodeInspectionExport.XLS" text="XLS" class="..." />
+ */
+public abstract class ExportActionBase extends AnAction implements DumbAware {
+
+  public abstract boolean isExportToHTML();
+
+  protected abstract String getTitle();
+
+  protected abstract void performExport(@NotNull InspectionResultsView myView, @NotNull String outputDirectoryName);
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {}
+
+  public void actionPerformed(final InspectionResultsView myView,
+                              final String outputDirectoryName,
+                              ExportToHTMLSettings exportToHTMLSettings) {
+    ApplicationManager.getApplication().invokeLater(() -> {
+      final Runnable exportRunnable = () -> ApplicationManager.getApplication().runReadAction(() -> performExport(myView, outputDirectoryName));
+
+      if (!ProgressManager.getInstance().runProcessWithProgressSynchronously(exportRunnable,
+                                                                             getTitle(), true,
+                                                                             myView.getProject())) {
+        return;
+      }
+
+      if (isExportToHTML() && exportToHTMLSettings.OPEN_IN_BROWSER) {
+        BrowserUtil.browse(new File(exportToHTMLSettings.OUTPUT_DIRECTORY, "index.html"));
+      }
+    });
+  }
+
+  public boolean isVisible(@NotNull InspectionResultsView myView) {
+    return true;
+  }
+}

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/export/ExportHTMLAction.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/export/ExportHTMLAction.java
@@ -1,0 +1,32 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.codeInspection.ui.actions.export;
+
+import com.intellij.codeInspection.InspectionsBundle;
+import com.intellij.codeInspection.export.InspectionTreeHtmlWriter;
+import com.intellij.codeInspection.ui.InspectionResultsView;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import org.jetbrains.annotations.NotNull;
+
+public class ExportHTMLAction extends ExportActionBase {
+
+  @Override
+  public boolean isExportToHTML() {
+    return true;
+  }
+
+  @Override
+  public String getTitle() {
+    return InspectionsBundle.message("inspection.generating.html.progress.title");
+  }
+
+  @Override
+  protected void performExport(@NotNull InspectionResultsView myView, @NotNull String outputDirectoryName) {
+    try {
+      new InspectionTreeHtmlWriter(myView, outputDirectoryName);
+    }
+    catch (ProcessCanceledException e) {
+      // Do nothing here.
+    }
+  }
+
+}

--- a/platform/platform-resources/src/idea/LangActions.xml
+++ b/platform/platform-resources/src/idea/LangActions.xml
@@ -1054,6 +1054,8 @@
       <action id="SuppressFixes" class="com.intellij.codeInspection.ui.actions.suppress.SuppressActionWrapper"/>
       <separator/>
       <action id="EditInspectionSettings" class="com.intellij.codeInspection.ui.actions.EditSettingsAction"/>
+      <action id="CodeInspectionExport.HTML" text="HTML" class="com.intellij.codeInspection.ui.actions.export.ExportHTMLAction"/>
+      <action id="CodeInspectionExport.XML" text="XML" class="com.intellij.codeInspection.ui.actions.export.ExportXMLAction"/>
       <action id="DisableInspection" class="com.intellij.codeInspection.ui.actions.KeyAwareInspectionViewAction$DisableInspection"/>
       <action id="RunInspectionOn" class="com.intellij.codeInspection.ui.actions.KeyAwareInspectionViewAction$RunInspectionOn"/>
     </group>


### PR DESCRIPTION
Split ExportHTMLAction into specific implementations, allowing plugins to add more export actions though xml registration.

Signed-off-by: Martin Zdarsky-Jones zdary@zdary.cz