### PR TITLE
ActionButton component should be focusable.

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionButton.java
+++ b/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionButton.java
@@ -61,8 +61,7 @@ public class ActionButton extends JComponent implements ActionButtonComponent, A
     myAction = action;
     myPresentation = presentation;
     myPlace = place;
-    // Button should be focusable if screen reader is active
-    setFocusable(ScreenReader.isActive());
+    setFocusable(true);
     enableEvents(AWTEvent.MOUSE_EVENT_MASK);
     // Pressing the SPACE key is the same as clicking the button
     addKeyListener(new KeyAdapter() {


### PR DESCRIPTION
Keyboard navigation can be needed not only for user using a screen
reader but also for user with difficulties using a mouse.

Enabling focus on ActionButton allows a better focus traversal policy.