### PR TITLE
Shorten command line option "Classpath file": Support for Java 9 and …

### DIFF
--- a/java/java-runtime/src/com/intellij/rt/execution/CommandLineWrapper.java
+++ b/java/java-runtime/src/com/intellij/rt/execution/CommandLineWrapper.java
@@ -184,7 +184,10 @@ public class CommandLineWrapper {
     }
 
     String mainClassName = args[startArgsIdx - 1];
-    ClassLoader loader = new URLClassLoader((URL[])classpathUrls.toArray(new URL[0]), null);
+    // Java 8 and below will get a null, which means the parent will be the bootstrap classloader
+    // Java 9 and above will get the platform classloader as defined in the new classloader hierarchy.
+    ClassLoader nullOrPlatformClassloader = CommandLineWrapper.class.getClassLoader().getParent();
+    ClassLoader loader = new URLClassLoader((URL[])classpathUrls.toArray(new URL[0]), nullOrPlatformClassloader);
     String systemLoaderName = System.getProperty("java.system.class.loader");
     if (systemLoaderName != null) {
       try {


### PR DESCRIPTION
…above

The classloader heirarchy has changed with Java 9. With the
modularization the bootstrap classloader has been split into two. One
for the core java classes, and a platform classloader which contains
miscellaneous classes.

The classloader created in the "Classpath file" uses a null parent to
signify that the parent should be the bootstrap classloader. This no
longer works with Java 9 and above. The correct way is to just get the
parent of the class itself. When running in Java 8 (and below) this will
be null which is the bootstrap classloader. When running Java 9 (and
above) this will be the platform classloader.