### PR TITLE
Register FileEditorManagerImpl for disposal

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.java
@@ -178,6 +178,7 @@ public class FileEditorManagerImpl extends FileEditorManagerEx implements Persis
         }
       }
     });
+    Disposer.register(myProject, this);
   }
 
   @Override


### PR DESCRIPTION
… with its parent project, since commit 84880bc registers its children
to it instead of the project.