### PR TITLE
Refactor ExportAction

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInspection/ex/GlobalInspectionContextImpl.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ex/GlobalInspectionContextImpl.java
@@ -20,7 +20,7 @@ import com.intellij.codeInspection.ui.DefaultInspectionToolPresentation;
 import com.intellij.codeInspection.ui.InspectionResultsView;
 import com.intellij.codeInspection.ui.InspectionToolPresentation;
 import com.intellij.codeInspection.ui.InspectionTreeState;
-import com.intellij.codeInspection.ui.actions.ExportHTMLAction;
+import com.intellij.codeInspection.ui.actions.ExportToXMLAction;
 import com.intellij.concurrency.JobLauncher;
 import com.intellij.concurrency.JobLauncherImpl;
 import com.intellij.concurrency.SensitiveProgressWrapper;
@@ -209,7 +209,7 @@ public class GlobalInspectionContextImpl extends GlobalInspectionContextBase imp
         for (ScopeToolState toolDescr : sameTools.getTools()) {
           InspectionToolWrapper toolWrapper = toolDescr.getTool();
           if (toolWrapper instanceof LocalInspectionToolWrapper) {
-            hasProblems = ExportHTMLAction.getInspectionResultFile(outputPath, toolWrapper.getShortName()).exists();
+            hasProblems = ExportToXMLAction.getInspectionResultFile(outputPath, toolWrapper.getShortName()).exists();
           }
           else {
             InspectionToolPresentation presentation = getPresentation(toolWrapper);
@@ -226,7 +226,7 @@ public class GlobalInspectionContextImpl extends GlobalInspectionContextBase imp
       // close "problem" tag for local inspections (see DefaultInspectionToolPresentation.addProblemElement())
       if (hasProblems) {
         try {
-          final File file = ExportHTMLAction.getInspectionResultFile(outputPath, sameTools.getShortName());
+          final File file = ExportToXMLAction.getInspectionResultFile(outputPath, sameTools.getShortName());
           inspectionsResults.add(file);
           FileUtil.writeToFile(file, ("</" + PROBLEMS_TAG_NAME + ">").getBytes(CharsetToolkit.UTF8_CHARSET), true);
         }
@@ -247,9 +247,9 @@ public class GlobalInspectionContextImpl extends GlobalInspectionContextBase imp
         try {
           int i = 0;
           for (Tools inspection : inspections) {
-            inspectionsResults.add(ExportHTMLAction.getInspectionResultFile(outputPath, inspection.getShortName()));
+            inspectionsResults.add(ExportToXMLAction.getInspectionResultFile(outputPath, inspection.getShortName()));
             try {
-              BufferedWriter writer = ExportHTMLAction.getWriter(outputPath, inspection.getShortName());
+              BufferedWriter writer = ExportToXMLAction.getWriter(outputPath, inspection.getShortName());
               writers[i] = writer;
               XMLStreamWriter xmlWriter = xmlOutputFactory.createXMLStreamWriter(writer);
               xmlWriters[i++] = xmlWriter;

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/DefaultInspectionToolPresentation.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/DefaultInspectionToolPresentation.java
@@ -12,7 +12,7 @@ import com.intellij.codeInspection.reference.RefElement;
 import com.intellij.codeInspection.reference.RefEntity;
 import com.intellij.codeInspection.reference.RefManager;
 import com.intellij.codeInspection.reference.RefVisitor;
-import com.intellij.codeInspection.ui.actions.ExportHTMLAction;
+import com.intellij.codeInspection.ui.actions.ExportToXMLAction;
 import com.intellij.codeInspection.ui.util.SynchronizedBidiMultiMap;
 import com.intellij.configurationStore.JbXmlOutputter;
 import com.intellij.injected.editor.VirtualFileWindow;
@@ -265,7 +265,7 @@ public class DefaultInspectionToolPresentation implements InspectionToolPresenta
   }
 
   private synchronized void writeOutput(@NotNull final CommonProblemDescriptor[] descriptions, @NotNull RefEntity refElement) {
-    final File file = ExportHTMLAction.getInspectionResultFile(myContext.getOutputPath(), myToolWrapper.getShortName());
+    final File file = ExportToXMLAction.getInspectionResultFile(myContext.getOutputPath(), myToolWrapper.getShortName());
     boolean exists = file.exists();
     FileUtil.createParentDirs(file);
     try (PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file, true), CharsetToolkit.UTF8_CHARSET)))) {

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/InspectionResultsView.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/InspectionResultsView.java
@@ -11,7 +11,6 @@ import com.intellij.codeInspection.ex.*;
 import com.intellij.codeInspection.offlineViewer.OfflineInspectionRVContentProvider;
 import com.intellij.codeInspection.reference.RefElement;
 import com.intellij.codeInspection.reference.RefEntity;
-import com.intellij.codeInspection.ui.actions.ExportHTMLAction;
 import com.intellij.codeInspection.ui.actions.InvokeQuickFixAction;
 import com.intellij.diff.util.DiffUtil;
 import com.intellij.ide.*;
@@ -307,7 +306,7 @@ public class InspectionResultsView extends JPanel implements Disposable, DataPro
     specialGroup.add(myGlobalInspectionContext.getUIOptions().createGroupByDirectoryAction(this));
     specialGroup.add(myGlobalInspectionContext.getUIOptions().createFilterResolvedItemsAction(this));
     specialGroup.add(myGlobalInspectionContext.createToggleAutoscrollAction());
-    specialGroup.add(new ExportHTMLAction(this));
+    specialGroup.addAll((ActionGroup)ActionManager.getInstance().getAction("InspectionToolWindow.Toolbar"));
     specialGroup.add(new InvokeQuickFixAction(this));
     return createToolbar(specialGroup);
   }

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportAction.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportAction.java
@@ -1,0 +1,31 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+package com.intellij.codeInspection.ui.actions;
+
+import com.intellij.codeInspection.InspectionsBundle;
+import com.intellij.codeInspection.ui.InspectionResultsView;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.ActionGroup;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.ui.popup.ListPopup;
+
+public class ExportAction extends AnAction implements DumbAware {
+
+  public ExportAction() {
+    super(InspectionsBundle.message("inspection.action.export.html"), null, AllIcons.ToolbarDecorator.Export);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final ActionGroup group = (ActionGroup)ActionManager.getInstance().getAction("InspectionToolWindow.ExportPopup");
+    final ListPopup popup = JBPopupFactory.getInstance().createActionGroupPopup(
+      InspectionsBundle.message("inspection.action.export.popup.title"), group, e.getDataContext(),
+      JBPopupFactory.ActionSelectionAid.MNEMONICS, true);
+
+    InspectionResultsView.showPopup(e, popup);
+  }
+}

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportInspectionResultsActionBase.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportInspectionResultsActionBase.java
@@ -1,0 +1,49 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.codeInspection.ui.actions;
+
+import com.intellij.codeEditor.printing.ExportToHTMLSettings;
+import com.intellij.codeInspection.export.ExportToHTMLDialog;
+import com.intellij.codeInspection.ui.InspectionResultsView;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.PathManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.io.File;
+
+public abstract class ExportInspectionResultsActionBase extends InspectionViewActionBase {
+
+  private final boolean canBeOpenInBrowser;
+
+  public ExportInspectionResultsActionBase(
+    @Nullable String text,
+    @Nullable String description,
+    @Nullable Icon icon,
+    boolean canBeOpenInBrowser
+  ) {
+    super(text, description, icon);
+    this.canBeOpenInBrowser = canBeOpenInBrowser;
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    final InspectionResultsView view = getView(e);
+
+    if (view == null) {
+      return;
+    }
+    ExportToHTMLDialog exportToHTMLDialog = new ExportToHTMLDialog(view.getProject(), canBeOpenInBrowser);
+    final ExportToHTMLSettings exportToHTMLSettings = ExportToHTMLSettings.getInstance(view.getProject());
+
+    if (exportToHTMLSettings.OUTPUT_DIRECTORY == null) {
+      exportToHTMLSettings.OUTPUT_DIRECTORY = PathManager.getHomePath() + File.separator + "inspections";
+    }
+    exportToHTMLDialog.reset();
+
+    if (!exportToHTMLDialog.showAndGet()) {
+      return;
+    }
+    exportToHTMLDialog.apply();
+  }
+}

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportToHTMLAction.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportToHTMLAction.java
@@ -1,0 +1,57 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+package com.intellij.codeInspection.ui.actions;
+
+import com.intellij.codeEditor.printing.ExportToHTMLSettings;
+import com.intellij.codeInspection.InspectionsBundle;
+import com.intellij.codeInspection.export.InspectionTreeHtmlWriter;
+import com.intellij.codeInspection.ui.InspectionResultsView;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.DumbAware;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+public class ExportToHTMLAction extends ExportInspectionResultsActionBase implements DumbAware {
+
+  public ExportToHTMLAction() {
+    super("HTML", "Exports inspection results to HTML", null, true);
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    super.actionPerformed(e);
+    final InspectionResultsView view = getView(e);
+
+    if (view == null) {
+      return;
+    }
+    final ExportToHTMLSettings exportToHTMLSettings = ExportToHTMLSettings.getInstance(view.getProject());
+    final String outputDirectoryName = exportToHTMLSettings.OUTPUT_DIRECTORY;
+
+    ApplicationManager.getApplication().invokeLater(() -> {
+      final Runnable exportRunnable = () -> ApplicationManager.getApplication().runReadAction(() -> {
+        try {
+          new InspectionTreeHtmlWriter(view, outputDirectoryName);
+        }
+        catch (ProcessCanceledException ex) {
+          // Do nothing here.
+        }
+      });
+
+      if (!ProgressManager.getInstance().runProcessWithProgressSynchronously(
+        exportRunnable, InspectionsBundle.message("inspection.generating.html.progress.title"), true, view.getProject())) {
+        return;
+      }
+
+      if (exportToHTMLSettings.OPEN_IN_BROWSER) {
+        BrowserUtil.browse(new File(exportToHTMLSettings.OUTPUT_DIRECTORY, "index.html"));
+      }
+    });
+  }
+
+}

--- a/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportToXMLAction.java
+++ b/platform/lang-impl/src/com/intellij/codeInspection/ui/actions/ExportToXMLAction.java
@@ -7,27 +7,15 @@ import com.intellij.codeEditor.printing.ExportToHTMLSettings;
 import com.intellij.codeInspection.InspectionApplication;
 import com.intellij.codeInspection.InspectionsBundle;
 import com.intellij.codeInspection.ex.*;
-import com.intellij.codeInspection.export.ExportToHTMLDialog;
-import com.intellij.codeInspection.export.InspectionTreeHtmlWriter;
 import com.intellij.codeInspection.ui.*;
 import com.intellij.configurationStore.JbXmlOutputter;
-import com.intellij.icons.AllIcons;
-import com.intellij.ide.BrowserUtil;
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.openapi.ui.popup.ListPopup;
-import com.intellij.openapi.ui.popup.PopupStep;
-import com.intellij.openapi.ui.popup.util.BaseListPopupStep;
-import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.JDOMUtil;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
@@ -47,80 +35,41 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class ExportHTMLAction extends AnAction implements DumbAware {
-  private static final Logger LOG = Logger.getInstance(ExportHTMLAction.class);
-  private final InspectionResultsView myView;
+public class ExportToXMLAction extends ExportInspectionResultsActionBase implements DumbAware {
+  private static final Logger LOG = Logger.getInstance(ExportToXMLAction.class);
   @NonNls private static final String ROOT = "root";
   @NonNls private static final String AGGREGATE = "_aggregate";
-  @NonNls private static final String HTML = "HTML";
-  @NonNls private static final String XML = "XML";
 
-  public ExportHTMLAction(final InspectionResultsView view) {
-    super(InspectionsBundle.message("inspection.action.export.html"), null, AllIcons.ToolbarDecorator.Export);
-    myView = view;
+  public ExportToXMLAction() {
+    super("XML", "Exports inspection results to XML", null, true);
   }
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
-    final ListPopup popup = JBPopupFactory.getInstance().createListPopup(
-      new BaseListPopupStep<String>(InspectionsBundle.message("inspection.action.export.popup.title"), HTML, XML) {
-        @Override
-        public PopupStep onChosen(final String selectedValue, final boolean finalChoice) {
-          return doFinalStep(() -> exportHTML(Comparing.strEqual(selectedValue, HTML)));
-        }
-      });
-    InspectionResultsView.showPopup(e, popup);
-  }
+    super.actionPerformed(e);
+    final InspectionResultsView view = getView(e);
 
-  private void exportHTML(final boolean exportToHTML) {
-    ExportToHTMLDialog exportToHTMLDialog = new ExportToHTMLDialog(myView.getProject(), exportToHTML);
-    final ExportToHTMLSettings exportToHTMLSettings = ExportToHTMLSettings.getInstance(myView.getProject());
-    if (exportToHTMLSettings.OUTPUT_DIRECTORY == null) {
-      exportToHTMLSettings.OUTPUT_DIRECTORY = PathManager.getHomePath() + File.separator + "inspections";
-    }
-    exportToHTMLDialog.reset();
-    if (!exportToHTMLDialog.showAndGet()) {
+    if (view == null) {
       return;
     }
-    exportToHTMLDialog.apply();
-
+    final ExportToHTMLSettings exportToHTMLSettings = ExportToHTMLSettings.getInstance(view.getProject());
     final String outputDirectoryName = exportToHTMLSettings.OUTPUT_DIRECTORY;
+
     ApplicationManager.getApplication().invokeLater(() -> {
-      final Runnable exportRunnable = () -> ApplicationManager.getApplication().runReadAction(() -> {
-        if (!exportToHTML) {
-          dump2xml(outputDirectoryName);
-        }
-        else {
-          try {
-            new InspectionTreeHtmlWriter(myView, outputDirectoryName);
-          }
-          catch (ProcessCanceledException e) {
-            // Do nothing here.
-          }
-        }
-      });
+      final Runnable exportRunnable = () -> ApplicationManager.getApplication().runReadAction(() -> dump2xml(view, outputDirectoryName));
 
-      if (!ProgressManager.getInstance().runProcessWithProgressSynchronously(exportRunnable,
-                                                                             InspectionsBundle.message(exportToHTML
-                                                                                                       ? "inspection.generating.html.progress.title"
-                                                                                                       : "inspection.generating.xml.progress.title"), true,
-                                                                             myView.getProject())) {
-        return;
-      }
-
-      if (exportToHTML && exportToHTMLSettings.OPEN_IN_BROWSER) {
-        BrowserUtil.browse(new File(exportToHTMLSettings.OUTPUT_DIRECTORY, "index.html"));
-      }
+      ProgressManager.getInstance().runProcessWithProgressSynchronously(
+        exportRunnable, InspectionsBundle.message("inspection.generating.xml.progress.title"), true, view.getProject());
     });
   }
 
-  private void dump2xml(final String outputDirectoryName) {
+  private static void dump2xml(InspectionResultsView view, final String outputDirectoryName) {
     try {
       final File outputDir = new File(outputDirectoryName);
       if (!outputDir.exists() && !outputDir.mkdirs()) {
         throw new IOException("Cannot create \'" + outputDir + "\'");
       }
-      final InspectionTreeNode root = myView.getTree().getRoot();
+      final InspectionTreeNode root = view.getTree().getRoot();
       final Exception[] ex = new Exception[1];
 
       final Set<String> visitedTools = new THashSet<>();
@@ -137,13 +86,14 @@ public class ExportHTMLAction extends AnAction implements DumbAware {
           if (!visitedTools.add(toolNode.getToolWrapper().getShortName())) return true;
 
           String name = toolWrapper.getShortName();
-          try (XmlWriterWrapper reportWriter = new XmlWriterWrapper(myView.getProject(), outputDirectoryName, name,
-                                                                    xmlOutputFactory, format, GlobalInspectionContextBase.PROBLEMS_TAG_NAME);
-               XmlWriterWrapper aggregateWriter = new XmlWriterWrapper(myView.getProject(), outputDirectoryName, name + AGGREGATE,
+          try (XmlWriterWrapper reportWriter = new XmlWriterWrapper(view.getProject(), outputDirectoryName, name,
+                                                                    xmlOutputFactory, format,
+                                                                    GlobalInspectionContextBase.PROBLEMS_TAG_NAME);
+               XmlWriterWrapper aggregateWriter = new XmlWriterWrapper(view.getProject(), outputDirectoryName, name + AGGREGATE,
                                                                        xmlOutputFactory, format, ROOT)) {
             reportWriter.checkOpen();
 
-            for (InspectionToolPresentation presentation : getPresentationsFromAllScopes(toolNode)) {
+            for (InspectionToolPresentation presentation : getPresentationsFromAllScopes(view, toolNode)) {
               presentation.exportResults(reportWriter::writeElement, presentation::isExcluded, presentation::isExcluded);
               if (presentation instanceof AggregateResultsExporter) {
                 ((AggregateResultsExporter)presentation).exportAggregateResults(aggregateWriter::writeElement);
@@ -161,7 +111,7 @@ public class ExportHTMLAction extends AnAction implements DumbAware {
         throw ex[0];
       }
       final Element element = new Element(InspectionApplication.INSPECTIONS_NODE);
-      final String profileName = myView.getCurrentProfileName();
+      final String profileName = view.getCurrentProfileName();
       if (profileName != null) {
         element.setAttribute(InspectionApplication.PROFILE, profileName);
       }
@@ -171,7 +121,7 @@ public class ExportHTMLAction extends AnAction implements DumbAware {
     }
     catch (Exception e) {
       LOG.error(e);
-      ApplicationManager.getApplication().invokeLater(() -> Messages.showErrorDialog(myView, e.getMessage()));
+      ApplicationManager.getApplication().invokeLater(() -> Messages.showErrorDialog(view, e.getMessage()));
     }
   }
 
@@ -188,22 +138,25 @@ public class ExportHTMLAction extends AnAction implements DumbAware {
   }
 
   @NotNull
-  private Collection<InspectionToolPresentation> getPresentationsFromAllScopes(@NotNull InspectionNode node) {
+  private static Collection<InspectionToolPresentation> getPresentationsFromAllScopes(
+    @NotNull InspectionResultsView view, @NotNull InspectionNode node) {
     final InspectionToolWrapper wrapper = node.getToolWrapper();
     Stream<InspectionToolWrapper> wrappers;
-    if (myView.getCurrentProfileName() == null){
+    if (view.getCurrentProfileName() == null) {
       wrappers = Stream.of(wrapper);
-    } else {
+    }
+    else {
       final String shortName = wrapper.getShortName();
-      final GlobalInspectionContextImpl context = myView.getGlobalInspectionContext();
+      final GlobalInspectionContextImpl context = view.getGlobalInspectionContext();
       final Tools tools = context.getTools().get(shortName);
       if (tools != null) {   //dummy entry points tool
         wrappers = tools.getTools().stream().map(ScopeToolState::getTool);
-      } else {
+      }
+      else {
         wrappers = Stream.empty();
       }
     }
-    return wrappers.map(w -> myView.getGlobalInspectionContext().getPresentation(w)).collect(Collectors.toList());
+    return wrappers.map(w -> view.getGlobalInspectionContext().getPresentation(w)).collect(Collectors.toList());
   }
 
   private static class XmlWriterWrapper implements Closeable {
@@ -254,7 +207,7 @@ public class ExportHTMLAction extends AnAction implements DumbAware {
     }
 
     @Override
-    public void close()  {
+    public void close() {
       if (myXmlWriter != null) {
         try {
           endWritingXml(myXmlWriter);

--- a/platform/platform-resources/src/idea/LangActions.xml
+++ b/platform/platform-resources/src/idea/LangActions.xml
@@ -308,7 +308,7 @@
       <separator/>
       <add-to-group group-id="MainMenu" anchor="after" relative-to-action="GoToMenu"/>
     </group>
-    
+
     <group id="ParameterNameHints" popup="true">
       <action id="ShowSettingsWithAddedPattern" class="com.intellij.codeInsight.hints.ShowSettingsWithAddedPattern"/>
       <action id="ToggleInlineHintsAction" class="com.intellij.codeInsight.hints.ToggleInlineHintsAction"/>
@@ -316,7 +316,7 @@
       <separator/>
       <action id="ToggleCompletionHintsAction" class="com.intellij.codeInsight.hints.ToggleCompletionHintsAction"/>
     </group>
-    
+
     <!-- Analyze -->
     <action id="SliceBackward" class="com.intellij.slicer.SliceBackwardAction"/>
     <action id="SliceForward" class="com.intellij.slicer.SliceForwardAction"/>
@@ -1070,6 +1070,15 @@
       <action id="EditInspectionSettings" class="com.intellij.codeInspection.ui.actions.EditSettingsAction"/>
       <action id="DisableInspection" class="com.intellij.codeInspection.ui.actions.KeyAwareInspectionViewAction$DisableInspection"/>
       <action id="RunInspectionOn" class="com.intellij.codeInspection.ui.actions.KeyAwareInspectionViewAction$RunInspectionOn"/>
+    </group>
+
+    <group id="InspectionToolWindow.Toolbar">
+      <action id="ExportInspectionResults" class="com.intellij.codeInspection.ui.actions.ExportAction"/>
+    </group>
+
+    <group id="InspectionToolWindow.ExportPopup">
+      <action id="ExportInspectionResultsToHTML" class="com.intellij.codeInspection.ui.actions.ExportToHTMLAction"/>
+      <action id="ExportInspectionResultsToXML" class="com.intellij.codeInspection.ui.actions.ExportToXMLAction"/>
     </group>
 
     <group id="ExtractMethodToolWindow.TreePopup" compact="true">


### PR DESCRIPTION
- Split ExportAction into 2 actions and add them into "InspectionToolWindow.ExportPopup" action group to allow plugins to add more actions there.
- Add "InspectionToolWindow.Toolbar" action group to allow plugins to add actions into toolbar of "Inspection Results".