### PR TITLE
[gradle] don't list too many projects in a dialog

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
@@ -434,6 +434,8 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
   }
 
   private class DataNodeCheckedTreeNode extends CheckedTreeNode {
+    private static final int MAX_DEPENDENCIES_TO_DESCRIBE = 5;
+
     private final DataNode myDataNode;
     @Nullable
     private final Icon icon;
@@ -579,23 +581,7 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
       }
 
       if (!deps.isEmpty() && !selectedModules.isEmpty()) {
-        final String listOfSelectedModules = StringUtil.join(selectedModules, node -> node.getData().getId(), ", ");
-
-        final String listOfDependencies = StringUtil.join(deps, node -> node.getData().getId(), "<br>");
-
-        final String message;
-        if (!checked) {
-          message = String.format(
-            "<html>The following module%s <br><b>%s</b><br>%s enabled and depend%s on selected modules. <br>Would you like to disable %s too?</html>",
-            deps.size() == 1 ? "" : "s", listOfDependencies, deps.size() == 1 ? "is" : "are", deps.size() == 1 ? "s" : "",
-            deps.size() == 1 ? "it" : "them");
-        }
-        else {
-          message = String.format(
-            "<html>The following module%s on which <b>%s</b> depend%s %s disabled:<br><b>%s</b><br>Would you like to enable %s?</html>",
-            deps.size() == 1 ? "" : "s", listOfSelectedModules, selectedModules.size() == 1 ? "s" : "", deps.size() == 1 ? "is" : "are",
-            listOfDependencies, deps.size() == 1 ? "it" : "them");
-        }
+        final String message = checked ? getEnableMessage(selectedModules, deps) : getDisableMessage(deps);
         if (Messages.showOkCancelDialog(message, checked ? "Enable Dependant Modules" : "Disable Modules with Dependency on this",
                                         Messages.getQuestionIcon()) == Messages.OK) {
           List<DataNodeCheckedTreeNode> nodes =
@@ -610,6 +596,32 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
           }
         }
       }
+    }
+
+    private String getEnableMessage(List<DataNode<Identifiable>> selectedModules, Set<DataNode<Identifiable>> deps) {
+      if (deps.size() > MAX_DEPENDENCIES_TO_DESCRIBE) {
+        return String.format("%d disabled modules depend on selected modules. Would you like to enable them too?", deps.size());
+      }
+
+      final String listOfSelectedModules = StringUtil.join(selectedModules, node -> node.getData().getId(), ", ");
+
+      final String listOfDependencies = StringUtil.join(deps, node -> node.getData().getId(), "<br>");
+      return String.format(
+        "<html>The following module%s on which <b>%s</b> depend%s %s disabled:<br><b>%s</b><br>Would you like to enable %s?</html>",
+        deps.size() == 1 ? "" : "s", listOfSelectedModules, selectedModules.size() == 1 ? "s" : "", deps.size() == 1 ? "is" : "are",
+        listOfDependencies, deps.size() == 1 ? "it" : "them");
+    }
+
+    private String getDisableMessage(Set<DataNode<Identifiable>> deps) {
+      if (deps.size() > MAX_DEPENDENCIES_TO_DESCRIBE) {
+        return String.format("%d enabled modules depend on selected modules. Would you like to disable them too?", deps.size());
+      }
+
+      final String listOfDependencies = StringUtil.join(deps, node -> node.getData().getId(), "<br>");
+      return String.format(
+        "<html>The following module%s <br><b>%s</b><br>%s enabled and depend%s on selected modules. <br>Would you like to disable %s too?</html>",
+        deps.size() == 1 ? "" : "s", listOfDependencies, deps.size() == 1 ? "is" : "are", deps.size() == 1 ? "s" : "",
+        deps.size() == 1 ? "it" : "them");
     }
   }
 


### PR DESCRIPTION
For a big project it just doesn't make sense to list more than 5 projects. The list will be just too big for a screen. Instead, let's just mention how many additional modules are affected.

to: @vladsoroka 