### PR TITLE
Do not throw exception when unable to get constant pool

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/jdi/MethodBytecodeUtil.java
+++ b/java/debugger/impl/src/com/intellij/debugger/jdi/MethodBytecodeUtil.java
@@ -292,6 +292,11 @@ public class MethodBytecodeUtil {
       return locations;
     }
 
+    // Android Studio: 'getConstantPool' is not supported on android. (b/123863053)
+    if (!method.declaringType().virtualMachine().canGetConstantPool()) {
+      return locations;
+    }
+
     int lineNumber = locations.get(0).lineNumber();
     List<Boolean> mask = new ArrayList<>(locationsSize);
     visit(method, new MethodVisitor(Opcodes.API_VERSION) {


### PR DESCRIPTION
Bug: https://issuetracker.google.com/issues/123863053
It is becuase ART(Android) JVM doesn't support the 'getConstantPool' capability.