### PR TITLE
Extend the Gradle project resolver to allow the following customizations

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BuildActionRunner.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/BuildActionRunner.kt
@@ -1,0 +1,165 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.plugins.gradle.service.project
+
+import org.gradle.tooling.BuildActionExecuter
+import org.gradle.tooling.GradleConnectionException
+import org.gradle.tooling.IntermediateResultHandler
+import org.gradle.tooling.ResultHandler
+import org.gradle.tooling.UnsupportedVersionException
+import org.gradle.tooling.model.idea.BasicIdeaProject
+import org.gradle.tooling.model.idea.IdeaProject
+import org.jetbrains.plugins.gradle.model.ProjectImportAction
+import org.jetbrains.plugins.gradle.model.ProjectImportAction.AllModels
+import org.jetbrains.plugins.gradle.service.execution.GradleExecutionHelper
+import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * This class handles setting up and running the [BuildActionExecuter] it deals with calling the correct APIs based on the version of
+ * Gradle that is present.
+ *
+ * In order to do this we require the current [resolverCtx], the [buildAction] that should be run and whether or not
+ * to initialize task running for the Gradle operation ([initializeTaskExecution]).
+ *
+ * We also require the [helper] which will be used to set up each [BuildActionExecuter]. We may need to set up more than one
+ * of these if the version of Gradle that we are connecting to doesn't support the certain features.
+ *
+ * We have three different cases which will be handled in [fetchModels] we will try the most recent first, falling back to the older
+ * ones if a [GradleConnectionException] is thrown.
+ * These three cases are as follows:
+ *   (Gradle 4.8 and above) Using the PhasedBuildActionExecuter, this allows us to inject build actions into different parts of the
+ *                          Gradle build. It also allows us to run schedule tasks to be run after fetching the models.
+ *   (Gradle 1.8 and above) Using the [BuildActionExecuter]
+ *   (Gradle 1.7 and below) Using [GradleExecutionHelper.getModelBuilder]
+ */
+class BuildActionRunner(
+  private val resolverCtx: ProjectResolverContext,
+  private val buildAction: ProjectImportAction,
+  private val initializeTaskExecution: Boolean,
+  private val settings: GradleExecutionSettings,
+  private val helper: GradleExecutionHelper
+) {
+  // This queue is used to synchronize the result of the models from the result handler passed to the projectsLoaded()
+  // method of the BuildActionExecutor. Either the result or an exception will be added to the queue in the handler.
+  // This will then be picked up and handled by the thread that is handling sync.
+  private val resultQueue = ArrayBlockingQueue<Any>(1)
+  private val modelsHandler: IntermediateResultHandler<AllModels?> = IntermediateResultHandler { allModels ->
+    if (allModels == null) {
+      resultQueue.add(IllegalStateException("Unable to get project model for the project: " + resolverCtx.projectPath))
+    }
+    else {
+      resultQueue.add(allModels)
+    }
+  }
+
+  /**
+   * Fetches the [AllModels] that have been populated as a result of running the [ProjectImportAction] against the Gradle tooling API.
+   *
+   * This method returns as soon as the models have been obtained but possibly before the build has finished. The [buildFinishedCallBack]
+   * will be run when the complete Gradle operation has finished (including any tasks that need to be run).
+   *
+   * For Gradle versions below 1.8 we fall back to the old [org.gradle.tooling.ModelBuilder] api, using the [helper] and
+   * [settings].
+   */
+  fun fetchModels(
+    buildFinishedCallBack: Runnable
+  ): AllModels {
+    // First try with the phased build executor
+    createPhasedExecuter().run(BuildActionResultHandler(buildFinishedCallBack))
+
+    val phasedResult = takeQueueResultBlocking()
+    // If we have a non-unsupported version exception pass the failure up to be dealt with by the ExternalSystem
+    if (phasedResult is Throwable && phasedResult !is UnsupportedVersionException) throw phasedResult
+    // If we have a result, return it
+    if (phasedResult !is Throwable) return phasedResult as AllModels
+
+    resolverCtx.checkCancelled()
+
+    // Otherwise we have a GradleConnectionException, try using the non-phased build action executer.
+    // If the handler fails
+    createDefaultExecuter().run(BuildActionResultHandler(buildFinishedCallBack))
+
+    val result = takeQueueResultBlocking()
+    // If we have a non-unsupported version exception pass the failure up to be dealt with by the ExternalSystem
+    if (result is Throwable && result !is UnsupportedVersionException) throw result
+    // If we have a result, return it
+    if (result !is Throwable) return result as AllModels
+
+    // BuildActions are unsupported in this version of Gradle, try the model builder API.
+    resolverCtx.checkCancelled()
+
+    // Old gradle distribution version used (before ver. 1.8)
+    // fallback to use ModelBuilder gradle tooling API
+    val aClass = if (resolverCtx.isPreviewMode) BasicIdeaProject::class.java else IdeaProject::class.java
+    val modelBuilder = helper.getModelBuilder(
+      aClass,
+      resolverCtx.externalSystemTaskId,
+      settings,
+      resolverCtx.connection,
+      resolverCtx.listener)
+
+    buildFinishedCallBack.run()
+
+    return ProjectImportAction.AllModels(modelBuilder.get())
+  }
+
+  private fun takeQueueResultBlocking(): Any {
+    var obtainedResult: Any? = null
+    // Every second check to ensure the user didn't cancel the operation. If something goes really wrong with the Gradle connection
+    // threads then at least the user should be able to cancel the refresh process.
+    while (obtainedResult == null) {
+      resolverCtx.checkCancelled()
+      obtainedResult = resultQueue.poll(1, TimeUnit.SECONDS)
+    }
+
+    return obtainedResult
+  }
+
+  /**
+   * Creates the [BuildActionExecuter] to be used to run the [ProjectImportAction].
+   */
+  private fun createPhasedExecuter(): BuildActionExecuter<Void> {
+    val executer = resolverCtx.connection.action().projectsLoaded(buildAction, modelsHandler).build()
+    executer.prepare()
+    executer.setCancellationToken(resolverCtx)
+    if (initializeTaskExecution) executer.forTasks(emptyList())
+    return executer
+  }
+
+  private fun createDefaultExecuter(): BuildActionExecuter<AllModels> {
+    val executer = resolverCtx.connection.action(buildAction)
+    executer.prepare()
+    executer.setCancellationToken(resolverCtx)
+    return executer
+  }
+
+  private fun BuildActionExecuter<*>.prepare() = GradleExecutionHelper.prepare(this, resolverCtx.externalSystemTaskId, settings,
+                                                                               resolverCtx.listener, resolverCtx.connection)
+
+  private inner class BuildActionResultHandler(
+    val buildFinishedCallBack: Runnable
+  ): ResultHandler<Any> {
+    override fun onFailure(connectionException: GradleConnectionException?) {
+      resultQueue.add(connectionException)
+    }
+
+    /**
+     * The parameter [allModels] will be null if running from the Phased executer as to obtain the models via [modelsHandler].
+     * However if it is not null then we must be running from the normal build action excuter and thus the [allModels] must be
+     * added to the queue to unblock the main thread.
+     */
+    override fun onComplete(allModels: Any?) {
+      if (allModels != null) {
+        resultQueue.add(allModels)
+      }
+      buildFinishedCallBack.run()
+    }
+  }
+}
+
+private fun BuildActionExecuter<*>.setCancellationToken(resolverCtx: ProjectResolverContext) {
+  resolverCtx.cancellationTokenSource?.token()?.let { token ->
+    withCancellationToken(token)
+  }
+}

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverExtension.java
@@ -100,6 +100,18 @@ public interface GradleProjectResolverExtension extends ParametersEnhancer {
   ProjectImportExtraModelProvider getExtraModelProvider();
 
   /**
+   * @return whether or not this resolver requires Gradle task running infrastructure to be initialized, if any of the resolvers which are
+   * used by the resolution return true then the {@link org.gradle.tooling.BuildActionExecuter} will have
+   * {@link org.gradle.tooling.BuildActionExecuter#forTasks(String...)} called with an empty list. This will allow
+   * any tasks that are scheduled by Gradle plugin in the model builders to be run.
+   *
+   * Note: If nothing inside Gradle (i.e the model builders) overwrites the task list then this will cause the default task to be run.
+   */
+  default boolean requiresTaskRunning() {
+    return false;
+  }
+
+  /**
    * add paths containing these classes to classpath of gradle tooling extension
    *
    * @return classes to be available for gradle
@@ -128,6 +140,15 @@ public interface GradleProjectResolverExtension extends ParametersEnhancer {
    * Performs project configuration and other checks before the actual project import (before invocation of gradle tooling API).
    */
   void preImportCheck();
+
+  /**
+   * Called once Gradle has finished executing everything, including any tasks that might need to be run. The models are obtained
+   * separately and in some cases before this method is called.
+   *
+   * Note: This method is called from a Gradle connection thread, within the {@link org.gradle.tooling.ResultHandler} passed to the
+   * tooling api.
+   */
+  default void buildFinished() { }
 
   /**
    * Allows extension to contribute to init script


### PR DESCRIPTION
We allow resolver extensions to initialize task running, this allows any model builders
to set tasks that should be run by Gradle during its invocation. If the tasks are not
changed by the model builders then this will cause the default task to be run. This is
currently used in Android IDEA Plugin to allow the Android Gradle Plugin to schedule
source generation tasks to be run after the build action.

We also add a callback to the resolver (buildFinished) that is called from the Gradle
connection thread that is called once the whole Gradle operation (including the running
of tasks) is finished.