### PR TITLE
Focus lost upon opening certain important dialogs.

### DIFF
--- a/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java
+++ b/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java
@@ -315,6 +315,7 @@ public class FindPopupPanel extends JBPanel implements FindUI {
       w.addWindowListener(new WindowAdapter() {
         @Override
         public void windowOpened(WindowEvent e) {
+          updateScopeDetailsPanel();
           w.addWindowFocusListener(new WindowAdapter() {
             @Override
             public void windowLostFocus(WindowEvent e) {
@@ -962,7 +963,6 @@ public class FindPopupPanel extends JBPanel implements FindUI {
     }
     myReplaceComponent.setText(toReplace);
     updateControls();
-    updateScopeDetailsPanel();
 
     boolean isReplaceState = myHelper.isReplaceState();
     myTitleLabel.setText(myHelper.getTitle());

--- a/platform/xdebugger-impl/src/com/intellij/xdebugger/impl/evaluate/XDebuggerEvaluationDialog.java
+++ b/platform/xdebugger-impl/src/com/intellij/xdebugger/impl/evaluate/XDebuggerEvaluationDialog.java
@@ -34,9 +34,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.tree.TreeNode;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
+import java.awt.event.*;
 import java.util.function.Supplier;
 
 /**
@@ -136,18 +134,23 @@ public class XDebuggerEvaluationDialog extends DialogWrapper {
 
     myTreePanel.getTree().expandNodesOnLoad(XDebuggerEvaluationDialog::isFirstChild);
 
-    EvaluationMode mode = XDebuggerSettingManagerImpl.getInstanceImpl().getGeneralSettings().getEvaluationDialogMode();
-    if (mode == EvaluationMode.CODE_FRAGMENT && !myIsCodeFragmentEvaluationSupported) {
-      mode = EvaluationMode.EXPRESSION;
-    }
-    if (mode == EvaluationMode.EXPRESSION && text.getMode() == EvaluationMode.CODE_FRAGMENT && myIsCodeFragmentEvaluationSupported) {
-      mode = EvaluationMode.CODE_FRAGMENT;
-    }
     setTitle(XDebuggerBundle.message("xdebugger.evaluate.dialog.title"));
-    switchToMode(mode, text);
-    if (mode == EvaluationMode.EXPRESSION) {
-      myInputComponent.getInputEditor().selectAll();
-    }
+    getPeer().getWindow().addWindowListener(new WindowAdapter() {
+      @Override
+      public void windowOpened(WindowEvent e) {
+        EvaluationMode mode = XDebuggerSettingManagerImpl.getInstanceImpl().getGeneralSettings().getEvaluationDialogMode();
+        if (mode == EvaluationMode.CODE_FRAGMENT && !myIsCodeFragmentEvaluationSupported) {
+          mode = EvaluationMode.EXPRESSION;
+        }
+        if (mode == EvaluationMode.EXPRESSION && text.getMode() == EvaluationMode.CODE_FRAGMENT && myIsCodeFragmentEvaluationSupported) {
+          mode = EvaluationMode.CODE_FRAGMENT;
+        }
+        switchToMode(mode, text);
+        if (mode == EvaluationMode.EXPRESSION) {
+          myInputComponent.getInputEditor().selectAll();
+        }
+      }
+    });
     init();
 
     if (mySession != null) mySession.addSessionListener(new XDebugSessionListener() {


### PR DESCRIPTION
this fixes absence of focus in edit field upon opening "Find in Path" dialog and
"Evaluate expression" dialog.

Symptoms: sometimes (there's racing somewhere) focus and caret remain in code editor window
   after launch of specified dialogs. Arch(Manjaro) Linux, Cinnamon or KDE. Same racing is very rare
   on non-compositing mode openbox WM.

Cause: under some conditions native awt peer refuses to focus window which has not been yet created
   and workarounds found around in awt do not work. JDK versions 11 and 8 (oracle/JB/openjdk) show same behavior.

Fix: making sure focus is requested AFTER window has been opened, not relying on awt magic to track and  properly route focus requests scheduled in advance. Thankfully, JB code does not need much work.

JB, PLEASE fix same stuff in CLion PLEASE! Impossible to work.