### PR TITLE
 Check for settings file when looking for location

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionErrorHandler.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionErrorHandler.java
@@ -42,8 +42,8 @@ public class GradleExecutionErrorHandler {
     UNSUPPORTED_GRADLE_VERSION_ERROR_PATTERN = Pattern.compile("Gradle version .* is required.*");
     DOWNLOAD_GRADLE_DISTIBUTION_ERROR_PATTERN = Pattern.compile("The specified Gradle distribution .* does not exist.");
     MISSING_METHOD_PATTERN = Pattern.compile("org.gradle.api.internal.MissingMethodException: Could not find method (.*?) .*");
-    ERROR_LOCATION_IN_FILE_PATTERN = Pattern.compile("Build file '(.*)' line: ([\\d]+)");
-    ERROR_IN_FILE_PATTERN = Pattern.compile("Build file '(.*)'");
+    ERROR_LOCATION_IN_FILE_PATTERN = Pattern.compile("(?:Build|Settings) file '(.*)' line: ([\\d]+)");
+    ERROR_IN_FILE_PATTERN = Pattern.compile("(?:Build|Settings) file '(.*)'");
   }
 
   private final Throwable myOriginError;


### PR DESCRIPTION
... in Gradle errors.

We currently have these patterns for Gradle errors with locations:

Build file '(.*)' line: ([\d]+)
Build file '(.*)'

But this type of messages can also be generated with Settings files and
thus those patterns need to be updated to also consider that.