### PR TITLE
IDEA-204927 Add divider resize listener to Splitter.

### DIFF
--- a/platform/platform-api/src/com/intellij/openapi/ui/ThreeComponentsSplitter.java
+++ b/platform/platform-api/src/com/intellij/openapi/ui/ThreeComponentsSplitter.java
@@ -25,12 +25,15 @@ import com.intellij.openapi.wm.IdeGlassPane;
 import com.intellij.openapi.wm.IdeGlassPaneUtil;
 import com.intellij.ui.ClickListener;
 import com.intellij.ui.UIBundle;
+import com.intellij.util.EventDispatcher;
 import com.intellij.util.ReflectionUtil;
 import com.intellij.util.ui.EmptyIcon;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import com.intellij.util.ui.update.Activatable;
 import com.intellij.util.ui.update.UiNotifyConnector;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -67,6 +70,7 @@ public class ThreeComponentsSplitter extends JPanel implements Disposable {
 
   private final Divider myFirstDivider;
   private final Divider myLastDivider;
+  private final EventDispatcher<ComponentListener> myDividerDispatcher = EventDispatcher.create(ComponentListener.class);
 
   @Nullable private JComponent myFirstComponent;
   @Nullable private JComponent myInnerComponent;
@@ -555,6 +559,14 @@ public class ThreeComponentsSplitter extends JPanel implements Disposable {
     return myMinSize;
   }
 
+  public void addDividerResizeListener(@NotNull ComponentListener listener) {
+    myDividerDispatcher.addListener(listener);
+  }
+
+  public void removeDividerResizeListener(@NotNull ComponentListener listener) {
+    myDividerDispatcher.removeListener(listener);
+  }
+
   @Override
   public void dispose() {
     myLastComponent = null;
@@ -878,6 +890,9 @@ public class ThreeComponentsSplitter extends JPanel implements Disposable {
           }
           if (isInside(e.getPoint()) && myGlassPane != null) {
             myGlassPane.setCursor(getResizeCursor(), myListener);
+          }
+          if (myDragging) {
+            myDividerDispatcher.getMulticaster().componentResized(new ComponentEvent(this, ComponentEvent.COMPONENT_RESIZED));
           }
           myWasPressedOnMe = false;
           myDragging = false;


### PR DESCRIPTION
Add a listener for user generated resize events of the first and
end components in a ThreeComponentsSplitter.
Hookup these resize events onto mouse release events for the
dividers.