### PR TITLE
Use getArrowButtonPreferredSize(comboBox) instead

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaComboBoxUI.java
+++ b/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaComboBoxUI.java
@@ -478,10 +478,7 @@ public class DarculaComboBoxUI extends BasicComboBoxUI implements Border, ErrorB
 
   protected Dimension getSizeWithButton(Dimension size, Dimension editorSize) {
     Insets i = getInsets();
-    Dimension abSize = arrowButton.getPreferredSize();
-    if (abSize == null) {
-      abSize = JBUI.emptySize();
-    }
+    Dimension abSize = getArrowButtonPreferredSize(comboBox);
 
     if (isCompact(comboBox) && size != null) {
       JBInsets.removeFrom(size, padding); // don't count paddings in compact mode


### PR DESCRIPTION
Of arrowButton.getPreferredSize(). There are times when getSizeWithButton
gets called with a null arrowButton.