### PR TITLE
Optimize async stack frame loading

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/engine/AsyncStacksUtils.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/AsyncStacksUtils.java
@@ -222,15 +222,15 @@ public class AsyncStacksUtils {
 
   private static Location findLocation(DebugProcessImpl debugProcess, ReferenceType type, String methodName, int line) {
     if (type != null && line >= 0) {
-      try {
-        Location location = type.locationsOfLine(DebugProcess.JAVA_STRATUM, null, line).stream()
-                                .filter(l -> l.method().name().equals(methodName))
-                                .findFirst().orElse(null);
-        if (location != null) {
-          return location;
+      for (Method method : type.methodsByName(methodName)) {
+        try {
+          List<Location> locations = method.locationsOfLine(DebugProcess.JAVA_STRATUM, null, line);
+          if (!locations.isEmpty()) {
+            return locations.get(0);
+          }
         }
-      }
-      catch (AbsentInformationException ignored) {
+        catch (AbsentInformationException ignored) {
+        }
       }
     }
     return new GeneratedLocation(debugProcess, type, methodName, line);


### PR DESCRIPTION
For each async stack frame we have to find a com.sun.jdi.Location
corresponding to a given line number. To do this we called
ReferenceType.locationsOfLine()---but that calls locationsOfLine() on
all methods in the class. Since we already know the name of the method
we're looking for, it's faster to first filter by method name, then
call locationsOfLine() directly on the matching methods.

This optimization is less important when running on a local JVM,
but very useful for remote debugging sessions. For example,
when debugging on an Android device, this change reduces the time spent
in findLocation() by 10x when loading 15 async stack frames, and the
frames show up in the UI significantly faster.

Before: 2767 ms spent in findLocation()
After: 247 ms spent in findLocation()