### PR TITLE
Fix StringSearcher.scan bug

### DIFF
--- a/platform/util/src/com/intellij/util/text/StringSearcher.java
+++ b/platform/util/src/com/intellij/util/text/StringSearcher.java
@@ -171,7 +171,7 @@ public class StringSearcher {
     }
     else {
       int start = 1;
-      int end = _end + 1;
+      int end = _end;
       while (start <= end - myPatternLength + 1) {
         int i = myPatternLength - 1;
         char lastChar = normalizedCharAt(text, textArray, end - (start + i));

--- a/platform/util/src/com/intellij/util/text/StringSearcher.java
+++ b/platform/util/src/com/intellij/util/text/StringSearcher.java
@@ -171,19 +171,18 @@ public class StringSearcher {
     }
     else {
       int start = 1;
-      int end = _end;
-      while (start <= end - myPatternLength + 1) {
+      while (start <= _end - myPatternLength + 1) {
         int i = myPatternLength - 1;
-        char lastChar = normalizedCharAt(text, textArray, end - (start + i));
+        char lastChar = normalizedCharAt(text, textArray, _end - (start + i));
 
         if (isSameChar(myPatternArray[myPatternLength - 1 - i], lastChar)) {
           i--;
           while (i >= 0) {
-            char c = textArray != null ? textArray[end - (start + i)] : text.charAt(end - (start + i));
+            char c = textArray != null ? textArray[_end - (start + i)] : text.charAt(_end - (start + i));
             if (!isSameChar(myPatternArray[myPatternLength - 1 - i], c)) break;
             i--;
           }
-          if (i < 0) return end - start - myPatternLength + 1;
+          if (i < 0) return _end - start - myPatternLength + 1;
         }
 
         int step = lastChar < 128 ? mySearchTable[lastChar] : 1;

--- a/platform/util/testSrc/com/intellij/util/text/StringSearcherTest.java
+++ b/platform/util/testSrc/com/intellij/util/text/StringSearcherTest.java
@@ -57,4 +57,14 @@ public class StringSearcherTest extends TestCase {
     assertEquals(secondPos, index);
     assertEquals(firstPos, searcher.scan(text, 0, index - 1));
   }
+
+  public void testSearchBackwardLastOne() {
+    final String pattern = "c";
+    final String text = "aabc";
+    final int pos = text.lastIndexOf(pattern);
+    final StringSearcher searcher = new StringSearcher(pattern, true, false);
+    final int index = searcher.scan(text);
+
+    assertEquals(pos, index);
+  }
 }


### PR DESCRIPTION
`new StringSearcher(pattern, any, false).scan(text)` starts scan from index `text.length() - myPatternLength + 1` in `text`.
So it throws StringIndexOutOfBoundsException if myPatternLength == 1.
