### PR TITLE
In the RegExp form, check for HIT_END

### DIFF
--- a/RegExpSupport/src/org/intellij/lang/regexp/RegExpMatchResult.java
+++ b/RegExpSupport/src/org/intellij/lang/regexp/RegExpMatchResult.java
@@ -19,5 +19,5 @@ package org.intellij.lang.regexp;
  * @author Bas Leijdekkers
  */
 public enum RegExpMatchResult {
-  MATCHES, NO_MATCH, TIMEOUT, BAD_REGEXP
+  MATCHES, NO_MATCH, TIMEOUT, BAD_REGEXP, HIT_END
 }

--- a/RegExpSupport/src/org/intellij/lang/regexp/intention/CheckRegExpForm.java
+++ b/RegExpSupport/src/org/intellij/lang/regexp/intention/CheckRegExpForm.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -191,6 +192,9 @@ public class CheckRegExpForm {
       case BAD_REGEXP:
         myMessage.setText("Bad pattern");
         break;
+      case HIT_END:
+        myMessage.setText("Go on typing \u2026");
+        break;
     }
     myRootPanel.revalidate();
     Balloon balloon = JBPopupFactory.getInstance().getParentBalloonFor(myRootPanel);
@@ -243,8 +247,11 @@ public class CheckRegExpForm {
 
     try {
       //noinspection MagicConstant
-      return Pattern.compile(regExp, patternFlags).matcher(StringUtil.newBombedCharSequence(sampleText, 1000)).matches()
+      Matcher matcher = Pattern.compile(regExp, patternFlags).matcher(StringUtil.newBombedCharSequence(sampleText, 1000));
+      return matcher.matches()
              ? RegExpMatchResult.MATCHES
+             : matcher.hitEnd()
+               ? RegExpMatchResult.HIT_END
              : RegExpMatchResult.NO_MATCH;
     } catch (ProcessCanceledException pc) {
       return RegExpMatchResult.TIMEOUT;


### PR DESCRIPTION
If the regular expression does not match the current sample text, but
a longer input might match, display a hint to the user. This is helpful
in deciding whether the regular expression is completely wrong or the
sample text is just unfinished.