### PR TITLE
Array can be replaced with enum values inspection added

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/InspectionGadgetsBundle.properties
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/InspectionGadgetsBundle.properties
@@ -2155,6 +2155,10 @@ junit5.converter.fix.name=Migrate to JUnit 5
 call.to.suspicious.string.method.display.name=Call to suspicious String method
 call.to.suspicious.string.method.problem.descriptor=<code>String.#ref()</code> called in internationalized context #loc
 
+array.can.be.replaced.with.enum.values = Array can be replaced with enum values
+array.can.be.replaced.with.enum.values.quickfix = Replace array with {0}.values()
+array.can.be.replaced.with.enum.values.family.quickfix = Replace array with EnumType.values()
+
 string.concatenation.replace.fix=Replace with StringBuilder
 string.concatenation.replace.fix.name=Convert variable ''{0}'' from String to {1}
 string.concatenation.introduce.fix=Introduce StringBuilder

--- a/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
+++ b/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
@@ -2536,6 +2536,10 @@
                      key="inspection.simplifiable.if.statement.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION"
                      implementationClass="com.siyeh.ig.style.SimplifiableIfStatementInspection"/>
+    <localInspection groupPath="Java" language="JAVA" shortName="ArrayCanBeReplacedWithEnumValues" bundle="com.siyeh.InspectionGadgetsBundle"
+                     key="array.can.be.replaced.with.enum.values" groupBundle="messages.InspectionsBundle"
+                     groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION"
+                     implementationClass="com.siyeh.ig.style.ArrayCanBeReplacedWithEnumValuesInspection"/>
 
     <!--group.names.threading.issues-->
     <localInspection groupPath="Java" language="JAVA" suppressId="AccessToNonThreadSafeStaticField" shortName="AccessToNonThreadSafeStaticFieldFromInstance"

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
@@ -1,0 +1,141 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.siyeh.ig.style;
+
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.*;
+import com.intellij.psi.impl.source.tree.java.PsiReferenceExpressionImpl;
+import com.intellij.psi.util.PsiUtil;
+import com.siyeh.InspectionGadgetsBundle;
+import com.siyeh.ig.BaseInspection;
+import com.siyeh.ig.BaseInspectionVisitor;
+import com.siyeh.ig.InspectionGadgetsFix;
+import com.siyeh.ig.PsiReplacementUtil;
+import one.util.streamex.StreamEx;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * @author okli
+ */
+public class ArrayCanBeReplacedWithEnumValuesInspection extends BaseInspection {
+  @Nls
+  @NotNull
+  @Override
+  public String getDisplayName() {
+    return InspectionGadgetsBundle.message("array.can.be.replaced.with.enum.values");
+  }
+
+  @NotNull
+  @Override
+  protected String buildErrorString(Object... infos) {
+    return getDisplayName();
+  }
+
+  @Override
+  public BaseInspectionVisitor buildVisitor() {
+    return new ArrayCreationExpressionVisitor();
+  }
+
+  @Nullable
+  @Override
+  protected InspectionGadgetsFix buildFix(Object... infos) {
+    if (infos.length == 1 && infos[0] instanceof String) {
+      return new ArrayCreationExpressionVisitor.ArrayToEnumValueFix((String)infos[0]);
+    }
+    return null;
+  }
+
+  private static class ArrayCreationExpressionVisitor extends BaseInspectionVisitor {
+    @Override
+    public void visitArrayInitializerExpression(PsiArrayInitializerExpression expression) {
+      super.visitArrayInitializerExpression(expression);
+
+      final PsiType type = expression.getType();
+      if (!(type instanceof PsiArrayType)) {
+        return;
+      }
+
+      final PsiType initType = expression.getType().getDeepComponentType();
+      final PsiClass initClass = PsiUtil.resolveClassInClassTypeOnly(initType);
+
+      if (initClass == null || !initClass.isEnum()) {
+        return;
+      }
+
+      List<String> enumValues = StreamEx.of(initClass.getAllFields())
+        .select(PsiEnumConstant.class)
+        .map(PsiEnumConstant::getName)
+        .toCollection(LinkedList::new);
+
+      if (enumValues == null) {
+        return;
+      }
+
+
+      final PsiExpression[] initializers = expression.getInitializers();
+
+      int nValues = enumValues.size();
+      if (nValues != initializers.length) {
+        return;
+      }
+
+      int i = 0;
+      for (String value : enumValues) {
+        String referenceName = ((PsiReferenceExpressionImpl)initializers[i]).getReferenceName();
+        if (referenceName !=null && referenceName.equals(value)) {
+          i++;
+        }
+        else {
+          return;
+        }
+      }
+
+      final PsiElement parent = expression.getParent();
+      if (i == nValues) {
+        final String typeText = ((PsiArrayType)type).getComponentType().getPresentableText();
+        registerError(parent, typeText);
+      }
+    }
+
+    private static class ArrayToEnumValueFix extends InspectionGadgetsFix {
+      private final String myType;
+
+      private ArrayToEnumValueFix(String enumType) {
+        this.myType = enumType;
+      }
+
+      @Nls
+      @NotNull
+      @Override
+      public String getName() {
+        return InspectionGadgetsBundle.message("array.can.be.replaced.with.enum.values.quickfix", myType);
+      }
+
+      @Nls(capitalization = Nls.Capitalization.Sentence)
+      @NotNull
+      @Override
+      public String getFamilyName() {
+        return InspectionGadgetsBundle.message("array.can.be.replaced.with.enum.values.family.quickfix");
+      }
+
+
+      @Override
+      protected void doFix(Project project, ProblemDescriptor descriptor) {
+        final PsiElement element = descriptor.getPsiElement();
+        if (element instanceof PsiNewExpression) {
+          final PsiNewExpression newExpression = (PsiNewExpression)element;
+          final PsiType type = newExpression.getType();
+          if (type != null) {
+            final String enumType = ((PsiArrayType)type).getComponentType().getPresentableText();
+            PsiReplacementUtil.replaceExpression(newExpression, enumType + ".values()");
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
@@ -4,7 +4,6 @@ package com.siyeh.ig.style;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
-import com.intellij.psi.impl.source.tree.java.PsiNewExpressionImpl;
 import com.intellij.psi.util.PsiUtil;
 import com.siyeh.InspectionGadgetsBundle;
 import com.siyeh.ig.BaseInspection;
@@ -81,17 +80,6 @@ public class ArrayCanBeReplacedWithEnumValuesInspection extends BaseInspection {
 
       for (int i = 0; i < initL; i++) {
           String value = enumValues.get(i);
-          //if (initializers[i] instanceof PsiMethodCallExpression && initL == 1) {
-          //  PsiMethodCallExpression methodExpr = (PsiMethodCallExpression)initializers[i];
-          //  PsiMethod methodR = methodExpr.resolveMethod();
-          //  if (methodR != null) {
-          //    PsiType returnV = methodR.getReturnType();
-          //    if (!initExprType.equals(returnV)) {
-          //      return;
-          //    }
-          //  }
-          //}
-          //else
             if (!(initializers[i] instanceof PsiReferenceExpression && initExprType.equals(initializers[i].getType()) && value.equals(((PsiReferenceExpression)initializers[i]).getReferenceName()))) {
             return;
         }
@@ -133,7 +121,7 @@ public class ArrayCanBeReplacedWithEnumValuesInspection extends BaseInspection {
           return;
         }
         final PsiElement element = descriptor.getPsiElement();
-        if (element instanceof PsiNewExpressionImpl || element instanceof PsiArrayInitializerExpression) {
+        if (element instanceof PsiNewExpression || element instanceof PsiArrayInitializerExpression) {
           final PsiExpression expression = (PsiExpression)element;
           PsiReplacementUtil.replaceExpression(expression, enumName + ".values()");
         }

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
@@ -66,6 +66,18 @@ public class ArrayCanBeReplacedWithEnumValuesInspection extends BaseInspection {
         return;
       }
 
+      final PsiExpression[] initializers = expression.getInitializers();
+      if (initializers.length < 2) {return;}
+
+      for (PsiExpression initV : initializers) {
+        if (initV instanceof PsiArrayInitializerExpression) {
+          return;
+        }
+        if (!(Objects.requireNonNull(initV.getType()).equals(initType))) {
+          return;
+        }
+      }
+
       List<String> enumValues = StreamEx.of(initClass.getAllFields())
         .select(PsiEnumConstant.class)
         .map(PsiEnumConstant::getName)
@@ -75,9 +87,6 @@ public class ArrayCanBeReplacedWithEnumValuesInspection extends BaseInspection {
         return;
       }
 
-
-      final PsiExpression[] initializers = expression.getInitializers();
-
       int nValues = enumValues.size();
       if (nValues != initializers.length) {
         return;
@@ -86,7 +95,7 @@ public class ArrayCanBeReplacedWithEnumValuesInspection extends BaseInspection {
       int i = 0;
       for (String value : enumValues) {
         String referenceName = ((PsiReferenceExpressionImpl)initializers[i]).getReferenceName();
-        if (referenceName !=null && referenceName.equals(value)) {
+        if (referenceName != null && referenceName.equals(value)) {
           i++;
         }
         else {

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCanBeReplacedWithEnumValuesInspection.java
@@ -65,8 +65,11 @@ public class ArrayCanBeReplacedWithEnumValuesInspection extends BaseInspection {
       }
 
       final PsiExpression[] initializers = expression.getInitializers();
-      int initL = initializers.length;
+      if (initializers[0] instanceof PsiMethodCallExpression) {
+        return;
+      }
 
+      int initL = initializers.length;
       List<String> enumValues = Stream.of(initClass.getFields())
         .filter(ev -> ev instanceof PsiEnumConstant)
         .map(ev -> (PsiEnumConstant) ev)

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ArrayCanBeReplacedWithEnumValues.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ArrayCanBeReplacedWithEnumValues.html
@@ -1,0 +1,6 @@
+<!-- Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<html>
+<body>
+Array can be replaced with enum values suggests to replace the creation of array with <code>EnumType.values()</code>.
+</body>
+</html>

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ClassWithEnum.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ClassWithEnum.after.java
@@ -1,0 +1,12 @@
+class ClassWithEnum {
+
+  public static void foo() {
+    testMethod(TestEnum.values());
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE, TWO, THREE
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ClassWithEnum.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ClassWithEnum.java
@@ -1,0 +1,12 @@
+class ClassWithEnum {
+
+  public static void foo() {
+    testMethod(new TestEnum[]<caret>{TestEnum.ONE, TestEnum.TWO, TestEnum.THREE});
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE, TWO, THREE
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ClassWithEnum.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ClassWithEnum.java
@@ -1,7 +1,7 @@
 class ClassWithEnum {
 
   public static void foo() {
-    testMethod(new TestEnum[]<caret>{TestEnum.ONE, TestEnum.TWO, TestEnum.THREE});
+    testMethod(new TestEnum[]{TestEnum.ONE<caret>, TestEnum.TWO, TestEnum.THREE});
   }
 
   private static void testMethod(TestEnum[] values) { }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumRevOrder.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumRevOrder.java
@@ -1,0 +1,12 @@
+class EnumRevOrder {
+
+  public static void foo() {
+    testMethod(new TestEnum[]<caret>{TestEnum.THREE, TestEnum.TWO, TestEnum.ONE});
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE, TWO, THREE;
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumRevOrder.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumRevOrder.java
@@ -1,7 +1,7 @@
 class EnumRevOrder {
 
   public static void foo() {
-    testMethod(new TestEnum[]<caret>{TestEnum.THREE, TestEnum.TWO, TestEnum.ONE});
+    testMethod(new TestEnum[]{TestEnum.THR<caret>EE, TestEnum.TWO, TestEnum.ONE});
   }
 
   private static void testMethod(TestEnum[] values) { }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumWithField.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumWithField.after.java
@@ -1,0 +1,18 @@
+class EnumWithField {
+
+  public static void foo() {
+    testMethod(TestEnum.values());
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE(1), TWO(2), THREE(3);
+
+    private final int levelCode;
+
+    TestEnum(int levelCode) {
+      this.levelCode = levelCode;
+    }
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumWithField.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/EnumWithField.java
@@ -1,0 +1,18 @@
+class EnumWithField {
+
+  public static void foo() {
+    testMethod(new TestEnum[]{TestE<caret>num.ONE, TestEnum.TWO, TestEnum.THREE});
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE(1), TWO(2), THREE(3);
+
+    private final int levelCode;
+
+    TestEnum(int levelCode) {
+      this.levelCode = levelCode;
+    }
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ErrorInMultiDArray.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/ErrorInMultiDArray.java
@@ -1,0 +1,11 @@
+class ErrorInMultiDArray {
+
+  public static void foo() {
+    testMethod(new TestEnum[]{{TestE<caret>num.ONE, TestEnum.TWO, TestEnum.THREE}});
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE, TWO, THREE;
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/FooInit.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/FooInit.after.java
@@ -1,0 +1,10 @@
+class Foo {
+  enum En {A;}
+  static En foo() {
+    return En.A;
+  }
+
+  {
+    En[] array = En.values();
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/FooInit.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/FooInit.java
@@ -1,0 +1,10 @@
+class Foo {
+  enum En {A;}
+  static En foo() {
+    return En.A;
+  }
+
+  {
+    En[] array = new En[] {fo<caret>o()};
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/InnerEnum.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/InnerEnum.after.java
@@ -1,0 +1,15 @@
+class InnerEnum {
+
+  public static void foo() {
+    testMethod(TestEnum.Inner.values());
+  }
+
+  private static void testMethod(TestEnum.Inner[] values) {
+  }
+
+  public enum TestEnum {
+    ONE, TWO, THREE;
+
+    enum Inner {FIVE, SIX, SEVEN}
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/InnerEnum.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/InnerEnum.after.java
@@ -1,7 +1,7 @@
 class InnerEnum {
 
   public static void foo() {
-    testMethod(TestEnum.Inner.values());
+    testMethod(Inner.values());
   }
 
   private static void testMethod(TestEnum.Inner[] values) {

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/InnerEnum.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/InnerEnum.java
@@ -1,0 +1,15 @@
+class InnerEnum {
+
+  public static void foo() {
+    testMethod(new TestEnum.Inner[]{TestEnum.Inn<caret>er.FIVE, TestEnum.Inner.SIX, TestEnum.Inner.SEVEN});
+  }
+
+  private static void testMethod(TestEnum.Inner[] values) {
+  }
+
+  public enum TestEnum {
+    ONE, TWO, THREE;
+
+    enum Inner {FIVE, SIX, SEVEN}
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/MultiDArrayNoError.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/MultiDArrayNoError.java
@@ -1,0 +1,14 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+class MultiDArrayNoError {
+
+  public static void foo() {
+    testMethod(new TestEnum[][]{{Test<caret>Enum.ONE, TestEnum.THREE, TestEnum.TWO}});
+  }
+
+  private static void testMethod(TestEnum[][] values) {
+  }
+
+  public enum TestEnum {
+    ONE, TWO, THREE;
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumInit.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumInit.java
@@ -1,0 +1,12 @@
+class NotEnumInit {
+
+  public static void foo() {
+    testMethod(new TestEnum[]<caret>{"", TestEnum.ONE});
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE, TWO, THREE
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumInit.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumInit.java
@@ -1,7 +1,7 @@
 class NotEnumInit {
 
   public static void foo() {
-    testMethod(new TestEnum[]<caret>{"", "", TestEnum.ONE});
+    testMethod(new TestEnum[]{"", "", TestEnum.O<caret>NE});
   }
 
   private static void testMethod(TestEnum[] values) { }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumInit.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumInit.java
@@ -1,7 +1,7 @@
 class NotEnumInit {
 
   public static void foo() {
-    testMethod(new TestEnum[]<caret>{"", TestEnum.ONE});
+    testMethod(new TestEnum[]<caret>{"", "", TestEnum.ONE});
   }
 
   private static void testMethod(TestEnum[] values) { }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumMulti.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumMulti.java
@@ -1,0 +1,12 @@
+class NotEnumMulti {
+
+  public static void foo() {
+    testMethod(new TestEnum[][]<caret>{{TestEnum.ONE}});
+  }
+
+  private static void testMethod(TestEnum[] values) { }
+
+  public enum TestEnum {
+    ONE, TWO, THREE
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumMulti.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumMulti.java
@@ -1,7 +1,7 @@
 class NotEnumMulti {
 
   public static void foo() {
-    testMethod(new TestEnum[][]<caret>{{TestEnum.ONE}});
+    testMethod(new TestEnum[][]<caret>{{TestEnum.ONE,"",""}});
   }
 
   private static void testMethod(TestEnum[] values) { }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumMulti.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/NotEnumMulti.java
@@ -1,7 +1,7 @@
 class NotEnumMulti {
 
   public static void foo() {
-    testMethod(new TestEnum[][]<caret>{{TestEnum.ONE,"",""}});
+    testMethod(new TestEnum[][]{{TestEnum.ON<caret>E,"",""}});
   }
 
   private static void testMethod(TestEnum[] values) { }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.after.java
@@ -1,8 +1,7 @@
-import outer.OuterEnum;
 class OuterEnumUse {
 
     public static void foo() {
-        testMethod(OuterEnum.TestEnum.values());
+        testMethod(TestEnum.values());
     }
     private static void testMethod(OuterEnum.TestEnum[] values) {
     }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.after.java
@@ -1,0 +1,9 @@
+import outer.OuterEnum;
+class OuterEnumUse {
+
+    public static void foo() {
+        testMethod(OuterEnum.TestEnum.values());
+    }
+    private static void testMethod(OuterEnum.TestEnum[] values) {
+    }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.java
@@ -1,8 +1,7 @@
-import outer.OuterEnum;
 class OuterEnumUse {
 
     public static void foo() {
-        testMethod(new OuterEnum.TestEnum[]{OuterEnum.TestEnum.A, OuterEnum.TestEnum.B, OuterEnum.TestEnum.C});
+        testMethod(new OuterEnum.TestEnum[]{OuterEnum.TestEnum.<caret>A, OuterEnum.TestEnum.B, OuterEnum.TestEnum.C});
     }
     private static void testMethod(OuterEnum.TestEnum[] values) {
     }

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/array_replaced_enum_values/OuterEnumUse.java
@@ -1,0 +1,9 @@
+import outer.OuterEnum;
+class OuterEnumUse {
+
+    public static void foo() {
+        testMethod(new OuterEnum.TestEnum[]{OuterEnum.TestEnum.A, OuterEnum.TestEnum.B, OuterEnum.TestEnum.C});
+    }
+    private static void testMethod(OuterEnum.TestEnum[] values) {
+    }
+}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
@@ -1,0 +1,34 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.siyeh.ig.fixes.style;
+
+import com.siyeh.InspectionGadgetsBundle;
+import com.siyeh.ig.IGQuickFixesTestCase;
+import com.siyeh.ig.style.ArrayCanBeReplacedWithEnumValuesInspection;
+
+
+public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCase {
+
+  public void testClassWithEnum() { doTest("TestEnum"); }
+  public void testNotEnumInit() { assertQuickfixNotAvailable(); }
+  public void testNotEnumMulti() { assertQuickfixNotAvailable(); }
+
+
+  @Override
+  protected void doTest(String hint) {
+    super.doTest(InspectionGadgetsBundle.message("array.can.be.replaced.with.enum.values.quickfix", hint));
+  }
+
+  @Override
+  protected void assertQuickfixNotAvailable() {
+    String message = InspectionGadgetsBundle.message("array.can.be.replaced.with.enum.values.quickfix", "@");
+    super.assertQuickfixNotAvailable(message.substring(0, message.indexOf('@')));
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    myFixture.enableInspections(new ArrayCanBeReplacedWithEnumValuesInspection());
+    myRelativePath = "style/array_replaced_enum_values";
+  }
+}
+

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
@@ -9,8 +9,14 @@ import com.siyeh.ig.style.ArrayCanBeReplacedWithEnumValuesInspection;
 public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCase {
 
   public void testClassWithEnum() { doTest("TestEnum"); }
+
+  public void testEnumWithField() {doTest("TestEnum");}
+
   public void testNotEnumInit() { assertQuickfixNotAvailable(); }
+
   public void testNotEnumMulti() { assertQuickfixNotAvailable(); }
+
+  public void testEnumRevOrder() { assertQuickfixNotAvailable();}
 
 
   @Override

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
@@ -22,11 +22,11 @@ public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCas
 
   public void testMultiDArrayNoError() {assertQuickfixNotAvailable();}
 
-  public void testInnerEnum() {doTest("TestEnum.Inner");}
+  public void testInnerEnum() {doTest("Inner");}
 
-  public void testFooInit() {doTest("En");}
+  //public void testFooInit() {doTest("En");}
 
-  //public void testOuterEnumUse() {doTest("OuterEnum.TestEnum");}
+  public void testOuterEnumUse() {doTest("TestEnum");}
 
 
 
@@ -52,7 +52,6 @@ public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCas
   @Override
   protected String[] getEnvironmentClasses() {
     return new String[] {
-      "package outer;\n" +
       "public class OuterEnum {\n" +
       "    public enum TestEnum {\n" +
       "        A, B, C\n" +

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
@@ -22,6 +22,8 @@ public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCas
 
   public void testMultiDArrayNoError() {assertQuickfixNotAvailable();}
 
+  public void testInnerEnum() {doTest("TestEnum.Inner");}
+
 
 
   @Override

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
@@ -24,6 +24,10 @@ public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCas
 
   public void testInnerEnum() {doTest("TestEnum.Inner");}
 
+  public void testFooInit() {doTest("En");}
+
+  //public void testOuterEnumUse() {doTest("OuterEnum.TestEnum");}
+
 
 
   @Override
@@ -42,6 +46,19 @@ public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCas
     super.setUp();
     myFixture.enableInspections(new ArrayCanBeReplacedWithEnumValuesInspection());
     myRelativePath = "style/array_replaced_enum_values";
+  }
+
+
+  @Override
+  protected String[] getEnvironmentClasses() {
+    return new String[] {
+      "package outer;\n" +
+      "public class OuterEnum {\n" +
+      "    public enum TestEnum {\n" +
+      "        A, B, C\n" +
+      "    }\n" +
+      "}"
+    };
   }
 }
 

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/ArrayCanBeReplacedWithEnumValuesFixTest.java
@@ -18,6 +18,11 @@ public class ArrayCanBeReplacedWithEnumValuesFixTest extends IGQuickFixesTestCas
 
   public void testEnumRevOrder() { assertQuickfixNotAvailable();}
 
+  public void testErrorInMultiDArray() { assertQuickfixNotAvailable();}
+
+  public void testMultiDArrayNoError() {assertQuickfixNotAvailable();}
+
+
 
   @Override
   protected void doTest(String hint) {


### PR DESCRIPTION
_Array can be replaced with enum values_ inspection suggests to replace the creation of array with EnumType.values()