### PR TITLE
Don't call setLoggerFactory() of DefaultArtifactResolver and of Defau…

### DIFF
--- a/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3ServerEmbedderImpl.java
+++ b/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3ServerEmbedderImpl.java
@@ -1234,14 +1234,20 @@ public class Maven3ServerEmbedderImpl extends Maven3ServerEmbedder {
       RepositorySystemSession repositorySystemSession = maven.newRepositorySession(request);
 
       final org.eclipse.aether.impl.ArtifactResolver artifactResolver = getComponent(org.eclipse.aether.impl.ArtifactResolver.class);
-      final MyLoggerFactory loggerFactory = new MyLoggerFactory();
-      if (artifactResolver instanceof DefaultArtifactResolver) {
-        ((DefaultArtifactResolver)artifactResolver).setLoggerFactory(loggerFactory);
-      }
-
       final org.eclipse.aether.RepositorySystem repositorySystem = getComponent(org.eclipse.aether.RepositorySystem.class);
-      if (repositorySystem instanceof DefaultRepositorySystem) {
-        ((DefaultRepositorySystem)repositorySystem).setLoggerFactory(loggerFactory);
+
+      // Don't try calling setLoggerFactory() removed by MRESOLVER-36 when Maven 3.6.0+ is used.
+      // For more information and link to the MRESOLVER-36 see IDEA-201282.
+      if (VersionComparatorUtil.compare(mavenVersion, "3.6.0") < 0) {
+        final MyLoggerFactory loggerFactory = new MyLoggerFactory();
+
+        if (artifactResolver instanceof DefaultArtifactResolver) {
+          ((DefaultArtifactResolver)artifactResolver).setLoggerFactory(loggerFactory);
+        }
+
+        if (repositorySystem instanceof DefaultRepositorySystem) {
+          ((DefaultRepositorySystem)repositorySystem).setLoggerFactory(loggerFactory);
+        }
       }
 
       // do not use request.getRemoteRepositories() here,


### PR DESCRIPTION
…ltRepositorySystem when Maven 3.6.0+ is used.

Those methods were removed by the MRESOLVER-36 task resolution of maven-resolver 1.3.0:
https://github.com/apache/maven-resolver/commit/e1976767cf714da24336339f7a6286c6ab50986a

This commit fixes IDEA-201282