### PR TITLE
IDEA-202032 replace '/' with '.' when typing class name in the Create New Class dialog

### DIFF
--- a/java/java-impl/src/com/intellij/ide/actions/CreateClassAction.java
+++ b/java/java-impl/src/com/intellij/ide/actions/CreateClassAction.java
@@ -36,7 +36,8 @@ public class CreateClassAction extends JavaCreateTemplateInPackageAction<PsiClas
     builder
       .setTitle(IdeBundle.message("action.create.new.class"))
       .addKind("Class", PlatformIcons.CLASS_ICON, JavaTemplateUtil.INTERNAL_CLASS_TEMPLATE_NAME)
-      .addKind("Interface", PlatformIcons.INTERFACE_ICON, JavaTemplateUtil.INTERNAL_INTERFACE_TEMPLATE_NAME);
+      .addKind("Interface", PlatformIcons.INTERFACE_ICON, JavaTemplateUtil.INTERNAL_INTERFACE_TEMPLATE_NAME)
+      .setKeyStrokeReplace('/', '.');
     LanguageLevel level = PsiUtil.getLanguageLevel(directory);
     if (level.isAtLeast(LanguageLevel.JDK_1_5)) {
       builder.addKind("Enum", PlatformIcons.ENUM_ICON, JavaTemplateUtil.INTERNAL_ENUM_TEMPLATE_NAME);

--- a/platform/lang-impl/src/com/intellij/ide/actions/CreateFileFromTemplateDialog.java
+++ b/platform/lang-impl/src/com/intellij/ide/actions/CreateFileFromTemplateDialog.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.awt.event.ActionEvent;
 import java.util.Map;
 
 /**
@@ -129,6 +130,15 @@ public class CreateFileFromTemplateDialog extends DialogWrapper {
     return new BuilderImpl(dialog, project);
   }
 
+  private void setKeyStrokeReplace(char keyStroke, char newKeyStroke) {
+    myNameField.getInputMap().put(KeyStroke.getKeyStroke(keyStroke), new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        myNameField.setText(myNameField.getText() + newKeyStroke);
+      }
+    });
+  }
+
   private static class BuilderImpl implements Builder {
     private final CreateFileFromTemplateDialog myDialog;
     private final Project myProject;
@@ -200,12 +210,19 @@ public class CreateFileFromTemplateDialog extends DialogWrapper {
     public Map<String,String> getCustomProperties() {
       return null;
     }
+
+    @Override
+    public Builder setKeyStrokeReplace(char keyStroke, char newKeyStroke) {
+      myDialog.setKeyStrokeReplace(keyStroke, newKeyStroke);
+      return this;
+    }
   }
 
   public interface Builder {
     Builder setTitle(String title);
     Builder setValidator(InputValidator validator);
     Builder addKind(@NotNull String kind, @Nullable Icon icon, @NotNull String templateName);
+    Builder setKeyStrokeReplace(char keyStroke, char newKeyStroke);
     @Nullable
     <T extends PsiElement> T show(@NotNull String errorTitle, @Nullable String selectedItem, @NotNull FileCreator<T> creator);
     @Nullable


### PR DESCRIPTION
Link to the ticket: https://youtrack.jetbrains.com/issue/IDEA-202032