### PR TITLE
Optimize plugin version checking when update intellij platform version

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/plugins/InstalledPluginsState.java
+++ b/platform/platform-impl/src/com/intellij/ide/plugins/InstalledPluginsState.java
@@ -83,7 +83,7 @@ public class InstalledPluginsState {
     }
 
     boolean supersedes = PluginManagerCore.isCompatible(descriptor) &&
-                         PluginDownloader.compareVersionsSkipBrokenAndIncompatible(existing, descriptor.getVersion()) > 0;
+                         PluginDownloader.compareVersionsSkipBrokenAndIncompatible(existing, descriptor) > 0;
 
     String idString = id.getIdString();
 

--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateChecker.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateChecker.kt
@@ -339,7 +339,7 @@ object UpdateChecker {
 
     val pluginVersion = downloader.pluginVersion
     val installedPlugin = PluginManager.getPlugin(PluginId.getId(pluginId))
-    if (installedPlugin == null || pluginVersion == null || PluginDownloader.compareVersionsSkipBrokenAndIncompatible(installedPlugin, pluginVersion) > 0) {
+    if (installedPlugin == null || pluginVersion == null || PluginDownloader.compareVersionsSkipBrokenAndIncompatible(installedPlugin, downloader.descriptor) > 0) {
       var descriptor: IdeaPluginDescriptor?
 
       val oldDownloader = ourUpdatedPlugins[pluginId]

--- a/platform/platform-tests/testSrc/com/intellij/openapi/updateSettings/PluginDownloaderTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/updateSettings/PluginDownloaderTest.java
@@ -1,0 +1,39 @@
+package com.intellij.openapi.updateSettings;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginNode;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.updateSettings.impl.PluginDownloader;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PluginDownloaderTest {
+
+  @Test
+  public void testSamePluginVersionAndDiffPlatformVersion() {
+    assertEquals(1, PluginDownloader.compareVersionsSkipBrokenAndIncompatible(
+      pluginDescriptor("135.0"),
+      pluginDescriptor("139.3")));
+
+    assertEquals(1, PluginDownloader.compareVersionsSkipBrokenAndIncompatible(
+      pluginDescriptor(null),
+      pluginDescriptor("139.0")));
+
+    // don't care the case
+    assertEquals(0, PluginDownloader.compareVersionsSkipBrokenAndIncompatible(
+      pluginDescriptor("135.0"),
+      pluginDescriptor(null)));
+
+    assertEquals(0, PluginDownloader.compareVersionsSkipBrokenAndIncompatible(
+      pluginDescriptor("135.0"),
+      pluginDescriptor("133.2")));
+  }
+
+  static IdeaPluginDescriptor pluginDescriptor(String sinceBuild) {
+    PluginNode node = new PluginNode(PluginId.getId("plugin-simple"));
+    node.setVersion("0.4.2");
+    node.setSinceBuild(sinceBuild);
+    return node;
+  }
+}


### PR DESCRIPTION
Merge remote-tracking branch 'JetBrains/master', and update #228.

Checking plugin version by plugin version and since build

@alexeypegov @ignatov 