### PR TITLE
IDEA-199694 Preserve line breaks in XML when reformatting.

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/generation/CommentByLineCommentHandler.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/generation/CommentByLineCommentHandler.java
@@ -651,7 +651,6 @@ public class CommentByLineCommentHandler extends MultiCaretCodeInsightActionHand
       if (endOffset == offset && block.startLine != block.endLine) return true;
       final int textLength = document.getTextLength();
       final CharSequence chars = document.getCharsSequence();
-      offset = CharArrayUtil.shiftForward(chars, offset, " \t");
       if (endOffset == textLength) {
         final int shifted = CharArrayUtil.shiftBackward(chars, textLength - 1, " \t") + 1;
         if (shifted < textLength) endOffset = shifted;

--- a/xml/impl/src/com/intellij/psi/formatter/xml/XmlBlock.java
+++ b/xml/impl/src/com/intellij/psi/formatter/xml/XmlBlock.java
@@ -270,6 +270,10 @@ public class XmlBlock extends AbstractXmlBlock {
       return createDefaultSpace(true, false);
     }
 
+    if (type1 == XmlElementType.XML_COMMENT) {
+      return createDefaultSpace(true, false);
+    }
+
     return createDefaultSpace(false, false);
   }
 


### PR DESCRIPTION
The line breaks of Xml comments at the end of an XML file were not preserved when the file was reformatted.
    
