### PR TITLE
Change wording in tooltip when no unused imports found

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/actions/OptimizeImportsAction.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/actions/OptimizeImportsAction.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 
 public class OptimizeImportsAction extends AnAction {
   private static final @NonNls String HELP_ID = "editing.manageImports";
-  private static final String NO_IMPORTS_OPTIMIZED = "Unused imports not found";
+  private static final String NO_IMPORTS_OPTIMIZED = "No unused imports found";
   private static boolean myProcessVcsChangedFilesInTests;
 
   public OptimizeImportsAction() {


### PR DESCRIPTION
Change the wording in the tooltip that shows up after "optimize imports" has been run and no unused imports were found, from "Unused imports not found" to "No unused imports found", since it reads as more natural English.