### PR TITLE
Prevent exception wrapping to UndeclaredThrowableException

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/RemoteExternalSystemFacadeImpl.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/RemoteExternalSystemFacadeImpl.java
@@ -23,10 +23,10 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.rmi.RemoteException;
@@ -113,6 +113,9 @@ public class RemoteExternalSystemFacadeImpl<S extends ExternalSystemExecutionSet
         myCallsInProgressNumber.incrementAndGet();
         try {
           return method.invoke(impl, args);
+        }
+        catch (InvocationTargetException e) {
+          throw e.getCause();
         }
         finally {
           myCallsInProgressNumber.decrementAndGet();


### PR DESCRIPTION
If the corresponding external system api implementation throw some exception (e.g. ExternalSystemException) this exception will be wrapped to UndeclaredThrowableException. This happens because method method.invoke throw InvocationTargetException which is checked exception and such exception not a part of the corresponding proxied interface signature (e.g. RemoteExternalSystemProjectResolver.resolveProjectInfo method)