### PR TITLE
IDEA-199694 Preserve line breaks in XML when reformatting.

### DIFF
--- a/xml/impl/src/com/intellij/psi/formatter/xml/XmlBlock.java
+++ b/xml/impl/src/com/intellij/psi/formatter/xml/XmlBlock.java
@@ -270,6 +270,10 @@ public class XmlBlock extends AbstractXmlBlock {
       return createDefaultSpace(true, false);
     }
 
+    if (type1 == XmlElementType.XML_COMMENT) {
+      return createDefaultSpace(true, false);
+    }
+
     return createDefaultSpace(false, false);
   }
 


### PR DESCRIPTION
The line breaks of Xml comments at the end of an XML file were
not preserved when the file was reformatted.

Change-Id: If8ebc954f4cdc8f0f3e385e2474ff50466ce88ff