### PR TITLE
Gradle: upgrade Tooling API from 4.7 up to 4.8

### DIFF
--- a/.idea/libraries/Gradle.xml
+++ b/.idea/libraries/Gradle.xml
@@ -1,11 +1,11 @@
 <component name="libraryTable">
   <library name="Gradle" type="repository">
-    <properties maven-id="org.jetbrains.intellij.deps:gradle-api:4.7" />
+    <properties maven-id="org.jetbrains.intellij.deps:gradle-api:4.8" />
     <CLASSES>
-      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-api/4.7/gradle-api-4.7.jar!/" />
-      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-api-impldep/4.7/gradle-api-impldep-4.7.jar!/" />
-      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-wrapper/4.7/gradle-wrapper-4.7.jar!/" />
-      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-launcher/4.7/gradle-launcher-4.7.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-api/4.8/gradle-api-4.8.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-api-impldep/4.8/gradle-api-impldep-4.8.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-wrapper/4.8/gradle-wrapper-4.8.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/gradle-launcher/4.8/gradle-launcher-4.8.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/build/dependencies/gradle.properties
+++ b/build/dependencies/gradle.properties
@@ -2,4 +2,4 @@
 kotlinPluginBuild=1.2.41-release-IJ2018.2-2
 jetSignBuild=42.30
 jdkBuild=u152b1248.6
-gradleApiVersion=4.7
+gradleApiVersion=4.8

--- a/platform/build-scripts/groovy/org/jetbrains/intellij/build/CommunityLibraryLicenses.groovy
+++ b/platform/build-scripts/groovy/org/jetbrains/intellij/build/CommunityLibraryLicenses.groovy
@@ -136,7 +136,7 @@ class CommunityLibraryLicenses {
     new LibraryLicense(name: "Gherkin", libraryName: "Gherkin", version: "2.12.2", license: "MIT",
                        licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt", url: "https://github.com/cucumber/gherkin"),
     new LibraryLicense(name: "Google Feedback", libraryName: "GoogleFeedback.jar", version: "", license: "TBD"),
-    new LibraryLicense(name: "Gradle", version: "4.7", license: "Apache 2.0", url: "http://gradle.org/",
+    new LibraryLicense(name: "Gradle", version: "4.8", license: "Apache 2.0", url: "http://gradle.org/",
                        licenseUrl: "http://gradle.org/license"),
     new LibraryLicense(name: "Groovy", version: "2.4.6", license: "Apache 2.0", url: "http://groovy-lang.org/"),
     new LibraryLicense(name: "Gson", version: "2.8.4", libraryName: "gson", license: "Apache 2.0", url: "http://code.google.com/p/google-gson/"),

--- a/plugins/gradle/resources/fileTemplates/internal/Gradle Build Script with wrapper.gradle.ft
+++ b/plugins/gradle/resources/fileTemplates/internal/Gradle Build Script with wrapper.gradle.ft
@@ -9,7 +9,7 @@ task wrapper(type: Wrapper) {
 #if (${GRADLE_VERSION} && ${GRADLE_VERSION} != "")
   gradleVersion = '${GRADLE_VERSION}'
 #else
-  gradleVersion = '4.7'
+  gradleVersion = '4.8'
 #end
   distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }

--- a/plugins/gradle/resources/fileTemplates/internal/Gradle Kotlin DSL Build Script with wrapper.gradle.ft
+++ b/plugins/gradle/resources/fileTemplates/internal/Gradle Kotlin DSL Build Script with wrapper.gradle.ft
@@ -9,7 +9,7 @@ val wrapper by tasks.creating(Wrapper::class) {
 #if (${GRADLE_VERSION} && ${GRADLE_VERSION} != "")
   gradleVersion = "${GRADLE_VERSION}"
 #else
-  gradleVersion = "4.7"
+  gradleVersion = "4.8"
 #end
   distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }


### PR DESCRIPTION
This PR upgrades Gradle version to last stable release 4.8.
No big change was required.