### PR TITLE
Update sphinx_runner to use Sphinx >= 2

### DIFF
--- a/python/helpers/rest_runners/sphinx_runner.py
+++ b/python/helpers/rest_runners/sphinx_runner.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
         raise NameError("Cannot find sphinx in selected interpreter.")
 
     version = sphinx.version_info
-    if version[0] >= 1 and version[1] >= 7:
+    if (version[0] >= 1 and version[1] >= 7) or version[0] >= 2:
         from sphinx.cmd import build
         build.main(sys.argv[1:])
     else:


### PR DESCRIPTION
sphinx_runner does not work with Sphinx >= 2.0 since it checks for sphinx >= 1.7, < 2 instead of checking for sphinx >= 1.7.