### PR TITLE
IJSDK-474 Clarify definition of "IDEA jdk" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ Kotlin), [enable, upgrade, or install that plugin](https://www.jetbrains.com/hel
  [refresh the Gradle projects](https://www.jetbrains.com/help/idea/jetgradle-tool-window.html). 
 
 ### IntelliJ Build Configuration
-JDK version 1.8 is required for building and developing for IntelliJ IDEA Community
-Edition.
-1. Using IntelliJ IDEA, [configure](https://www.jetbrains.com/help/idea/sdk.html) a JSDK
-   named "**1.8**", pointing to `<JDK_18_HOME>`.
-   * If not already present, add `<JDK_18_HOME>/lib/tools.jar` [to the Classpath](https://www.jetbrains.com/help/idea/sdk.html#manage_sdks) tab for the **1.8** JSDK.
-2. Also configure a JSDK named "**IDEA jdk**" (case sensitive), pointing to `<JDK_16_HOME>`. If you don’t want to install JDK 1.6 then you may configure **IDEA jdk** to point to `<JDK_18_HOME>`. However, you must be careful to avoid using Java 8 APIs in IntelliJ IDEA Community Edition modules that use **IDEA jdk**. 
+JDK version 1.8 is required for building and developing for IntelliJ IDEA Community Edition.
+1. Using IntelliJ IDEA, [configure](https://www.jetbrains.com/help/idea/sdk.html) a JSDK named "**1.8**", pointing to `<JDK_18_HOME>`.
+   * If not already present, add `<JDK_18_HOME>/lib/tools.jar` [to the Classpath](https://www.jetbrains.com/help/idea/sdk.html#manage_sdks) tab for the **1.8** JSDK.  
+2. Configure a JSDK named "**IDEA jdk**" (case sensitive) pointing to `<JDK_18_HOME>`. This is the recommended configuration.  
+   _**Note:**_ This configuration can be used for modifying existing open source IntelliJ IDEA Community Edition modules, but allows accidentally   
+   using Java 1.8 APIs in modules that use JDK language levels lower than 1.8. Pointing **IDEA jdk** to `<JDK_16_HOME>` is an option that avoids this risk
+   when modifying IntelliJ IDEA Community Edition modules.
    * If not already present, add the corresponding path for tools.jar to the Classpath for "**IDEA jdk**" JSDK.
 3. If the _Maven Integration_ plugin is disabled, [add the path variable](https://www.jetbrains.com/help/idea/working-with-projects.html#path-variables) "**MAVEN_REPOSITORY**" pointing to `<USER_HOME>/.m2/repository` directory.
 4. _**Speed Tip:**_ If you have enough RAM on your computer, [configure the compiler settings](https://www.jetbrains.com/help/idea/specifying-compilation-settings.html) to enable the "Compile independent modules in parallel" option. Also set the "User-local build process VM options" to `-Xmx2G`. These changes will greatly reduce the compile time.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Kotlin), [enable, upgrade, or install that plugin](https://www.jetbrains.com/hel
 JDK version 1.8 is required for building and developing for IntelliJ IDEA Community Edition.
 1. Using IntelliJ IDEA, [configure](https://www.jetbrains.com/help/idea/sdk.html) a JSDK named "**1.8**", pointing to `<JDK_18_HOME>`.
    * If not already present, add `<JDK_18_HOME>/lib/tools.jar` [to the Classpath](https://www.jetbrains.com/help/idea/sdk.html#manage_sdks) tab for the **1.8** JSDK.  
-2. Configure a JSDK named "**IDEA jdk**" (case sensitive) pointing to `<JDK_18_HOME>`. This is the recommended configuration.  
-   _**Note:**_ This configuration can be used for modifying existing open source IntelliJ IDEA Community Edition modules, but allows accidentally   
-   using Java 1.8 APIs in modules that use JDK language levels lower than 1.8. Pointing **IDEA jdk** to `<JDK_16_HOME>` is an option that avoids this risk
-   when modifying IntelliJ IDEA Community Edition modules.
+2. Configure a JSDK named "**IDEA jdk**" (case sensitive) pointing to `<JDK_18_HOME>`. This is the recommended build configuration if you are developing 
+   new plugin projects using the IntelliJ Platform SDK.  
+   However, if you are configuring a build with the intention of modifying the IntelliJ IDEA codebase, then the recommended build configuration
+   is to point **IDEA jdk** to `<JDK_16_HOME>`. 
    * If not already present, add the corresponding path for tools.jar to the Classpath for "**IDEA jdk**" JSDK.
 3. If the _Maven Integration_ plugin is disabled, [add the path variable](https://www.jetbrains.com/help/idea/working-with-projects.html#path-variables) "**MAVEN_REPOSITORY**" pointing to `<USER_HOME>/.m2/repository` directory.
 4. _**Speed Tip:**_ If you have enough RAM on your computer, [configure the compiler settings](https://www.jetbrains.com/help/idea/specifying-compilation-settings.html) to enable the "Compile independent modules in parallel" option. Also set the "User-local build process VM options" to `-Xmx2G`. These changes will greatly reduce the compile time.


### PR DESCRIPTION
This change attempts to clarify whether users should define the IDEA jdk based on JDK 1.6 or 1.8.

I found explaining this definition to be tricky because there are three audiences: plugin developers, internal engineers, and contributors to the IntelliJ IDEA Community Edition open source project.  I tried to reach the plugin developer audience first, and clarify which JDK should be used based on how a build will be used. 

/cc @yole 