### PR TITLE
Add missing break statement (see IDEA-208467)

### DIFF
--- a/java/java-analysis-impl/src/com/intellij/analysis/JavaAnalysisScope.java
+++ b/java/java-analysis-impl/src/com/intellij/analysis/JavaAnalysisScope.java
@@ -59,6 +59,7 @@ public class JavaAnalysisScope extends AnalysisScope {
         for (final PsiClass aClass : classes) {
           if (aClass.hasModifierProperty(PsiModifier.PUBLIC)) {
             onlyPackLocalClasses = false;
+            break;
           }
         }
         if (onlyPackLocalClasses) {

--- a/java/java-impl/src/com/intellij/refactoring/inline/InlineParameterExpressionProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/inline/InlineParameterExpressionProcessor.java
@@ -372,6 +372,7 @@ public class InlineParameterExpressionProcessor extends BaseRefactoringProcessor
         for (PsiParameter parameter : myMethod.getParameterList().getParameters()) {
           if (parameter.getType().equals(((PsiParameter)element).getType()) && parameter.getName().equals(((PsiParameter)element).getName())) {
             bound = true;
+            break;
           }
         }
         if (!bound) {

--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightingSettingsPerFile.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightingSettingsPerFile.java
@@ -105,7 +105,10 @@ public class HighlightingSettingsPerFile extends HighlightingLevelManager implem
     defaults[rootIndex] = setting;
     boolean toRemove = true;
     for (FileHighlightingSetting aDefault : defaults) {
-      if (aDefault != FileHighlightingSetting.NONE) toRemove = false;
+      if (aDefault != FileHighlightingSetting.NONE) {
+        toRemove = false;
+        break;
+      }
     }
     if (toRemove) {
       myHighlightSettings.remove(virtualFile);

--- a/platform/lang-impl/src/com/intellij/ide/impl/PatchProjectUtil.java
+++ b/platform/lang-impl/src/com/intellij/ide/impl/PatchProjectUtil.java
@@ -164,6 +164,7 @@ public class PatchProjectUtil {
         for (VirtualFile includeRoot : included) {
           if (VfsUtilCore.isAncestor(toExclude, includeRoot, false)) {
             toExcludeSibling = false;
+            break;
           }
         }
         if (toExcludeSibling) {

--- a/platform/lang-impl/src/com/intellij/openapi/paths/WebReferencesAnnotatorBase.java
+++ b/platform/lang-impl/src/com/intellij/openapi/paths/WebReferencesAnnotatorBase.java
@@ -84,6 +84,7 @@ public abstract class WebReferencesAnnotatorBase extends ExternalAnnotator<WebRe
     for (MyFetchResult fetchResult : fetchResults) {
       if (fetchResult != MyFetchResult.UNKNOWN_HOST) {
         containsAvailableHosts = true;
+        break;
       }
     }
 

--- a/platform/testFramework/src/com/intellij/testFramework/UsefulTestCase.java
+++ b/platform/testFramework/src/com/intellij/testFramework/UsefulTestCase.java
@@ -734,6 +734,7 @@ public abstract class UsefulTestCase extends TestCase {
     for (T v : values) {
       if (Objects.equals(value, v)) {
         found = true;
+        break;
       }
     }
     Assert.assertTrue(value + " should be equal to one of " + Arrays.toString(values), found);

--- a/python/src/com/jetbrains/python/PyParameterInfoHandler.java
+++ b/python/src/com/jetbrains/python/PyParameterInfoHandler.java
@@ -218,6 +218,7 @@ public class PyParameterInfoHandler implements ParameterInfoHandler<PyArgumentLi
     for (EnumSet<ParameterInfoUIContextEx.Flag> set : hintFlags.values()) {
       if (set.contains(ParameterInfoUIContextEx.Flag.HIGHLIGHT)) {
         canOfferNext = false;
+        break;
       }
     }
     // highlight the next parameter to be filled

--- a/python/src/com/jetbrains/python/refactoring/PyReplaceExpressionUtil.java
+++ b/python/src/com/jetbrains/python/refactoring/PyReplaceExpressionUtil.java
@@ -166,6 +166,7 @@ public class PyReplaceExpressionUtil implements PyElementTypes {
       for (PyExpression argument : arguments) {
         if (argument instanceof PyStarArgument) {
           hasStarArguments = true;
+          break;
         }
       }
       if (!hasStarArguments) {


### PR DESCRIPTION
This raise-a-flag pattern is very wide-spread and often implemented without break statement after flag is raised.
In case `if`-statement doesn't have any side-effects all iterations executed after the flag is raised are useless, as flag's value won't change.
The statement or iteration however are often time-consuming which impacts performance.