### PR TITLE
Fix unstable order of dependencies and modules listed in iml files after import from Gradle

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractModuleDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/AbstractModuleDataService.java
@@ -426,30 +426,38 @@ public abstract class AbstractModuleDataService<E extends ModuleData> extends Ab
       11, (o1, o2) -> {
       int order1 = o1.second.getOrder();
       int order2 = o2.second.getOrder();
-      return order1 != order2 ? order1 < order2 ? -1 : 1 : 0;
+      if (order1 != order2) {
+        return order1 < order2 ? -1 : 1;
+      }
+      return o1.second.toString().compareTo(o2.second.toString());
     });
-
-    int shift = 0;
+    final List<OrderEntry> noOrderAwareItems = new ArrayList<>();
     for (int i = 0; i < length; i++) {
       OrderEntry orderEntry = orderEntries[i];
       final OrderAware orderAware = orderEntryDataMap.get(orderEntry);
       if (orderAware == null) {
-        newOrder[i] = orderEntry;
-        shift++;
+        noOrderAwareItems.add(orderEntry);
       }
       else {
         priorityQueue.add(Pair.create(orderEntry, orderAware));
       }
     }
 
+    Collections.sort(noOrderAwareItems, new Comparator<OrderEntry>() {
+      @Override
+      public int compare(OrderEntry o1, OrderEntry o2) {
+        return o1.toString().compareTo(o2.toString());
+      }
+    });
+
+    for (int i = 0; i < noOrderAwareItems.size(); i++) {
+      newOrder[i] = noOrderAwareItems.get(i);
+    }
+    int index = noOrderAwareItems.size();
     Pair<OrderEntry, OrderAware> pair;
     while ((pair = priorityQueue.poll()) != null) {
-      final OrderEntry orderEntry = pair.first;
-      final OrderAware orderAware = pair.second;
-      final int order = orderAware.getOrder() != -1 ? orderAware.getOrder() : length - 1;
-      final int newPlace = findNewPlace(newOrder, order - shift);
-      assert newPlace != -1;
-      newOrder[newPlace] = orderEntry;
+      newOrder[index] = pair.first;
+      index++;
     }
 
     if (LOG.isDebugEnabled()) {

--- a/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/RootModelImpl.java
+++ b/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/RootModelImpl.java
@@ -320,7 +320,7 @@ public class RootModelImpl extends RootModelBase implements ModifiableRootModel 
   private void removeOrderEntryInternal(@NotNull OrderEntry entry) {
     LOG.assertTrue(myOrderEntries.contains(entry));
     Disposer.dispose((Disposable)entry);
-    myOrderEntries.remove(entry);
+    while (myOrderEntries.remove(entry));
   }
 
   @Override

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
@@ -310,7 +310,7 @@ public class DependencyResolverImpl implements DependencyResolver {
                                       Map<File, Integer> runtimeClasspathOrder,
                                       ExternalDependency dependency) {
     String scope = dependency.getScope();
-    Map<File, Integer> classpathOrderMap = scope == CompileDependenciesProvider.SCOPE ? compileClasspathOrder :
+    Map<File, Integer> classpathOrderMap = scope == CompileDependenciesProvider.SCOPE || scope == PROVIDED_SCOPE ? compileClasspathOrder :
                                            scope == RuntimeDependenciesProvider.SCOPE ? runtimeClasspathOrder : null;
     final Collection<File> depFiles = getFiles(dependency);
     int order = getOrder(classpathOrderMap, depFiles);


### PR DESCRIPTION
What actually done:
1. add OrderAware for dependencies with PROVIDED scope
2. library order entries with the same order are sorted alphabetically (case when a dependency is resolved in file collection)
3. OrderEntries without order are added in the beginning of the order list (these entries are actually added by extension plugins)
