### PR TITLE
fixed English language typo in Tip of the Day text

### DIFF
--- a/resources-en/src/tips/SecondBasicClassNameCompletion.html
+++ b/resources-en/src/tips/SecondBasicClassNameCompletion.html
@@ -7,7 +7,7 @@
 
 
       When you invoked Basic Completion (<span class="shortcut">&shortcut:CodeCompletion;</span>) in Java and didn't find your desired class in the list, it means
-      that it's not yet imported in current file. Pressing <span class="shortcut">&shortcut:CodeCompletion;</span> once more to view all accessible classes.
+      that it's not yet imported in the current file. Press <span class="shortcut">&shortcut:CodeCompletion;</span> once more to view all accessible classes.
       <p class="image"><img src="images/second_code_completion.png"></p>
 
 


### PR DESCRIPTION
Minor typo.

It could be either
- "Press CodeCompletion once more to view all accessible classes."
(as in the suggested change) or
- "Pressing CodeCompletion once more will enable you to view all accessible classes."