### PR TITLE
Fix IDEA-202846: Use the Document and not the root Element to run XPath

### DIFF
--- a/java/java-impl/src/com/intellij/jarFinder/SourceSearcher.java
+++ b/java/java-impl/src/com/intellij/jarFinder/SourceSearcher.java
@@ -7,7 +7,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.io.HttpRequests;
-import org.jdom.Element;
+import org.jdom.Document;
 import org.jdom.JDOMException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -52,14 +52,14 @@ public abstract class SourceSearcher {
   }
 
   @NotNull
-  protected static Element readDocumentCancelable(final ProgressIndicator indicator, String url) throws IOException {
+  protected static Document readDocumentCancelable(final ProgressIndicator indicator, String url) throws IOException {
     return HttpRequests.request(url)
       .accept("application/xml")
-      .connect(new HttpRequests.RequestProcessor<Element>() {
+      .connect(new HttpRequests.RequestProcessor<Document>() {
         @Override
-        public Element process(@NotNull HttpRequests.Request request) throws IOException {
+        public Document process(@NotNull HttpRequests.Request request) throws IOException {
           try {
-            return JDOMUtil.load(request.getReader(indicator));
+            return JDOMUtil.loadDocument(request.getReader(indicator));
           }
           catch (JDOMException e) {
             throw new IOException(e);


### PR DESCRIPTION
The IDEA-202846 is actually a regression introduced in the a992508f728fdefee4de267d229edf05dc300695 commit. `Element`, even root element, is not always a good chose to run xpath on it (for example if your xpath is absolute, i.e. starts with `/`) and this is why the old and correct xpath-es stopped to work properly.

This PR makes xpath-es in the `com.intellij.jarFinder.MavenCentralSourceSearcher` and in the `com.intellij.jarFinder.SonatypeSourceSearcher` classes run properly again.

Please review, merge and consider to undepricate the `JDOMUtil.loadDocument()` methods.