### PR TITLE
Fix patching args in monkey patched subprocess module.

### DIFF
--- a/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
+++ b/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
@@ -76,12 +76,15 @@ def is_python(path):
 
 
 def remove_quotes_from_args(args):
-    new_args = []
-    for x in args:
-        if len(x) > 1 and x.startswith('"') and x.endswith('"'):
-            x = x[1:-1]
-        new_args.append(x)
-    return new_args
+    if sys.platform == "win32":
+        new_args = []
+        for x in args:
+            if len(x) > 1 and x.startswith('"') and x.endswith('"'):
+                x = x[1:-1]
+            new_args.append(x)
+        return new_args
+    else:
+        return args
 
 
 def quote_args(args):


### PR DESCRIPTION
Commit taken from: https://github.com/fabioz/PyDev.Debugger/commit/c0b2a445c4c40cc079a5a60c02cefcc207cb964c

Example script:
```
import subprocess
subprocess.Popen('"python" -c "import json, sys; print(json.dumps(sys.path));"', shell=True).wait()
```
Here is the error output from when you debug this script with PyCharm's debugger on Linux:
```
/bin/sh: -c: line 0: syntax error near unexpected token `json.dumps'
/bin/sh: -c: line 0: `python" -c "import json, sys; print(json.dumps(sys.path));'
```

`remove_quotes_from_args` changed:
```
'"python" -c "import json, sys; print(json.dumps(sys.path));"'
```
to:
```
'python" -c "import json, sys; print(json.dumps(sys.path));'
```

Output after applying changes from this commit:
```
["", "/tmp/PyDev.Debugger", ...]
```