### PR TITLE
Fix AndroidXmlFormat issue when creating new layout

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/fileTemplates/DefaultCreateFromTemplateHandler.java
+++ b/platform/lang-impl/src/com/intellij/ide/fileTemplates/DefaultCreateFromTemplateHandler.java
@@ -55,11 +55,11 @@ public class DefaultCreateFromTemplateHandler implements CreateFromTemplateHandl
     FileType type = FileTypeRegistry.getInstance().getFileTypeByFileName(fileName);
     PsiFile file = PsiFileFactory.getInstance(project).createFileFromText(fileName, type, templateText);
 
+    file = (PsiFile)directory.add(file);
     if (template.isReformatCode()) {
       CodeStyleManager.getInstance(project).reformat(file);
     }
 
-    file = (PsiFile)directory.add(file);
     return file;
   }
 


### PR DESCRIPTION
We're seeing an issue where Default XML styling takes higher priority
over Android XML styling when creating Android XML Layout.

Newly created layout files do not have directory set yet when format is
applied. However, almost everywhere, directory info is used to determine
the format. Which causes all android formatting to be ignored for newly
created files, and default formats were being applied.

This change sets the directory info before applying style formats.

Related bugs :
https://buganizer.corp.google.com/issues/135967844
https://youtrack.jetbrains.com/issue/IDEA-219512