### PR TITLE
Additional modules not visible through thread context class loader

### DIFF
--- a/java/java-runtime/src/com/intellij/rt/execution/CommandLineWrapper.java
+++ b/java/java-runtime/src/com/intellij/rt/execution/CommandLineWrapper.java
@@ -182,7 +182,7 @@ public class CommandLineWrapper {
     }
 
     String mainClassName = args[startArgsIdx - 1];
-    ClassLoader loader = new URLClassLoader((URL[])classpathUrls.toArray(new URL[0]), null);
+    ClassLoader loader = new URLClassLoader((URL[])classpathUrls.toArray(new URL[0]), ClassLoader.getPlatformClassLoader());
     String systemLoaderName = System.getProperty("java.system.class.loader");
     if (systemLoaderName != null) {
       try {


### PR DESCRIPTION
We had a problem where compiling GWT on JDK 11 in IDEA would fail due to `java.sql` module classes not being found even with `--add-modules java.sql`, but would succeed when done through Maven, which led me to look into the `CommandLineWrapper` implementation, in particular how it manages the class path entries. I've discovered that `URLClassLoader`, which is constructed in `CommandLineWrapper` has its parent set as `null`, which stands for the Bootstrap class loader. 
With the introduction of modular system I believe this needs to have changed to be the Platform class loader instead. 
I've successfully tested this change by compiling a modified `idea-rt.jar` and replacing it in my local IDEA installation, which has allowed GWT compilation to succeed.