### PR TITLE
[platform] Support Python 2.6 in python launcher

### DIFF
--- a/platform/platform-resources/src/launcher.py
+++ b/platform/platform-resources/src/launcher.py
@@ -86,7 +86,7 @@ def try_activate_instance(args):
 
     if found:
         cmd = 'activate ' + token + '\0' + os.getcwd() + '\0' + '\0'.join(args)
-        if sys.version_info.major >= 3: cmd = cmd.encode('utf-8')
+        if sys.version_info[0] >= 3: cmd = cmd.encode('utf-8')
         encoded = struct.pack('>h', len(cmd)) + cmd
         s.send(encoded)
         time.sleep(0.5)  # don't close the socket immediately


### PR DESCRIPTION
sys.version_info does not return a named tuple until Python 2.7