### PR TITLE
Fix path for open command in launcher

### DIFF
--- a/platform/platform-resources/src/launcher.py
+++ b/platform/platform-resources/src/launcher.py
@@ -99,7 +99,7 @@ def start_new_instance(args):
     if sys.platform == 'darwin':
         if len(args) > 0:
             args.insert(0, '--args')
-        os.execvp('open', ['-a', RUN_PATH] + args)
+        os.execvp('/usr/bin/open', ['-a', RUN_PATH] + args)
     else:
         bin_file = os.path.split(RUN_PATH)[1]
         os.execv(RUN_PATH, [bin_file] + args)


### PR DESCRIPTION
It's a common pattern for power users to replace `open` with some other
file manager. Since the launcher relies on the OS `open` command, having
the full path will avoid issues with users aliasing `open` to something
else while keeping the current behavior the same.