### PR TITLE
Added comparing description in MessageEvent.equals

### DIFF
--- a/platform/lang-impl/src/com/intellij/build/events/impl/MessageEventImpl.java
+++ b/platform/lang-impl/src/com/intellij/build/events/impl/MessageEventImpl.java
@@ -69,6 +69,7 @@ public class MessageEventImpl extends AbstractBuildEvent implements MessageEvent
     if (o == null || getClass() != o.getClass()) return false;
     MessageEventImpl event = (MessageEventImpl)o;
     return Objects.equals(getMessage(), event.getMessage()) &&
+           Objects.equals(getDescription(), event.getDescription()) &&
            Objects.equals(myGroup, event.myGroup);
   }
 


### PR DESCRIPTION
In Android Studio we have problem where multiple error messages are
skipped because they have the same message, although they differ in
their descriptions.

This changes adds comparing the message description to the equals
function.