### PR TITLE
Add flake8 inspection supressor

### DIFF
--- a/python/src/META-INF/python-core-common.xml
+++ b/python/src/META-INF/python-core-common.xml
@@ -666,6 +666,9 @@
     <statistics.projectUsagesCollector implementation="com.jetbrains.python.statistics.PyInterpreterTypeUsagesCollector"/>
     <statistics.projectUsagesCollector implementation="com.jetbrains.python.statistics.PyPackageUsagesCollector"/>
     <statistics.projectUsagesCollector implementation="com.jetbrains.python.statistics.PyPackageVersionUsagesCollector"/>
+
+    <!-- flake8 -->
+    <lang.inspectionSuppressor language="Python" implementationClass="com.jetbrains.python.inspections.flake8.FlakeInspectionSuppressor" />
   </extensions>
 
   <extensionPoints>

--- a/python/src/com/jetbrains/python/inspections/flake8/Flake8EndOfLineSuppressionQuickFix.java
+++ b/python/src/com/jetbrains/python/inspections/flake8/Flake8EndOfLineSuppressionQuickFix.java
@@ -1,0 +1,78 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python.inspections.flake8;
+
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.SuppressQuickFix;
+import com.intellij.codeInspection.SuppressionUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This adds a end-of-line # noqa comment on the same line as the highlighted element.
+ *
+ * @author jansorg
+ */
+public class Flake8EndOfLineSuppressionQuickFix implements SuppressQuickFix {
+  @Override
+  public boolean isAvailable(@NotNull Project project, @NotNull PsiElement psiElement) {
+    // always available because it's only added when we know we're suppressing something
+    return true;
+  }
+
+  @Override
+  public boolean isSuppressAll() {
+    return false;
+  }
+
+  @Override
+  public boolean startInWriteAction() {
+    // true because we're modifying the PSI structure
+    return true;
+  }
+
+  @Nls(capitalization = Nls.Capitalization.Sentence)
+  @NotNull
+  @Override
+  public String getName() {
+    return "Suppress with flake8 # noqa";
+  }
+
+  @Nls(capitalization = Nls.Capitalization.Sentence)
+  @NotNull
+  @Override
+  public String getFamilyName() {
+    return "Python";
+  }
+
+  @Override
+  public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor problemDescriptor) {
+    PsiElement endElement = problemDescriptor.getEndElement();
+
+    // find last leaf on the current line
+    PsiElement anchor = endElement;
+    while (anchor != null) {
+      PsiElement next = PsiTreeUtil.nextLeaf(anchor);
+      if (next == null || next instanceof PsiWhiteSpace && next.textContains('\n')) {
+        break;
+      }
+      anchor = next;
+    }
+
+    // we're reusing IntelliJ's code to create comments suitable for suppressions
+    PsiComment comment = SuppressionUtil.createComment(project, "noqa", endElement.getLanguage());
+    if (anchor == null) {
+      // e.g. when we're editing at the end of the file
+      endElement.getContainingFile().add(comment);
+    }
+    else {
+      // insert right after our anchor element, this will still be on the same line.
+      // The whitespace with the newline is after our anchor element
+      anchor.getParent().addAfter(comment, anchor);
+    }
+  }
+}

--- a/python/src/com/jetbrains/python/inspections/flake8/FlakeInspectionSuppressor.java
+++ b/python/src/com/jetbrains/python/inspections/flake8/FlakeInspectionSuppressor.java
@@ -1,0 +1,111 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python.inspections.flake8;
+
+import com.intellij.codeInspection.InspectionSuppressor;
+import com.intellij.codeInspection.SuppressQuickFix;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.python.PyTokenTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Suppress highlighting (errors, warning, unused, ...) which were added by Python inspections when either
+ * # noqa is at the end of a line or
+ * # flake8: noqa is on a single line anywhere in a Python file.
+ * flake8 seems to do prefix checking, so both "# noqa123" and "# flake8: noqa123" are also valid.
+ * We're replicating this behavior in this suppressor.
+ *
+ * @author jansorg
+ */
+public class FlakeInspectionSuppressor implements InspectionSuppressor {
+  @Override
+  public boolean isSuppressedFor(@NotNull PsiElement element, @NotNull String toolId) {
+    // suppress Python inspections only
+    // this might be a bit too eager here, we'll see if there are use cases to also suppress other types of inspections
+    if (!toolId.startsWith("Py")) {
+      return false;
+    }
+
+    return isSuppressedByEndOfLine(element) || isSuppressedByLineComment(element);
+  }
+
+  private boolean isSuppressedByEndOfLine(PsiElement element) {
+    // a comment token is always a leaf, the start element is never the comment which is suppressing our warning
+    for (PsiElement leaf = PsiTreeUtil.nextLeaf(element); leaf != null; leaf = PsiTreeUtil.nextLeaf(leaf)) {
+      // end of line reached without a comment before, returning false to not suppress
+      if (leaf instanceof PsiWhiteSpace && leaf.textContains('\n')) {
+        return false;
+      }
+
+      // the leaf is a comment and still on the same line
+      // return true to suppress if it's containing our marker text
+      if (isFlakeLineMarker(leaf, "# noqa")) {
+        return true;
+      }
+    }
+
+    // happens when the end of a file was reached, for example
+    return false;
+  }
+
+  /**
+   * Locate line comments matching # flake8: noqa
+   * This has to be fast as it's called a lot of times.
+   *
+   * @param element our start element containing the error element
+   * @return {@code true} if the highlighting should be suppressed, {@code false} otherwise
+   */
+  private boolean isSuppressedByLineComment(PsiElement element) {
+    // we'll iterate top to bottom. It's easier to implement and markers at the beginning of a file are more likely
+    PsiFile file = element.getContainingFile();
+
+    return isContainingFlakeLineMarker(file);
+  }
+
+  private boolean isContainingFlakeLineMarker(PsiElement element) {
+    // we assume that markers are most likely at the top-level of a file, i.e. not nested in other elements like functions or classes
+    // therefore we iterate the child first to see if top-level child element is a marker element
+    // if that failed then we iterate the children again and check if they contain the line marker in the sub-elements
+    for (PsiElement child = element.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (isFlakeLineMarker(child, "# flake8: noqa")) {
+        return true;
+      }
+    }
+
+    for (PsiElement child = element.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (isContainingFlakeLineMarker(child)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * A hopefully better test for a comment token than using instanceof.
+   *
+   * @param element The element to check
+   * @param prefix  The prefix which must match the comment's text
+   * @return {@code true} if it's a comment starting with the prefix
+   */
+  private boolean isFlakeLineMarker(PsiElement element, String prefix) {
+    // this is equivalent to "element instanceof PsiComment && element.getText().startWidth(prefix)"
+    // for now we assume that the equality check is faster than the instanceof check
+    ASTNode node = element.getNode();
+    return node != null
+           && node.getElementType() == PyTokenTypes.END_OF_LINE_COMMENT
+           && element.getText().startsWith(prefix);
+  }
+
+  @NotNull
+  @Override
+  public SuppressQuickFix[] getSuppressActions(@Nullable PsiElement element, @NotNull String toolId) {
+    return new SuppressQuickFix[]{
+      new Flake8EndOfLineSuppressionQuickFix()
+    };
+  }
+}

--- a/python/testSrc/com/jetbrains/python/inspections/flake8/Flake8EndOfLineSuppressionQuickFixTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/flake8/Flake8EndOfLineSuppressionQuickFixTest.java
@@ -1,0 +1,50 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python.inspections.flake8;
+
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.SuppressQuickFix;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.MockProblemDescriptor;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
+import org.intellij.lang.annotations.Language;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author jansorg
+ */
+public class Flake8EndOfLineSuppressionQuickFixTest extends LightPlatformCodeInsightFixture4TestCase {
+  @Test
+  public void testQuickFix() {
+    assertFixResult(
+      "x<caret> = 1",
+      "x = 1  # noqa");
+
+    assertFixResult(
+      "def foo():\n    x<caret> = 1",
+      "def foo():\n    x = 1  # noqa");
+
+    assertFixResult(
+      "def foo():\n    x<caret> = 1\n    \ndef bar():\n    x = 1 # noqa",
+      "def foo():\n    x = 1  # noqa\n\n\ndef bar():\n    x = 1 # noqa");
+  }
+
+  private void assertFixResult(@Language("Python") String code, @Language("Python") String expectedCode) {
+    myFixture.configureByText("test.py", code);
+
+    PsiElement current = myFixture.getElementAtCaret();
+    Assert.assertNotNull(current);
+
+    SuppressQuickFix fix = new Flake8EndOfLineSuppressionQuickFix();
+    Assert.assertTrue(fix.isAvailable(getProject(), current));
+
+    WriteCommandAction.runWriteCommandAction(getProject(), () -> {
+      ProblemDescriptor descriptor = new MockProblemDescriptor(current, "", ProblemHighlightType.LIKE_UNUSED_SYMBOL);
+      fix.applyFix(getProject(), descriptor);
+    });
+
+    Assert.assertEquals(expectedCode, myFixture.getFile().getText());
+  }
+}

--- a/python/testSrc/com/jetbrains/python/inspections/flake8/FlakeInspectionSuppressorTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/flake8/FlakeInspectionSuppressorTest.java
@@ -1,0 +1,79 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python.inspections.flake8;
+
+import com.google.common.collect.Sets;
+import com.intellij.codeInspection.InspectionEP;
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.codeInspection.LocalInspectionEP;
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
+import org.junit.Before;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class FlakeInspectionSuppressorTest extends LightPlatformCodeInsightFixture4TestCase {
+  private Set<String> excluded =
+    Sets.newHashSet("PyInterpreterInspection", "PyMandatoryEncodingInspection", "PyMissingOrEmptyDocstringInspection");
+
+  @Before
+  public void setup() {
+    InspectionProfileEntry[] inspections = LocalInspectionEP.LOCAL_INSPECTION.extensions()
+      .map(InspectionEP::instantiateTool)
+      .filter(e -> e.getShortName().startsWith("Py"))
+      .filter(e -> !excluded.contains(e.getShortName()))
+      .toArray(InspectionProfileEntry[]::new);
+    myFixture.enableInspections(inspections);
+  }
+
+  /**
+   * Test that markers are suppressing errors
+   */
+  @Test
+  public void testErrorSuppression() {
+    //language=Python
+    assertNoErrors("def foo():\n    x = 1 # noqa");
+
+    // testing prefix matching # noqa
+    //language=Python
+    assertNoErrors("def foo():\n    x = 1 # noqa123   ");
+
+    //language=Python
+    assertNoErrors("# flake8: noqa\ndef foo():\n    x = 1");
+
+    // testing prefix matching # flake8: noqa
+    //language=Python
+    assertNoErrors("# flake8: noqa123   \ndef foo():\n    x = 1");
+  }
+
+  /**
+   * Tests that we're not suppressing more than we should
+   */
+  @Test
+  public void testNoErrorSuppression() {
+    //language=Python
+    assertErrors("def foo():\n    x = 1");
+
+    // noq instead of noqa must not suppress inspections
+    //language=Python
+    assertErrors("def foo():\n    x = 1 # noq");
+
+    //language=Python
+    assertErrors("def foo():\n    x = 1");
+  }
+
+  private void assertNoErrors(String code) {
+    myFixture.configureByText("file.py", code);
+    myFixture.checkHighlighting();
+  }
+
+  private void assertErrors(String code) {
+    try {
+      myFixture.configureByText("file.py", code);
+      myFixture.checkHighlighting();
+    }
+    catch (ComparisonFailure ignored) {
+      // this is expected because errors must be added by inspections
+    }
+  }
+}


### PR DESCRIPTION
This adds my inspection suppressor at https://github.com/jansorg/pycharm-flake8 to the PyCharm community sources, as requested by the PyCharm team.