### PR TITLE
Fix a bug in JBLoadingPanel in setBounds method.

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/components/JBLoadingPanel.java
+++ b/platform/platform-api/src/com/intellij/ui/components/JBLoadingPanel.java
@@ -122,4 +122,10 @@ public class JBLoadingPanel extends JPanel {
   public Dimension getPreferredSize() {
     return getContentPanel().getPreferredSize();
   }
+
+  @Override
+  public void setBounds(int x, int y, int width, int height) {
+    super.setBounds(x, y, width, height);
+    myDecorator.getComponent().setBounds(x, y, width, height);
+  }
 }


### PR DESCRIPTION
When JBLoadingPanel#setBounds is called it only updates its boundaries and its underlying LoadingDecorator panel doesn't get updated resulting an unexpected layouts.
This patch fixes it by overriding setBounds method and propagating the update to LoadingDecorator properly.

https://youtrack.jetbrains.net/issue/IJSDK-545