### PR TITLE
Prevent ProgressSuspender from crashing in isInImpatientReader mode.

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/progress/impl/ProgressSuspender.java
+++ b/platform/platform-impl/src/com/intellij/openapi/progress/impl/ProgressSuspender.java
@@ -17,6 +17,7 @@ package com.intellij.openapi.progress.impl;
 
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ex.ApplicationEx;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressIndicatorProvider;
 import com.intellij.openapi.progress.ProgressManager;
@@ -114,8 +115,17 @@ public class ProgressSuspender {
     myPublisher.suspendedStatusChanged(this);
   }
 
+  private boolean safeIsReadAccessAllowed() {
+    // isReadAccessAllowed throws if running as isInImpatientReader.
+    return ((ApplicationEx)ourApp).isInImpatientReader() || ourApp.isReadAccessAllowed();
+  }
+
   private boolean freezeIfNeeded(@Nullable ProgressIndicator current) {
-    if (current == null || ourApp.isReadAccessAllowed() || !CoreProgressManager.isThreadUnderIndicator(current, myThread)) {
+    // Note: instead of safeIsReadAccessAllowed it is enough to make isThreadUnderIndicator check first, but it is expected to be slower
+    //       than an additional call to ourApp.isInImpatientReader()
+    if (current == null
+        || safeIsReadAccessAllowed()
+        || !CoreProgressManager.isThreadUnderIndicator(current, myThread)) {
       return false;
     }
 


### PR DESCRIPTION
If ProgressSuspender has installed its check cancelled hook it should
not crash on checking isReadAccessAllowed (especially when the current
thread is not under the suspended ProgressIndicator).

It happens when JobLauncher.invokeConcurrentlyUnderProgress runs a job
in isInImpatientReader mode.

Change-Id: Ib6fec3045626fd09d8ec1e38e121419b416b6d27