### PR TITLE
IJSDK-563 Fix incorrect rendering of copyable labels

### DIFF
--- a/platform/lang-impl/src/com/intellij/execution/impl/SingleConfigurationConfigurable.java
+++ b/platform/lang-impl/src/com/intellij/execution/impl/SingleConfigurationConfigurable.java
@@ -334,6 +334,7 @@ public final class SingleConfigurationConfigurable<Config extends RunConfigurati
 
       getEditor().addSettingsEditorListener(settingsEditor -> updateWarning());
       myWarningLabel.setCopyable(true);
+      myWarningLabel.setAllowAutoWrapping(true);
       myWarningLabel.setIcon(AllIcons.General.BalloonError);
 
       myComponentPlace.setLayout(new GridBagLayout());

--- a/platform/platform-api/src/com/intellij/ui/components/JBLabel.java
+++ b/platform/platform-api/src/com/intellij/ui/components/JBLabel.java
@@ -230,7 +230,8 @@ public class JBLabel extends JLabel implements AnchorableComponent, JBComponent<
   /**
    * In 'copyable' mode JBLabel has the same appearance but user can select text with mouse and copy it to clipboard with standard shortcut.
    * By default JBLabel is NOT copyable
-   * Also 'copyable' label supports web hyperlinks (e.g. opens browser on click)
+   * Note: 'copyable' labels support web hyperlinks (e.g. opens browser on click)
+   *       'copyable' labels do not allow auto wrapping by default and will render "..." as label text when there isn't enough space.
    *
    * @return 'this' (the same instance)
    */
@@ -243,7 +244,7 @@ public class JBLabel extends JLabel implements AnchorableComponent, JBComponent<
           @Override
           public void paint(Graphics g) {
             Dimension size = getSize();
-            boolean paintEllipsis = getPreferredSize().width > size.width && !myMultiline;
+            boolean paintEllipsis = getPreferredSize().width > size.width && !myMultiline && !myAllowAutoWrapping;
 
             if (!paintEllipsis) {
               super.paint(g);


### PR DESCRIPTION
By default JBLabels will autowrap its text contents when the container
is not wide enough to render the whole text on a single line.  In
copyable mode however, the JBLabel will render "..." if  the container
isn't wide enough when autowrapping is set to false.  This lead to error
messages in the Edit Configuration window (a very narrow window) to
render as "..." with no obvious clue as to what's wrong.

This commit fixes the bug in JBLabel to respond properly to autowrapping
and adds autowrapping to the JBLabel in Edit Configuration window.