### PR TITLE
Uniformize all color scheme hexadecimal colors

### DIFF
--- a/colorSchemes/src/colorSchemes/WarmNeon.xml
+++ b/colorSchemes/src/colorSchemes/WarmNeon.xml
@@ -1,176 +1,176 @@
 <scheme name="WarmNeon" version="142" parent_scheme="Darcula">
   <colors>
     <option name="ADDED_LINES_COLOR" value="395439" />
-    <option name="ANNOTATIONS_COLOR" value="8178af" />
-    <option name="CARET_COLOR" value="ff00" />
+    <option name="ANNOTATIONS_COLOR" value="8178AF" />
+    <option name="CARET_COLOR" value="FF00" />
     <option name="CARET_ROW_COLOR" value="282828" />
     <option name="CONSOLE_BACKGROUND_KEY" value="404040" />
     <option name="DELETED_LINES_COLOR" value="747474" />
-    <option name="FILESTATUS_MODIFIED" value="215ee6" />
+    <option name="FILESTATUS_MODIFIED" value="215EE6" />
     <option name="GUTTER_BACKGROUND" value="424242" />
     <option name="INDENT_GUIDE" value="505050" />
-    <option name="LEFT_GUTTER_BACKGROUND" value="8a8a8a" />
-    <option name="LINE_NUMBERS_COLOR" value="6da0a1" />
+    <option name="LEFT_GUTTER_BACKGROUND" value="8A8A8A" />
+    <option name="LINE_NUMBERS_COLOR" value="6DA0A1" />
     <option name="METHOD_SEPARATORS_COLOR" value="868686" />
-    <option name="MODIFIED_LINES_COLOR" value="522a2a" />
+    <option name="MODIFIED_LINES_COLOR" value="522A2A" />
     <option name="READONLY_FRAGMENT_BACKGROUND" value="374037" />
-    <option name="RIGHT_MARGIN_COLOR" value="6b6b6b" />
-    <option name="SELECTED_FOLDING_TREE_COLOR" value="32be33" />
-    <option name="SELECTED_INDENT_GUIDE" value="6b5656" />
-    <option name="SELECTION_BACKGROUND" value="348d34" />
+    <option name="RIGHT_MARGIN_COLOR" value="6B6B6B" />
+    <option name="SELECTED_FOLDING_TREE_COLOR" value="32BE33" />
+    <option name="SELECTED_INDENT_GUIDE" value="6B5656" />
+    <option name="SELECTION_BACKGROUND" value="348D34" />
     <option name="WHITESPACES" value="656565" />
-    <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="6e5a5a" />
+    <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="6E5A5A" />
   </colors>
   <attributes>
     <option name="ABSTRACT_CLASS_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ccccff" />
-        <option name="EFFECT_COLOR" value="5f8e9e" />
+        <option name="FOREGROUND" value="CCCCFF" />
+        <option name="EFFECT_COLOR" value="5F8E9E" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="66ffff" />
+        <option name="FOREGROUND" value="66FFFF" />
       </value>
     </option>
     <option name="ANNOTATION_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="7a8fd9" />
+        <option name="FOREGROUND" value="7A8FD9" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="Annotation">
       <value>
-        <option name="FOREGROUND" value="3fa7d4" />
+        <option name="FOREGROUND" value="3FA7D4" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="9f0e44" />
-        <option name="BACKGROUND" value="ffcccc" />
+        <option name="FOREGROUND" value="9F0E44" />
+        <option name="BACKGROUND" value="FFCCCC" />
       </value>
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3a4a6f" />
+        <option name="BACKGROUND" value="3A4A6F" />
       </value>
     </option>
     <option name="CLASS_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="f2f0b5" />
+        <option name="FOREGROUND" value="F2F0B5" />
       </value>
     </option>
     <option name="CONSOLE_BLACK_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="7a8fd9" />
+        <option name="FOREGROUND" value="7A8FD9" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="405ec9" />
+        <option name="FOREGROUND" value="405EC9" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="59d1e6" />
+        <option name="FOREGROUND" value="59D1E6" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="20bad5" />
+        <option name="FOREGROUND" value="20BAD5" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e54242" />
+        <option name="FOREGROUND" value="E54242" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="9bc28e" />
+        <option name="FOREGROUND" value="9BC28E" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="34b434" />
+        <option name="FOREGROUND" value="34B434" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="f971bb" />
+        <option name="FOREGROUND" value="F971BB" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff00ff" />
+        <option name="FOREGROUND" value="FF00FF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="aedbb5" />
+        <option name="FOREGROUND" value="AEDBB5" />
         <option name="BACKGROUND" value="404040" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE" baseAttributes="INJECTED_LANGUAGE_FRAGMENT" />
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="eb6f6f" />
+        <option name="FOREGROUND" value="EB6F6F" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e54242" />
+        <option name="FOREGROUND" value="E54242" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="9d9d9d" />
+        <option name="FOREGROUND" value="9D9D9D" />
         <option name="BACKGROUND" value="404040" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="1fb81f" />
+        <option name="FOREGROUND" value="1FB81F" />
         <option name="BACKGROUND" value="404040" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="dedb74" />
+        <option name="FOREGROUND" value="DEDB74" />
       </value>
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="dbe439" />
+        <option name="FOREGROUND" value="DBE439" />
       </value>
     </option>
     <option name="CSS.COMMENT">
       <value>
-        <option name="FOREGROUND" value="e2e95d" />
+        <option name="FOREGROUND" value="E2E95D" />
       </value>
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="3fa7d4" />
+        <option name="FOREGROUND" value="3FA7D4" />
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -182,13 +182,13 @@
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4F" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.STRING">
       <value>
-        <option name="FOREGROUND" value="21bf21" />
+        <option name="FOREGROUND" value="21BF21" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -199,38 +199,38 @@
     </option>
     <option name="CSS.URL">
       <value>
-        <option name="FOREGROUND" value="80b52a" />
+        <option name="FOREGROUND" value="80B52A" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CTRL_CLICKABLE">
       <value>
-        <option name="FOREGROUND" value="62ccb5" />
-        <option name="EFFECT_COLOR" value="83b9a3" />
+        <option name="FOREGROUND" value="62CCB5" />
+        <option name="EFFECT_COLOR" value="83B9A3" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e6e5a9" />
+        <option name="FOREGROUND" value="E6E5A9" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="aa8000" />
+        <option name="FOREGROUND" value="AA8000" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="75b3b3" />
+        <option name="FOREGROUND" value="75B3B3" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="a27a7a" />
+        <option name="FOREGROUND" value="A27A7A" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -252,20 +252,20 @@
     </option>
     <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ff00" />
+        <option name="FOREGROUND" value="FF00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_ATTRIBUTE" baseAttributes="DEFAULT_IDENTIFIER" />
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="b44141" />
+        <option name="FOREGROUND" value="B44141" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="f2f0b5" />
+        <option name="FOREGROUND" value="F2F0B5" />
       </value>
     </option>
     <option name="DEFAULT_CONSTANT">
@@ -275,7 +275,7 @@
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="b3524c" />
+        <option name="FOREGROUND" value="B3524C" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
@@ -285,48 +285,48 @@
     </option>
     <option name="DEFAULT_ENTITY">
       <value>
-        <option name="FOREGROUND" value="7abf44" />
+        <option name="FOREGROUND" value="7ABF44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER" baseAttributes="TEXT" />
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="b9b9b9" />
+        <option name="FOREGROUND" value="B9B9B9" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_INTERFACE_NAME">
       <value>
-        <option name="FOREGROUND" value="59d1e6" />
+        <option name="FOREGROUND" value="59D1E6" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="9f0e44" />
-        <option name="BACKGROUND" value="ffcccc" />
+        <option name="FOREGROUND" value="9F0E44" />
+        <option name="BACKGROUND" value="FFCCCC" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="e54242" />
+        <option name="FOREGROUND" value="E54242" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_METADATA">
       <value>
-        <option name="FOREGROUND" value="7a8fd9" />
+        <option name="FOREGROUND" value="7A8FD9" />
       </value>
     </option>
     <option name="DEFAULT_NUMBER">
       <value>
-        <option name="FOREGROUND" value="f971bb" />
+        <option name="FOREGROUND" value="F971BB" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_FIELD">
@@ -336,7 +336,7 @@
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="34b434" />
+        <option name="FOREGROUND" value="34B434" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -344,20 +344,20 @@
     <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR" baseAttributes="TEXT" />
     <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="97e85a" />
+        <option name="FOREGROUND" value="97E85A" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="8b7474" />
+        <option name="EFFECT_COLOR" value="8B7474" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="4e243d" />
-        <option name="ERROR_STRIPE_COLOR" value="ff4766" />
+        <option name="BACKGROUND" value="4E243D" />
+        <option name="ERROR_STRIPE_COLOR" value="FF4766" />
       </value>
     </option>
     <option name="DIFF_DELETED">
@@ -369,57 +369,57 @@
     <option name="DIFF_INSERTED">
       <value>
         <option name="BACKGROUND" value="184818" />
-        <option name="ERROR_STRIPE_COLOR" value="2df32d" />
+        <option name="ERROR_STRIPE_COLOR" value="2DF32D" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="25314b" />
-        <option name="ERROR_STRIPE_COLOR" value="3471ff" />
+        <option name="BACKGROUND" value="25314B" />
+        <option name="ERROR_STRIPE_COLOR" value="3471FF" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
       <value>
-        <option name="FOREGROUND" value="e54242" />
+        <option name="FOREGROUND" value="E54242" />
       </value>
     </option>
     <option name="DJANGO_ID">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DJANGO_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
       </value>
     </option>
     <option name="DJANGO_STRING_LITERAL">
       <value>
-        <option name="FOREGROUND" value="34b434" />
+        <option name="FOREGROUND" value="34B434" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DJANGO_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DOC_COMMENT_TAG_VALUE">
       <value>
-        <option name="FOREGROUND" value="b8b8b8" />
+        <option name="FOREGROUND" value="B8B8B8" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="273b40" />
+        <option name="BACKGROUND" value="273B40" />
       </value>
     </option>
     <option name="EL.BOUNDS">
       <value>
-        <option name="FOREGROUND" value="ffff" />
+        <option name="FOREGROUND" value="FFFF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -430,13 +430,13 @@
     </option>
     <option name="EL.IDENT">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="EL.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -447,19 +447,19 @@
     </option>
     <option name="EL.STRING">
       <value>
-        <option name="FOREGROUND" value="34b434" />
+        <option name="FOREGROUND" value="34B434" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="EL_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2a2a2a" />
+        <option name="BACKGROUND" value="2A2A2A" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="eaed5b" />
-        <option name="BACKGROUND" value="1a65a5" />
+        <option name="FOREGROUND" value="EAED5B" />
+        <option name="BACKGROUND" value="1A65A5" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -471,135 +471,135 @@
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="98aca9" />
+        <option name="FOREGROUND" value="98ACA9" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="7a9c95" />
+        <option name="EFFECT_COLOR" value="7A9C95" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
-        <option name="EFFECT_COLOR" value="f49810" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="F49810" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="GQL_ID">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
       </value>
     </option>
     <option name="GQL_INT_LITERAL">
       <value>
-        <option name="FOREGROUND" value="ff0000" />
+        <option name="FOREGROUND" value="FF0000" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="GQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="GQL_STRING_LITERAL">
       <value>
-        <option name="FOREGROUND" value="34b434" />
+        <option name="FOREGROUND" value="34B434" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="GROOVY_KEYWORD" baseAttributes="JAVA_KEYWORD" />
     <option name="GString">
       <value>
-        <option name="FOREGROUND" value="99cc00" />
+        <option name="FOREGROUND" value="99CC00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="ded772" />
+        <option name="FOREGROUND" value="DED772" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="2bba2b" />
+        <option name="FOREGROUND" value="2BBA2B" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="d26666" />
+        <option name="FOREGROUND" value="D26666" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="7abf44" />
+        <option name="FOREGROUND" value="7ABF44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="c9a765" />
+        <option name="FOREGROUND" value="C9A765" />
       </value>
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="c69557" />
+        <option name="FOREGROUND" value="C69557" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="62ccb5" />
+        <option name="FOREGROUND" value="62CCB5" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="83b9a3" />
+        <option name="EFFECT_COLOR" value="83B9A3" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="525259" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9cd4de" />
+        <option name="FOREGROUND" value="9CD4DE" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="cccccc" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="EFFECT_COLOR" value="CCCCCC" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="284e28" />
+        <option name="BACKGROUND" value="284E28" />
       </value>
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="b9b9b9" />
+        <option name="FOREGROUND" value="B9B9B9" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="INTERFACE_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="59d1e6" />
+        <option name="FOREGROUND" value="59D1E6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JAVA_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="b44141" />
+        <option name="FOREGROUND" value="B44141" />
       </value>
     </option>
     <option name="JAVA_BRACES">
@@ -614,7 +614,7 @@
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="c87878" />
+        <option name="FOREGROUND" value="C87878" />
       </value>
     </option>
     <option name="JAVA_DOC_MARKUP">
@@ -625,25 +625,25 @@
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="df7e7e" />
+        <option name="EFFECT_COLOR" value="DF7E7E" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="e54242" />
+        <option name="FOREGROUND" value="E54242" />
       </value>
     </option>
     <option name="JAVA_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="c8c8c8" />
+        <option name="FOREGROUND" value="C8C8C8" />
       </value>
     </option>
     <option name="JAVA_PARENTH">
@@ -653,19 +653,19 @@
     </option>
     <option name="JAVA_STRING">
       <value>
-        <option name="FOREGROUND" value="34b434" />
+        <option name="FOREGROUND" value="34B434" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="97e85a" />
+        <option name="FOREGROUND" value="97E85A" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JS.BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="e45041" />
+        <option name="FOREGROUND" value="E45041" />
       </value>
     </option>
     <option name="JS.BRACKETS">
@@ -675,12 +675,12 @@
     </option>
     <option name="JS.DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="c87878" />
+        <option name="FOREGROUND" value="C87878" />
       </value>
     </option>
     <option name="JS.DOC_MARKUP">
       <value>
-        <option name="FOREGROUND" value="a63434" />
+        <option name="FOREGROUND" value="A63434" />
       </value>
     </option>
     <option name="JS.DOC_TAG">
@@ -699,18 +699,18 @@
     <option name="JS.GLOBAL_VARIABLE" baseAttributes="DEFAULT_GLOBAL_VARIABLE" />
     <option name="JS.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="d14c42" />
+        <option name="FOREGROUND" value="D14C42" />
       </value>
     </option>
     <option name="JS.LOCAL_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="8db4f2" />
+        <option name="FOREGROUND" value="8DB4F2" />
 
       </value>
     </option>
     <option name="JS.PARAMETER">
       <value>
-        <option name="FOREGROUND" value="cfdb96" />
+        <option name="FOREGROUND" value="CFDB96" />
         <option name="EFFECT_COLOR" value="8080" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
@@ -722,52 +722,52 @@
     </option>
     <option name="JS.REGEXP">
       <value>
-        <option name="FOREGROUND" value="a6ea3f" />
+        <option name="FOREGROUND" value="A6EA3F" />
 
       </value>
     </option>
     <option name="JS.STRING">
       <value>
-        <option name="FOREGROUND" value="34ae34" />
+        <option name="FOREGROUND" value="34AE34" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JS.VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="47e846" />
+        <option name="FOREGROUND" value="47E846" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="ded772" />
+        <option name="FOREGROUND" value="DED772" />
       </value>
     </option>
     <option name="JSP_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="2bba2b" />
+        <option name="FOREGROUND" value="2BBA2B" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_COMMENT">
       <value>
-        <option name="FOREGROUND" value="dd2e2e" />
+        <option name="FOREGROUND" value="DD2E2E" />
       </value>
     </option>
     <option name="JSP_DIRECTIVE_NAME">
       <value>
-        <option name="FOREGROUND" value="c9a666" />
+        <option name="FOREGROUND" value="C9A666" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="FOREGROUND" value="9dd4de" />
+        <option name="FOREGROUND" value="9DD4DE" />
       </value>
     </option>
     <option name="KOTLIN_ANNOTATION">
       <value>
-        <option name="FOREGROUND" value="7a8fd9" />
+        <option name="FOREGROUND" value="7A8FD9" />
       </value>
     </option>
     <option name="KOTLIN_PROPERTY_WITH_BACKING_FIELD">
@@ -780,66 +780,66 @@
     </option>
     <option name="Keyword">
       <value>
-        <option name="FOREGROUND" value="d2ac67" />
+        <option name="FOREGROUND" value="A2AC67" />
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="LOGCAT_ASSERT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="87cece" />
+        <option name="FOREGROUND" value="87CECE" />
       </value>
     </option>
     <option name="LOGCAT_DEBUG_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="deb860" />
+        <option name="FOREGROUND" value="DEB860" />
       </value>
     </option>
     <option name="LOGCAT_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff0000" />
+        <option name="FOREGROUND" value="FF0000" />
       </value>
     </option>
     <option name="LOGCAT_INFO_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="LOGCAT_VERBOSE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
       </value>
     </option>
     <option name="LOGCAT_WARNING_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffff00" />
+        <option name="FOREGROUND" value="FFFF00" />
       </value>
     </option>
     <option name="List/map to object conversion">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="495f2a" />
+        <option name="BACKGROUND" value="495F2A" />
       </value>
     </option>
     <option name="METHOD_CALL_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="79cf81" />
+        <option name="FOREGROUND" value="79CF81" />
       </value>
     </option>
     <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="Map key">
@@ -850,38 +850,38 @@
     </option>
     <option name="NOT_TOP_FRAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="eaed5b" />
-        <option name="BACKGROUND" value="2a526e" />
+        <option name="FOREGROUND" value="EAED5B" />
+        <option name="BACKGROUND" value="2A526E" />
       </value>
     </option>
     <option name="PHP_VAR" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
     <option name="PHP_PARAMETER" baseAttributes="DEFAULT_PARAMETER" />
     <option name="PROPERTIES.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="e75252" />
+        <option name="FOREGROUND" value="E75252" />
       </value>
     </option>
     <option name="PROPERTIES.VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="a1e660" />
+        <option name="FOREGROUND" value="A1E660" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.VALUE">
       <value>
-        <option name="FOREGROUND" value="15af15" />
+        <option name="FOREGROUND" value="15AF15" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.BRACES">
       <value>
-        <option name="FOREGROUND" value="d8f69c" />
+        <option name="FOREGROUND" value="D8F69C" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.BRACKETS">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -892,43 +892,42 @@
     </option>
     <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="FONT_TYPE" value="1" />
-
       </value>
     </option>
     <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="6699ff" />
+        <option name="FOREGROUND" value="6699FF" />
       </value>
     </option>
     <option name="PY.DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="d2c200" />
+        <option name="FOREGROUND" value="D2C200" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="FONT_TYPE" value="1" />
 
       </value>
     </option>
     <option name="PY.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="cc9900" />
+        <option name="FOREGROUND" value="CC9900" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="ff6666" />
+        <option name="FOREGROUND" value="FF6666" />
       </value>
     </option>
     <option name="PY.OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -939,47 +938,47 @@
     </option>
     <option name="PY.PREDEFINED_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="83d6f1" />
+        <option name="FOREGROUND" value="83D6F1" />
         <option name="FONT_TYPE" value="1" />
 
       </value>
     </option>
     <option name="PY.PREDEFINED_NAME">
       <value>
-        <option name="FOREGROUND" value="33ccff" />
+        <option name="FOREGROUND" value="33CCFF" />
         <option name="FONT_TYPE" value="1" />
 
       </value>
     </option>
     <option name="PY.PREDEFINED_USAGE">
       <value>
-        <option name="FOREGROUND" value="bbb06a" />
+        <option name="FOREGROUND" value="BBB06A" />
 
       </value>
     </option>
     <option name="PY.STRING.B">
       <value>
-        <option name="FOREGROUND" value="85cd00" />
+        <option name="FOREGROUND" value="85CD00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.STRING.U">
       <value>
-        <option name="FOREGROUND" value="b580" />
+        <option name="FOREGROUND" value="B580" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.VALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="ff00" />
+        <option name="FOREGROUND" value="FF00" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="ff00" />
+        <option name="EFFECT_COLOR" value="FF00" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="REASSIGNED_LOCAL_VARIABLE_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="9bc28e" />
+        <option name="EFFECT_COLOR" value="9BC28E" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -1001,87 +1000,85 @@
     </option>
     <option name="REGEXP.ESC_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REGEXP.PARENTHS">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REST.BOLD">
       <value>
-        <option name="FOREGROUND" value="d2c200" />
+        <option name="FOREGROUND" value="D2C200" />
         <option name="FONT_TYPE" value="1" />
-
       </value>
     </option>
     <option name="REST.EXPLICIT">
       <value>
-        <option name="FOREGROUND" value="cacc" />
+        <option name="FOREGROUND" value="CACC" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REST.FIELD">
       <value>
-        <option name="FOREGROUND" value="6699ff" />
+        <option name="FOREGROUND" value="6699FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="FOREGROUND" value="85cd00" />
+        <option name="FOREGROUND" value="85CD00" />
         <option name="FONT_TYPE" value="1" />
-
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="1d4739" />
+        <option name="BACKGROUND" value="1D4739" />
 
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
 
       </value>
     </option>
     <option name="REST.ITALIC">
       <value>
-        <option name="FOREGROUND" value="83d7f2" />
+        <option name="FOREGROUND" value="83D7F2" />
         <option name="FONT_TYPE" value="2" />
 
       </value>
     </option>
     <option name="REST.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="ff6666" />
+        <option name="FOREGROUND" value="FF6666" />
       </value>
     </option>
     <option name="REST.REF.NAME">
       <value>
-        <option name="FOREGROUND" value="cc9900" />
+        <option name="FOREGROUND" value="CC9900" />
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="REST.SECTION.HEADER">
       <value>
-        <option name="FOREGROUND" value="cc01" />
+        <option name="FOREGROUND" value="CC01" />
       </value>
     </option>
     <option name="Regular expression">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1092,36 +1089,36 @@
     </option>
     <option name="SASS_COMMENT">
       <value>
-        <option name="FOREGROUND" value="c87878" />
+        <option name="FOREGROUND" value="C87878" />
       </value>
     </option>
     <option name="SASS_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SASS_DIRECTIVE">
       <value>
-        <option name="FOREGROUND" value="3fa7d4" />
+        <option name="FOREGROUND" value="3FA7D4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SASS_MIXIN">
       <value>
-        <option name="FOREGROUND" value="ca9e4d" />
+        <option name="FOREGROUND" value="CA9E4D" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SASS_RULE">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SASS_STRING">
       <value>
-        <option name="FOREGROUND" value="34b434" />
+        <option name="FOREGROUND" value="34B434" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1138,37 +1135,37 @@
     </option>
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="532b2e" />
+        <option name="BACKGROUND" value="532B22" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="3a3a3a" />
+        <option name="BACKGROUND" value="3A3A3A" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.PATH_LEVEL_ONE">
       <value>
-        <option name="BACKGROUND" value="425f44" />
+        <option name="BACKGROUND" value="425F44" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.PATH_LEVEL_TWO">
       <value>
-        <option name="EFFECT_COLOR" value="a9b7c6" />
+        <option name="EFFECT_COLOR" value="A9B7C6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="3a3a3a" />
+        <option name="BACKGROUND" value="3A3A3A" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.VALUE_HINT">
       <value>
-        <option name="EFFECT_COLOR" value="a9b7c6" />
+        <option name="EFFECT_COLOR" value="A9B7C6" />
       </value>
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
@@ -1178,45 +1175,45 @@
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c257d2" />
+        <option name="FOREGROUND" value="C257D2" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="Static field">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e2b8b8" />
+        <option name="FOREGROUND" value="E2B8B8" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="9bc28e" />
+        <option name="FOREGROUND" value="9BC28E" />
         <option name="BACKGROUND" value="404040" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="0" />
-        <option name="BACKGROUND" value="f3f34d" />
-        <option name="ERROR_STRIPE_COLOR" value="ff00" />
+        <option name="BACKGROUND" value="F3F34D" />
+        <option name="ERROR_STRIPE_COLOR" value="FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffff00" />
+        <option name="FOREGROUND" value="FFFF00" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="f8f870" />
+        <option name="FOREGROUND" value="F8F870" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1228,12 +1225,12 @@
     </option>
     <option name="UNMATCHED_BRACE_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="dc4040" />
+        <option name="BACKGROUND" value="DC4040" />
       </value>
     </option>
     <option name="Unresolved reference access">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <!--<option name="BACKGROUND" value="412817" />-->
         <option name="EFFECT_COLOR" value="808080" />
         <option name="EFFECT_TYPE" value="1" />
@@ -1241,101 +1238,101 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5a4601" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="BACKGROUND" value="5A4601" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="594B52" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="0" />
-        <option name="BACKGROUND" value="ffcdd3" />
+        <option name="BACKGROUND" value="FFCDD3" />
       </value>
     </option>
     <option name="WRONG_REFERENCES_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ff0000" />
-        <option name="BACKGROUND" value="402d39" />
+        <option name="FOREGROUND" value="FF0000" />
+        <option name="BACKGROUND" value="402D39" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="a0a0a0" />
+        <option name="FOREGROUND" value="A0A0A0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="44ae44" />
+        <option name="FOREGROUND" value="44AE44" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="d95c5c" />
+        <option name="FOREGROUND" value="D95C5C" />
       </value>
     </option>
     <option name="XML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="a8e148" />
+        <option name="FOREGROUND" value="A8E148" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_TAG">
       <value>
-        <option name="FOREGROUND" value="99732f" />
+        <option name="FOREGROUND" value="99732F" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="b8ae5b" />
+        <option name="FOREGROUND" value="B8AE5B" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="1b801" />
+        <option name="FOREGROUND" value="1B801" />
         <option name="BACKGROUND" value="404040" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
       <value>
-        <option name="FOREGROUND" value="c0c0c0" />
+        <option name="FOREGROUND" value="C0C0C0" />
       </value>
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="99cc00" />
+        <option name="FOREGROUND" value="99CC00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_SIGN">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="BACKGROUND" value="404040" />
       </value>
     </option>
     <option name="OC.CONDITIONALLY_NOT_COMPILED">
       <value>
-        <option name="FOREGROUND" value="686a4e" />
+        <option name="FOREGROUND" value="686A4E" />
       </value>
     </option>
     <option name="OC.MACRONAME">
       <value>
-        <option name="FOREGROUND" value="908b25" />
+        <option name="FOREGROUND" value="908B25" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1343,13 +1340,13 @@
     <option name="OC.METHOD_DECLARATION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
     <option name="OC.STRUCT_FIELD">
       <value>
-        <option name="FOREGROUND" value="b9b9b9" />
+        <option name="FOREGROUND" value="B9B9B9" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="OC.TYPEDEF">
       <value>
-        <option name="FOREGROUND" value="50861a" />
+        <option name="FOREGROUND" value="50861A" />
       </value>
     </option>
   </attributes>

--- a/colorSchemes/src/colorSchemes/all_hallows_eve.xml
+++ b/colorSchemes/src/colorSchemes/all_hallows_eve.xml
@@ -2,7 +2,7 @@
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="000000" />
     <option name="INDENT_GUIDE" value="404040" />
-    <option name="SELECTION_BACKGROUND" value="644d6e" />
+    <option name="SELECTION_BACKGROUND" value="644D6E" />
     <option name="CARET_ROW_COLOR" value="333300" />
     <option name="WHITESPACES" value="404040" />
     <option name="CARET_COLOR" value="FFFFFF" />
@@ -13,12 +13,12 @@
   <attributes>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="743d3d" />
+        <option name="BACKGROUND" value="743D3D" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
@@ -50,7 +50,7 @@
     <option baseAttributes="TYPEDEF" name="CLASS_REFERENCE" />
     <option name="COFFEESCRIPT.BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BLOCK_COMMENT">
@@ -199,52 +199,52 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="06b8b8" />
+        <option name="FOREGROUND" value="06B8B8" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="FFB3B3" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="FF2EFF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="FF6767" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="FOREGROUND" value="E4E4FF" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="6AE96A" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -276,7 +276,7 @@
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -293,31 +293,31 @@
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FOREGROUND" value="71D7D7" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FOREGROUND" value="FFC2C2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -482,7 +482,7 @@
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
+        <option name="EFFECT_COLOR" value="C0C0C0" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
@@ -513,14 +513,14 @@
     </option>
     <option name="DJANGO_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option baseAttributes="DEFAULT_BRACES" name="DJANGO_TAG_START_END" />
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="30322b" />
+        <option name="BACKGROUND" value="30322B" />
       </value>
     </option>
     <option name="ENUM_CONST">
@@ -531,17 +531,17 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_COLOR" value="FF6767" />
+        <option name="ERROR_STRIPE_COLOR" value="FF0000" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="BACKGROUND" value="161717" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="First symbol in list">
@@ -552,8 +552,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="AA4E00" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
@@ -734,34 +734,34 @@
     <option baseAttributes="XML_TAG" name="HTML_TAG" />
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="3C3C57" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -771,7 +771,7 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -803,20 +803,20 @@
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
+        <option name="EFFECT_COLOR" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="JAVA_DOT" />
     <option name="JAVA_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
@@ -896,7 +896,7 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="80807f" />
+        <option name="FOREGROUND" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="OC.BADCHARACTER" />
@@ -978,7 +978,7 @@
     <option baseAttributes="CLASS_REFERENCE" name="PROTOCOL_REFERENCE" />
     <option name="PUPPET_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="PUPPET_BLOCK_COMMENT">
@@ -1112,7 +1112,7 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="48485f" />
+        <option name="BACKGROUND" value="48485F" />
       </value>
     </option>
     <option name="REST.INLINE">
@@ -1122,7 +1122,7 @@
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="4d5d3d" />
+        <option name="BACKGROUND" value="4D5D3D" />
       </value>
     </option>
     <option name="REST.ITALIC">
@@ -1315,7 +1315,7 @@
     </option>
     <option name="SASS_PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1337,7 +1337,7 @@
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="4F4F82" />
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">
@@ -1404,14 +1404,14 @@
     </option>
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="723f3f" />
+        <option name="BACKGROUND" value="723F3F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2e2e1f" />
+        <option name="BACKGROUND" value="2E2E1F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
       </value>
@@ -1431,7 +1431,7 @@
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2b2b2b" />
+        <option name="BACKGROUND" value="2B2B2B" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
       </value>
@@ -1439,7 +1439,7 @@
     <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
@@ -1457,15 +1457,15 @@
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="5F5F00" />
+        <option name="ERROR_STRIPE_COLOR" value="00FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="TYPEDEF" />
@@ -1476,16 +1476,16 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
+        <option name="BACKGROUND" value="4A3F10" />
         <option name="EFFECT_TYPE" value="1" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="472C47" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1517,7 +1517,7 @@
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>

--- a/colorSchemes/src/colorSchemes/blackboard.xml
+++ b/colorSchemes/src/colorSchemes/blackboard.xml
@@ -1,24 +1,24 @@
 <scheme name="Blackboard" parent_scheme="Darcula" version="1">
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="0C1021" />
-    <option name="INDENT_GUIDE" value="484b58" />
+    <option name="INDENT_GUIDE" value="484B58" />
     <option name="SELECTION_BACKGROUND" value="253B76" />
-    <option name="CARET_ROW_COLOR" value="1a1e2e" />
-    <option name="WHITESPACES" value="484b58" />
+    <option name="CARET_ROW_COLOR" value="1A1E2E" />
+    <option name="WHITESPACES" value="484B58" />
     <option name="CARET_COLOR" value="FFFFFF" />
     <option name="LINE_NUMBERS_COLOR" value="F8F8F8" />
-    <option name="SELECTED_INDENT_GUIDE" value="484b58" />
+    <option name="SELECTED_INDENT_GUIDE" value="484B58" />
     <option name="GUTTER_BACKGROUND" value="0C1021" />
   </colors>
   <attributes>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="743d3d" />
+        <option name="BACKGROUND" value="743D3D" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
@@ -54,7 +54,7 @@
     </option>
     <option name="COFFEESCRIPT.BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BLOCK_COMMENT">
@@ -199,52 +199,52 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="06b8b8" />
+        <option name="FOREGROUND" value="06B8B8" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="FFB3B3" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="FF2EFF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="FF6767" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="FOREGROUND" value="E4E4FF" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="6AE96A" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -280,7 +280,7 @@
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -292,31 +292,31 @@
     <option baseAttributes="HTML_ATTRIBUTE_VALUE" name="CSS.URL" />
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FOREGROUND" value="71D7D7" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FOREGROUND" value="FFC2C2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -512,7 +512,7 @@
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
+        <option name="EFFECT_COLOR" value="C0C0C0" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
@@ -553,7 +553,7 @@
     <option baseAttributes="DEFAULT_BRACES" name="DJANGO_TAG_START_END" />
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="30322b" />
+        <option name="BACKGROUND" value="30322B" />
       </value>
     </option>
     <option name="ENUM_CONST">
@@ -564,17 +564,17 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_COLOR" value="FF6767" />
+        <option name="ERROR_STRIPE_COLOR" value="FF0000" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="BACKGROUND" value="161717" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="First symbol in list">
@@ -585,8 +585,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="AA4E00" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
@@ -713,28 +713,28 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="3C3C57" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -744,7 +744,7 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -784,20 +784,20 @@
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
+        <option name="EFFECT_COLOR" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="JAVA_DOT" />
     <option name="JAVA_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
@@ -872,7 +872,7 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="80807f" />
+        <option name="FOREGROUND" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="OC.BADCHARACTER" />
@@ -954,7 +954,7 @@
     </option>
     <option name="PUPPET_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="PUPPET_BLOCK_COMMENT">
@@ -1099,7 +1099,7 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="48485f" />
+        <option name="BACKGROUND" value="48485F" />
       </value>
     </option>
     <option name="REST.INLINE">
@@ -1109,7 +1109,7 @@
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="4d5d3d" />
+        <option name="BACKGROUND" value="4D5D3D" />
       </value>
     </option>
     <option name="REST.ITALIC">
@@ -1330,7 +1330,7 @@
     <option baseAttributes="TEXT" name="SASS_VARIABLE" />
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="4F4F82" />
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">
@@ -1392,14 +1392,14 @@
     <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_TAG_START" />
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="713f3f" />
+        <option name="BACKGROUND" value="713F3F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2e2e1f" />
+        <option name="BACKGROUND" value="2E2E1F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
       </value>
@@ -1419,7 +1419,7 @@
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2b2b2b" />
+        <option name="BACKGROUND" value="2B2B2B" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
       </value>
@@ -1427,7 +1427,7 @@
     <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
@@ -1449,15 +1449,15 @@
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="5F5F00" />
+        <option name="ERROR_STRIPE_COLOR" value="00FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TYPEDEF">
@@ -1472,16 +1472,16 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
+        <option name="BACKGROUND" value="4A3F10" />
         <option name="EFFECT_TYPE" value="1" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="472C47" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">

--- a/colorSchemes/src/colorSchemes/cobalt.xml
+++ b/colorSchemes/src/colorSchemes/cobalt.xml
@@ -1,13 +1,13 @@
 <scheme name="Cobalt" parent_scheme="Darcula" version="1">
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="002240" />
-    <option name="INDENT_GUIDE" value="25425c" />
-    <option name="SELECTION_BACKGROUND" value="85533a" />
+    <option name="INDENT_GUIDE" value="25425C" />
+    <option name="SELECTION_BACKGROUND" value="85533A" />
     <option name="CARET_ROW_COLOR" value="001629" />
-    <option name="WHITESPACES" value="25425c" />
+    <option name="WHITESPACES" value="25425C" />
     <option name="CARET_COLOR" value="FFFFFF" />
     <option name="LINE_NUMBERS_COLOR" value="FFFFFF" />
-    <option name="SELECTED_INDENT_GUIDE" value="25425c" />
+    <option name="SELECTED_INDENT_GUIDE" value="25425C" />
     <option name="GUTTER_BACKGROUND" value="002240" />
   </colors>
   <attributes>
@@ -19,7 +19,7 @@
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="743d3d" />
+        <option name="BACKGROUND" value="743D3D" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
@@ -261,52 +261,52 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="06b8b8" />
+        <option name="FOREGROUND" value="06B8B8" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="FFB3B3" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="FF2EFF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="FF6767" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="FOREGROUND" value="E4E4FF" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="6AE96A" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -343,7 +343,7 @@
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -365,25 +365,25 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FOREGROUND" value="71D7D7" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FOREGROUND" value="FFC2C2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -644,7 +644,7 @@
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
+        <option name="EFFECT_COLOR" value="C0C0C0" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
@@ -690,7 +690,7 @@
     </option>
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="30322b" />
+        <option name="BACKGROUND" value="30322B" />
       </value>
     </option>
     <option name="ENUM_CONST">
@@ -701,17 +701,17 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_COLOR" value="FF6767" />
+        <option name="ERROR_STRIPE_COLOR" value="FF0000" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="BACKGROUND" value="161717" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="First symbol in list">
@@ -723,8 +723,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="AA4E00" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
@@ -882,28 +882,28 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="3C3C57" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -913,7 +913,7 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -971,14 +971,14 @@
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
+        <option name="EFFECT_COLOR" value="80807F" />
       </value>
     </option>
     <option name="JAVA_DOT">
@@ -1094,7 +1094,7 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="80807f" />
+        <option name="FOREGROUND" value="80807F" />
       </value>
     </option>
     <option name="OC.BADCHARACTER">
@@ -1417,7 +1417,7 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="48485f" />
+        <option name="BACKGROUND" value="48485F" />
       </value>
     </option>
     <option name="REST.INLINE">
@@ -1427,7 +1427,7 @@
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="4d5d3d" />
+        <option name="BACKGROUND" value="4D5D3D" />
       </value>
     </option>
     <option name="REST.ITALIC">
@@ -1735,7 +1735,7 @@
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="4F4F82" />
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">
@@ -1810,14 +1810,14 @@
     </option>
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="713f3f" />
+        <option name="BACKGROUND" value="713F3F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2e2e20" />
+        <option name="BACKGROUND" value="2E2E20" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
       </value>
@@ -1837,7 +1837,7 @@
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2b2b2c" />
+        <option name="BACKGROUND" value="2B2B2C" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
       </value>
@@ -1845,7 +1845,7 @@
     <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
@@ -1867,15 +1867,15 @@
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="5F5F00" />
+        <option name="ERROR_STRIPE_COLOR" value="00FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TYPEDEF">
@@ -1890,16 +1890,16 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
+        <option name="BACKGROUND" value="4A3F10" />
         <option name="EFFECT_TYPE" value="1" />
         <option name="EFFECT_COLOR" value="FFFFFF" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="472C47" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">

--- a/colorSchemes/src/colorSchemes/github.xml
+++ b/colorSchemes/src/colorSchemes/github.xml
@@ -3,7 +3,7 @@
     <option name="CONSOLE_BACKGROUND_KEY" value="F8F8FF" />
     <option name="INDENT_GUIDE" value="BFBFBF" />
     <option name="SELECTION_BACKGROUND" value="BCD5FA" />
-    <option name="CARET_ROW_COLOR" value="e6e6ed" />
+    <option name="CARET_ROW_COLOR" value="E6E6ED" />
     <option name="WHITESPACES" value="BFBFBF" />
     <option name="CARET_COLOR" value="000000" />
     <option name="LINE_NUMBERS_COLOR" value="000000" />
@@ -13,12 +13,12 @@
   <attributes>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="ffcccc" />
+        <option name="BACKGROUND" value="FFCCCC" />
       </value>
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="ffc8c8" />
+        <option name="BACKGROUND" value="FFC8C8" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
@@ -47,7 +47,7 @@
     <option name="BUILDOUT.VALUE">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="CLASS_NAME_ATTRIBUTES" />
@@ -59,7 +59,7 @@
     </option>
     <option name="COFFEESCRIPT.BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="ffcccc" />
+        <option name="BACKGROUND" value="FFCCCC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BLOCK_COMMENT">
@@ -123,13 +123,13 @@
     <option name="COFFEESCRIPT.HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREDOC_ID">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREGEX_CONTENT">
@@ -145,13 +145,13 @@
     <option baseAttributes="TEXT" name="COFFEESCRIPT.IDENTIFIER" />
     <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
       <value>
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.JAVASCRIPT_ID">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.KEYWORD">
@@ -207,13 +207,13 @@
     <option name="COFFEESCRIPT.STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.STRING_LITERAL">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.THIS">
@@ -228,7 +228,7 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff" />
+        <option name="FOREGROUND" value="FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
@@ -238,7 +238,7 @@
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="7f0000" />
+        <option name="FOREGROUND" value="7F0000" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
@@ -253,7 +253,7 @@
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff00ff" />
+        <option name="FOREGROUND" value="FF00FF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
@@ -263,23 +263,23 @@
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff0000" />
+        <option name="FOREGROUND" value="FF0000" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="00007f" />
+        <option name="FOREGROUND" value="00007F" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="007f00" />
+        <option name="FOREGROUND" value="007F00" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffcc00" />
+        <option name="FOREGROUND" value="FFCC00" />
       </value>
     </option>
     <option name="CSS.COMMENT">
@@ -327,7 +327,7 @@
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8000" />
-        <option name="BACKGROUND" value="ffcccc" />
+        <option name="BACKGROUND" value="FFCCCC" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
@@ -338,7 +338,7 @@
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="660e7a" />
+        <option name="FOREGROUND" value="660E7A" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -374,7 +374,7 @@
     <option name="CUSTOM_STRING_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -393,7 +393,7 @@
     <option name="Clojure Character">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="RUBY_IDENTIFIER" name="Clojure Keyword" />
@@ -416,7 +416,7 @@
     <option name="Clojure Strings">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="DEFAULT_ATTRIBUTE">
@@ -549,7 +549,7 @@
     <option name="DEFAULT_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="DEFAULT_TAG">
@@ -594,7 +594,7 @@
     <option name="DJANGO_STRING_LITERAL">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="DJANGO_TAG_NAME">
@@ -606,7 +606,7 @@
     <option baseAttributes="DEFAULT_BRACES" name="DJANGO_TAG_START_END" />
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="f5f7f0" />
+        <option name="BACKGROUND" value="F5F7F0" />
       </value>
     </option>
     <option name="ENUM_CONST">
@@ -617,17 +617,17 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff0000" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_COLOR" value="FF0000" />
+        <option name="ERROR_STRIPE_COLOR" value="FF0000" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="0000ff" />
-        <option name="BACKGROUND" value="e9e9e9" />
+        <option name="FOREGROUND" value="0000FF" />
+        <option name="BACKGROUND" value="E9E9E9" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="0000ff" />
+        <option name="EFFECT_COLOR" value="0000FF" />
       </value>
     </option>
     <option name="First symbol in list">
@@ -638,8 +638,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="f49810" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="F49810" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
@@ -662,13 +662,13 @@
     <option name="GHERKIN_PYSTRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="GHERKIN_TEXT" name="GHERKIN_TABLE_CELL" />
@@ -709,7 +709,7 @@
     <option name="GQL_STRING_LITERAL">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="HAML_CLASS">
@@ -741,13 +741,13 @@
     <option name="HAML_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="HAML_STRING_INTERPOLATED">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="HAML_TAG">
@@ -771,7 +771,7 @@
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -782,7 +782,7 @@
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="ff" />
+        <option name="FOREGROUND" value="FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -799,38 +799,38 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="0000ff" />
+        <option name="FOREGROUND" value="0000FF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="0000ff" />
+        <option name="EFFECT_COLOR" value="0000FF" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="e4e4ff" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="E4E4FF" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="660e7a" />
+        <option name="FOREGROUND" value="660E7A" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="cccccc" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="EFFECT_COLOR" value="CCCCCC" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="edfced" />
+        <option name="BACKGROUND" value="EDFCED" />
       </value>
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="660e7a" />
+        <option name="FOREGROUND" value="660E7A" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -842,7 +842,7 @@
     <option name="JADE_FILE_PATH">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="DEFAULT_LABEL" name="JADE_FILTER_NAME" />
@@ -883,7 +883,7 @@
     <option name="JAVA_INVALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="008000" />
-        <option name="BACKGROUND" value="ffcccc" />
+        <option name="BACKGROUND" value="FFCCCC" />
       </value>
     </option>
     <option name="JAVA_KEYWORD">
@@ -914,7 +914,7 @@
     <option name="JAVA_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
@@ -981,7 +981,7 @@
     <option baseAttributes="TEXT" name="MACRO_PARAMETER" />
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="99ccff" />
+        <option name="BACKGROUND" value="99CCFF" />
       </value>
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
@@ -1076,7 +1076,7 @@
     <option name="OC.STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="OC.STRUCT_FIELD">
@@ -1087,7 +1087,7 @@
     <option name="OC_FORMAT_TOKEN">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="PARAMETER_ATTRIBUTES" />
@@ -1109,7 +1109,7 @@
     </option>
     <option name="PUPPET_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="ffcccc" />
+        <option name="BACKGROUND" value="FFCCCC" />
       </value>
     </option>
     <option name="PUPPET_BLOCK_COMMENT">
@@ -1163,13 +1163,13 @@
     <option name="PUPPET_SQ_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="PUPPET_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="PUPPET_VARIABLE">
@@ -1180,7 +1180,7 @@
     <option name="PUPPET_VARIABLE_INTERPOLATION">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="DEFAULT_BRACES" name="PY.BRACES" />
@@ -1250,7 +1250,7 @@
     <option name="PY.STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="DEFAULT_VALID_STRING_ESCAPE" name="PY.VALID_STRING_ESCAPE" />
@@ -1273,17 +1273,17 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="d9d9f0" />
+        <option name="BACKGROUND" value="D9D9F0" />
       </value>
     </option>
     <option name="REST.INLINE">
       <value>
-        <option name="BACKGROUND" value="edfced" />
+        <option name="BACKGROUND" value="EDFCED" />
       </value>
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="cadaba" />
+        <option name="BACKGROUND" value="CADABA" />
       </value>
     </option>
     <option name="REST.ITALIC">
@@ -1300,7 +1300,7 @@
     <option name="REST.REF.NAME">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="REST.SECTION.HEADER">
@@ -1375,7 +1375,7 @@
     <option name="RUBY_EXPR_IN_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="RUBY_GVAR">
@@ -1392,20 +1392,20 @@
     <option name="RUBY_HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="RUBY_HEREDOC_ID">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="RUBY_IDENTIFIER" />
     <option name="RUBY_INTERPOLATED_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="DEFAULT_INVALID_STRING_ESCAPE" name="RUBY_INVALID_ESCAPE_SEQUENCE" />
@@ -1470,7 +1470,7 @@
     <option name="RUBY_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="RUBY_SYMBOL">
@@ -1481,7 +1481,7 @@
     <option name="RUBY_WORDS">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="SASS_COMMENT">
@@ -1549,7 +1549,7 @@
     <option name="SASS_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="SASS_TAG_NAME">
@@ -1570,7 +1570,7 @@
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="ccccff" />
+        <option name="BACKGROUND" value="CCCCFF" />
       </value>
     </option>
     <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_BAD_CHARACTER" />
@@ -1605,7 +1605,7 @@
     <option name="SLIM_INTERPOLATION">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option baseAttributes="DEFAULT_PARENTHS" name="SLIM_PARENTHS" />
@@ -1618,7 +1618,7 @@
     <option name="SLIM_STRING_INTERPOLATED">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="SLIM_TAG">
@@ -1638,14 +1638,14 @@
     </option>
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="fecccc" />
+        <option name="BACKGROUND" value="FECCCC" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="000000" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="fefef0" />
+        <option name="BACKGROUND" value="FEFEF0" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="000000" />
       </value>
@@ -1665,7 +1665,7 @@
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="fefeff" />
+        <option name="BACKGROUND" value="FEFEFF" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="000000" />
       </value>
@@ -1673,7 +1673,7 @@
     <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="660e7a" />
+        <option name="FOREGROUND" value="660E7A" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
@@ -1695,15 +1695,15 @@
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="ffff00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="FFFF00" />
+        <option name="ERROR_STRIPE_COLOR" value="00FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ff" />
+        <option name="FOREGROUND" value="FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TYPEDEF">
@@ -1714,26 +1714,26 @@
     </option>
     <option name="UNMATCHED_BRACE_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="ffdcdc" />
+        <option name="BACKGROUND" value="FFDCDC" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="f6ebbc" />
+        <option name="BACKGROUND" value="F6EBBC" />
         <option name="EFFECT_TYPE" value="1" />
         <option name="EFFECT_COLOR" value="000000" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="ffe4ff" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="FFE4FF" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="ffcdff" />
+        <option name="BACKGROUND" value="FFCDFF" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_NAME">
@@ -1744,7 +1744,7 @@
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="XML_ENTITY_REFERENCE">
@@ -1782,7 +1782,7 @@
     <option name="YAML_SCALAR_DSTRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
@@ -1793,19 +1793,19 @@
     <option name="YAML_SCALAR_LIST">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
     <option name="YAML_SIGN">
@@ -1817,7 +1817,7 @@
     <option name="YAML_TEXT">
       <value>
         <option name="FOREGROUND" value="DD1144" />
-        <option name="BACKGROUND" value="f7e7f1" />
+        <option name="BACKGROUND" value="F7E7F1" />
       </value>
     </option>
   </attributes>

--- a/colorSchemes/src/colorSchemes/monokai.xml
+++ b/colorSchemes/src/colorSchemes/monokai.xml
@@ -19,7 +19,7 @@
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="743d3d" />
+        <option name="BACKGROUND" value="743D3D" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
@@ -208,52 +208,52 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="06b8b8" />
+        <option name="FOREGROUND" value="06B8B8" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="FFB3B3" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="FF2EFF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="FF6767" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="FOREGROUND" value="E4E4FF" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="6AE96A" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -290,7 +290,7 @@
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -313,25 +313,25 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FOREGROUND" value="71D7D7" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FOREGROUND" value="FFC2C2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -543,7 +543,7 @@
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
+        <option name="EFFECT_COLOR" value="C0C0C0" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
@@ -578,14 +578,14 @@
     </option>
     <option name="DJANGO_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option baseAttributes="DEFAULT_BRACES" name="DJANGO_TAG_START_END" />
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="30322b" />
+        <option name="BACKGROUND" value="30322B" />
       </value>
     </option>
     <option name="ENUM_CONST">
@@ -596,17 +596,17 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_COLOR" value="FF6767" />
+        <option name="ERROR_STRIPE_COLOR" value="FF0000" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="BACKGROUND" value="161717" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="First symbol in list">
@@ -617,8 +617,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="AA4E00" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
@@ -741,34 +741,34 @@
     <option baseAttributes="XML_TAG" name="HTML_TAG" />
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="3C3C57" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -778,7 +778,7 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -810,14 +810,14 @@
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
+        <option name="EFFECT_COLOR" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="JAVA_DOT" />
@@ -909,7 +909,7 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="80807f" />
+        <option name="FOREGROUND" value="80807F" />
       </value>
     </option>
     <option name="OC.BADCHARACTER">
@@ -1173,7 +1173,7 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="48485f" />
+        <option name="BACKGROUND" value="48485F" />
       </value>
     </option>
     <option name="REST.INLINE">
@@ -1183,7 +1183,7 @@
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="4d5d3d" />
+        <option name="BACKGROUND" value="4D5D3D" />
       </value>
     </option>
     <option name="REST.ITALIC">
@@ -1421,7 +1421,7 @@
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="4F4F82" />
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">
@@ -1483,14 +1483,14 @@
     <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_TAG_START" />
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="713f3f" />
+        <option name="BACKGROUND" value="713F3F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F2" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2e2e1f" />
+        <option name="BACKGROUND" value="2E2E1F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F2" />
       </value>
@@ -1510,7 +1510,7 @@
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2b2b2b" />
+        <option name="BACKGROUND" value="2B2B2B" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F2" />
       </value>
@@ -1518,7 +1518,7 @@
     <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
@@ -1540,15 +1540,15 @@
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="5F5F00" />
+        <option name="ERROR_STRIPE_COLOR" value="00FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TYPEDEF">
@@ -1564,16 +1564,16 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
+        <option name="BACKGROUND" value="4A3F10" />
         <option name="EFFECT_TYPE" value="1" />
         <option name="EFFECT_COLOR" value="F8F8F2" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="472C47" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1609,7 +1609,7 @@
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>

--- a/colorSchemes/src/colorSchemes/rails_casts.xml
+++ b/colorSchemes/src/colorSchemes/rails_casts.xml
@@ -2,7 +2,7 @@
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="2B2B2B" />
     <option name="INDENT_GUIDE" value="404040" />
-    <option name="SELECTION_BACKGROUND" value="545c73" />
+    <option name="SELECTION_BACKGROUND" value="545C73" />
     <option name="CARET_ROW_COLOR" value="333435" />
     <option name="WHITESPACES" value="404040" />
     <option name="CARET_COLOR" value="FFFFFF" />
@@ -19,7 +19,7 @@
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="743d3d" />
+        <option name="BACKGROUND" value="743D3D" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
@@ -213,52 +213,52 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="06b8b8" />
+        <option name="FOREGROUND" value="06B8B8" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="FFB3B3" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="FF2EFF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="FF6767" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="FOREGROUND" value="E4E4FF" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="6AE96A" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -295,7 +295,7 @@
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -306,7 +306,7 @@
     </option>
     <option name="CSS.URL">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -318,25 +318,25 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FOREGROUND" value="71D7D7" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FOREGROUND" value="FFC2C2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -549,7 +549,7 @@
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
+        <option name="EFFECT_COLOR" value="C0C0C0" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
@@ -591,7 +591,7 @@
     <option baseAttributes="DEFAULT_BRACES" name="DJANGO_TAG_START_END" />
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="30322b" />
+        <option name="BACKGROUND" value="30322B" />
       </value>
     </option>
     <option name="ENUM_CONST">
@@ -602,17 +602,17 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_COLOR" value="FF6767" />
+        <option name="ERROR_STRIPE_COLOR" value="FF0000" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="BACKGROUND" value="161717" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="First symbol in list">
@@ -623,8 +623,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="AA4E00" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
@@ -766,28 +766,28 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="3C3C57" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -797,7 +797,7 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -835,14 +835,14 @@
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
+        <option name="EFFECT_COLOR" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="JAVA_DOT" />
@@ -946,7 +946,7 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="80807f" />
+        <option name="FOREGROUND" value="80807F" />
       </value>
     </option>
     <option name="OC.BADCHARACTER">
@@ -1217,7 +1217,7 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="48485f" />
+        <option name="BACKGROUND" value="48485F" />
       </value>
     </option>
     <option name="REST.INLINE">
@@ -1227,7 +1227,7 @@
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="4d5d3d" />
+        <option name="BACKGROUND" value="4D5D3D" />
       </value>
     </option>
     <option name="REST.ITALIC">
@@ -1478,7 +1478,7 @@
     <option baseAttributes="TEXT" name="SASS_VARIABLE" />
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="4F4F82" />
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">
@@ -1545,14 +1545,14 @@
     <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_TAG_START" />
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="713f3f" />
+        <option name="BACKGROUND" value="713F3F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="E6E1DC" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2e2e1f" />
+        <option name="BACKGROUND" value="2E2E1F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="E6E1DC" />
       </value>
@@ -1572,7 +1572,7 @@
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2b2b2b" />
+        <option name="BACKGROUND" value="2B2B2B" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="E6E1DC" />
       </value>
@@ -1580,7 +1580,7 @@
     <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
@@ -1602,15 +1602,15 @@
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="5F5F00" />
+        <option name="ERROR_STRIPE_COLOR" value="00FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TYPEDEF">
@@ -1625,16 +1625,16 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
+        <option name="BACKGROUND" value="4A3F10" />
         <option name="EFFECT_TYPE" value="1" />
         <option name="EFFECT_COLOR" value="E6E1DC" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="472C47" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">

--- a/colorSchemes/src/colorSchemes/twilight.xml
+++ b/colorSchemes/src/colorSchemes/twilight.xml
@@ -1,24 +1,24 @@
 <scheme name="Twilight" parent_scheme="Darcula" version="1">
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="141414" />
-    <option name="INDENT_GUIDE" value="4e4e4e" />
-    <option name="SELECTION_BACKGROUND" value="3c3f42" />
-    <option name="CARET_ROW_COLOR" value="1b1b1b" />
-    <option name="WHITESPACES" value="4e4e4e" />
+    <option name="INDENT_GUIDE" value="4E4E4E" />
+    <option name="SELECTION_BACKGROUND" value="3C3F42" />
+    <option name="CARET_ROW_COLOR" value="1B1B1B" />
+    <option name="WHITESPACES" value="4E4E4E" />
     <option name="CARET_COLOR" value="A7A7A7" />
     <option name="LINE_NUMBERS_COLOR" value="F8F8F8" />
-    <option name="SELECTED_INDENT_GUIDE" value="4e4e4e" />
+    <option name="SELECTED_INDENT_GUIDE" value="4E4E4E" />
     <option name="GUTTER_BACKGROUND" value="141414" />
   </colors>
   <attributes>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="743d3d" />
+        <option name="BACKGROUND" value="743D3D" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
@@ -55,7 +55,7 @@
     </option>
     <option name="COFFEESCRIPT.BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BLOCK_COMMENT">
@@ -215,52 +215,52 @@
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="06b8b8" />
+        <option name="FOREGROUND" value="06B8B8" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="FFB3B3" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="FF2EFF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="FF6767" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="FOREGROUND" value="E4E4FF" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="6AE96A" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -297,7 +297,7 @@
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -313,31 +313,31 @@
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FOREGROUND" value="71D7D7" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FOREGROUND" value="FFC2C2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -565,7 +565,7 @@
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
+        <option name="EFFECT_COLOR" value="C0C0C0" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
@@ -607,7 +607,7 @@
     <option baseAttributes="DEFAULT_BRACES" name="DJANGO_TAG_START_END" />
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="30322b" />
+        <option name="BACKGROUND" value="30322B" />
       </value>
     </option>
     <option name="ENUM_CONST">
@@ -618,17 +618,17 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+        <option name="EFFECT_COLOR" value="FF6767" />
+        <option name="ERROR_STRIPE_COLOR" value="FF0000" />
       </value>
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="BACKGROUND" value="161717" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="First symbol in list">
@@ -640,8 +640,8 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="AA4E00" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
@@ -779,28 +779,28 @@
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="3C3C57" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
@@ -810,7 +810,7 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -856,20 +856,20 @@
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
+        <option name="EFFECT_COLOR" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="JAVA_DOT" />
     <option name="JAVA_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
@@ -966,7 +966,7 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="80807f" />
+        <option name="FOREGROUND" value="80807F" />
       </value>
     </option>
     <option baseAttributes="TEXT" name="OC.BADCHARACTER" />
@@ -1082,7 +1082,7 @@
     </option>
     <option name="PUPPET_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="PUPPET_BLOCK_COMMENT">
@@ -1234,7 +1234,7 @@
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="48485f" />
+        <option name="BACKGROUND" value="48485F" />
       </value>
     </option>
     <option name="REST.INLINE">
@@ -1244,7 +1244,7 @@
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="4d5d3d" />
+        <option name="BACKGROUND" value="4D5D3D" />
       </value>
     </option>
     <option name="REST.ITALIC">
@@ -1501,7 +1501,7 @@
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="4F4F82" />
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">
@@ -1564,14 +1564,14 @@
     <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_TAG_START" />
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="713f3f" />
+        <option name="BACKGROUND" value="713F3F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2e2e1f" />
+        <option name="BACKGROUND" value="2E2E1F" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
       </value>
@@ -1591,7 +1591,7 @@
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2b2b2b" />
+        <option name="BACKGROUND" value="2B2B2B" />
         <option name="EFFECT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
       </value>
@@ -1599,7 +1599,7 @@
     <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
@@ -1621,15 +1621,15 @@
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="5F5F00" />
+        <option name="ERROR_STRIPE_COLOR" value="00FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TYPEDEF">
@@ -1644,16 +1644,16 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
+        <option name="BACKGROUND" value="4A3F10" />
         <option name="EFFECT_TYPE" value="1" />
         <option name="EFFECT_COLOR" value="F8F8F8" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFF00" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="472C47" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">

--- a/colorSchemes/src/colorSchemes/vibrant_ink.xml
+++ b/colorSchemes/src/colorSchemes/vibrant_ink.xml
@@ -1,53 +1,53 @@
 <scheme name="VibrantInk" version="142" parent_scheme="Darcula">
   <colors>
-    <option name="CARET_COLOR" value="ffffff" />
+    <option name="CARET_COLOR" value="FFFFFF" />
     <option name="CARET_ROW_COLOR" value="333300" />
     <option name="CONSOLE_BACKGROUND_KEY" value="0" />
     <option name="GUTTER_BACKGROUND" value="0" />
     <option name="INDENT_GUIDE" value="404040" />
-    <option name="LINE_NUMBERS_COLOR" value="ffffff" />
-    <option name="SELECTION_BACKGROUND" value="2e3f34" />
+    <option name="LINE_NUMBERS_COLOR" value="FFFFFF" />
+    <option name="SELECTION_BACKGROUND" value="2E3F34" />
     <option name="WHITESPACES" value="404040" />
   </colors>
   <attributes>
     <option name="APACHE_CONFIG.ARG_LEXEM">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="APACHE_CONFIG.COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="APACHE_CONFIG.IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="BREAKPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="743d3d" />
+        <option name="BACKGROUND" value="743D3D" />
       </value>
     </option>
     <option name="BUILDOUT.KEY">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="BUILDOUT.KEY_VALUE_SEPARATOR">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="BUILDOUT.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="BUILDOUT.SECTION_NAME">
@@ -57,17 +57,17 @@
     </option>
     <option name="BUILDOUT.VALUE">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.BOOLEAN">
@@ -77,12 +77,12 @@
     </option>
     <option name="COFFEESCRIPT.CLASS_NAME">
       <value>
-        <option name="FOREGROUND" value="ffcc00" />
+        <option name="FOREGROUND" value="FFCC00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.COLON">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="COFFEESCRIPT.COMMA">
@@ -95,7 +95,7 @@
     </option>
     <option name="COFFEESCRIPT.EXISTENTIAL">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="COFFEESCRIPT.FUNCTION">
@@ -110,37 +110,37 @@
     </option>
     <option name="COFFEESCRIPT.FUNCTION_NAME">
       <value>
-        <option name="FOREGROUND" value="ffcc00" />
+        <option name="FOREGROUND" value="FFCC00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.GLOBAL_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREDOC_CONTENT">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREGEX_CONTENT">
       <value>
-        <option name="FOREGROUND" value="44b4cc" />
+        <option name="FOREGROUND" value="44B4CC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.HEREGEX_ID">
       <value>
-        <option name="FOREGROUND" value="44b4cc" />
+        <option name="FOREGROUND" value="44B4CC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
@@ -148,22 +148,22 @@
     </option>
     <option name="COFFEESCRIPT.JAVASCRIPT_ID">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="COFFEESCRIPT.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.LOCAL_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="COFFEESCRIPT.NUMBER">
@@ -176,7 +176,7 @@
     </option>
     <option name="COFFEESCRIPT.OPERATIONS">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="COFFEESCRIPT.PARAMETER">
@@ -186,22 +186,22 @@
     </option>
     <option name="COFFEESCRIPT.PROTOTYPE">
       <value>
-        <option name="FOREGROUND" value="ffcc00" />
+        <option name="FOREGROUND" value="FFCC00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
       <value>
-        <option name="FOREGROUND" value="44b4cc" />
+        <option name="FOREGROUND" value="44B4CC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_FLAG">
       <value>
-        <option name="FOREGROUND" value="44b4cc" />
+        <option name="FOREGROUND" value="44B4CC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
       <value>
-        <option name="FOREGROUND" value="44b4cc" />
+        <option name="FOREGROUND" value="44B4CC" />
       </value>
     </option>
     <option name="COFFEESCRIPT.SEMICOLON">
@@ -209,27 +209,27 @@
     </option>
     <option name="COFFEESCRIPT.STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.STRING_LITERAL">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="COFFEESCRIPT.THIS">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="CONSOLE_BLACK_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_BLUE_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
       </value>
     </option>
     <option name="CONSOLE_CYAN_OUTPUT">
@@ -239,43 +239,43 @@
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="FFB3B3" />
       </value>
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="A7A7A7" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="FF2EFF" />
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CONSOLE_RANGE_TO_EXECUTE" baseAttributes="INJECTED_LANGUAGE_FRAGMENT" />
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="FF6767" />
       </value>
     </option>
     <option name="CONSOLE_SYSTEM_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="FOREGROUND" value="E4E4FF" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="6AE96A" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -286,48 +286,48 @@
     </option>
     <option name="CSS.COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="CSS.FUNCTION">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.IDENT">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="CSS.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="ff6600" />
+        <option name="EFFECT_COLOR" value="FF6600" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.NUMBER">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CSS.STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -341,43 +341,43 @@
     </option>
     <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FOREGROUND" value="71D7D7" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FOREGROUND" value="FFC2C2" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -388,7 +388,7 @@
     </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -400,22 +400,22 @@
     </option>
     <option name="Clojure Atom">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="Clojure Character">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="Clojure Line comment">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="Clojure Literal">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -426,29 +426,29 @@
     </option>
     <option name="Clojure Strings">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="DEFAULT_ATTRIBUTE">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
@@ -458,7 +458,7 @@
     </option>
     <option name="DEFAULT_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="DEFAULT_ENTITY">
@@ -469,31 +469,31 @@
     </option>
     <option name="DEFAULT_GLOBAL_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DEFAULT_IDENTIFIER" baseAttributes="TEXT" />
     <option name="DEFAULT_INSTANCE_FIELD">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="DEFAULT_NUMBER">
@@ -503,18 +503,18 @@
     </option>
     <option name="DEFAULT_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="DEFAULT_STATIC_FIELD">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -527,24 +527,24 @@
     </option>
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="c0c0c0" />
+        <option name="EFFECT_COLOR" value="C0C0C0" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
     </option>
     <option name="DJANGO_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="DJANGO_ID">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DJANGO_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="DJANGO_NUMBER">
@@ -554,23 +554,23 @@
     </option>
     <option name="DJANGO_STRING_LITERAL">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="DJANGO_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="DUPLICATE_FROM_SERVER">
       <value>
-        <option name="BACKGROUND" value="30322b" />
+        <option name="BACKGROUND" value="30322B" />
       </value>
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="ff6767" />
+        <option name="EFFECT_COLOR" value="FF6767" />
         <option name="ERROR_STRIPE_COLOR" value="cf5b56" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
@@ -586,10 +586,10 @@
     </option>
     <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="BACKGROUND" value="161717" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -607,62 +607,62 @@
     </option>
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+        <option name="EFFECT_COLOR" value="AA4E00" />
+        <option name="ERROR_STRIPE_COLOR" value="F49810" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="GHERKIN_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="GHERKIN_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="GHERKIN_OUTLINE_PARAMETER_SUBSTITUTION">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="GHERKIN_PYSTRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="GHERKIN_REGEXP_PARAMETER">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="GHERKIN_TABLE_CELL">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="GHERKIN_TABLE_HEADER_CELL">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="GHERKIN_TABLE_PIPE">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="GHERKIN_TAG">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="GHERKIN_TEXT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="GQL_ID">
@@ -677,12 +677,12 @@
     </option>
     <option name="GQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="GQL_STRING_LITERAL">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="HAML_CLASS">
@@ -690,19 +690,19 @@
     </option>
     <option name="HAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="HAML_FILTER">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HAML_FILTER_CONTENT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HAML_ID">
@@ -710,8 +710,8 @@
     </option>
     <option name="HAML_LINE_CONTINUATION">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HAML_RUBY_CODE">
@@ -719,24 +719,24 @@
     </option>
     <option name="HAML_RUBY_START">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HAML_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="HAML_STRING_INTERPOLATED">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="HAML_TAG">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HAML_TAG_NAME">
@@ -744,37 +744,37 @@
     </option>
     <option name="HAML_TEXT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HAML_WS_REMOVAL">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HAML_XHTML">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HTML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
@@ -788,33 +788,33 @@
     </option>
     <option name="HTML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
+        <option name="EFFECT_COLOR" value="C7C7FF" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="3C3C57" />
+        <option name="ERROR_STRIPE_COLOR" value="CCCCFF" />
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="FFFFCC" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -825,46 +825,46 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JAVA_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="JAVA_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="JAVA_DOC_MARKUP">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="JAVA_DOC_TAG">
       <value>
         <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
+        <option name="EFFECT_COLOR" value="80807F" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="JAVA_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="JAVA_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="JAVA_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="JAVA_NUMBER">
@@ -874,12 +874,12 @@
     </option>
     <option name="JAVA_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="JAVA_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="JAVA_VALID_STRING_ESCAPE">
@@ -894,7 +894,7 @@
     </option>
     <option name="JS.BLOCK_COMEMNT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="JS.COMMA">
@@ -908,7 +908,7 @@
     </option>
     <option name="JS.LOCAL_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="7a8fd9" />
+        <option name="FOREGROUND" value="7A8FD9" />
       </value>
     </option>
     <option name="JS.PARAMETER">
@@ -931,48 +931,48 @@
     </option>
     <option name="LESS_JS_CODE_DELIM">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="BACKGROUND" value="0" />
       </value>
     </option>
     <option name="LESS_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="LOCALE.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="LOCALE.MSGCTXT_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="LOCALE.MSGID_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="LOCALE.MSGID_PLURAL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="LOCALE.MSGSTR_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="LOCALE.MSGSTR_PLURAL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="LOCALE.STRING_LITERAL">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
@@ -982,12 +982,12 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="80807f" />
+        <option name="FOREGROUND" value="80807F" />
       </value>
     </option>
     <option name="PHP_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="PHP_COMMA">
@@ -995,7 +995,7 @@
     </option>
     <option name="PHP_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="PHP_CONSTANT">
@@ -1005,7 +1005,7 @@
     </option>
     <option name="PHP_DOC_COMMENT_ID">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="PHP_DOC_TAG">
@@ -1020,12 +1020,12 @@
     </option>
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="PHP_HEREDOC_CONTENT">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="PHP_HEREDOC_ID">
@@ -1038,12 +1038,12 @@
     </option>
     <option name="PHP_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PHP_MARKUP_ID">
       <value>
-        <option name="BACKGROUND" value="223f22" />
+        <option name="BACKGROUND" value="223F22" />
       </value>
     </option>
     <option name="PHP_NUMBER">
@@ -1053,7 +1053,7 @@
     </option>
     <option name="PHP_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PHP_PREDEFINED SYMBOL">
@@ -1061,7 +1061,7 @@
     </option>
     <option name="PHP_SCRIPTING_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2a2d32" />
+        <option name="BACKGROUND" value="2A2D32" />
       </value>
     </option>
     <option name="PHP_SEMICOLON">
@@ -1069,32 +1069,32 @@
     </option>
     <option name="PHP_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="PHP_TAG">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PHP_PARAMETER">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PUPPET_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="PUPPET_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="PUPPET_ESCAPE_SEQUENCE">
@@ -1104,7 +1104,7 @@
     </option>
     <option name="PUPPET_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PUPPET_NUMBER">
@@ -1114,64 +1114,64 @@
     </option>
     <option name="PUPPET_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PUPPET_REGEX">
       <value>
-        <option name="FOREGROUND" value="44b4cc" />
+        <option name="FOREGROUND" value="44B4CC" />
       </value>
     </option>
     <option name="PUPPET_SQ_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="PUPPET_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="PUPPET_VARIABLE_INTERPOLATION">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="PY.CLASS_DEFINITION">
       <value>
-        <option name="EFFECT_COLOR" value="ffffff" />
+        <option name="EFFECT_COLOR" value="FFFFFF" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.DECORATOR">
       <value>
-        <option name="FOREGROUND" value="ffcc00" />
+        <option name="FOREGROUND" value="FFCC00" />
       </value>
     </option>
     <option name="PY.DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="PY.FUNC_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="ffcc00" />
+        <option name="FOREGROUND" value="FFCC00" />
       </value>
     </option>
     <option name="PY.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="PY.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PY.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="PY.NUMBER">
@@ -1181,12 +1181,12 @@
     </option>
     <option name="PY.OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="PY.STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="PY.VALID_STRING_ESCAPE">
@@ -1196,7 +1196,7 @@
     </option>
     <option name="REGEXP.BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="REGEXP.CHAR_CLASS">
@@ -1209,7 +1209,7 @@
     </option>
     <option name="REGEXP.COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="REGEXP.ESC_CHARACTER">
@@ -1219,13 +1219,13 @@
     </option>
     <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="REGEXP.META">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
@@ -1240,17 +1240,17 @@
     </option>
     <option name="REST.EXPLICIT">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="REST.FIELD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="REST.FIXED">
       <value>
-        <option name="BACKGROUND" value="48485f" />
+        <option name="BACKGROUND" value="48485F" />
       </value>
     </option>
     <option name="REST.INLINE">
@@ -1260,17 +1260,17 @@
     </option>
     <option name="REST.INTERPRETED">
       <value>
-        <option name="BACKGROUND" value="4d5d3d" />
+        <option name="BACKGROUND" value="4D5D3D" />
       </value>
     </option>
     <option name="REST.LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="REST.REF.NAME">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="REST.SECTION.HEADER">
@@ -1280,7 +1280,7 @@
     </option>
     <option name="RHTML_COMMENT_ID">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="RHTML_SCRIPTING_BACKGROUND_ID">
@@ -1290,7 +1290,7 @@
     </option>
     <option name="RUBY_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="RUBY_CONSTANT">
@@ -1300,7 +1300,7 @@
     </option>
     <option name="RUBY_CVAR">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="RUBY_ESCAPE_SEQUENCE">
@@ -1310,58 +1310,58 @@
     </option>
     <option name="RUBY_EXPR_IN_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="RUBY_GVAR">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="RUBY_HASH_ASSOC">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="RUBY_HEREDOC_CONTENT">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="RUBY_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="RUBY_INTERPOLATED_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="BACKGROUND" value="481515" />
       </value>
     </option>
     <option name="RUBY_IVAR">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="RUBY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="RUBY_LINE_CONTINUATION">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="RUBY_METHOD_NAME">
       <value>
-        <option name="FOREGROUND" value="ffcc00" />
+        <option name="FOREGROUND" value="FFCC00" />
       </value>
     </option>
     <option name="RUBY_NUMBER">
@@ -1371,7 +1371,7 @@
     </option>
     <option name="RUBY_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="RUBY_PARAMETER_ID">
@@ -1381,12 +1381,12 @@
     </option>
     <option name="RUBY_REGEXP">
       <value>
-        <option name="FOREGROUND" value="44b4cc" />
+        <option name="FOREGROUND" value="44B4CC" />
       </value>
     </option>
     <option name="RUBY_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="RUBY_SYMBOL">
@@ -1396,54 +1396,54 @@
     </option>
     <option name="RUBY_WORDS">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="SASS_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="SASS_DEFAULT">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SASS_EXTEND">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SASS_FUNCTION">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SASS_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SASS_IMPORTANT">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SASS_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SASS_MIXIN">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="SASS_NUMBER">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
       </value>
     </option>
     <option name="SASS_PROPERTY_NAME">
@@ -1453,18 +1453,18 @@
     </option>
     <option name="SASS_PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="68E868" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="SASS_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="SASS_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SASS_URL">
@@ -1479,73 +1479,73 @@
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="4F4F82" />
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="SLIM_CALL">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="SLIM_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="SLIM_FILTER_CONTENT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="SLIM_INTERPOLATION">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="SLIM_STATIC_CONTENT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="SLIM_STRING_INTERPOLATED">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="SLIM_TAG_ATTR_KEY">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="SLIM_TAG_START">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="f0f0f" />
+        <option name="FOREGROUND" value="FFFFFF" />
+        <option name="BACKGROUND" value="F0F0F" />
       </value>
     </option>
     <option name="SMARTY_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2a2d32" />
+        <option name="BACKGROUND" value="2A2D32" />
       </value>
     </option>
     <option name="SMARTY_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="SMARTY_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="SMARTY_IDENTIFIER">
@@ -1553,7 +1553,7 @@
     </option>
     <option name="SMARTY_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SMARTY_NUMBER">
@@ -1563,57 +1563,57 @@
     </option>
     <option name="SMARTY_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SMARTY_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="532b2e" />
+        <option name="BACKGROUND" value="532B22" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="3a3a3a" />
+        <option name="BACKGROUND" value="3A3A3A" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.PATH_LEVEL_ONE">
       <value>
-        <option name="BACKGROUND" value="425f44" />
+        <option name="BACKGROUND" value="425F44" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.PATH_LEVEL_TWO">
       <value>
-        <option name="EFFECT_COLOR" value="a9b7c6" />
+        <option name="EFFECT_COLOR" value="A9B7C6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="SPY-JS.PROGRAM_SCOPE">
       <value>
-        <option name="BACKGROUND" value="3a3a3a" />
+        <option name="BACKGROUND" value="3A3A3A" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="SPY-JS.VALUE_HINT">
       <value>
-        <option name="EFFECT_COLOR" value="a9b7c6" />
+        <option name="EFFECT_COLOR" value="A9B7C6" />
       </value>
     </option>
     <option name="SQL_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="SQL_COLUMN">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1622,7 +1622,7 @@
     </option>
     <option name="SQL_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="SQL_DATABASE_OBJECT">
@@ -1636,7 +1636,7 @@
     </option>
     <option name="SQL_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="SQL_LOCAL_ALIAS">
@@ -1663,12 +1663,12 @@
     </option>
     <option name="SQL_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="SQL_SYNTHETIC_ENTITY">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="SQL_TABLE">
@@ -1676,48 +1676,48 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
         <option name="FONT_TYPE" value="3" />
       </value>
     </option>
     <option name="TAG_ATTR_KEY">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="TEXT">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="FOREGROUND" value="FFFFFF" />
         <option name="BACKGROUND" value="0" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="ff00" />
+        <option name="BACKGROUND" value="5F5F00" />
+        <option name="ERROR_STRIPE_COLOR" value="FF00" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FOREGROUND" value="C7C7FF" />
         <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="ERROR_STRIPE_COLOR" value="FF" />
       </value>
     </option>
     <option name="TWIG_BACKGROUND">
       <value>
-        <option name="BACKGROUND" value="2a2d32" />
+        <option name="BACKGROUND" value="2A2D32" />
       </value>
     </option>
     <option name="TWIG_BAD_CHARACTER">
       <value>
-        <option name="BACKGROUND" value="6e3b3b" />
+        <option name="BACKGROUND" value="6E3B3B" />
       </value>
     </option>
     <option name="TWIG_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="TWIG_IDENTIFIER">
@@ -1725,7 +1725,7 @@
     </option>
     <option name="TWIG_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="TWIG_NUMBER">
@@ -1735,12 +1735,12 @@
     </option>
     <option name="TWIG_OPERATION_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="TWIG_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="UNMATCHED_BRACE_ATTRIBUTES">
@@ -1750,16 +1750,16 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
-        <option name="EFFECT_COLOR" value="ffffff" />
-        <option name="ERROR_STRIPE_COLOR" value="ebc700" />
+        <option name="BACKGROUND" value="4A3F10" />
+        <option name="EFFECT_COLOR" value="FFFFFF" />
+        <option name="ERROR_STRIPE_COLOR" value="EBC700" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="472C47" />
+        <option name="ERROR_STRIPE_COLOR" value="FFCDFF" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
@@ -1769,18 +1769,18 @@
     </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
-        <option name="FOREGROUND" value="99cc99" />
+        <option name="FOREGROUND" value="99CC99" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_VALUE">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="XML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1799,18 +1799,18 @@
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FOREGROUND" value="E3E3FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="YAML_COMMENT">
       <value>
-        <option name="FOREGROUND" value="9933cc" />
+        <option name="FOREGROUND" value="9933CC" />
       </value>
     </option>
     <option name="YAML_SCALAR_DSTRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
@@ -1818,37 +1818,37 @@
     </option>
     <option name="YAML_SCALAR_LIST">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="YAML_SCALAR_STRING">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="YAML_SIGN">
       <value>
-        <option name="FOREGROUND" value="ff6600" />
+        <option name="FOREGROUND" value="FF6600" />
       </value>
     </option>
     <option name="YAML_TEXT">
       <value>
-        <option name="FOREGROUND" value="66ff00" />
+        <option name="FOREGROUND" value="66FF00" />
       </value>
     </option>
     <option name="OC.CONDITIONALLY_NOT_COMPILED">
       <value>
-        <option name="FOREGROUND" value="686a4e" />
+        <option name="FOREGROUND" value="686A4E" />
       </value>
     </option>
     <option name="OC.MACRONAME">
       <value>
-        <option name="FOREGROUND" value="908b25" />
+        <option name="FOREGROUND" value="908B25" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -1856,12 +1856,12 @@
     <option name="OC.METHOD_DECLARATION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
     <option name="OC.STRUCT_FIELD">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FOREGROUND" value="FDA5FF" />
       </value>
     </option>
     <option name="OC.TYPEDEF">
       <value>
-        <option name="FOREGROUND" value="50861a" />
+        <option name="FOREGROUND" value="50861A" />
       </value>
     </option>
   </attributes>


### PR DESCRIPTION
With the `colorSchemes` folder left untouched for the past 6 months and my obsession with consistency, I could no longer deal with the mix of uppercase and lowercase hexadecimal color values.

Thus, I've replaced all lowercase hexadecimal colors to uppercase.

Since the color schemes are very unlikely to be modified anyways, I figured it might as well be properly formatted.