### PR TITLE
Re-enable canonicalization cache

### DIFF
--- a/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/TestingTasksImpl.groovy
+++ b/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/TestingTasksImpl.groovy
@@ -291,7 +291,7 @@ class TestingTasksImpl extends TestingTasks {
       jvmArgs.addAll([
         "-Xmx750m",
         "-Xms750m",
-        "-Dsun.io.useCanonCaches=false"
+        "-Dsun.io.useCanonPrefixCache=false"
       ])
     }
 

--- a/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/VmOptionsGenerator.groovy
+++ b/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/VmOptionsGenerator.groovy
@@ -25,7 +25,7 @@ import org.jetbrains.intellij.build.ProductProperties
 @CompileStatic
 class VmOptionsGenerator {
   private static final String COMMON_VM_OPTIONS = "-XX:+UseConcMarkSweepGC -XX:SoftRefLRUPolicyMSPerMB=50 -ea " +
-                                          "-Dsun.io.useCanonCaches=false -Djava.net.preferIPv4Stack=true " +
+                                          "-Dsun.io.useCanonPrefixCache=false -Djava.net.preferIPv4Stack=true " +
                                           "-Djdk.http.auth.tunneling.disabledSchemes=\"\" " +
                                           "-XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow"
 

--- a/platform/testGuiFramework/src/com/intellij/testGuiFramework/launcher/GuiTestLocalLauncher.kt
+++ b/platform/testGuiFramework/src/com/intellij/testGuiFramework/launcher/GuiTestLocalLauncher.kt
@@ -278,7 +278,7 @@ object GuiTestLocalLauncher {
       .plus("-ea")
       .plus("-Xbootclasspath/p:${GuiTestOptions.bootClasspath}")
       .plus("-Dsun.awt.disablegrab=true")
-      .plus("-Dsun.io.useCanonCaches=false")
+      .plus("-Dsun.io.useCanonPrefixCache=false")
       .plus("-Djava.net.preferIPv4Stack=true")
       .plus("-Dapple.laf.useScreenMenuBar=${GuiTestOptions.useAppleScreenMenuBar}")
       .plus("-Didea.is.internal=${GuiTestOptions.isInternal}")


### PR DESCRIPTION
This CL still keeps the canonicalization prefix cache disabled since
that is known to have consistency issues.
The canonicalization cache helps to address performance issues on the
Windows platform where the File.getCanonicalPath is significantly slower
than in other platforms.

As per my conversation with @trespasserw, this was disabled back in Apple JDK6 since it didn't handle correctly symlinks and kept re-indexing parts of the JDK. I've tested this locally and it seems to work correctly now. 