### PR TITLE
Suspend indexing while refreshing project structure

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
@@ -40,6 +40,7 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.progress.PerformInBackgroundOption;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Messages;
@@ -52,6 +53,7 @@ import com.intellij.ui.*;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBLoadingPanel;
 import com.intellij.ui.treeStructure.Tree;
+import com.intellij.util.BooleanValueHolder;
 import com.intellij.util.CachedValueImpl;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.MultiMap;
@@ -780,5 +782,15 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
     public boolean displayTextInToolbar() {
       return true;
     }
+  }
+
+  @Override
+  public boolean showAndGet() {
+    final BooleanValueHolder result = new BooleanValueHolder(false);
+    DumbService.getInstance(myProject).suspendIndexingAndRun(
+      "Select External Data",
+      () -> result.setValue(super.showAndGet())
+    );
+    return result.getValue();
   }
 }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
@@ -74,6 +74,7 @@ import com.intellij.openapi.progress.PerformInBackgroundOption;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.progress.util.AbstractProgressIndicatorExBase;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.*;
@@ -391,6 +392,13 @@ public class ExternalSystemUtil {
       @SuppressWarnings({"IOResourceOpenedButNotSafelyClosed"})
       @Override
       public void execute(@NotNull ProgressIndicator indicator) {
+        DumbService.getInstance(project).suspendIndexingAndRun(
+          "External Project Refresh",
+          () -> executeImpl(indicator)
+        );
+      }
+
+      private void executeImpl(@NotNull ProgressIndicator indicator) {
         if (project.isDisposed()) return;
 
         if (indicator instanceof ProgressIndicatorEx) {


### PR DESCRIPTION
In my testing it actually improved the initial importing time from roughly 14 minutes to just 3 and a half minutes.

Also included pausing indexing while choosing projects to import. It's very handy with `external.system.show.selective.import.dialog`  to avoid unnecessary indexing.