### PR TITLE
Support contributed references for the ShVariable PSI element

### DIFF
--- a/plugins/sh/gen/com/intellij/sh/psi/ShVariable.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShVariable.java
@@ -4,10 +4,14 @@ package com.intellij.sh.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
 
 public interface ShVariable extends ShLiteral {
 
   @NotNull
   PsiElement getVar();
+
+  @NotNull
+  PsiReference[] getReferences();
 
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/impl/ShVariableImpl.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/impl/ShVariableImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
 import static com.intellij.sh.ShTypes.*;
 import com.intellij.sh.psi.*;
+import com.intellij.psi.PsiReference;
 
 public class ShVariableImpl extends ShLiteralImpl implements ShVariable {
 
@@ -29,6 +30,12 @@ public class ShVariableImpl extends ShLiteralImpl implements ShVariable {
   @NotNull
   public PsiElement getVar() {
     return findNotNullChildByType(VAR);
+  }
+
+  @Override
+  @NotNull
+  public PsiReference[] getReferences() {
+    return ShPsiImplUtil.getReferences(this);
   }
 
 }

--- a/plugins/sh/grammar/sh.bnf
+++ b/plugins/sh/grammar/sh.bnf
@@ -298,7 +298,10 @@ literal ::= word | string | number | variable {
 }
 private not_lvalue ::= '!' | vars | '$' | brace_expansion | 'file descriptor'
 brace_expansion ::= '{' (word | brace_expansion)* '}'
-variable ::= var {extends=literal}
+variable ::= var {
+    methods=[getReferences]
+    extends=literal
+}
 
 number ::= int | hex | octal {extends=literal}
 string ::= (OPEN_QUOTE (STRING_CONTENT | vars | <<notQuote>>)* CLOSE_QUOTE) | RAW_STRING {

--- a/plugins/sh/src/com/intellij/sh/ShSupport.java
+++ b/plugins/sh/src/com/intellij/sh/ShSupport.java
@@ -5,6 +5,8 @@ import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.psi.PsiReference;
+import com.intellij.sh.psi.ShVariable;
 import com.intellij.sh.run.ShRunConfiguration;
 import com.intellij.sh.run.ShRunConfigurationProfileState;
 import org.jetbrains.annotations.NotNull;
@@ -20,6 +22,11 @@ public interface ShSupport {
   RunProfileState createRunProfileState(@NotNull Executor executor,
                                         @NotNull ExecutionEnvironment environment,
                                         @NotNull ShRunConfiguration configuration);
+
+  @NotNull
+  default PsiReference[] getReferences(ShVariable variable) {
+    return PsiReference.EMPTY_ARRAY;
+  }
 
   class Impl implements ShSupport {
     @Override

--- a/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
+++ b/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
@@ -3,8 +3,10 @@ package com.intellij.sh.psi.impl;
 
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry;
+import com.intellij.sh.ShSupport;
 import com.intellij.sh.psi.ShLiteral;
 import com.intellij.sh.psi.ShString;
+import com.intellij.sh.psi.ShVariable;
 import org.jetbrains.annotations.NotNull;
 
 public class ShPsiImplUtil {
@@ -13,5 +15,10 @@ public class ShPsiImplUtil {
     return o instanceof ShString || o.getWord() != null
            ? ReferenceProvidersRegistry.getReferencesFromProviders(o)
            : PsiReference.EMPTY_ARRAY;
+  }
+
+  @NotNull
+  static PsiReference[] getReferences(@NotNull ShVariable o) {
+    return ShSupport.getInstance().getReferences(o);
   }
 }


### PR DESCRIPTION
This PR adds support for contributed references to the `ShVariable` implementation. Variables can be resolved to definitions and this adds the possibility to let extensions contribute references.

I'm following the style which is used by other elements of the `sh.bnf` grammar. 