### PR TITLE
IDEA-208615: Fix one of UiNotifyConnector leak channels

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/tabs/JBEditorTabsBase.kt
+++ b/platform/platform-api/src/com/intellij/ui/tabs/JBEditorTabsBase.kt
@@ -1,13 +1,24 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.ui.tabs
 
+import com.intellij.openapi.Disposable
 import java.awt.Color
 import java.util.function.Supplier
 
 /**
  * @author yole
  */
-interface JBEditorTabsBase : JBTabs {
+interface JBEditorTabsBase : JBTabsEx {
+  /**
+   * Creates a tab without firing any SelectionChanged events.
+   *
+   * @param info parameters of the tab
+   * @param index zero-based index of the tab, or -1 to insert at the end
+   * @param tabDisposable the disposable that will be disposed when the tab is closed
+   * @return the same as the `info` parameter
+   */
+  fun addTabSilently(info: TabInfo, index: Int, tabDisposable: Disposable): TabInfo
+
   @Deprecated("Used only by the old tabs implementation")
   fun setEmptySpaceColorCallback(callback: Supplier<Color>);
 }

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorTabbedContainer.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorTabbedContainer.java
@@ -68,7 +68,7 @@ import java.util.Map;
 public final class EditorTabbedContainer implements Disposable, CloseAction.CloseTarget {
   private final EditorWindow myWindow;
   private final Project myProject;
-  private final JBTabsEx myTabs;
+  private final JBEditorTabsBase myTabs;
 
   @NonNls public static final String HELP_ID = "ideaInterface.editor";
 
@@ -327,10 +327,11 @@ public final class EditorTabbedContainer implements Disposable, CloseAction.Clos
     tab.setTestableUi(new MyQueryable(tab));
 
     final DefaultActionGroup tabActions = new DefaultActionGroup();
-    tabActions.add(new CloseTab(comp, file));
+    Disposable tabDisposable = Disposer.newDisposable();
+    tabActions.add(new CloseTab(comp, file, tabDisposable));
 
     tab.setTabLabelActions(tabActions, ActionPlaces.EDITOR_TAB);
-    myTabs.addTabSilently(tab, indexToInsert);
+    myTabs.addTabSilently(tab, indexToInsert, tabDisposable);
   }
 
   boolean isEmptyVisible() {
@@ -398,9 +399,9 @@ public final class EditorTabbedContainer implements Disposable, CloseAction.Clos
   private final class CloseTab extends AnAction implements DumbAware {
     private final VirtualFile myFile;
 
-    CloseTab(@NotNull JComponent c, @NotNull VirtualFile file) {
+    CloseTab(@NotNull JComponent c, @NotNull VirtualFile file, @NotNull Disposable tabDisposable) {
       myFile = file;
-      new ShadowAction(this, ActionManager.getInstance().getAction(IdeActions.ACTION_CLOSE), c, (Disposable) myTabs);
+      new ShadowAction(this, ActionManager.getInstance().getAction(IdeActions.ACTION_CLOSE), c, tabDisposable);
     }
 
     @Override


### PR DESCRIPTION
Introduce disposables corresponding to individual tabs. Use such a disposable to control lifecycle of UiNotifyConnector used by EditorTabbedContainer.CloseTab.