### PR TITLE
 Add zip store properties from Gradle wrapper

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleUtil.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleUtil.java
@@ -118,6 +118,14 @@ public class GradleUtil {
       if(!isEmpty(distPathBase)) {
         wrapperConfiguration.setDistributionBase(distPathBase);
       }
+      String zipStorePath = props.getProperty(WrapperExecutor.ZIP_STORE_PATH_PROPERTY);
+      if(!isEmpty(zipStorePath)) {
+        wrapperConfiguration.setZipPath(zipStorePath);
+      }
+      String zipStoreBase = props.getProperty(WrapperExecutor.ZIP_STORE_BASE_PROPERTY);
+      if(!isEmpty(zipStoreBase)) {
+        wrapperConfiguration.setZipBase(zipStoreBase);
+      }
       return wrapperConfiguration;
     }
     catch (Exception e) {


### PR DESCRIPTION
GradleUtil#getWrapperConfiguration reads properties from the gradle
wrapper into a WrapperConfiguration, but it is missing zip store
properties. Currently, instances of WrapperConfiguration generated by
this function will have the default values regardless of what the values
are in the wrapper properties.