### PR TITLE
[IDEA-201343] Add standard Maven properties to pom.xml of just created Maven based module

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/references/MavenModulePsiReference.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/references/MavenModulePsiReference.java
@@ -132,7 +132,8 @@ public class MavenModulePsiReference extends MavenPsiReference implements LocalQ
                                                      new MavenId(groupId, artifactId, version),
                                                      myWithParent ? id : null,
                                                      psiFile.getVirtualFile(),
-                                                     true);
+                                                     true,
+                                                     null);
       }
       catch (IOException e) {
         MavenUtil.showError(project, MavenProjectBundle.message("notification.title.cannot.create.module"), e);

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/wizards/AbstractMavenModuleBuilder.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/wizards/AbstractMavenModuleBuilder.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 
 import static icons.OpenapiIcons.RepositoryLibraryLogo;
-import static org.jetbrains.idea.maven.utils.MavenUtil.MAVEN_NAME;
 
 public abstract class AbstractMavenModuleBuilder extends ModuleBuilder implements SourcePathsBuilder {
   private MavenProject myAggregatorProject;
@@ -73,7 +72,7 @@ public abstract class AbstractMavenModuleBuilder extends ModuleBuilder implement
       }
 
       new MavenModuleBuilderHelper(myProjectId, myAggregatorProject, myParentProject, myInheritGroupId,
-                                   myInheritVersion, myArchetype, myPropertiesToCreateByArtifact,
+                                   myInheritVersion, myArchetype, myPropertiesToCreateByArtifact, rootModel.getSdk(),
                                    MavenProjectBundle.message("command.name.create.new.maven.module")).configure(project, root, false);
     });
   }

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/wizards/MavenFrameworkSupportProvider.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/wizards/MavenFrameworkSupportProvider.java
@@ -72,7 +72,7 @@ public class MavenFrameworkSupportProvider extends FrameworkSupportProvider {
           prepareProjectStructure(model, root);
 
           new MavenModuleBuilderHelper(new MavenId("groupId", module.getName(), "1.0-SNAPSHOT"), null, null, false, false, null,
-                                       null, MavenProjectBundle.message("command.name.add.maven.support")).configure(model.getProject(), root, true);
+                                       null, null, MavenProjectBundle.message("command.name.add.maven.support")).configure(model.getProject(), root, true);
         }
       }
     };

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/wizards/MavenModuleBuilderHelper.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/wizards/MavenModuleBuilderHelper.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -52,6 +53,8 @@ public class MavenModuleBuilderHelper {
   private final MavenArchetype myArchetype;
   private final Map<String, String> myPropertiesToCreateByArtifact;
 
+  private final Sdk mySdk;
+
   @NlsContexts.Command private final String myCommandName;
 
   public MavenModuleBuilderHelper(@NotNull MavenId projectId,
@@ -61,6 +64,7 @@ public class MavenModuleBuilderHelper {
                                   boolean inheritVersion,
                                   MavenArchetype archetype,
                                   Map<String, String> propertiesToCreateByArtifact,
+                                  Sdk sdk,
                                   @NlsContexts.Command String commandName) {
     myProjectId = projectId;
     myAggregatorProject = aggregatorProject;
@@ -69,6 +73,7 @@ public class MavenModuleBuilderHelper {
     myInheritVersion = inheritVersion;
     myArchetype = archetype;
     myPropertiesToCreateByArtifact = propertiesToCreateByArtifact;
+    mySdk = sdk;
     myCommandName = commandName;
   }
 
@@ -82,7 +87,7 @@ public class MavenModuleBuilderHelper {
           file = root.findChild(MavenConstants.POM_XML);
           if (file != null) file.delete(this);
           file = root.createChildData(this, MavenConstants.POM_XML);
-          MavenUtil.runOrApplyMavenProjectFileTemplate(project, file, myProjectId, isInteractive);
+          MavenUtil.runOrApplyMavenProjectFileTemplate(project, file, myProjectId, isInteractive, mySdk);
         }
         catch (IOException e) {
           showError(project, e);

--- a/plugins/maven/src/main/resources/fileTemplates/j2ee/Maven Project.xml.ft
+++ b/plugins/maven/src/main/resources/fileTemplates/j2ee/Maven Project.xml.ft
@@ -19,5 +19,15 @@
     <artifactId>${ARTIFACT_ID}</artifactId>
     <version>${VERSION}</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+#if (${JAVA_RELEASE})
+        <maven.compiler.release>${JAVA_RELEASE}</maven.compiler.release>
+#end
+#if (${JAVA_LEVEL})
+        <maven.compiler.source>${JAVA_LEVEL}</maven.compiler.source>
+        <maven.compiler.target>${JAVA_LEVEL}</maven.compiler.target>
+#end
+    </properties>
     ${END}
 </project>


### PR DESCRIPTION
Properties that are added are:
1. project.build.sourceEncoding - always "UTF-8"
2. maven.compiler.source - according to the module SDK
3. maven.compiler.target - according to the module SDK

This should resolve the IDEA-201343 improvement ticket submitted by me.