### PR TITLE
Ensure GradleProjectResolver uses extensions extra model provider

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolver.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolver.java
@@ -227,8 +227,7 @@ public class GradleProjectResolver implements ExternalSystemProjectResolver<Grad
       if(!resolverCtx.isPreviewMode()){
         // register classes of extra gradle project models required for extensions (e.g. com.android.builder.model.AndroidProject)
         try {
-          projectImportAction.addProjectImportExtraModelProvider(
-            new ClassSetProjectImportExtraModelProvider(resolverExtension.getExtraProjectModelClasses()));
+          projectImportAction.addProjectImportExtraModelProvider(resolverExtension.getExtraModelProvider());
         }
         catch (Throwable t) {
           LOG.warn(t);


### PR DESCRIPTION
I missed this when submitting the last pull request, apologies. This ensures that the providers are taken correctly from the GradleProjectResolverExtensions.

This change should not affect the behavior since currently no resolver extensions override this method, the default implementation in AbsractProjectResolverExtension uses the ClassSetProjectImportExtraModelProvider which is exactly what this is currently doing.