### PR TITLE
IDEA-188964 prefer an older but compatible plugin

### DIFF
--- a/platform/core-impl/src/com/intellij/ide/plugins/PluginManagerCore.java
+++ b/platform/core-impl/src/com/intellij/ide/plugins/PluginManagerCore.java
@@ -983,6 +983,12 @@ public class PluginManagerCore {
             result.set(oldIndex, descriptor);
           }
         }
+        else { // We again prefer the older compatible version
+          if (isIncompatible(oldDescriptor) && isCompatible(descriptor)) {
+            getLogger().info("newer plugin is incompatible, ignoring: " + oldDescriptor.getPath());
+            result.set(oldIndex, descriptor);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
We expand on the fix for IDEA-188964 from commit 11b64c4617, by also
taking into account the possibility that the first plugin version
(loaded from the user's config) is newer but incompatible, while the
version bundled with the platform is compatible.

This is a recurring problem for Studio and the Kotlin plugin, whenever
we update the platform: http://issuetracker.google.com/129260858