### PR TITLE
Fixed assigning single elements to varargs in named form.

### DIFF
--- a/plugins/junit/src/com/intellij/execution/junit/JUnitRunConfigurationImporter.kt
+++ b/plugins/junit/src/com/intellij/execution/junit/JUnitRunConfigurationImporter.kt
@@ -46,7 +46,7 @@ class JUnitRunConfigurationImporter : RunConfigurationImporter {
         data.TEST_OBJECT = when (testKind) {
           "package" -> JUnitConfiguration.TEST_PACKAGE.also { data.PACKAGE_NAME = testKindValue }
           "directory" -> JUnitConfiguration.TEST_DIRECTORY.also { data.dirName = testKindValue }
-          "pattern" -> JUnitConfiguration.TEST_PATTERN.also { data.setPatterns(LinkedHashSet(testKindValue.split(delimiters = ','))) }
+          "pattern" -> JUnitConfiguration.TEST_PATTERN.also { data.setPatterns(LinkedHashSet(testKindValue.split(','))) }
           "class" -> JUnitConfiguration.TEST_CLASS.also { data.MAIN_CLASS_NAME = testKindValue }
           "method" -> JUnitConfiguration.TEST_METHOD.also {
             val className = testKindValue.substringBefore('#')

--- a/plugins/testng/src/com/theoryinpractice/testng/configuration/TestNGRunConfigurationImporter.kt
+++ b/plugins/testng/src/com/theoryinpractice/testng/configuration/TestNGRunConfigurationImporter.kt
@@ -40,7 +40,7 @@ class TestNGRunConfigurationImporter: RunConfigurationImporter {
           }
           "group" -> TestType.GROUP.type.also { data.GROUP_NAME = testKindValue }
           "suite" -> TestType.SUITE.type.also { data.SUITE_NAME = testKindValue }
-          "pattern" -> TestType.PATTERN.type.also { data.setPatterns(LinkedHashSet(testKindValue.split(delimiters = ','))) }
+          "pattern" -> TestType.PATTERN.type.also { data.setPatterns(LinkedHashSet(testKindValue.split(','))) }
           else -> data.TEST_OBJECT
         }
       }


### PR DESCRIPTION
Kotlin 1.3.0 reports such cases as errors.