### PR TITLE
Allow override implementation handlers to customize result

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/generation/OverrideImplementsAnnotationsHandler.java
+++ b/java/java-impl/src/com/intellij/codeInsight/generation/OverrideImplementsAnnotationsHandler.java
@@ -44,6 +44,10 @@ public interface OverrideImplementsAnnotationsHandler {
     return ArrayUtil.EMPTY_STRING_ARRAY;
   }
 
+  /** Perform post processing on the annotations, such as deleting or renaming or otherwise updating annotations in the override */
+  default void cleanup(PsiModifierListOwner source, @Nullable PsiElement targetClass, PsiModifierListOwner target) {
+  }
+
   static void repeatAnnotationsFromSource(PsiModifierListOwner source, @Nullable PsiElement targetClass, PsiModifierListOwner target) {
     Module module = ModuleUtilCore.findModuleForPsiElement(targetClass != null ? targetClass : target);
     GlobalSearchScope moduleScope = module != null ? GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(module) : null;
@@ -64,6 +68,10 @@ public interface OverrideImplementsAnnotationsHandler {
           AddAnnotationPsiFix.addPhysicalAnnotation(annotation, valuePairs, modifierList);
         }
       }
+    }
+
+    for (OverrideImplementsAnnotationsHandler each : Extensions.getExtensions(EP_NAME)) {
+      each.cleanup(source, targetClass, target);
     }
   }
 }


### PR DESCRIPTION
The OverrideImplementsAnnotationHandler extension point
allows plugins to specify names of annotations that
should be copied into overriding methods.

This CL adds an additional optional method on the interface:
"cleanup", which runs afterwards. This allows plugins to
do further post processing on the annotations. In particular,
this will let plugins *rename* annotations (which we're
using to for example rename the new @RecentlyNullable
and @RecentlyNonNull annotations that are specially recognized
by the Kotlin compiler as nullable annotations with
@Migrate, which means violations should be treated as only
warnings). However, the cleanup step can do other tasks too,
such as additing additional annotations not present in the
overridden method, or changing attribute values, etc.