### PR TITLE
Fix bug in ScrollColorProducer.

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/components/ScrollColorProducer.java
+++ b/platform/platform-api/src/com/intellij/ui/components/ScrollColorProducer.java
@@ -54,7 +54,7 @@ final class ScrollColorProducer implements NotNullProducer<Color> {
     Container parent = myComponent.getParent();
     if (isBackground && parent instanceof JScrollPane && ScrollSettings.isBackgroundFromView()) {
       Color background = JBScrollPane.getViewBackground((JScrollPane)parent);
-      if (background != null) {
+      if (background != null && !(background instanceof JBColor)) {
         if (!background.equals(myOriginal)) {
           myModified = ColorUtil.shift(background, ColorUtil.isDark(background) ? 1.05 : 0.96);
           myOriginal = background;


### PR DESCRIPTION
The ScrollBarProducer has code to produce a color based on the
view that is hosting the scrollbar.
If the hosting view has not changed its background color
instance then the background color of the scrollbar will remain
the same.

This works fine unless the hosting view uses a JBColor for its
background, in which case the color never changes after a theme
change.

Bug: IDEA-197981
Change-Id: I6d9c3482ae9712cc3add6f3c9465a0edd2dc6cd5