### PR TITLE
Have common Icons for nodes in build view

### DIFF
--- a/platform/lang-impl/src/com/intellij/build/AbstractViewManager.java
+++ b/platform/lang-impl/src/com/intellij/build/AbstractViewManager.java
@@ -46,6 +46,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.intellij.build.ExecutionNode.getEventResultIcon;
+
 /**
  * @author Vladislav.Soroka
  */
@@ -171,24 +173,11 @@ public abstract class AbstractViewManager implements ViewManager, BuildProgressL
     }
 
     public Icon getIcon() {
-      return getIcon(result);
+      return getEventResultIcon(result);
     }
 
     public boolean isRunning() {
       return endTime == -1;
-    }
-
-    private static Icon getIcon(EventResult result) {
-      if (result == null) {
-        return ExecutionNodeProgressAnimator.getCurrentFrame();
-      }
-      if (result instanceof FailureResult) {
-        return AllIcons.Process.State.RedExcl;
-      }
-      if (result instanceof SkippedResult) {
-        return AllIcons.Process.State.YellowStr;
-      }
-      return AllIcons.Process.State.GreenOK;
     }
   }
 

--- a/platform/lang-impl/src/com/intellij/build/ExecutionNode.java
+++ b/platform/lang-impl/src/com/intellij/build/ExecutionNode.java
@@ -40,6 +40,15 @@ import java.util.function.Supplier;
  * @author Vladislav.Soroka
  */
 public class ExecutionNode extends CachingSimpleNode {
+  private static final Icon NODE_ICON_OK = AllIcons.Process.State.GreenOK;
+  private static final Icon NODE_ICON_ERROR = AllIcons.General.Error;
+  private static final Icon NODE_ICON_WARNING = AllIcons.General.Warning;
+  private static final Icon NODE_ICON_INFO =  AllIcons.General.Information;
+  private static final Icon NODE_ICON_SKIPPED = AllIcons.Process.State.YellowStr;
+  private static final Icon NODE_ICON_STATISTICS = AllIcons.General.Mdot_empty;
+  private static final Icon NODE_ICON_SIMPLE = AllIcons.General.Mdot_empty;
+  private static final Icon NODE_ICON_DEFAULT = AllIcons.General.Mdot_empty;
+
   private final List<ExecutionNode> myChildrenList = ContainerUtil.newSmartList();
   private long startTime;
   private long endTime;
@@ -153,7 +162,7 @@ public class ExecutionNode extends CachingSimpleNode {
       return "Running for " + durationText;
     }
     else {
-      return isSkipped() ? null : StringUtil.formatDuration(endTime - startTime);
+      return isSkipped(myResult) ? null : StringUtil.formatDuration(endTime - startTime);
     }
   }
 
@@ -173,16 +182,16 @@ public class ExecutionNode extends CachingSimpleNode {
     this.endTime = endTime;
   }
 
-  public boolean isFailed() {
-    return myResult instanceof FailureResult;
+  public static boolean isFailed(@Nullable EventResult result) {
+    return result instanceof FailureResult;
   }
 
-  public boolean isSkipped() {
-    return myResult instanceof SkippedResult;
+  public static boolean isSkipped(@Nullable EventResult result) {
+    return result instanceof SkippedResult;
   }
 
   public boolean isRunning() {
-    return endTime <= 0 && !isSkipped() && !isFailed();
+    return endTime <= 0 && !isSkipped(myResult) && !isFailed(myResult);
   }
 
   public void setResult(@Nullable EventResult result) {
@@ -277,27 +286,40 @@ public class ExecutionNode extends CachingSimpleNode {
     }
     else {
       return isRunning() ? ExecutionNodeProgressAnimator.getCurrentFrame() :
-             isFailed() ? AllIcons.General.Error :
-             isSkipped() ? AllIcons.Process.State.YellowStr :
-             myErrors.get() > 0 ? AllIcons.General.Error :
-             myWarnings.get() > 0 ? AllIcons.General.Warning :
-             AllIcons.Process.State.GreenOK;
+             isFailed(myResult) ? NODE_ICON_ERROR :
+             isSkipped(myResult) ? NODE_ICON_SKIPPED :
+             myErrors.get() > 0 ? NODE_ICON_ERROR :
+             myWarnings.get() > 0 ? NODE_ICON_WARNING :
+             NODE_ICON_OK;
     }
+  }
+
+  public static Icon getEventResultIcon(@Nullable EventResult result) {
+    if (result == null) {
+      return ExecutionNodeProgressAnimator.getCurrentFrame();
+    }
+    if (isFailed(result)) {
+      return NODE_ICON_ERROR;
+    }
+    if (isSkipped(result)) {
+      return NODE_ICON_SKIPPED;
+    }
+    return NODE_ICON_OK;
   }
 
   private static Icon getIcon(MessageEvent.Kind kind) {
     switch (kind) {
       case ERROR:
-        return AllIcons.General.Error;
+        return NODE_ICON_ERROR;
       case WARNING:
-        return AllIcons.General.Warning;
+        return NODE_ICON_WARNING;
       case INFO:
-        return AllIcons.General.Information;
+        return NODE_ICON_INFO;
       case STATISTICS:
-        return AllIcons.General.Mdot_empty;
+        return NODE_ICON_STATISTICS;
       case SIMPLE:
-        return AllIcons.General.Mdot_empty;
+        return NODE_ICON_SIMPLE;
     }
-    return AllIcons.General.Mdot_empty;
+    return NODE_ICON_DEFAULT;
   }
 }


### PR DESCRIPTION
When there are multiple builds on the build view, each one of them get
its Icon from AbstractViewManager#getIcon, but the icons used are not
consistent with the ones used in ExecutionNode.

This change causes getIcon to use a new function (getEventResultIcon)
that shares the same icons as ExecutionNode#getCurrentIcon. Also, the
icons are defined using constants to cause any change on them to be used
in both functions.