### PR TITLE
Skip/ignore disposed modules in the project view.

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/projectView/impl/AbstractProjectViewPane.java
+++ b/platform/lang-impl/src/com/intellij/ide/projectView/impl/AbstractProjectViewPane.java
@@ -600,7 +600,7 @@ public abstract class AbstractProjectViewPane implements DataProvider, Disposabl
   protected PsiDirectory[] getSelectedDirectoriesInAmbiguousCase(Object userObject) {
     if (userObject instanceof AbstractModuleNode) {
       final Module module = ((AbstractModuleNode)userObject).getValue();
-      if (module != null) {
+      if (module != null && !module.isDisposed()) {
         final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
         final VirtualFile[] sourceRoots = moduleRootManager.getSourceRoots();
         List<PsiDirectory> dirs = new ArrayList<>(sourceRoots.length);

--- a/platform/lang-impl/src/com/intellij/ide/projectView/impl/nodes/AbstractModuleNode.java
+++ b/platform/lang-impl/src/com/intellij/ide/projectView/impl/nodes/AbstractModuleNode.java
@@ -66,7 +66,9 @@ public abstract class AbstractModuleNode extends ProjectViewNode<Module> impleme
   @Override
   public Collection<VirtualFile> getRoots() {
     Module module = getValue();
-    return module != null ? Arrays.asList(ModuleRootManager.getInstance(module).getContentRoots()) : Collections.emptyList();
+    return module != null && !module.isDisposed()
+           ? Arrays.asList(ModuleRootManager.getInstance(module).getContentRoots())
+           : Collections.emptyList();
   }
 
   @Override
@@ -90,7 +92,7 @@ public abstract class AbstractModuleNode extends ProjectViewNode<Module> impleme
   @Override
   public void navigate(final boolean requestFocus) {
     Module module = getValue();
-    if (module != null) {
+    if (module != null && !module.isDisposed()) {
       ProjectSettingsService.getInstance(myProject).openModuleSettings(module);
     }
   }
@@ -102,7 +104,9 @@ public abstract class AbstractModuleNode extends ProjectViewNode<Module> impleme
 
   @Override
   public boolean canNavigate() {
-    return ProjectSettingsService.getInstance(myProject).canOpenModuleSettings() && getValue() != null;
+    if (!ProjectSettingsService.getInstance(myProject).canOpenModuleSettings() ) return false;
+    final Module module = getValue();
+    return module != null && !module.isDisposed();
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
The project view is updated asynchronously via a MergeQueue and
invokeLater calls. Therefore its nodes may for short periods of time
refer to disposed modules. If it happens that such a node is accessed
before it is updated it typically results in a crash.

This change fixes several most common cases where this type of crash can
happen. The fix is similar to how disposed modules are already handled
in the same classes.

Bug: 133469297
Test: n/a (manually by increasing MergeQueue update time to 10 seconds)
Change-Id: I0b1d247990b8d491c744249a02d2ef12897a1179