### PR TITLE
decompiler: Recognize enum as keyword on Java 5

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/util/TextUtil.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/util/TextUtil.java
@@ -70,7 +70,7 @@ public class TextUtil {
   }
 
   private static boolean isKeyword(String id, int version) {
-    return KEYWORDS.contains(id) || version > CodeConstants.BYTECODE_JAVA_5 && "enum".equals(id);
+    return KEYWORDS.contains(id) || version >= CodeConstants.BYTECODE_JAVA_5 && "enum".equals(id);
   }
 
   public static String getInstructionName(int opcode) {


### PR DESCRIPTION
The current code recognizes `enum` as keyword on versions **greater than 5**. However, enums and the keyword have been introduced in Java 5. This PR simply changes the check to check whether a given version is **greater than or equal to 5**.