### PR TITLE
IDEA-209898 SpeedSearch: Make Ctrl-Backspace also delete trailing whitespace first

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/speedSearch/SpeedSearch.java
+++ b/platform/platform-api/src/com/intellij/ui/speedSearch/SpeedSearch.java
@@ -71,6 +71,11 @@ public class SpeedSearch extends SpeedSearchSupply implements KeyListener {
     if (e.getID() == KeyEvent.KEY_PRESSED) {
       if (KeymapUtil.isEventForAction(e, "EditorDeleteToWordStart")) {
         if (isHoldingFilter()) {
+          // first delete all consecutive whitespace
+          while (!myString.isEmpty() && Character.isWhitespace(myString.charAt(myString.length() - 1))) {
+            backspace();
+          }
+          // now delete all until whitespace is found
           while (!myString.isEmpty() && !Character.isWhitespace(myString.charAt(myString.length() - 1))) {
             backspace();
           }


### PR DESCRIPTION
Fixes IDEA-209898 SpeedSearch: Ctrl-Backspace only works if cursor is after non-whitespace character

See https://youtrack.jetbrains.net/issue/IDEA-209898