### PR TITLE
Add a programmatic way to switch between views in the Build toolwindow.

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
@@ -27,14 +27,10 @@ class JetGradlePlugin implements Plugin<Gradle> {
     else {
       gradle.rootProject { project ->
         registries.add(((ProjectInternal)project).services.get(ToolingModelBuilderRegistry.class))
-        try {
-          if (isCompositeBuildsSupported) {
-            project.gradle.includedBuilds.each {
-              registries.add(it.configuredBuild.services.get(ToolingModelBuilderRegistry.class))
-            }
+        if (isCompositeBuildsSupported) {
+          project.gradle.includedBuilds.each {
+            registries.add(it.configuredBuild.services.get(ToolingModelBuilderRegistry.class))
           }
-        }
-        catch (ignore) {
         }
       }
     }


### PR DESCRIPTION
Extract functionality from SwitchViewAction and provide a public method (toggleView) to expose this.

This will be used by Android Studio in order to provide a actionable link to increase awareness of the full text output view. It will also guide people to problems when the graphical tree view only surfaces Gradle error messages such as "Compilation failed; see the compiler error output for details.".

Also I can't seem to find any tests that cover this area, any pointers to how to test this would be appreciated. Or if there is a better way to achieve the above effect with the current setup.

Thanks