### PR TITLE
Detect extra syspath correctly

### DIFF
--- a/python/helpers/extra_syspath.py
+++ b/python/helpers/extra_syspath.py
@@ -5,10 +5,10 @@ path = qualified_name.split(".")
 try:
   module =  __import__(qualified_name, globals(), locals(), [path[-1]])
   try:
-    p = module.__path__
+    p = module.__path__[0]
     sys.stdout.write(os.sep.join(p.split(os.sep)[:-1]))
     sys.stdout.flush()
-  except AttributeError:
+  except (IndexError, AttributeError):
     pass
 except ImportError:
   pass


### PR DESCRIPTION
Code completion for GTK and other PyGObject based libraries is broken because the stub generation does not work. The reason for this is that the gi-repository directory which contains the typelibs is not detected by PyCharm due to a bug in the extra_syspath.py helper script. This script fails because it assumes that module.\_\_path__ is a string while it actually is a list. This causes the call of p.split() to fail and the script to terminate seemingly successfully (as AttributeErrors are caught and ignored) but without returning an extra syspath directory.

This commit fixes this problem by extracting the first element of the module.\_\_path__ list. After applying this fix stub generation finds the typelibs in the gi-repository and code completion for GTK is working again.

Fixes PY-29817: No code completion for GTK