### PR TITLE
Missing remote repository for org.jetbrains:markdown:0.1.31

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -42,6 +42,11 @@
       <option name="url" value="https://cache-redirector.jetbrains.com/jetbrains.bintray.com/jediterm/" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="a93311a0-6b4a-43ad-94e7-90f6ea1986ee" />
+      <option name="name" value="a93311a0-6b4a-43ad-94e7-90f6ea1986ee" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/jetbrains.bintray.com/markdown" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="7f849d18-5038-490f-a93d-226871e8f98c" />
       <option name="name" value="7f849d18-5038-490f-a93d-226871e8f98c" />
       <option name="url" value="https://cache-redirector.jetbrains.com/www.myget.org/F/rd-snapshots/maven" />


### PR DESCRIPTION
I have updated the remote jar repositories to contain the repository for org.jetbrains:markdown:0.1.31

Otherwise, the build fails if the library is not yet in the local maven repository with this error:

14:45	Repository library synchronization: No files were downloaded for org.jetbrains:markdown:0.1.31