### PR TITLE
[Gradle] Avoid task configuration in tooling model builders.

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalProjectBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalProjectBuilderImpl.groovy
@@ -120,17 +120,14 @@ class ExternalProjectBuilderImpl extends AbstractModelBuilderService {
 
   static void addArtifactsData(final Project project, DefaultExternalProject externalProject) {
     final List<File> artifacts = new ArrayList<File>()
-    for (Task task : project.getTasks()) {
-      if (task instanceof Jar) {
-        Jar jar = (Jar)task
-        try {
-          // TODO use getArchiveFile method since Gradle 5.1
-          artifacts.add(jar.getArchivePath())
-        }
-        catch (e) {
-          // TODO add reporting for such issues
-          project.getLogger().error("warning: [task $jar.path] $e.message")
-        }
+    for (Jar jar : project.getTasks().withType(Jar.class)) {
+      try {
+        // TODO use getArchiveFile method since Gradle 5.1
+        artifacts.add(jar.getArchivePath())
+      }
+      catch (e) {
+        // TODO add reporting for such issues
+        project.getLogger().error("warning: [task $jar.path] $e.message")
       }
     }
     externalProject.setArtifacts(artifacts)

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
@@ -39,10 +39,8 @@ class ExternalTestsModelBuilderImpl implements ModelBuilderService {
 
   private static List<ExternalTestSourceMapping> getMapping(Project project) {
     def taskToClassesDirs = new LinkedHashMap<Test, Set<String>>()
-    for (task in project.tasks) {
-      if (task instanceof Test) {
-        taskToClassesDirs.put(task as Test, getClassesDirs(task))
-      }
+    for (task in project.tasks.withType(Test.class)) {
+      taskToClassesDirs.put(task, getClassesDirs(task))
     }
 
     def sourceSetContainer = JavaPluginUtil.getSourceSetContainer(project)


### PR DESCRIPTION
When building Gradle tooling models, there are a few usages of
TaskCollection.all, which triggers creation and configuration of
all registered tasks.
To avoid this expensive operation, replace the usage with lighter
API - TaskCollection.withType, which only configures the affected
tasks.

Besides, introduce project property idea.do.not.resolve.task.list.
When defined, the task list in ExternalProject will not be populated.
Because this operation requires configuration for all tasks and there
is no light-weight alternatives.
This property provides a way to disable task configuration from idea.