### PR TITLE
[external-system] better message when many selected modules

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
@@ -626,8 +626,12 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
     }
 
     private String getEnableMessage(List<DataNode<Identifiable>> selectedModules, Set<DataNode<Identifiable>> deps) {
-      if (deps.size() > MAX_DEPENDENCIES_TO_DESCRIBE) {
-        return String.format("%d disabled modules depend on selected modules. Would you like to enable them too?", deps.size());
+      if (deps.size() > MAX_DEPENDENCIES_TO_DESCRIBE || selectedModules.size() > MAX_DEPENDENCIES_TO_DESCRIBE) {
+        return String.format(
+          "%d disabled module%s depend on %d selected module%s. Would you like to enable %s too?",
+          deps.size(), deps.size() == 1 ? "" : "s",
+          selectedModules.size(), selectedModules.size() == 1 ? "" : "s",
+          deps.size() == 1 ? "it" : "them");
       }
 
       final String listOfSelectedModules = StringUtil.join(selectedModules, node -> node.getData().getId(), ", ");

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/ui/ExternalProjectDataSelectorDialog.java
@@ -628,9 +628,9 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
     private String getEnableMessage(List<DataNode<Identifiable>> selectedModules, Set<DataNode<Identifiable>> deps) {
       if (deps.size() > MAX_DEPENDENCIES_TO_DESCRIBE || selectedModules.size() > MAX_DEPENDENCIES_TO_DESCRIBE) {
         return String.format(
-          "%d disabled module%s depend on %d selected module%s. Would you like to enable %s too?",
-          deps.size(), deps.size() == 1 ? "" : "s",
-          selectedModules.size(), selectedModules.size() == 1 ? "" : "s",
+          "%d disabled %s depend on %d selected %s. Would you like to enable %s too?",
+          deps.size(), StringUtil.pluralize("module", deps.size()),
+          selectedModules.size(), StringUtil.pluralize("module", selectedModules.size()),
           deps.size() == 1 ? "it" : "them");
       }
 
@@ -638,8 +638,9 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
 
       final String listOfDependencies = StringUtil.join(deps, node -> node.getData().getId(), "<br>");
       return String.format(
-        "<html>The following module%s on which <b>%s</b> depend%s %s disabled:<br><b>%s</b><br>Would you like to enable %s?</html>",
-        deps.size() == 1 ? "" : "s", listOfSelectedModules, selectedModules.size() == 1 ? "s" : "", deps.size() == 1 ? "is" : "are",
+        "<html>The following %s on which <b>%s</b> %s %s disabled:<br><b>%s</b><br>Would you like to enable %s?</html>",
+        StringUtil.pluralize("module", deps.size()), listOfSelectedModules,
+        StringUtil.pluralize("depend", selectedModules.size()), deps.size() == 1 ? "is" : "are",
         listOfDependencies, deps.size() == 1 ? "it" : "them");
     }
 
@@ -650,8 +651,9 @@ public class ExternalProjectDataSelectorDialog extends DialogWrapper {
 
       final String listOfDependencies = StringUtil.join(deps, node -> node.getData().getId(), "<br>");
       return String.format(
-        "<html>The following module%s <br><b>%s</b><br>%s enabled and depend%s on selected modules. <br>Would you like to disable %s too?</html>",
-        deps.size() == 1 ? "" : "s", listOfDependencies, deps.size() == 1 ? "is" : "are", deps.size() == 1 ? "s" : "",
+        "<html>The following %s <br><b>%s</b><br>%s enabled and %s on selected modules. <br>Would you like to disable %s too?</html>",
+        StringUtil.pluralize("module", deps.size()), listOfDependencies, deps.size() == 1 ? "is" : "are",
+        StringUtil.pluralize("depend", deps.size()),
         deps.size() == 1 ? "it" : "them");
     }
   }


### PR DESCRIPTION
When there are too many selected modules the dialog is also not quite usable.

Relates to #901

to: @vladsoroka @nskvortsov 