### PR TITLE
Catch ClassCastException on GroupByTypeComparator

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/projectView/impl/GroupByTypeComparator.java
+++ b/platform/lang-impl/src/com/intellij/ide/projectView/impl/GroupByTypeComparator.java
@@ -134,6 +134,12 @@ public class GroupByTypeComparator implements Comparator<NodeDescriptor> {
       return naturalCompare((String)key1, (String)key2);
     }
     //noinspection unchecked
-    return key1.compareTo(key2);
+    try {
+      //noinspection unchecked
+      return key1.compareTo(key2);
+    }
+    catch (ClassCastException ignored) {
+      return 0;
+    }
   }
 }


### PR DESCRIPTION
When comparing ProjectViewNodes using type, the comparator calls to
getTypeSortKey, this function returns an instance of Comparable, but the
only warranty is that we can compare elements of the same type. In most
of the cases the value is a String but there are a couple of places that
it is not, possibly causing ClassCastException when comparing an String
to a different type. This is the cause of
[https://issuetracker.google.com/issues/113159120](https://issuetracker.google.com/issues/113159120).

This change ignores ClassCastException when comparing keys while sorting
by type.