### PR TITLE
Add support for multiple type parameters

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/extractclass/ExtractClassProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/extractclass/ExtractClassProcessor.java
@@ -412,9 +412,13 @@ public class ExtractClassProcessor extends FixableUsagesRefactoringProcessor {
     final String fullyQualifiedName = getQualifiedName();
     fieldBuffer.append(fullyQualifiedName);
     if (!typeParams.isEmpty()) {
+      boolean isFirst = true;
       fieldBuffer.append('<');
       for (PsiTypeParameter typeParameter : typeParams) {
+        if(!isFirst)
+          fieldBuffer.append(", ");
         fieldBuffer.append(typeParameter.getName());
+        isFirst = false;
       }
       fieldBuffer.append('>');
     }
@@ -423,8 +427,12 @@ public class ExtractClassProcessor extends FixableUsagesRefactoringProcessor {
     fieldBuffer.append(" = new ").append(fullyQualifiedName);
     if (!typeParams.isEmpty()) {
       fieldBuffer.append('<');
+      boolean isFirst = true;
       for (PsiTypeParameter typeParameter : typeParams) {
+        if(!isFirst)
+          fieldBuffer.append(", ");
         fieldBuffer.append(typeParameter.getName());
+        isFirst = false;
       }
       fieldBuffer.append('>');
     }

--- a/java/java-tests/testData/refactoring/extractClass/typeParameters/after/Extracted.java
+++ b/java/java-tests/testData/refactoring/extractClass/typeParameters/after/Extracted.java
@@ -1,0 +1,8 @@
+public class Extracted<T, U> {
+    public Extracted() {
+    }
+
+    public T foo(U u) {
+        return null;
+    }
+}

--- a/java/java-tests/testData/refactoring/extractClass/typeParameters/after/Test.java
+++ b/java/java-tests/testData/refactoring/extractClass/typeParameters/after/Test.java
@@ -1,0 +1,12 @@
+class Test<T, U> {
+
+    private final Extracted<T, U> extracted = new Extracted<T, U>();
+
+    public T foo(U u) {
+        return extracted.foo(u);
+    }
+
+    public void goo(T t, U u){
+        t = extracted.foo(u)
+    }
+}

--- a/java/java-tests/testData/refactoring/extractClass/typeParameters/before/Test.java
+++ b/java/java-tests/testData/refactoring/extractClass/typeParameters/before/Test.java
@@ -1,0 +1,8 @@
+class Test<T, U> {
+
+    public T foo(U u) { return null; }
+
+    public void goo(T t, U u){
+        t = foo(u)
+    }
+}

--- a/java/java-tests/testSrc/com/intellij/java/refactoring/ExtractClassTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/refactoring/ExtractClassTest.java
@@ -137,6 +137,10 @@ public class ExtractClassTest extends MultiFileTestCase {
     doTestMethod();
   }
 
+  public void testTypeParameters() {
+    doTestMethod();
+  }
+
   public void testStaticImports() {
     doTestMethod("foo", null, "foo.Test");
   }


### PR DESCRIPTION
Until now, multiple type parameters (e.g T, U) were parsed as <TU> without commas. We added commas and test to check integrity.