### PR TITLE
Don't modify TestPlan

### DIFF
--- a/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestExecutionListener.java
+++ b/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestExecutionListener.java
@@ -165,11 +165,6 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
   }
 
   @Override
-  public void dynamicTestRegistered(TestIdentifier testIdentifier) {
-    myTestPlan.add(testIdentifier);
-  }
-
-  @Override
   public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
     final TestExecutionResult.Status status = testExecutionResult.getStatus();
     final Throwable throwableOptional = testExecutionResult.getThrowable().orElse(null);


### PR DESCRIPTION
Although `TestPlan` exposes an `add(TestIdentifier)` method, it was only
ever intended for internal use by JUnit's `DefaultLauncher` which
already adds dynamic test identifiers to the `TestPlan`. The JUnit team
is going to make the `add()` throw an exception on modifications from
listeners. Thus, this commit removes the unnecessary call.

@akozlova Please have a look and let me know what you think.