### PR TITLE
IDEA-195932 enable "Check connection" for "No proxy"

### DIFF
--- a/platform/platform-api/src/com/intellij/util/net/HttpProxySettingsUi.java
+++ b/platform/platform-api/src/com/intellij/util/net/HttpProxySettingsUi.java
@@ -163,7 +163,7 @@ class HttpProxySettingsUi implements ConfigurableUi<HttpConfigurable> {
   }
 
   private boolean canEnableConnectionCheck() {
-    return !myNoProxyRb.isSelected();
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Solves https://youtrack.jetbrains.com/issue/IDEA-195932

Currently, "Check connection" is disabled for "No proxy", which doesn't make sense.