### PR TITLE
allow overwrite key completion register

### DIFF
--- a/plugins/yaml/src/org/jetbrains/yaml/meta/impl/YamlMetaTypeCompletionProviderBase.java
+++ b/plugins/yaml/src/org/jetbrains/yaml/meta/impl/YamlMetaTypeCompletionProviderBase.java
@@ -121,7 +121,7 @@ public abstract class YamlMetaTypeCompletionProviderBase extends CompletionProvi
     }
   }
 
-  private static void addKeyCompletions(@NotNull CompletionParameters params,
+  private void addKeyCompletions(@NotNull CompletionParameters params,
                                         @NotNull YamlMetaTypeProvider metaTypeProvider,
                                         @NotNull YamlMetaTypeProvider.MetaTypeProxy meta,
                                         @NotNull CompletionResultSet result,
@@ -184,7 +184,7 @@ public abstract class YamlMetaTypeCompletionProviderBase extends CompletionProvi
            !parentField.hasRelationSpecificType(Field.Relation.OBJECT_CONTENTS);
   }
 
-  private static void registerBasicKeyCompletion(@NotNull YamlMetaClass metaClass,
+  protected void registerBasicKeyCompletion(@NotNull YamlMetaClass metaClass,
                                                  @NotNull Field toBeInserted,
                                                  @NotNull CompletionResultSet result,
                                                  @NotNull PsiElement insertedScalar,


### PR DESCRIPTION
I'm extending this module to create an Ansible IDE. And now I'm facing a problem to group suggestions and prioritize keywords before modules.
I'm not able to return a PrioritizedLookupElement from getKeyLookups in my custom Field implementation since it returns a list of LookupElementBuilder. So, the best options is to overwrite YamlMetaTypeCompletionProviderBase#registerBasicKeyCompletion but it's private and static. So, with this PR I'm broadening it to protected and removing the static flag so I'm group the LookupElements before add to CompletionResultSet.
@olegs 