### PR TITLE
Make code in UnnecessaryUnicodeEscapeInspection shorter

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/internationalization/UnnecessaryUnicodeEscapeInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/internationalization/UnnecessaryUnicodeEscapeInspection.java
@@ -131,14 +131,10 @@ public class UnnecessaryUnicodeEscapeInspection extends BaseInspection {
         if (!isEscape) {
           continue;
         }
-        int nextChar = i;
-        do {
-          nextChar++;
-          if (nextChar >= length) {
-            break;
-          }
+        int nextChar = i + 1;
+        while (nextChar < length && text.charAt(nextChar) == 'u') {
+          nextChar++; // \\uuuu0061 is a legal Unicode escape
         }
-        while (text.charAt(nextChar) == 'u'); // \\uuuu0061 is a legal unicode escape
         if (nextChar == i + 1 || nextChar + 3 >= length) {
           continue;
         }


### PR DESCRIPTION
The keyword "while" at the beginning of a line usually starts a while
loop instead of ending a do-while loop. To avoid further confusion,
replace the do-while loop with a typical while-loop.