### PR TITLE
Fix bug in BuildOutputInstantReaderImpl

### DIFF
--- a/platform/lang-impl/src/com/intellij/build/output/BuildOutputInstantReaderImpl.java
+++ b/platform/lang-impl/src/com/intellij/build/output/BuildOutputInstantReaderImpl.java
@@ -135,6 +135,9 @@ public class BuildOutputInstantReaderImpl implements BuildOutputInstantReader {
 
     myCurrentIndex++;
     int bufferIndex = myCurrentIndex - bufferOffset;
+    if (bufferIndex < 0) {
+      return null;
+    }
     if (myLinesBuffer.size() > bufferIndex) {
       return myLinesBuffer.get(bufferIndex);
     }


### PR DESCRIPTION
The bug is that the buffer size stops at 50 though myCurrentIndex keeps
going up. So after finishing reading 50 lines, myCurrentIndex would
always go over the buffer size, in which case getCurrentLine() would
always return null.

https://youtrack.jetbrains.com/issue/IDEA-209816