### PR TITLE
Reduce memory used for comparing branches (IDEA-209343)

### DIFF
--- a/plugins/git4idea/src/git4idea/history/GitLogParser.java
+++ b/plugins/git4idea/src/git4idea/history/GitLogParser.java
@@ -333,7 +333,7 @@ public class GitLogParser {
     private Map<GitLogOption, String> createOptions(@NotNull List<String> options) {
       Map<GitLogOption, String> optionsMap = new HashMap<>(options.size());
       for (int index = 0; index < options.size(); index++) {
-        optionsMap.put(myOptions[index], options.get(index));
+        optionsMap.put(myOptions[index], GitStringInterner.intern(options.get(index)));
       }
       return optionsMap;
     }
@@ -391,11 +391,11 @@ public class GitLogParser {
     private String tryUnescapePath(@Nullable String path) {
       if (path == null) return null;
       try {
-        return GitUtil.unescapePath(path);
+        return GitStringInterner.intern(GitUtil.unescapePath(path));
       }
       catch (VcsException e) {
         LOG.error(e);
-        return path;
+        return GitStringInterner.intern(path);
       }
     }
 

--- a/plugins/git4idea/src/git4idea/history/GitStringInterner.java
+++ b/plugins/git4idea/src/git4idea/history/GitStringInterner.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package git4idea.history;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Cache of String objects that can be used to avoid creating duplicate strings with the same content.
+ * This class is thread-safe but the effects of {@link #clearAndEnable} and {@link #clearAndDisable} methods
+ * may not be visible to all threads immediately.
+ */
+public class GitStringInterner {
+  @Nullable private static ConcurrentMap<String, String> ourStringCache;
+  @NotNull private static final AtomicLong ourTotalSize = new AtomicLong();
+  @NotNull private static final AtomicLong ourUniqueSize = new AtomicLong();
+
+  /**
+   * Enables caching of strings and clears the cache if it was not empty.
+   */
+  public static void clearAndEnable() {
+    ourTotalSize.set(0);
+    ourUniqueSize.set(0);
+    ourStringCache = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Disables caching of strings and clears the cache.
+   *
+   * @return the hit ratio for the time the cache was enabled defined as the total length of strings returned
+   *     from the cache divided by the total length of strings passed to the {@link #intern(String)} method.
+   */
+  public static double clearAndDisable() {
+    long totalSize = ourTotalSize.getAndSet(0);
+    long uniqueSize = ourUniqueSize.getAndSet(0);
+    ourStringCache = null;
+    return totalSize == 0 ? 0 : (totalSize - uniqueSize) / (double)totalSize;
+  }
+
+  /**
+   * Returns the string from the cache equal to the argument, if present, or puts the string to the cache and returns it.
+   *
+   * @param str the string to intern
+   * @return the interned string
+   */
+  @NotNull
+  public static String intern(@NotNull String str) {
+    ConcurrentMap<String, String> cache = ourStringCache;
+    if (cache == null) {
+      return str;
+    }
+    String s = cache.computeIfAbsent(str, Function.identity());
+    int length = s.length();
+    ourTotalSize.addAndGet(length);
+    if (s == str) {
+      ourUniqueSize.addAndGet(length);
+    }
+    return s;
+  }
+}


### PR DESCRIPTION
Memory consumption is reduced by not creating duplicate String objects. In my testing it reduced amount of memory occupied by the String objects used by the branch comparison by 11x. Opening the comparison dialog became faster by 13%, probably due to reduced memory pressure.

Deduplication of strings is done using a new GitStringInterner class that contains a global string cache. The cache is cleared at the end of the GitBranchWorker.loadCommitsToCompare method. It would be nice to use a local cache and pass it explicitly to all GitLogParser instances created by the branch comparison code, but that would require significant changes to existing APIs.