### PR TITLE
Add missing quotes in NSIS configuration

### DIFF
--- a/build/conf/nsis/idea.nsi
+++ b/build/conf/nsis/idea.nsi
@@ -1498,7 +1498,7 @@ HKLM:
 
 cant_find_installation:
 ; compare installdir with default user location
-  ${UnStrStr} $R0 $INSTDIR $LOCALAPPDATA\${MANUFACTURER}
+  ${UnStrStr} $R0 $INSTDIR "$LOCALAPPDATA\${MANUFACTURER}"
   StrCmp $R0 $INSTDIR HKCU 0
 
 ; compare installdir with default admin location


### PR DESCRIPTION
Without this, a manufacturer with a space in the name causes `UnStrStr`
to be invoked with bogus extra arguments.