### PR TITLE
IDEA-201317: Add Cucumber4 Formatter

### DIFF
--- a/.idea/libraries/cucumber_core_4_0_1.xml
+++ b/.idea/libraries/cucumber_core_4_0_1.xml
@@ -1,0 +1,16 @@
+<component name="libraryTable">
+  <library name="cucumber-core:4.0.1" type="repository">
+    <properties maven-id="io.cucumber:cucumber-core:4.0.1" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/io/cucumber/cucumber-core/4.0.1/cucumber-core-4.0.1.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/io/cucumber/gherkin/5.1.0/gherkin-5.1.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/io/cucumber/cucumber-expressions/6.1.0/cucumber-expressions-6.1.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/io/cucumber/datatable/1.1.3/datatable-1.1.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/io/cucumber/datatable-dependencies/1.1.3/datatable-dependencies-1.1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -427,6 +427,7 @@
       <module fileurl="file://$PROJECT_DIR$/plugins/copyright/intellij.copyright.iml" filepath="$PROJECT_DIR$/plugins/copyright/intellij.copyright.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/cucumber-jvm-formatter/intellij.cucumber.jvmFormatter.iml" filepath="$PROJECT_DIR$/plugins/cucumber-jvm-formatter/intellij.cucumber.jvmFormatter.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/cucumber-jvm-formatter3/intellij.cucumber.jvmFormatter3.iml" filepath="$PROJECT_DIR$/plugins/cucumber-jvm-formatter3/intellij.cucumber.jvmFormatter3.iml" />
+	  <module fileurl="file://$PROJECT_DIR$/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml" filepath="$PROJECT_DIR$/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml" />
       <module fileurl="file://$PROJECT_DIR$/build/cucumber-test-runner/intellij.cucumber.testRunner.iml" filepath="$PROJECT_DIR$/build/cucumber-test-runner/intellij.cucumber.testRunner.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/devkit/devkit-core/intellij.devkit.iml" filepath="$PROJECT_DIR$/plugins/devkit/devkit-core/intellij.devkit.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/devkit/devkit-java-tests/intellij.devkit.java.tests.iml" filepath="$PROJECT_DIR$/plugins/devkit/devkit-java-tests/intellij.devkit.java.tests.iml" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -427,7 +427,7 @@
       <module fileurl="file://$PROJECT_DIR$/plugins/copyright/intellij.copyright.iml" filepath="$PROJECT_DIR$/plugins/copyright/intellij.copyright.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/cucumber-jvm-formatter/intellij.cucumber.jvmFormatter.iml" filepath="$PROJECT_DIR$/plugins/cucumber-jvm-formatter/intellij.cucumber.jvmFormatter.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/cucumber-jvm-formatter3/intellij.cucumber.jvmFormatter3.iml" filepath="$PROJECT_DIR$/plugins/cucumber-jvm-formatter3/intellij.cucumber.jvmFormatter3.iml" />
-	  <module fileurl="file://$PROJECT_DIR$/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml" filepath="$PROJECT_DIR$/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml" />
+      <module fileurl="file://$PROJECT_DIR$/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml" filepath="$PROJECT_DIR$/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml" />
       <module fileurl="file://$PROJECT_DIR$/build/cucumber-test-runner/intellij.cucumber.testRunner.iml" filepath="$PROJECT_DIR$/build/cucumber-test-runner/intellij.cucumber.testRunner.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/devkit/devkit-core/intellij.devkit.iml" filepath="$PROJECT_DIR$/plugins/devkit/devkit-core/intellij.devkit.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/devkit/devkit-java-tests/intellij.devkit.java.tests.iml" filepath="$PROJECT_DIR$/plugins/devkit/devkit-java-tests/intellij.devkit.java.tests.iml" />

--- a/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml
+++ b/plugins/cucumber-jvm-formatter4/intellij.cucumber.jvmFormatter4.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="jdk" jdkName="IDEA jdk" jdkType="JavaSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="cucumber-core:4.0.1" level="project" />
+    <orderEntry type="module" module-name="intellij.cucumber.jvmFormatter" />
+    <orderEntry type="module" module-name="intellij.cucumber.jvmFormatter3" />
+  </component>
+</module>

--- a/plugins/cucumber-jvm-formatter4/src/org/jetbrains/plugins/cucumber/java/run/CucumberJvm4SMFormatter.java
+++ b/plugins/cucumber-jvm-formatter4/src/org/jetbrains/plugins/cucumber/java/run/CucumberJvm4SMFormatter.java
@@ -1,0 +1,50 @@
+package org.jetbrains.plugins.cucumber.java.run;
+
+import cucumber.api.Plugin;
+import cucumber.api.event.*;
+
+@SuppressWarnings("unused")
+public class CucumberJvm4SMFormatter implements ConcurrentEventListener, Plugin {
+  private CucumberJvm3SMFormatter cucumberJvm3SMFormatter = new CucumberJvm3SMFormatter();
+
+  @Override
+  public void setEventPublisher(EventPublisher publisher) {
+    cucumberJvm3SMFormatter.setEventPublisher(publisher);
+  }
+
+  public String getEventUri(TestCaseStarted event) {
+    return cucumberJvm3SMFormatter.getEventUri(event);
+  }
+
+  public int getEventLine(TestCaseStarted event) {
+    return cucumberJvm3SMFormatter.getEventLine(event);
+  }
+
+  public String getEventName(TestCaseStarted event) {
+    return cucumberJvm3SMFormatter.getEventName(event);
+  }
+
+  public String getScenarioName(TestCaseStarted testCaseStarted) {
+    return cucumberJvm3SMFormatter.getScenarioName(testCaseStarted);
+  }
+
+  public String getScenarioName(TestCaseFinished testCaseFinished) {
+    return cucumberJvm3SMFormatter.getScenarioName(testCaseFinished);
+  }
+
+  public String getStepLocation(TestStepStarted testStepStarted) {
+    return cucumberJvm3SMFormatter.getStepLocation(testStepStarted);
+  }
+
+  public String getStepLocation(TestStepFinished testStepFinished) {
+    return cucumberJvm3SMFormatter.getStepLocation(testStepFinished);
+  }
+
+  public String getStepName(TestStepStarted testStepStarted) {
+    return cucumberJvm3SMFormatter.getStepName(testStepStarted);
+  }
+
+  public String getStepName(TestStepFinished testStepFinished) {
+    return cucumberJvm3SMFormatter.getStepName(testStepFinished);
+  }
+}

--- a/plugins/maven/intellij.maven.iml
+++ b/plugins/maven/intellij.maven.iml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/out" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -62,6 +64,53 @@
     <orderEntry type="module" module-name="intellij.maven.server.m3.common" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="assertJ" level="project" />
     <orderEntry type="module" module-name="intellij.maven.errorProne.compiler" scope="RUNTIME" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-embedder:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-core:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings-builder:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-repository-metadata:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-aether-provider:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-spi:1.13.1" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-impl:1.13.1" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-api:1.13.1" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-util:1.13.1" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-interpolation:1.14" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-plugin-api:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-model-builder:3.0.5" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.maven:maven-compat:3.0.5" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-utils:2.0.6" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-classworlds:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-inject-plexus:2.3.0" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-inject-bean:2.3.0" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-guice:no_aop:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-guava:0.9.9" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-component-annotations:1.5.5" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.plexus:plexus-sec-dispatcher:1.3" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.plexus:plexus-cipher:1.7" level="project" />
+    <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.nexus:nexus-indexer:3.0.4" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.nexus:nexus-indexer-artifact:1.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.plugin:plugin-host-api:1.0.3" level="project" />
+    <orderEntry type="library" name="Maven: javax.inject:javax.inject:1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-artifact:2.2.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-model:2.2.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-provider-api:1.0-beta-6" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.archetype:archetype-common:2.0-alpha-4" level="project" />
+    <orderEntry type="library" name="Maven: net.sourceforge.jchardet:jchardet:1.0" level="project" />
+    <orderEntry type="library" name="Maven: dom4j:dom4j:1.6.1" level="project" />
+    <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
+    <orderEntry type="library" name="Maven: jdom:jdom:1.0" level="project" />
+    <orderEntry type="library" name="Maven: commons-io:commons-io:1.3.1" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-velocity:1.1.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.velocity:velocity:1.5" level="project" />
+    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.1" level="project" />
+    <orderEntry type="library" name="Maven: oro:oro:2.0.8" level="project" />
+    <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.spice:spice-inject-plexus:1.3.4" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.spice:spice-inject-bean:1.3.4" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.spice.inject:guice-patches:noaop:2.1.6" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-core:2.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-highlighter:2.4.1" level="project" />
   </component>
   <component name="copyright">
     <Base>

--- a/plugins/maven/intellij.maven.iml
+++ b/plugins/maven/intellij.maven.iml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
-    <output url="file://$MODULE_DIR$/target/classes" />
-    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+<module relativePaths="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/out" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -64,53 +62,6 @@
     <orderEntry type="module" module-name="intellij.maven.server.m3.common" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="assertJ" level="project" />
     <orderEntry type="module" module-name="intellij.maven.errorProne.compiler" scope="RUNTIME" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-embedder:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-core:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings-builder:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-repository-metadata:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-aether-provider:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-spi:1.13.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-impl:1.13.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-api:1.13.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-util:1.13.1" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-interpolation:1.14" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-plugin-api:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-model-builder:3.0.5" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.maven:maven-compat:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-utils:2.0.6" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-classworlds:2.4" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-inject-plexus:2.3.0" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-inject-bean:2.3.0" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-guice:no_aop:3.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-guava:0.9.9" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-component-annotations:1.5.5" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.plexus:plexus-sec-dispatcher:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.plexus:plexus-cipher:1.7" level="project" />
-    <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.nexus:nexus-indexer:3.0.4" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.nexus:nexus-indexer-artifact:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.plugin:plugin-host-api:1.0.3" level="project" />
-    <orderEntry type="library" name="Maven: javax.inject:javax.inject:1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-artifact:2.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-model:2.2.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-provider-api:1.0-beta-6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.archetype:archetype-common:2.0-alpha-4" level="project" />
-    <orderEntry type="library" name="Maven: net.sourceforge.jchardet:jchardet:1.0" level="project" />
-    <orderEntry type="library" name="Maven: dom4j:dom4j:1.6.1" level="project" />
-    <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
-    <orderEntry type="library" name="Maven: jdom:jdom:1.0" level="project" />
-    <orderEntry type="library" name="Maven: commons-io:commons-io:1.3.1" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-velocity:1.1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.velocity:velocity:1.5" level="project" />
-    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.1" level="project" />
-    <orderEntry type="library" name="Maven: oro:oro:2.0.8" level="project" />
-    <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.spice:spice-inject-plexus:1.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.spice:spice-inject-bean:1.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.spice.inject:guice-patches:noaop:2.1.6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-core:2.4.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-highlighter:2.4.1" level="project" />
   </component>
   <component name="copyright">
     <Base>


### PR DESCRIPTION
### Background:
Add the ability to see tests executing in realtime as per current Cucumber3 Behaviour. Currently IntelliJ only displays test results at the end of the complete test run.

See details tracked here: https://youtrack.jetbrains.com/issue/IDEA-201317

### Summary:
Added a new Cucumber formatter module that implements the ```ConcurrentEventListener``` interface
* New formatter simply delegates to the existing Cucumber3 formatter.

**NB**. No attempt has been made to make this threadsafe as the current IDE plugin for cucumber does not pass the new --threads option and therefore cucumber defaults to a single thread. If this functionality is required then further changes will need to be made.

Also note the cucumber plugin will need to be updated to pass the new Formatter package name.



