### PR TITLE
IDEA-205629 Shift text range when getStartTagNameElement is null

### DIFF
--- a/xml/dom-openapi/src/com/intellij/util/xml/DomUtil.java
+++ b/xml/dom-openapi/src/com/intellij/util/xml/DomUtil.java
@@ -479,9 +479,9 @@ public class DomUtil {
   }
 
   public static Pair<TextRange, PsiElement> getProblemRange(final XmlTag tag) {
-    final PsiElement startToken = XmlTagUtil.getStartTagNameElement(tag);
+    PsiElement startToken = XmlTagUtil.getStartTagNameElement(tag);
     if (startToken == null) {
-      return Pair.create(tag.getTextRange(), (PsiElement)tag);
+      startToken = tag;
     }
 
     return Pair.create(startToken.getTextRange().shiftRight(-tag.getTextRange().getStartOffset()), (PsiElement)tag);


### PR DESCRIPTION
Apply necessary range shift both to startToken and original tag to avoid
“Argument rangeInElement … endOffset must not exceed descriptor text range”