### PR TITLE
Remove interactive option for shells

### DIFF
--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/LocalTerminalDirectRunner.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/LocalTerminalDirectRunner.java
@@ -258,7 +258,6 @@ public class LocalTerminalDirectRunner extends AbstractTerminalRunner<PtyProcess
           if (hasLoginArgument(shellName) && SystemInfoRt.isMac) {
             command.add(LOGIN_CLI_OPTION);
           }
-          command.add("-i");
         }
 
         List<String> result = Lists.newArrayList(shellCommand);


### PR DESCRIPTION
Fixes IDEA-215394 (https://youtrack.jetbrains.com/issue/IDEA-215394)
Tested with bash and fish, removal of the option produces no visible effects for them. For Ion, it allows it to start.