### PR TITLE
Added test state to AccessibleName of test results entry

### DIFF
--- a/platform/platform-resources-en/src/messages/SMTestsRunnerBundle.properties
+++ b/platform/platform-resources-en/src/messages/SMTestsRunnerBundle.properties
@@ -18,6 +18,14 @@ sm.test.runner.ui.tests.tree.presentation.labels.no.tests.were.found.with.errors
 sm.test.runner.ui.tests.tree.presentation.labels.all.tests.passed=All Tests Passed
 sm.test.runner.ui.tests.tree.presentation.labels.all.but.ignored.passed=All Tests Passed (except ignored)
 sm.test.runner.ui.tests.tree.presentation.labels.test.noname=<no name>
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.passed=passed
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.ignored=ignored
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.failed=failed
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.terminated=terminated
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.tests.running=running
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.not.run=Not run
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.error=error
+sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.contains.ignored.tests=Contains ignored tests
 
 sm.test.runner.ui.tabs.statistics.columns.test.title=Test
 sm.test.runner.ui.tabs.statistics.columns.test.total.title=Total:

--- a/platform/smRunner/src/com/intellij/execution/testframework/sm/runner/ui/TestTreeRenderer.java
+++ b/platform/smRunner/src/com/intellij/execution/testframework/sm/runner/ui/TestTreeRenderer.java
@@ -11,6 +11,7 @@ import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
+import javax.accessibility.AccessibleContext;
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.awt.*;
@@ -25,6 +26,7 @@ public class TestTreeRenderer extends ColoredTreeCellRenderer {
   private SMRootTestProxyFormatter myAdditionalRootFormatter;
   private int myDurationWidth = -1;
   private int myRow;
+  private String myCurrentState;
 
   public TestTreeRenderer(final TestConsoleProperties consoleProperties) {
     myConsoleProperties = consoleProperties;
@@ -59,7 +61,7 @@ public class TestTreeRenderer extends ColoredTreeCellRenderer {
       } else {
         TestsPresentationUtil.formatTestProxy(testProxy, this);
       }
-
+TestsPresentationUtil.formatCurrentState(testProxy, this);
       if (TestConsoleProperties.SHOW_INLINE_STATISTICS.value(myConsoleProperties)) {
         String durationString = testProxy.getDurationString(myConsoleProperties);
         if (durationString != null) {
@@ -101,4 +103,23 @@ public class TestTreeRenderer extends ColoredTreeCellRenderer {
     myAdditionalRootFormatter = null;
   }
 
+  public void setCurrentStateString(String currentState) {
+    this.myCurrentState = currentState;
+  }
+
+  @Override
+  public AccessibleContext getAccessibleContext() {
+    if(accessibleContext == null) {
+      return new AccessibleTestTreeRenderer();
+    }
+    return accessibleContext;
+  }
+
+  protected class AccessibleTestTreeRenderer extends AccessibleColoredTreeCellRenderer {
+
+    @Override
+    public String getAccessibleName() {
+      return myCurrentState + ", " + super.getAccessibleName();
+    }
+  }
 }

--- a/platform/smRunner/src/com/intellij/execution/testframework/sm/runner/ui/TestsPresentationUtil.java
+++ b/platform/smRunner/src/com/intellij/execution/testframework/sm/runner/ui/TestsPresentationUtil.java
@@ -195,6 +195,33 @@ public class TestsPresentationUtil {
     renderer.append(testProxy.getPresentableName(), SimpleTextAttributes.REGULAR_ATTRIBUTES);
   }
 
+  public static void formatCurrentState(final SMTestProxy testProxy,
+                             final TestTreeRenderer renderer) {
+    TestStateInfo.Magnitude magnitude = testProxy.getMagnitudeInfo();
+    if (magnitude == TestStateInfo.Magnitude.RUNNING_INDEX) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message("sm.test.runner.ui.tests.tree.accessible.presentation.labels.tests.running"));
+    } else if (magnitude == TestStateInfo.Magnitude.NOT_RUN_INDEX) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message(
+        "sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.not.run"));
+    } else if (magnitude == TestStateInfo.Magnitude.TERMINATED_INDEX) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message(
+        "sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.terminated"));
+    } else if (magnitude == TestStateInfo.Magnitude.PASSED_INDEX) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message(
+        "sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.passed"));
+    } else if (magnitude == TestStateInfo.Magnitude.IGNORED_INDEX && testProxy.isFinal()) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message(
+        "sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.ignored"));
+    } else if( magnitude == TestStateInfo.Magnitude.FAILED_INDEX) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message("sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.failed"));
+    } else if(magnitude == TestStateInfo.Magnitude.ERROR_INDEX) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message("sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.error"));
+    } else if(magnitude == TestStateInfo.Magnitude.IGNORED_INDEX && !testProxy.isFinal()) {
+      renderer.setCurrentStateString(SMTestsRunnerBundle.message("sm.test.runner.ui.tests.tree.accessible.presentation.labels.test.contains.ignored.tests"));
+    }
+
+  }
+
   @NotNull
   public static String getPresentableName(final SMTestProxy testProxy) {
     final SMTestProxy parent = testProxy.getParent();

--- a/plugins/junit/src/com/intellij/execution/junit/JUnitRunDashboardContributor.java
+++ b/plugins/junit/src/com/intellij/execution/junit/JUnitRunDashboardContributor.java
@@ -59,6 +59,8 @@ public class JUnitRunDashboardContributor extends RunDashboardContributor {
         presentation.setIcon(renderer.getIcon());
       }
 
+      TestsPresentationUtil.formatCurrentState(rootNode, renderer);
+
       addTestSummary(presentation, rootNode);
     }
     finally {


### PR DESCRIPTION
This PR adds the state information, visually represented by icons, to the AccessibleName of the entries in the test results tree structure. It partly solves: https://youtrack.jetbrains.com/issue/IDEA-193979

It does not solve the problem of the "Hide successful tests" button not being found by tabbing through the tool window, but the most pressing problem - the test results not being immediately clear, is gone.