### PR TITLE
[external-system] make IDE grouping by external project path

### DIFF
--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ModuleData.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ModuleData.java
@@ -2,7 +2,7 @@ package com.intellij.openapi.externalSystem.model.project;
 
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
-import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.PathUtil;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -226,12 +226,12 @@ public class ModuleData extends AbstractNamedData implements Named, ExternalConf
 
   @Nullable
   public String getIdeGrouping() {
-    return StringUtil.isEmpty(myGroup) ? getExternalName() : getGroup() + '.' + getExternalName();
+    return getLinkedExternalProjectPath();
   }
 
   @Nullable
   public String getIdeParentGrouping() {
-    return StringUtil.nullize(getGroup());
+    return PathUtil.getParentPath(getLinkedExternalProjectPath());
   }
 
   @Override

--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ProjectData.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ProjectData.java
@@ -62,6 +62,11 @@ public class ProjectData extends AbstractNamedData implements ExternalConfigPath
     return myLinkedExternalProjectPath;
   }
 
+  @Nullable
+  public String getIdeGrouping() {
+    return getLinkedExternalProjectPath();
+  }
+
   @Override
   public int hashCode() {
     int result = super.hashCode();

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
@@ -143,10 +143,6 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
   }
 
   public boolean hasMultipleDataToSelect() {
-    Object root = myTree.getModel().getRoot();
-    if (root instanceof CheckedTreeNode && ((CheckedTreeNode)root).getChildCount() == 1) {
-      return false;
-    }
     return myModulesCount > 1;
   }
 

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/view/ExternalSystemViewDefaultContributor.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/view/ExternalSystemViewDefaultContributor.java
@@ -182,10 +182,11 @@ public class ExternalSystemViewDefaultContributor extends ExternalSystemViewCont
       for (ModuleNode moduleNode : moduleNodes) {
         moduleNode.setAllModules(moduleNodes);
         String parentGroup = moduleNode.getIdeParentGrouping();
-        if (parentGroup == null) {
+        ModuleNode parent = parentGroup != null ? groupToModule.get(parentGroup) : null;
+        if (parent == null) {
           continue;
         }
-        moduleNode.setParent(groupToModule.get(parentGroup));
+        moduleNode.setParent(parent);
       }
 
       result.addAll(moduleNodes);

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/view/ModuleNode.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/view/ModuleNode.java
@@ -72,7 +72,7 @@ public class ModuleNode extends ExternalSystemNode<ModuleData> {
   @Override
   protected List<? extends ExternalSystemNode> doBuildChildren() {
     List<ExternalSystemNode<?>> myChildNodes = ContainerUtil.newArrayList();
-    if (getExternalProjectsView().getGroupModules()) {
+    if (!myIsRoot && getExternalProjectsView().getGroupModules()) {
       List<ModuleNode> childModules = ContainerUtil.findAll(
         myAllModules,
         module -> module != this && StringUtil.equals(module.getIdeParentGrouping(), getIdeGrouping())
@@ -115,14 +115,13 @@ public class ModuleNode extends ExternalSystemNode<ModuleData> {
   public boolean isVisible() {
     if (!myIsRoot && getExternalProjectsView().getGroupModules()) {
       ModuleNode parentModule = findParent(ModuleNode.class);
-
-      String actualParentModuleIdeGroup = parentModule != null ? parentModule.getIdeGrouping() : null;
-      ProjectNode parentProject = findParent(ProjectNode.class);
-      if (actualParentModuleIdeGroup == null && parentProject != null && parentProject.isSingleModuleProject()) {
-        actualParentModuleIdeGroup = parentProject.getName();
+      if (parentModule != null) {
+        return StringUtil.equals(parentModule.getIdeGrouping(), getIdeParentGrouping());
       }
-
-      return StringUtil.equals(actualParentModuleIdeGroup, getIdeParentGrouping());
+      ProjectNode parentProject = findParent(ProjectNode.class);
+      if (parentProject != null) {
+        return StringUtil.equals(parentProject.getIdeGrouping(), getIdeParentGrouping());
+      }
     }
     return super.isVisible();
   }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/view/ProjectNode.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/view/ProjectNode.java
@@ -103,6 +103,13 @@ public class ProjectNode extends ExternalSystemNode<ProjectData> {
     return desc.toString();
   }
 
+  @Nullable
+  public String getIdeGrouping() {
+    ProjectData data = getData();
+    if (data == null) return null;
+    return data.getIdeGrouping();
+  }
+
   @Override
   @Nullable
   @NonNls

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/model/data/GradleSourceSetData.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/model/data/GradleSourceSetData.java
@@ -42,9 +42,19 @@ public class GradleSourceSetData extends ModuleData {
           moduleFileDirectoryPath, externalConfigPath);
   }
 
+  @Nullable
+  @Override
+  public String getIdeGrouping() {
+    return super.getIdeGrouping() + ":" + getSourceSetName();
+  }
+
   @Override
   @Nullable
   public String getIdeParentGrouping() {
-    return StringUtil.substringBeforeLast(getExternalName(), ":");
+    return super.getIdeGrouping();
+  }
+
+  private String getSourceSetName() {
+    return StringUtil.substringAfterLast(getExternalName(), ":");
   }
 }


### PR DESCRIPTION
In the IDE grouping we want to pursue the same structure as we have projects structured on a disk. In this situation it makes sense to switch to grouping by an external project path. With the current implementation if, for example, a Gradle sub-project in a `projects/foo` folder overrides `group` in `build.gradle` like this:

```groovy
group "com.example.foo"
```

Then the current grouping will put `:project:foo` under `com.example.foo` node which is not what we want.