### PR TITLE
Add support for Fish completions in terminal

### DIFF
--- a/plugins/terminal/resources/fish/config.fish
+++ b/plugins/terminal/resources/fish/config.fish
@@ -4,6 +4,12 @@ else
   set -e XDG_CONFIG_HOME
 end
 
+if test -d ~/.config/fish/completions
+  for f in ~/.config/fish/completions/*.fish
+    source $f
+  end
+end
+
 if test -d ~/.config/fish/conf.d
   for f in ~/.config/fish/conf.d/*.fish
     source $f


### PR DESCRIPTION
Just like functions from #660, `.config/fish` can contain completions (I have them for `docker-compose` for instance).
This trivial change adds support for them into terminal plugin.