### PR TITLE
Check that build view is not null before sending events

### DIFF
--- a/platform/lang-impl/src/com/intellij/build/MultipleBuildsView.java
+++ b/platform/lang-impl/src/com/intellij/build/MultipleBuildsView.java
@@ -226,7 +226,10 @@ public class MultipleBuildsView implements BuildProgressListener, Disposable {
           buildInfo.statusMessage = event.getMessage();
         }
 
-        myViewMap.get(buildInfo).onEvent(event);
+        BuildView view = myViewMap.get(buildInfo);
+        if (view != null) {
+          view.onEvent(event);
+        }
       }
     });
 


### PR DESCRIPTION
There is a NPE when multiple projects are open in Android Studio, the
reason is that if there are multiple build views, the map that holds
them can be updated by other threads. Every time this map::get method is
called in MultipleBuildsView.java the code checks that the value is not
null, except for a case.

This change also makes sure that the view is not null in the missing
part.