### PR TITLE
Fixed an issue related to accessibility of changes tree

### DIFF
--- a/platform/util/src/com/intellij/util/ui/ThreeStateCheckBox.java
+++ b/platform/util/src/com/intellij/util/ui/ThreeStateCheckBox.java
@@ -185,7 +185,7 @@ public class ThreeStateCheckBox extends JCheckBox {
    * Emulate accessibility behavior of tri-state checkboxes, as tri-state checkboxes
    * are not part of the JAB specification.
    */
-  protected class AccessibleThreeStateCheckBox extends AccessibleJCheckBox {
+  public class AccessibleThreeStateCheckBox extends AccessibleJCheckBox {
     @Override
     public AccessibleRole getAccessibleRole() {
       if (myThirdStateEnabled) {

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ui/ChangesTree.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ui/ChangesTree.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 import javax.swing.*;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -597,12 +598,32 @@ public abstract class ChangesTree extends Tree implements DataProvider {
       return myTextRenderer.getToolTipText();
     }
 
+    @Override
     public AccessibleContext getAccessibleContext() {
       if(accessibleContext == null) {
-        myCheckBox.getAccessibleContext().setAccessibleName(myTextRenderer.getAccessibleContext().getAccessibleName());
-        return myCheckBox.getAccessibleContext();
+        return new AccessibleChangesTreeRenderer();
       }
       return accessibleContext;
+    }
+
+    // this is, in effect, a ThreeStateCheckboxRenderer, since another renderer is returned when the checkbox is not enabled
+    // Therefore, it has to behave like a checkbox, in almost every way
+    protected class AccessibleChangesTreeRenderer extends AccessibleJTree{
+
+      @Override
+      public String getAccessibleName() {
+        // AccessibleThreeStateCheckbox returns standard accessible name, plus checked, unchecked, partially checked information
+        // therefore, all we need to do is add the file name as the standard accessibleName, and let the AccessibleThreeStateCheckBox do the rest
+        myCheckBox.getAccessibleContext().setAccessibleName(myTextRenderer.getAccessibleContext().getAccessibleName());
+        return myCheckBox.getAccessibleContext().getAccessibleName();
+      }
+
+      @Override
+      public AccessibleRole getAccessibleRole() {
+        // Because of a problem with NVDA, we have to make this an AccessibleLabel
+        // if we don't do this, NVDA will read out the entire tree path, causing confusion
+        return AccessibleRole.LABEL;
+      }
     }
   }
 

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ui/ChangesTree.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ui/ChangesTree.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.accessibility.AccessibleContext;
 import javax.swing.*;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -594,6 +595,14 @@ public abstract class ChangesTree extends Tree implements DataProvider {
     @Override
     public String getToolTipText() {
       return myTextRenderer.getToolTipText();
+    }
+
+    public AccessibleContext getAccessibleContext() {
+      if(accessibleContext == null) {
+        myCheckBox.getAccessibleContext().setAccessibleName(myTextRenderer.getAccessibleContext().getAccessibleName());
+        return myCheckBox.getAccessibleContext();
+      }
+      return accessibleContext;
     }
   }
 


### PR DESCRIPTION
Changes tree that shows up when reverting issues and commiting was not accessible to screen readers. File names where not read out, and checked/unchecked states of the files (signaling inclusion of files) where not announced. Fix tested with NVDA and Jaws. NVDA announces a bit too much information for my taste, but that is probably due to settings. Related YouTrack issue: https://youtrack.jetbrains.com/issue/IDEA-201167*