### PR TITLE
Remove option USE_PROJECT_PROFILE

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
     <option name="PROJECT_PROFILE" value="idea.default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
     <version value="1.0" />
   </settings>
 </component>


### PR DESCRIPTION
IntelliJ IDEA 2019.1 deletes it automatically.