### PR TITLE
Enabling cross plugin communication.

### DIFF
--- a/platform/util/src/com/intellij/util/PluginCommunicationsListener.java
+++ b/platform/util/src/com/intellij/util/PluginCommunicationsListener.java
@@ -1,0 +1,17 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.util;
+
+import com.intellij.util.messages.Topic;
+
+import java.util.EventListener;
+
+/**
+ * Enables cross plugin communications.
+ * Plugins may publish and subscribe to the topic instance provided with this interface.
+ *
+ */
+public interface PluginCommunicationsListener extends EventListener {
+  Topic<PluginCommunicationsListener> TOPIC = Topic.create("Plugin Message Topic", PluginCommunicationsListener.class);
+
+  void messageReceived(String pluginId, String messageType, String messagePayload);
+}


### PR DESCRIPTION
### Change Summary
Added a new `Topic` instance and interface which is a `EventListener` subclass. 

### Reason for Change
I maintain a couple of plugins and would like to enable communications between the two products. So I can implement new and cool features! 

Currently, plugins can only can publish and receive messages from a topic whose instance they can reference. In order for plugins to have access to a shared instance, it needs to come from the intellij SDK. Since all JetBrains products contain the `com.intellij.modules.platform`, I figured that this would be the best place to put this.

**Thanks for your time!**