### PR TITLE
FileTypeManager logger message correction

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileTypes/impl/FileTypeManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileTypes/impl/FileTypeManagerImpl.java
@@ -1710,6 +1710,6 @@ public class FileTypeManagerImpl extends FileTypeManagerEx implements Persistent
 
   @Override
   public void dispose() {
-    LOG.info("FileTypeManager: "+ counterAutoDetect +" auto-detected files\nElapsed time on auto-detect: "+elapsedAutoDetect+" ms");
+    LOG.info("FileTypeManager: "+ counterAutoDetect +" auto-detected files. Elapsed time on auto-detect: "+elapsedAutoDetect+" ms");
   }
 }


### PR DESCRIPTION
Current message cause to break log output like this:
```
2019-06-26 15:47:20,685 [  61631]   INFO - org.jetbrains.io.BuiltInServer - web server stopped 
2019-06-26 15:47:20,688 [  61634]   INFO - Types.impl.FileTypeManagerImpl - FileTypeManager: 173 auto-detected files
Elapsed time on auto-detect: 1390 ms 
2019-06-26 15:47:20,692 [  61638]   INFO - pl.local.NativeFileWatcherImpl - Watcher terminated with exit code 0 
```