### PR TITLE
IDEA-209506 Skip empty classpath roots fed to JUnit5TestRunner

### DIFF
--- a/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestRunnerUtil.java
+++ b/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestRunnerUtil.java
@@ -18,6 +18,7 @@ package com.intellij.junit5;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.discovery.ClassNameFilter;
+import org.junit.platform.engine.discovery.ClasspathRootSelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TagFilter;
@@ -79,7 +80,10 @@ public class JUnit5TestRunnerUtil {
 
           List<DiscoverySelector> selectors = new ArrayList<>();
           while ((line = reader.readLine()) != null) {
-            selectors.add(createSelector(line));
+            DiscoverySelector selector = createSelector(line);
+            if (selector != null) {
+              selectors.add(selector);
+            }
           }
           packageNameRef[0] = packageName.length() == 0 ? "<default package>" : packageName;
           if (selectors.isEmpty()) {
@@ -112,7 +116,10 @@ public class JUnit5TestRunnerUtil {
         builder = builder.configurationParameter("junit.jupiter.conditions.deactivate", disableDisabledCondition);
       }
 
-      return builder.selectors(createSelector(suiteClassNames[0])).build();
+      DiscoverySelector selector = createSelector(suiteClassNames[0]);
+      if (selector != null) {
+        return builder.selectors(selector).build();
+      }
     }
 
     return null;
@@ -199,7 +206,12 @@ public class JUnit5TestRunnerUtil {
     }
     else if (line.startsWith("\u002B")) {
       String directory = line.substring("\u002B".length());
-      return DiscoverySelectors.selectClasspathRoots(Collections.singleton(Paths.get(directory))).iterator().next();
+      List<ClasspathRootSelector> selectors = DiscoverySelectors.selectClasspathRoots(Collections.singleton(Paths.get(directory)));
+      if (selectors.isEmpty()) {
+        return null;
+      } else {
+        return selectors.iterator().next();
+      }
     }
     else if (line.contains(",")) {
       return DiscoverySelectors.selectMethod(line.replaceFirst(",", "#"));


### PR DESCRIPTION
Change `JUnit5TestRunnerUtil` to validate emptiness of the classpath roots returned from JUnit 5. Only propagate non-empty results to the test runner. Fixes an issue with recent versions of Android Studio, which don't support the execution of single-module test suites using JUnit 5 at the moment because of an overzealous iterator.

Resolves [IDEA-209506](https://youtrack.jetbrains.com/issue/IDEA-209506).