### PR TITLE
Don't suggest using streams if minSdkVersion < 24

### DIFF
--- a/java/typeMigration/src/com/intellij/refactoring/typeMigration/inspections/GuavaInspection.java
+++ b/java/typeMigration/src/com/intellij/refactoring/typeMigration/inspections/GuavaInspection.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.AtomicNotNullLazyValue;
+import com.intellij.pom.java.JavaFeature;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.GlobalSearchScopesCore;
@@ -56,7 +57,7 @@ public class GuavaInspection extends AbstractBaseJavaLocalInspectionTool {
   @NotNull
   @Override
   public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
-    if (!PsiUtil.isLanguageLevel8OrHigher(holder.getFile())) {
+    if (!JavaFeature.STREAMS.isFeatureSupported(holder.getFile())) {
       return PsiElementVisitor.EMPTY_VISITOR;
     }
     return new JavaElementVisitor() {


### PR DESCRIPTION
This CL makes the Guava inspection check the JavaFeature
support lookup instead of being hardcoded to Java 8.

This is the same logical change that was made in commit
f995b33d86b6673a111de944aba77bce88d8c775 to various
other inspections.

Bug: https://issuetracker.google.com/118596848