### PR TITLE
removed deprecated option --recompile-scripts

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
@@ -133,7 +133,6 @@ public class GradleExecutionHelper {
       if (!settings.getArguments().contains("--quiet") && !settings.getArguments().contains("--debug")) {
         settings.withArgument("--info");
       }
-      settings.withArgument("--recompile-scripts");
     }
 
     if (!settings.getArguments().isEmpty()) {


### PR DESCRIPTION
Gradle 5.0 has deprecated --recompile-scripts
see https://github.com/gradle/gradle/issues/1425

Gradle considers that it is useless to have such flags as caching
should always be correct.