### PR TITLE
IDEA-198933: Fix painting of splash screen progress bar

### DIFF
--- a/platform/core-impl/src/com/intellij/openapi/application/impl/ApplicationInfoImpl.java
+++ b/platform/core-impl/src/com/intellij/openapi/application/impl/ApplicationInfoImpl.java
@@ -362,9 +362,9 @@ public class ApplicationInfoImpl extends ApplicationInfoEx {
     if (myProgressTailIcon == null && myProgressTailIconName != null) {
       try {
         final URL url = getClass().getResource(myProgressTailIconName);
-        @SuppressWarnings({"deprecation", "UnnecessaryFullyQualifiedName"}) final Image image = com.intellij.util.ImageLoader.loadFromUrl(url, false);
+        @SuppressWarnings({"deprecation", "UnnecessaryFullyQualifiedName"}) final Image image = com.intellij.util.ImageLoader.loadFromUrl(url);
         if (image != null) {
-          myProgressTailIcon = new ImageIcon(image);
+          myProgressTailIcon = new JBImageIcon(image);
         }
       } catch (Exception ignore) {}
     }


### PR DESCRIPTION
* On Windows HiDPI mode (JRE managed) with a fractional scaling
  factor (e.g. 1.5), the progress tail shows as garbled pixels instead
  of a semi transparent icon.

* There were 2 HiDPI specific issue when loading the tail icon

  * The icon should allow fractional scaling, otherwise it is just scaled
    too much (scaling of 2.0 instead of 1.5 for a 1.5 monitor scaling)

  * The icon image should be wrapped into a JBImageIcon, so that paintIcon
    method ends up calling into a HiDPI aware paint method.