### PR TITLE
Recognize Chrome OS in SystemInfo

### DIFF
--- a/platform/util/src/com/intellij/openapi/util/SystemInfo.java
+++ b/platform/util/src/com/intellij/openapi/util/SystemInfo.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.lang.JavaVersion;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
 import java.util.List;
 import java.util.Locale;
 
@@ -41,6 +42,7 @@ public class SystemInfo extends SystemInfoRt {
   public static final boolean isFreeBSD = SystemInfoRt.isFreeBSD;
   public static final boolean isSolaris = SystemInfoRt.isSolaris;
   public static final boolean isUnix = SystemInfoRt.isUnix;
+  public static final boolean isChromeOS = SystemInfoRt.isLinux && isCrostini();
 
   public static final boolean isAppleJvm = containsIgnoreCase(JAVA_VENDOR, "Apple");
   public static final boolean isOracleJvm = containsIgnoreCase(JAVA_VENDOR, "Oracle");
@@ -60,6 +62,10 @@ public class SystemInfo extends SystemInfoRt {
     catch (Throwable t) {
       return false;
     }
+  }
+
+  private static boolean isCrostini() {
+    return new File("/dev/.cros_milestone").exists();
   }
 
   public static boolean isOsVersionAtLeast(@NotNull String version) {


### PR DESCRIPTION
Android Studio (and the Android plugin) would benefit from having the detection done in platform code.