### PR TITLE
Make Gradle's ProjectImportAction more flexible

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/AbstractProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/AbstractProjectResolverExtension.java
@@ -31,6 +31,7 @@ import org.gradle.tooling.model.idea.IdeaProject;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.gradle.model.ProjectImportExtraModelProvider;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -122,6 +123,12 @@ public abstract class AbstractProjectResolverExtension implements GradleProjectR
   @Override
   public Set<Class> getExtraProjectModelClasses() {
     return Collections.emptySet();
+  }
+
+  @NotNull
+  @Override
+  public ProjectImportExtraModelProvider getExtraModelProvider() {
+    return new ClassSetProjectImportExtraModelProvider(getExtraProjectModelClasses());
   }
 
   @NotNull

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BaseGradleProjectResolverExtension.java
@@ -679,6 +679,12 @@ public class BaseGradleProjectResolverExtension implements GradleProjectResolver
 
   @NotNull
   @Override
+  public ProjectImportExtraModelProvider getExtraModelProvider() {
+    return new ClassSetProjectImportExtraModelProvider(getExtraProjectModelClasses());
+  }
+
+  @NotNull
+  @Override
   public Set<Class> getToolingExtensionsClasses() {
     return ContainerUtil.set(
       // external-system-rt.jar

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/ClassSetProjectImportExtraModelProvider.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/ClassSetProjectImportExtraModelProvider.java
@@ -1,0 +1,38 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.plugins.gradle.service.project;
+
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.idea.IdeaModule;
+import org.gradle.tooling.model.idea.IdeaProject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.gradle.model.ProjectImportExtraModelProvider;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class ClassSetProjectImportExtraModelProvider implements ProjectImportExtraModelProvider {
+  @NotNull private Set<Class> classSet = new LinkedHashSet<>();
+
+  public ClassSetProjectImportExtraModelProvider(@NotNull Collection<Class> classes) {
+    classSet.addAll(classes);
+  }
+
+  @Override
+  public void populateBuildModels(@NotNull BuildController controller, @NotNull IdeaProject project, @NotNull BuildModelConsumer consumer) {
+    // Do nothing, this provider only works on the project model level
+  }
+
+  @Override
+  public void populateProjectModels(@NotNull BuildController controller,
+                                    @Nullable IdeaModule module,
+                                    @NotNull ProjectModelConsumer modelConsumer) {
+    for (Class<?> aClass : classSet) {
+      Object instance = controller.findModel(module, aClass);
+      if (instance != null) {
+        modelConsumer.consume(instance, aClass);
+      }
+    }
+  }
+}

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolver.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolver.java
@@ -201,7 +201,7 @@ public class GradleProjectResolver implements ExternalSystemProjectResolver<Grad
     if(resolverCtx.isPreviewMode()){
       executionSettings.withArgument("-Didea.isPreviewMode=true");
       final Set<Class> previewLightWeightToolingModels = ContainerUtil.set(ExternalProjectPreview.class, GradleBuild.class);
-      projectImportAction.addExtraProjectModelClasses(previewLightWeightToolingModels);
+      projectImportAction.addProjectImportExtraModelProvider(new ClassSetProjectImportExtraModelProvider(previewLightWeightToolingModels));
     }
     if(resolverCtx.isResolveModulePerSourceSet()) {
       executionSettings.withArgument("-Didea.resolveSourceSetDependencies=true");
@@ -228,7 +228,8 @@ public class GradleProjectResolver implements ExternalSystemProjectResolver<Grad
       if(!resolverCtx.isPreviewMode()){
         // register classes of extra gradle project models required for extensions (e.g. com.android.builder.model.AndroidProject)
         try {
-          projectImportAction.addExtraProjectModelClasses(resolverExtension.getExtraProjectModelClasses());
+          projectImportAction.addProjectImportExtraModelProvider(
+            new ClassSetProjectImportExtraModelProvider(resolverExtension.getExtraProjectModelClasses()));
         }
         catch (Throwable t) {
           LOG.warn(t);

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverExtension.java
@@ -30,6 +30,7 @@ import org.gradle.tooling.model.idea.IdeaProject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.GradleManager;
+import org.jetbrains.plugins.gradle.model.ProjectImportExtraModelProvider;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -94,6 +95,9 @@ public interface GradleProjectResolverExtension extends ParametersEnhancer {
 
   @NotNull
   Set<Class> getExtraProjectModelClasses();
+
+  @NotNull
+  ProjectImportExtraModelProvider getExtraModelProvider();
 
   /**
    * add paths containing these classes to classpath of gradle tooling extension

--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportExtraModelProvider.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportExtraModelProvider.java
@@ -1,0 +1,36 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.plugins.gradle.model;
+
+
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.idea.IdeaModule;
+import org.gradle.tooling.model.idea.IdeaProject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * Allows the {@link ProjectImportAction} to be extended to allow extra flexibility to extensions when requesting the models.
+ *
+ * {@link #populateProjectModels(BuildController, IdeaModule, ProjectModelConsumer)} is called once for each {@link IdeaModule} obtained
+ * from the Gradle Tooling API (this includes modules from included builds).
+ *
+ * {@link #populateBuildModels(BuildController, IdeaProject, BuildModelConsumer)} is called once for each {@link IdeaProject} that is
+ * obtained from the Gradle Tooling API, for none-composite builds this will be called exactly once, for composite builds this will be
+ * called once for each included build and once for the name build. This will always be called after
+ * {@link #populateProjectModels(BuildController, IdeaModule, ProjectModelConsumer)}.
+ */
+public interface ProjectImportExtraModelProvider extends Serializable {
+  interface ProjectModelConsumer {
+    void consume(@NotNull Object object, @NotNull Class clazz);
+  }
+
+  interface BuildModelConsumer {
+    void consume(@Nullable IdeaModule module, @NotNull Object object, @NotNull Class  clazz);
+  }
+
+  void populateBuildModels(@NotNull BuildController controller, @NotNull IdeaProject project, @NotNull BuildModelConsumer consumer);
+
+  void populateProjectModels(@NotNull BuildController controller, @Nullable IdeaModule module, @NotNull ProjectModelConsumer modelConsumer);
+}

--- a/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/builder/AbstractModelBuilderTest.java
+++ b/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/builder/AbstractModelBuilderTest.java
@@ -37,6 +37,7 @@ import org.jetbrains.plugins.gradle.model.ClasspathEntryModel;
 import org.jetbrains.plugins.gradle.model.ExternalProject;
 import org.jetbrains.plugins.gradle.model.ProjectImportAction;
 import org.jetbrains.plugins.gradle.service.execution.GradleExecutionHelper;
+import org.jetbrains.plugins.gradle.service.project.ClassSetProjectImportExtraModelProvider;
 import org.jetbrains.plugins.gradle.tooling.VersionMatcherRule;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
 import org.junit.After;
@@ -155,7 +156,7 @@ public abstract class AbstractModelBuilderTest {
       boolean isCompositeBuildsSupported = isGradleProjectDirSupported && _gradleVersion.compareTo(GradleVersion.version("3.1")) >= 0;
       final ProjectImportAction projectImportAction = new ProjectImportAction(false, isGradleProjectDirSupported,
                                                                               isCompositeBuildsSupported);
-      projectImportAction.addExtraProjectModelClasses(getModels());
+      projectImportAction.addProjectImportExtraModelProvider(new ClassSetProjectImportExtraModelProvider(getModels()));
       BuildActionExecuter<ProjectImportAction.AllModels> buildActionExecutor = connection.action(projectImportAction);
       File initScript = GradleExecutionHelper.generateInitScript(false, getToolingExtensionClasses());
       assertNotNull(initScript);


### PR DESCRIPTION
This change gives more flexibility providers of GradleProjectResolverExtensions to inject logic when requesting models from Gradle during the ProjectImportAction. We allow extensions to provide a ProjectImportExtraModelProvider instead of a set list of classes, this provider has two methods which are both run within the build action. Each method provides a consumer-like interface for the provider to register the models that they are interested in so they are visible to the resolver context during setup.
</p>
The motivation behind this is part of an ongoing effort to unify the Sync infrastructure in Android Studio with the External System pipeline in Intellij. In Android Studio we only request models for the specified variant that is needed by the IDE, in order to pass this information to Gradle we need to be able to do two things:
<ul>
<li>Use the new parameterized model builder API to tell the model builder not to build variant information</li>
<li>The ability to alter model requests based on information contained in previously obtained models</li>
</ul>
</p>
This change attempts to provide both of these things to GradleProjectResolverExtensions.

I've ran any tests that I could that look like they might be affected. E.g in intellij.gradle.tests the results are consistent with or without the change (though both end up with ~100 failures). Any instruction on how best to test the new functionality would be appreciated.

Thanks! 