### PR TITLE
Show modules in bold on Project View

### DIFF
--- a/plugins/gradle/java/src/projectView/GradleTreeStructureProvider.java
+++ b/plugins/gradle/java/src/projectView/GradleTreeStructureProvider.java
@@ -235,6 +235,7 @@ public class GradleTreeStructureProvider implements TreeStructureProvider, DumbA
   private static class GradleModuleDirectoryNode extends PsiDirectoryNode {
     private final String myModuleShortName;
     private final Module myModule;
+    private final boolean appendModuleName;
 
     GradleModuleDirectoryNode(Project project,
                               @NotNull PsiDirectory psiDirectory,
@@ -245,21 +246,20 @@ public class GradleTreeStructureProvider implements TreeStructureProvider, DumbA
       super(project, psiDirectory, settings, filter);
       myModuleShortName = moduleShortName;
       myModule = module;
+      VirtualFile directoryFile = psiDirectory.getVirtualFile();
+      appendModuleName = StringUtil.isNotEmpty(myModuleShortName) &&
+                         !StringUtil.equalsIgnoreCase(myModuleShortName.replace("-", ""), directoryFile.getName().replace("-", ""));
     }
 
     @Override
     protected boolean shouldShowModuleName() {
-      return false;
+      return !appendModuleName;
     }
 
     @Override
     protected void updateImpl(@NotNull PresentationData data) {
       super.updateImpl(data);
-      PsiDirectory psiDirectory = getValue();
-      assert psiDirectory != null;
-      VirtualFile directoryFile = psiDirectory.getVirtualFile();
-      if (StringUtil.isNotEmpty(myModuleShortName) &&
-          !StringUtil.equalsIgnoreCase(myModuleShortName.replace("-", ""), directoryFile.getName().replace("-", ""))) {
+      if (appendModuleName) {
         data.addText("[" + myModuleShortName + "]", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
       }
     }


### PR DESCRIPTION
When a GradleModuleDirectoryNode is shown the name of the module is
appended in boldeface, unless it is the same as the path, but since
shouldShowModuleName is overloaded to return false, this causes that the
module's directory is not shown in bold face.

This change causes the name of the module to appear in bold face when
the module name is not appended. This fixes this bug:

https://issuetracker.google.com/issues/77235561