### PR TITLE
Add message bus topic for typing latency events

### DIFF
--- a/platform/platform-api/src/com/intellij/openapi/editor/actionSystem/LatencyListener.java
+++ b/platform/platform-api/src/com/intellij/openapi/editor/actionSystem/LatencyListener.java
@@ -1,0 +1,15 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.openapi.editor.actionSystem;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.util.messages.Topic;
+
+/**
+ * Reports typing latency measurements on the application-level {@link com.intellij.util.messages.MessageBus}.
+ */
+public interface LatencyListener {
+  Topic<LatencyListener> TOPIC = new Topic<>("Typing latency notifications", LatencyListener.class);
+
+  /** Record latency for a single key typed. */
+  void recordTypingLatency(Editor editor, String action, long latencyMs);
+}

--- a/platform/platform-impl/src/com/intellij/internal/performance/Latenciometer.kt
+++ b/platform/platform-impl/src/com/intellij/internal/performance/Latenciometer.kt
@@ -1,7 +1,9 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.internal.performance
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.actionSystem.LatencyListener
 import com.intellij.openapi.editor.actionSystem.LatencyRecorder
 import com.intellij.openapi.editor.impl.EditorImpl
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -64,15 +66,22 @@ var currentLatencyRecordKey: LatencyDistributionRecordKey? = null
 
 val latencyRecorderProperties: MutableMap<String, String> = mutableMapOf()
 
-fun recordTypingLatency(editor: Editor, action: String, latencyInMS: Long) {
-  val key = currentLatencyRecordKey ?: run {
-    val fileType = FileDocumentManager.getInstance().getFile(editor.document)?.fileType ?: return
-    LatencyDistributionRecordKey(fileType.name)
+class LatenciometerListener : LatencyListener {
+
+  init {
+    ApplicationManager.getApplication().messageBus.connect().subscribe(LatencyListener.TOPIC, this)
   }
-  val latencyRecord = latencyMap.getOrPut(key) {
-    LatencyDistributionRecord(key)
+
+  override fun recordTypingLatency(editor: Editor, action: String, latencyInMS: Long) {
+    val key = currentLatencyRecordKey ?: run {
+      val fileType = FileDocumentManager.getInstance().getFile(editor.document)?.fileType ?: return
+      LatencyDistributionRecordKey(fileType.name)
+    }
+    val latencyRecord = latencyMap.getOrPut(key) {
+      LatencyDistributionRecord(key)
+    }
+    latencyRecord.update(getActionKey(action), latencyInMS.toInt())
   }
-  latencyRecord.update(getActionKey(action), latencyInMS.toInt())
 }
 
 fun getActionKey(action: String): String =

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
@@ -154,6 +154,7 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
   private final FocusModeModel myFocusModeModel;
   private volatile long myLastTypedActionTimestamp = -1;
   private String myLastTypedAction;
+  private final LatencyListener myLatencyPublisher;
 
   private static final Cursor EMPTY_CURSOR;
   private final Map<Object, Cursor> myCustomCursors = new LinkedHashMap<>();
@@ -551,6 +552,8 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
 
     myFocusModeModel = new FocusModeModel(this);
     myPopupHandlers.add(new DefaultPopupHandler());
+
+    myLatencyPublisher = ApplicationManager.getApplication().getMessageBus().syncPublisher(LatencyListener.TOPIC);
   }
 
   public void applyFocusMode() {
@@ -3379,7 +3382,7 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
 
   void measureTypingLatency() {
     if (myLastTypedActionTimestamp != -1) {
-      LatenciometerKt.recordTypingLatency(this, myLastTypedAction, System.currentTimeMillis() - myLastTypedActionTimestamp);
+      myLatencyPublisher.recordTypingLatency(this, myLastTypedAction, System.currentTimeMillis() - myLastTypedActionTimestamp);
       myLastTypedActionTimestamp = -1;
     }
   }

--- a/platform/platform-resources/src/componentSets/Platform.xml
+++ b/platform/platform-resources/src/componentSets/Platform.xml
@@ -140,6 +140,10 @@
     </component>
 
     <component>
+      <implementation-class>com.intellij.internal.performance.LatenciometerListener</implementation-class>
+    </component>
+
+    <component>
       <interface-class>org.jetbrains.ide.BuiltInServerManager</interface-class>
       <implementation-class>org.jetbrains.ide.BuiltInServerManagerImpl</implementation-class>
     </component>


### PR DESCRIPTION
This allows plugins to accurately measure typing latency.

Also updates Latenciometer.kt to subscribe to this new topic.