### PR TITLE
Fix Gradle Daemons window with Gradle 5.3

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/internal/daemon/DaemonStatusAction.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/internal/daemon/DaemonStatusAction.java
@@ -15,10 +15,10 @@ import org.gradle.launcher.daemon.registry.DaemonStopEvent;
 import org.gradle.launcher.daemon.registry.DaemonStopEvents;
 import org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus;
 import org.gradle.util.GradleVersion;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -31,7 +31,8 @@ public class DaemonStatusAction extends DaemonAction {
     super(serviceDirectoryPath);
   }
 
-  public List<DaemonState> run(DaemonClientFactory daemonClientFactory) {
+  public List<DaemonState> run(DaemonClientFactory daemonClientFactory)
+    throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
     ServiceRegistry daemonServices = getDaemonServices(daemonClientFactory);
     DaemonConnector daemonConnector = daemonServices.get(DaemonConnector.class);
     DaemonRegistry daemonRegistry = daemonServices.get(DaemonRegistry.class);

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/internal/daemon/DaemonStopAction.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/internal/daemon/DaemonStopAction.java
@@ -15,6 +15,7 @@ import org.gradle.launcher.daemon.protocol.Stop;
 import org.gradle.launcher.daemon.registry.DaemonInfo;
 import org.gradle.launcher.daemon.registry.DaemonRegistry;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -28,7 +29,8 @@ public class DaemonStopAction extends DaemonAction {
     super(serviceDirectoryPath);
   }
 
-  public void run(DaemonClientFactory daemonClientFactory) {
+  public void run(DaemonClientFactory daemonClientFactory)
+    throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
     ServiceRegistry daemonServices = getDaemonServices(daemonClientFactory);
     DaemonStopClient stopClient = daemonServices.get(DaemonStopClient.class);
     stopClient.stop();


### PR DESCRIPTION
The constructor of DaemonParameters class in Gradle tooling API
is updated since Gradle 5.3. It now takes FileCollectionFactory
as required parameter.
This change calls the constructor by reflection if current Gradle
version is newer than 5.3.

Change-Id: I21eeb8f1e95267892ab378a98ca4517eb3d50e07