### PR TITLE
Change UI designer form compiler modality to any

### DIFF
--- a/plugins/ui-designer/src/com/intellij/uiDesigner/make/Form2SourceCompiler.java
+++ b/plugins/ui-designer/src/com/intellij/uiDesigner/make/Form2SourceCompiler.java
@@ -202,7 +202,7 @@ public final class Form2SourceCompiler implements SourceInstrumentingCompiler{
           }
         }), "", null);
         FileDocumentManager.getInstance().saveAllDocuments();
-      }, ModalityState.NON_MODAL);
+      }, ModalityState.any());
     }
 
     CompilerUtil.refreshIOFiles(filesToRefresh);


### PR DESCRIPTION
I do not understand why the form compilation task referred to in this commit is requiring the application to have a non-modal state, as it seems to me this process can fulfill its job even if there is a modal dialog present. This PR changes the requirement to any modality state.

I hope I understood the API correctly, and please check that there are no modality requirements for the form compile task.