### PR TITLE
Decrement the current index after removing first element from buffer

### DIFF
--- a/platform/lang-impl/src/com/intellij/build/output/BuildOutputInstantReaderImpl.java
+++ b/platform/lang-impl/src/com/intellij/build/output/BuildOutputInstantReaderImpl.java
@@ -147,6 +147,7 @@ public class BuildOutputInstantReaderImpl implements BuildOutputInstantReader {
       myLinesBuffer.addLast(line);
       if (myLinesBuffer.size() > MAX_LINES_BUFFER_SIZE) {
         myLinesBuffer.removeFirst();
+        myCurrentIndex--;
       }
       return line;
     }


### PR DESCRIPTION
There is an issue in Android Studio where the build output parsers are
not receiving all errors. The reason to that is when we try to read the
next line while the buffer is full, the first element is removed and the
current index will be pointing to the next element so this line will be
skipped in the next call of readLine.

This change decrements the current index after the first element is
removed from the buffer so it will point to the same element before
the removal.