### PR TITLE
Allow alternative resolve in CombinedTestLocator.

### DIFF
--- a/platform/smRunner/src/com/intellij/execution/testframework/sm/SMTestRunnerConnectionUtil.java
+++ b/platform/smRunner/src/com/intellij/execution/testframework/sm/SMTestRunnerConnectionUtil.java
@@ -236,7 +236,9 @@ public class SMTestRunnerConnectionUtil {
       if (URLUtil.FILE_PROTOCOL.equals(protocol)) {
         return FileUrlProvider.INSTANCE.getLocation(protocol, path, project, scope);
       }
-      else if (!DumbService.isDumb(project) || DumbService.isDumbAware(myLocator)) {
+      else if (!DumbService.isDumb(project) || DumbService.isDumbAware(myLocator)
+               // Android Studio: add the following check due to our custom handling of dumb mode during Gradle builds
+               || DumbService.getInstance(project).isAlternativeResolveEnabled()) {
         return myLocator.getLocation(protocol, path, metainfo, project, scope);
       }
       else {


### PR DESCRIPTION
Android Studio runs gradle builds in dumb mode. This change allows
Android Studio to resolve test case locations even in dumb mode, if
alternative resolve is enabled.