### PR TITLE
DocumentationComponent: Added Base64 image support

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/documentation/DocumentationComponent.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/documentation/DocumentationComponent.java
@@ -80,6 +80,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.ide.BuiltInServerManager;
 
+import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
@@ -99,6 +100,8 @@ import java.awt.image.RenderedImage;
 import java.awt.image.renderable.RenderContext;
 import java.awt.image.renderable.RenderableImage;
 import java.awt.image.renderable.RenderableImageProducer;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
@@ -281,98 +284,53 @@ public class DocumentationComponent extends JPanel implements Disposable, DataPr
         return new HTMLFactory() {
           @Override
           public View create(Element elem) {
+            AttributeSet attrs = elem.getAttributes();
             if ("icon".equals(elem.getName())) {
-              Object src = elem.getAttributes().getAttribute(HTML.Attribute.SRC);
+              Object src = attrs.getAttribute(HTML.Attribute.SRC);
               Icon icon = src != null ? IconLoader.findIcon((String)src, false) : null;
               if (icon == null) {
                 ModuleType id = ModuleTypeManager.getInstance().findByID((String)src);
                 if (id != null) icon = id.getIcon();
               }
               if (icon != null) {
-                Icon viewIcon = icon;
-                return new View(elem) {
-                  @Override
-                  public float getPreferredSpan(int axis) {
-                    switch (axis) {
-                      case View.X_AXIS:
-                        return viewIcon.getIconWidth();
-                      case View.Y_AXIS:
-                        return viewIcon.getIconHeight();
-                      default:
-                        throw new IllegalArgumentException("Invalid axis: " + axis);
+                return new MyIconView(elem, icon);
+              }
+            }
+            else if ("img".equals(elem.getName())) {
+              String src = (String)attrs.getAttribute(HTML.Attribute.SRC);
+              // example: "data:image/png;base64,ENCODED_IMAGE_HERE"
+              if (src != null && src.startsWith("data:image") && src.contains("base64")) {
+                String[] split = src.split(",");
+                if (split.length == 2) {
+                  ByteArrayInputStream bis = null;
+                  try {
+                    byte[] bytes = Base64.getDecoder().decode(split[1]);
+                    bis = new ByteArrayInputStream(bytes);
+                    BufferedImage image = ImageIO.read(bis);
+                    if (image != null) {
+                      return new MyBufferedImageView(elem, image);
                     }
                   }
-
-                  @Override
-                  public String getToolTipText(float x, float y, Shape allocation) {
-                     return (String)getElement().getAttributes().getAttribute(HTML.Attribute.ALT);
+                  catch (IllegalArgumentException | IOException e) {
+                    LOG.trace(e);
                   }
-
-                  @Override
-                  public void paint(Graphics g, Shape allocation) {
-                    viewIcon.paintIcon(null, g, allocation.getBounds().x, allocation.getBounds().y - 4);
-                  }
-
-                  @Override
-                  public Shape modelToView(int pos, Shape a, Position.Bias b) throws BadLocationException {
-                    int p0 = getStartOffset();
-                    int p1 = getEndOffset();
-                    if ((pos >= p0) && (pos <= p1)) {
-                      Rectangle r = a.getBounds();
-                      if (pos == p1) {
-                        r.x += r.width;
+                  finally {
+                    try {
+                      if (bis != null) {
+                        bis.close();
                       }
-                      r.width = 0;
-                      return r;
                     }
-                    throw new BadLocationException(pos + " not in range " + p0 + "," + p1, pos);
-                  }
-
-                  @Override
-                  public int viewToModel(float x, float y, Shape a, Position.Bias[] bias) {
-                    Rectangle alloc = (Rectangle)a;
-                    if (x < alloc.x + (alloc.width / 2f)) {
-                      bias[0] = Position.Bias.Forward;
-                      return getStartOffset();
+                    catch (IOException e) {
+                      LOG.trace(e);
                     }
-                    bias[0] = Position.Bias.Backward;
-                    return getEndOffset();
                   }
-                };
+                }
               }
             }
             View view = super.create(elem);
             if (view instanceof ImageView) {
               // we have to work with raw image, apply scaling manually
-              return new ImageView(elem) {
-                @Override
-                public float getMaximumSpan(int axis) {
-                  return super.getMaximumSpan(axis) / JBUIScale.sysScale(myEditorPane);
-                }
-
-                @Override
-                public float getMinimumSpan(int axis) {
-                  return super.getMinimumSpan(axis) / JBUIScale.sysScale(myEditorPane);
-                }
-
-                @Override
-                public float getPreferredSpan(int axis) {
-                  return super.getPreferredSpan(axis) / JBUIScale.sysScale(myEditorPane);
-                }
-
-                @Override
-                public void paint(Graphics g, Shape a) {
-                  Rectangle bounds = a.getBounds();
-                  int width = (int)super.getPreferredSpan(View.X_AXIS);
-                  int height = (int)super.getPreferredSpan(View.Y_AXIS);
-                  if (width <= 0 || height <= 0) return;
-                  @SuppressWarnings("UndesirableClassUsage")
-                  BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-                  Graphics2D graphics = image.createGraphics();
-                  super.paint(graphics, new Rectangle(image.getWidth(), image.getHeight()));
-                  UIUtil.drawImage(g, ImageUtil.ensureHiDPI(image, ScaleContext.create(myEditorPane)), bounds.x, bounds.y, null);
-                }
-              };
+              return new MyScalingImageView(elem);
             }
             return view;
           }
@@ -1855,6 +1813,182 @@ public class DocumentationComponent extends JPanel implements Disposable, DataPr
         myHint.setDimensionServiceKey(null);
       }
       showHint();
+    }
+  }
+
+  private class MyScalingImageView extends ImageView {
+    private MyScalingImageView(Element elem) {super(elem);}
+
+    @Override
+    public float getMaximumSpan(int axis) {
+      return super.getMaximumSpan(axis) / JBUIScale.sysScale(myEditorPane);
+    }
+
+    @Override
+    public float getMinimumSpan(int axis) {
+      return super.getMinimumSpan(axis) / JBUIScale.sysScale(myEditorPane);
+    }
+
+    @Override
+    public float getPreferredSpan(int axis) {
+      return super.getPreferredSpan(axis) / JBUIScale.sysScale(myEditorPane);
+    }
+
+    @Override
+    public void paint(Graphics g, Shape a) {
+      Rectangle bounds = a.getBounds();
+      int width = (int)super.getPreferredSpan(View.X_AXIS);
+      int height = (int)super.getPreferredSpan(View.Y_AXIS);
+      if (width <= 0 || height <= 0) return;
+      @SuppressWarnings("UndesirableClassUsage")
+      BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D graphics = image.createGraphics();
+      super.paint(graphics, new Rectangle(image.getWidth(), image.getHeight()));
+      UIUtil.drawImage(g, ImageUtil.ensureHiDPI(image, ScaleContext.create(myEditorPane)), bounds.x, bounds.y, null);
+    }
+  }
+
+  private class MyBufferedImageView extends View {
+
+    private static final int DEFAULT_BORDER = 2;
+    private final BufferedImage myBufferedImage;
+    private final int width;
+    private final int height;
+
+    MyBufferedImageView(Element elem, BufferedImage myBufferedImage) {
+      super(elem);
+      this.myBufferedImage = myBufferedImage;
+      this.width = getIntAttr(HTML.Attribute.WIDTH, myBufferedImage.getWidth());
+      this.height = getIntAttr(HTML.Attribute.HEIGHT, myBufferedImage.getHeight());
+    }
+
+    private int getIntAttr(HTML.Attribute name, int defaultValue) {
+      AttributeSet attr = getElement().getAttributes();
+      if (attr.isDefined(name)) {
+        String val = (String)attr.getAttribute(name);
+        if (val == null) {
+          return defaultValue;
+        }
+        else {
+          try {
+            return Math.max(0, Integer.parseInt(val));
+          }
+          catch (NumberFormatException x) {
+            return defaultValue;
+          }
+        }
+      }
+      else {
+        return defaultValue;
+      }
+    }
+
+    @Override
+    public float getPreferredSpan(int axis) {
+      switch (axis) {
+        case View.X_AXIS:
+          return width + 2 * DEFAULT_BORDER;
+        case View.Y_AXIS:
+          return height + 2 * DEFAULT_BORDER;
+        default:
+          throw new IllegalArgumentException("Invalid axis: " + axis);
+      }
+    }
+
+    @Override
+    public String getToolTipText(float x, float y, Shape allocation) {
+      return (String)super.getElement().getAttributes().getAttribute(HTML.Attribute.ALT);
+    }
+
+    @Override
+    public void paint(Graphics g, Shape a) {
+      Rectangle bounds = a.getBounds();
+      Rectangle dstBounds = new Rectangle(bounds.x + DEFAULT_BORDER, bounds.y + DEFAULT_BORDER, width, height);
+      UIUtil.drawImage(g, ImageUtil.ensureHiDPI(myBufferedImage, ScaleContext.create(myEditorPane)), dstBounds, null);
+    }
+
+    @Override
+    public Shape modelToView(int pos, Shape a, Position.Bias b) throws BadLocationException {
+      int p0 = getStartOffset();
+      int p1 = getEndOffset();
+      if ((pos >= p0) && (pos <= p1)) {
+        Rectangle r = a.getBounds();
+        if (pos == p1) {
+          r.x += r.width;
+        }
+        r.width = 0;
+        return r;
+      }
+      return null;
+    }
+
+    @Override
+    public int viewToModel(float x, float y, Shape a, Position.Bias[] bias) {
+      Rectangle alloc = (Rectangle) a;
+      if (x < alloc.x + alloc.width) {
+        bias[0] = Position.Bias.Forward;
+        return getStartOffset();
+      }
+      bias[0] = Position.Bias.Backward;
+      return getEndOffset();
+    }
+
+  }
+
+  private static class MyIconView extends View {
+    private final Icon myViewIcon;
+
+    private MyIconView(Element elem, Icon viewIcon) {
+      super(elem);
+      myViewIcon = viewIcon;
+    }
+
+    @Override
+    public float getPreferredSpan(int axis) {
+      switch (axis) {
+        case View.X_AXIS:
+          return myViewIcon.getIconWidth();
+        case View.Y_AXIS:
+          return myViewIcon.getIconHeight();
+        default:
+          throw new IllegalArgumentException("Invalid axis: " + axis);
+      }
+    }
+
+    @Override
+    public String getToolTipText(float x, float y, Shape allocation) {
+      return (String)super.getElement().getAttributes().getAttribute(HTML.Attribute.ALT);
+    }
+
+    @Override
+    public void paint(Graphics g, Shape allocation) {
+      myViewIcon.paintIcon(null, g, allocation.getBounds().x, allocation.getBounds().y - 4);
+    }
+
+    @Override
+    public Shape modelToView(int pos, Shape a, Position.Bias b) throws BadLocationException {
+      int p0 = getStartOffset();
+      int p1 = getEndOffset();
+      if ((pos >= p0) && (pos <= p1)) {
+        Rectangle r = a.getBounds();
+        if (pos == p1) {
+          r.x += r.width;
+        }
+        r.width = 0;
+        return r;
+      }
+      throw new BadLocationException(pos + " not in range " + p0 + "," + p1, pos);
+    }
+
+    @Override
+    public int viewToModel(float x, float y, Shape a, Position.Bias[] bias) {
+      Rectangle alloc = (Rectangle)a;
+      if (x < alloc.x + (alloc.width / 2f)) {
+        bias[0] = Position.Bias.Forward;
+        return getStartOffset();
+      }
+      bias[0] = Position.Bias.Backward;
+      return getEndOffset();
     }
   }
 }


### PR DESCRIPTION
This adds Base64 image support to the DocumentationComponent via data uris.

### Example
Put this into Javadoc:
```html
<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot" />
```
Source: https://en.wikipedia.org/wiki/Data_URI_scheme

### Notes
* I tried using the ImageView/MyScalingImageView but without luck, it just doesn't support anything other than an URL in the `src` attribute.
* I only implemented support for the src, width and height attribute while ImageView also has support for attributes like `hspace`, `vspace`, `border`...
* I made some inner classes from anonymous ones, but didn't change the logic of them. If that is not wanted i could revert those changes.
* ImageIO.read is used, so this implementation only supports png, jpg and gif. Sadly no svg.

Certain competitors are able to show base64 encoded images in JavaDoc. So i think IntelliJ should also be able. At work we use that to display the icons behind String constants in the JavaDoc.

Also this fixes the following: https://youtrack.jetbrains.com/issue/IDEA-104317