### PR TITLE
Respect conf.d of fish

### DIFF
--- a/plugins/terminal/resources/fish/config.fish
+++ b/plugins/terminal/resources/fish/config.fish
@@ -4,6 +4,12 @@ else
   set -e XDG_CONFIG_HOME
 end
 
+if test -d ~/.config/fish/conf.d
+  for f in ~/.config/fish/conf.d/*.fish
+    source $f
+  end
+end
+
 if test -d ~/.config/fish/functions
   for f in ~/.config/fish/functions/*.fish
     source $f


### PR DESCRIPTION
### Problem
I have been using [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) along with fish shell for a long while, and have fish separately worked well in IDEA's embedded terminal. However now I got a boring message after I upgraded my All Product Pack to 2018.2
```
fish: Unknown command 'git_is_repo'
~/.config/fish/functions/fish_prompt.fish (line 31): 
  if git_is_repo
     ^
in function “fish_prompt”
        called on standard input

in command substitution
        called on standard input
```

### Reason
IDEA now load all my functions from `~/fish/.config/fish/functions/`. but one of them, `fish_prompt.fish`, is based on `git_is_repo` which is provided by `oh-my-fish`.
No matter where `oh-my-fish` itself locates, it is bootstrapped by `~/fish/.config/fish/conf.d/omf.fish`, which should be loaded by IDEA.

From official [document](https://fishshell.com/docs/current/index.html#initialization) of fish, these files located in `~/fish/.config/fish/conf.d/` are called `Configuration snippets` and will be evaluated on startup of fish. Beside, it is noted that they are sourced before `~/.config/fish/config.fish`

### Solution
Source all snippets in `~/fish/.config/fish/conf.d/`

PS:
I used to point out this part but seemed to be ignored months ago.
https://github.com/JetBrains/intellij-community/pull/749#issuecomment-399869171