### PR TITLE
IDEA-210834 fix gradle properties not being read on distribution initialization

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
@@ -428,7 +428,7 @@ public class GradleExecutionHelper {
           break;
         case WRAPPED:
           if (settings.getWrapperPropertyFile() != null) {
-            DistributionFactoryExt.setWrappedDistribution(connector, settings.getWrapperPropertyFile(), serviceDirectory);
+            DistributionFactoryExt.setWrappedDistribution(connector, settings.getWrapperPropertyFile(), serviceDirectory, projectDir);
           }
           break;
       }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/DistributionFactoryExt.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/DistributionFactoryExt.java
@@ -18,6 +18,7 @@ import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
 import org.gradle.util.DistributionLocator;
 import org.gradle.util.GradleVersion;
 import org.gradle.wrapper.GradleUserHomeLookup;
+import org.gradle.wrapper.SystemPropertiesHandler;
 import org.gradle.wrapper.WrapperConfiguration;
 import org.gradle.wrapper.WrapperExecutor;
 
@@ -39,12 +40,12 @@ public class DistributionFactoryExt extends DistributionFactory {
     super(Time.clock());
   }
 
-  public static void setWrappedDistribution(GradleConnector connector, String wrapperPropertyFile, File gradleUserHome) {
+  public static void setWrappedDistribution(GradleConnector connector, String wrapperPropertyFile, File gradleUserHome, File projectDir) {
     File propertiesFile = new File(wrapperPropertyFile);
     if (propertiesFile.exists()) {
       WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile);
       if (wrapper.getDistribution() != null) {
-        Distribution distribution = new DistributionFactoryExt().getWrappedDistribution(propertiesFile, gradleUserHome);
+        Distribution distribution = new DistributionFactoryExt().getWrappedDistribution(propertiesFile, gradleUserHome, projectDir);
         try {
           setDistributionField(connector, distribution);
         }
@@ -58,10 +59,10 @@ public class DistributionFactoryExt extends DistributionFactory {
   /**
    * Returns the default distribution to use for the specified project.
    */
-  private Distribution getWrappedDistribution(File propertiesFile, final File userHomeDir) {
+  private Distribution getWrappedDistribution(File propertiesFile, final File userHomeDir, File projectDir) {
     WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile);
     if (wrapper.getDistribution() != null) {
-      return new ZippedDistribution(wrapper.getConfiguration(), determineRealUserHomeDir(userHomeDir), Time.clock());
+      return new ZippedDistribution(wrapper.getConfiguration(), determineRealUserHomeDir(userHomeDir), projectDir, Time.clock());
     }
     return getDownloadedDistribution(GradleVersion.current().getVersion());
   }
@@ -118,11 +119,13 @@ public class DistributionFactoryExt extends DistributionFactory {
     private InstalledDistribution installedDistribution;
     private final WrapperConfiguration wrapperConfiguration;
     private final File distributionBaseDir;
+    private final File projectDir;
     private final Clock clock;
 
-    private ZippedDistribution(WrapperConfiguration wrapperConfiguration, File distributionBaseDir, Clock clock) {
+    private ZippedDistribution(WrapperConfiguration wrapperConfiguration, File distributionBaseDir, File projectDir, Clock clock) {
       this.wrapperConfiguration = wrapperConfiguration;
       this.distributionBaseDir = distributionBaseDir;
+      this.projectDir = projectDir;
       this.clock = clock;
     }
 
@@ -141,6 +144,7 @@ public class DistributionFactoryExt extends DistributionFactory {
         File installDir;
         try {
           cancellationToken.addCallback(() -> installer.cancel());
+          readGradleProperties(determineRealUserHomeDir(userHomeDir), projectDir);
           installDir = installer.install(determineRealUserHomeDir(userHomeDir), wrapperConfiguration);
         }
         catch (CancellationException e) {
@@ -166,6 +170,11 @@ public class DistributionFactoryExt extends DistributionFactory {
       }
 
       return userHomeDir != null ? userHomeDir : GradleUserHomeLookup.gradleUserHome();
+    }
+
+    private void readGradleProperties(File userHomeDir, File projectDir) {
+      System.getProperties().putAll(SystemPropertiesHandler.getSystemProperties(new File(userHomeDir, "gradle.properties")));
+      System.getProperties().putAll(SystemPropertiesHandler.getSystemProperties(new File(projectDir, "gradle.properties")));
     }
   }
 


### PR DESCRIPTION
This fixes an issue when Gradle distribution can't be downloaded if remote repo requires an authentication.

The suggested solution duplicates the `GradleWrapperMain` behavior: https://github.com/gradle/gradle/blob/ae6478d485a613b6b4c1f9761882a956adb9156c/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java#L70