### PR TITLE
Maven: Import folders from multiple executions

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenFoldersImporter.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenFoldersImporter.java
@@ -38,6 +38,7 @@ import com.intellij.util.containers.MultiMap;
 import com.intellij.util.containers.NotNullList;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.idea.maven.model.MavenPlugin;
 import org.jetbrains.idea.maven.model.MavenResource;
 import org.jetbrains.idea.maven.project.MavenImportingSettings;
 import org.jetbrains.idea.maven.project.MavenProject;
@@ -151,25 +152,39 @@ public class MavenFoldersImporter {
   }
 
   private void addBuilderHelperPaths(String goal, Collection<String> folders) {
-    final Element configurationElement = myMavenProject.getPluginGoalConfiguration("org.codehaus.mojo", "build-helper-maven-plugin", goal);
-    if (configurationElement != null) {
-      final Element sourcesElement = configurationElement.getChild("sources");
-      if (sourcesElement != null) {
-        for (Element element : sourcesElement.getChildren()) {
-          folders.add(element.getTextTrim());
+    final MavenPlugin plugin = myMavenProject.findPlugin("org.codehaus.mojo", "build-helper-maven-plugin");
+    if (plugin != null) {
+      for (MavenPlugin.Execution execution : plugin.getExecutions()) {
+        if (execution.getGoals().contains(goal)) {
+          final Element configurationElement = execution.getConfigurationElement();
+          if (configurationElement != null) {
+            final Element sourcesElement = configurationElement.getChild("sources");
+            if (sourcesElement != null) {
+              for (Element element : sourcesElement.getChildren()) {
+                folders.add(element.getTextTrim());
+              }
+            }
+          }
         }
       }
     }
   }
 
   private void addBuilderHelperResourcesPaths(String goal, Collection<String> folders) {
-    final Element configurationElement = myMavenProject.getPluginGoalConfiguration("org.codehaus.mojo", "build-helper-maven-plugin", goal);
-    if (configurationElement != null) {
-      final Element sourcesElement = configurationElement.getChild("resources");
-      if (sourcesElement != null) {
-        for (Element element : sourcesElement.getChildren()) {
-          Element directory = element.getChild("directory");
-          if (directory != null) folders.add(directory.getTextTrim());
+    final MavenPlugin plugin = myMavenProject.findPlugin("org.codehaus.mojo", "build-helper-maven-plugin");
+    if (plugin != null) {
+      for (MavenPlugin.Execution execution : plugin.getExecutions()) {
+        if (execution.getGoals().contains(goal)) {
+          final Element configurationElement = execution.getConfigurationElement();
+          if (configurationElement != null) {
+            final Element sourcesElement = configurationElement.getChild("resources");
+            if (sourcesElement != null) {
+              for (Element element : sourcesElement.getChildren()) {
+                Element directory = element.getChild("directory");
+                if (directory != null) folders.add(directory.getTextTrim());
+              }
+            }
+          }
         }
       }
     }

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/importing/FoldersImportingTest.java
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/importing/FoldersImportingTest.java
@@ -513,6 +513,133 @@ public class FoldersImportingTest extends MavenImportingTestCase {
     assertResources("m1", "src/main/resources");
   }
 
+  public void testPluginExtraFilesInMultipleExecutions() {
+    createStdProjectFolders();
+    createProjectSubDirs("src1", "src2");
+    createProjectSubDirs("resources1", "resources2");
+    createProjectSubDirs("test1", "test2");
+    createProjectSubDirs("test-resources1", "test-resources2");
+
+    importProject("<groupId>test</groupId>" +
+                  "<artifactId>project</artifactId>" +
+                  "<version>1</version>" +
+
+                  "<build>" +
+                  "  <plugins>" +
+                  "    <plugin>" +
+                  "      <groupId>org.codehaus.mojo</groupId>" +
+                  "      <artifactId>build-helper-maven-plugin</artifactId>" +
+                  "      <version>1.3</version>" +
+                  "      <executions>" +
+                  "        <execution>" +
+                  "          <id>add-src1</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-source</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <sources>" +
+                  "              <source>${basedir}/src1</source>" +
+                  "            </sources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "        <execution>" +
+                  "          <id>add-src2</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-source</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <sources>" +
+                  "              <source>${basedir}/src2</source>" +
+                  "            </sources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "        <execution>" +
+                  "          <id>add-resources1</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-resource</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <resources>" +
+                  "              <resource><directory>${basedir}/resources1</directory></resource>" +
+                  "            </resources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "        <execution>" +
+                  "          <id>add-resources2</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-resource</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <resources>" +
+                  "              <resource><directory>${basedir}/resources2</directory></resource>" +
+                  "            </resources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "        <execution>" +
+                  "          <id>add-test1</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-test-source</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <sources>" +
+                  "              <source>${basedir}/test1</source>" +
+                  "            </sources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "        <execution>" +
+                  "          <id>add-test2</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-test-source</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <sources>" +
+                  "              <source>${basedir}/test2</source>" +
+                  "            </sources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "        <execution>" +
+                  "          <id>add-test-resources1</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-test-resource</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <resources>" +
+                  "              <resource><directory>${basedir}/test-resources1</directory></resource>" +
+                  "            </resources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "        <execution>" +
+                  "          <id>add-test-resources2</id>" +
+                  "          <phase>generate-sources</phase>" +
+                  "          <goals>" +
+                  "            <goal>add-test-resource</goal>" +
+                  "          </goals>" +
+                  "          <configuration>" +
+                  "            <resources>" +
+                  "              <resource><directory>${basedir}/test-resources2</directory></resource>" +
+                  "            </resources>" +
+                  "          </configuration>" +
+                  "        </execution>" +
+                  "      </executions>" +
+                  "    </plugin>" +
+                  "  </plugins>" +
+                  "</build>");
+    resolveFoldersAndImport();
+    assertModules("project");
+
+    assertSources("project", "src/main/java", "src1", "src2");
+    assertResources("project", "resources1", "resources2", "src/main/resources");
+    assertTestSources("project", "src/test/java", "test1", "test2");
+    assertTestResources("project", "src/test/resources", "test-resources1", "test-resources2");
+  }
+
   public void testDownloadingNecessaryPlugins() throws Exception {
     try {
       MavenCustomRepositoryHelper helper = new MavenCustomRepositoryHelper(myDir, "local1");


### PR DESCRIPTION
With maven-build-helper, one can define multiple executions that can
each add source or resource folders to the project. With the current
implementation, IntelliJ only considers the very first execution that
matches the given maven goal, like add-sources. However, it is perfectly
fine with Maven to define multiple executions with the same goal. This
also happens automatically, for example when multiple Maven profiles are
defined and active, that each call add-source of the maven-build-helper.

With this commit, I changed the folder importing strategy, so that not
only the first matching execution is considered, but all executions that
call the appropriate Maven goal.

I also added a test case that fails on current master, but passes with
this commit. It simulates a project structure with multiple additional
sources and resources folders, with each of them added in different
executions of the maven-build-helper. This can be a common scenario if
one extensively uses Maven profiles to trigger specific actions.