### PR TITLE
added "EvaluateExpression" to TouchBar

### DIFF
--- a/platform/platform-resources/src/idea/LangActions.xml
+++ b/platform/platform-resources/src/idea/LangActions.xml
@@ -1169,6 +1169,8 @@
         <group id="TouchBarDebug_alt" text="Debugger with Alt key">
           <reference ref="ViewBreakpoints"/>
           <separator text="type.flexible"/>
+          <reference ref="EvaluateExpression"/>
+          <separator text="type.flexible"/>
           <group id="TouchBarDebug.ForceStepButtons" compact="true" text="Debugger ForceStep Actions">
             <reference ref="RunToCursor"/>
             <reference ref="ForceStepOver"/>


### PR DESCRIPTION
I really missed the "EvaluateExpression" on the touch bar, so I added it on my own. I think I found an acceptable position for this.