### PR TITLE
IDEA-208067: Fix memory leak via InlayModelImpl$AfterLineEndElementTree

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/InlayModelImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/InlayModelImpl.java
@@ -107,12 +107,14 @@ public class InlayModelImpl implements InlayModel, Disposable, Dumpable {
   void reinitSettings() {
     myInlineElementsTree.processAll(UPDATE_SIZE_PROCESSOR);
     myBlockElementsTree.processAll(UPDATE_SIZE_PROCESSOR);
+    myAfterLineEndElementsTree.processAll(UPDATE_SIZE_PROCESSOR);
   }
 
   @Override
   public void dispose() {
     myInlineElementsTree.dispose(myEditor.getDocument());
     myBlockElementsTree.dispose(myEditor.getDocument());
+    myAfterLineEndElementsTree.dispose(myEditor.getDocument());
   }
 
   @Nullable


### PR DESCRIPTION
AfterLineEndElementTrees register themselves as document listeners in
their constructor, but the disposal call in InlayModelImpl which removes
this listener was omitted.