### PR TITLE
Make descriptor loading lazy in editorconfig plugin

### DIFF
--- a/plugins/editorconfig/resources/META-INF/plugin.xml
+++ b/plugins/editorconfig/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<!-- Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
 <idea-plugin>
   <id>org.editorconfig.editorconfigjetbrains</id>
   <name>EditorConfig</name>
@@ -372,7 +372,7 @@
         serviceImplementation="org.editorconfig.language.services.impl.EditorConfigFileHierarchyServiceImpl"/>
 
     <schemeExporter
-        name="EditorConfig File"
+        name="EditorConfig file"
         schemeClass="com.intellij.psi.codeStyle.CodeStyleScheme"
         implementationClass="org.editorconfig.configmanagement.export.EditorConfigExporter"/>
   </extensions>

--- a/plugins/editorconfig/resources/META-INF/plugin.xml
+++ b/plugins/editorconfig/resources/META-INF/plugin.xml
@@ -362,8 +362,8 @@
 
     <!-- Services -->
     <applicationService
-        serviceInterface="org.editorconfig.language.services.EditorConfigOptionDescriptorManager"
-        serviceImplementation="org.editorconfig.language.services.impl.EditorConfigOptionDescriptorManagerImpl"/>
+        serviceInterface="org.editorconfig.language.services.EditorConfigOptionDescriptorManagerProvider"
+        serviceImplementation="org.editorconfig.language.services.impl.EditorConfigOptionDescriptorManagerProviderImpl"/>
     <projectService
         serviceInterface="org.editorconfig.language.services.EditorConfigElementFactory"
         serviceImplementation="org.editorconfig.language.services.impl.EditorConfigElementFactoryImpl"/>

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/EditorConfigFoldingBuilder.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/EditorConfigFoldingBuilder.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight
 
 import com.intellij.lang.ASTNode
@@ -13,6 +13,7 @@ import com.intellij.psi.PsiElement
 import org.editorconfig.language.psi.EditorConfigElementTypes
 import org.editorconfig.language.psi.EditorConfigPsiFile
 import org.editorconfig.language.psi.EditorConfigSection
+import kotlin.math.min
 
 class EditorConfigFoldingBuilder : FoldingBuilderEx(), DumbAware {
   override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
@@ -89,7 +90,7 @@ class EditorConfigFoldingBuilder : FoldingBuilderEx(), DumbAware {
   private val COMMENT_FOLD_LENGTH_LIMIT = 40
 
   override fun getPlaceholderText(node: ASTNode) = when (node.elementType) {
-    EditorConfigElementTypes.LINE_COMMENT -> "${node.text.substring(0 until Math.min(node.textLength, COMMENT_FOLD_LENGTH_LIMIT))}..."
+    EditorConfigElementTypes.LINE_COMMENT -> "${node.text.substring(0 until min(node.textLength, COMMENT_FOLD_LENGTH_LIMIT))}..."
     EditorConfigElementTypes.SECTION -> "..."
     else -> {
       Log.warn("Requested folding placeholder for unknown node (${node.elementType})")

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/actions/EnterInEditorConfigFileHandler.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/actions/EnterInEditorConfigFileHandler.kt
@@ -1,8 +1,7 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.actions
 
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate
-import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate.Result
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegateAdapter
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
@@ -24,7 +23,7 @@ class EnterInEditorConfigFileHandler : EnterHandlerDelegateAdapter() {
     dataContext: DataContext,
     originalHandler: EditorActionHandler?
   ): EnterHandlerDelegate.Result {
-    if (file !is EditorConfigPsiFile) return Result.Continue
+    if (file !is EditorConfigPsiFile) return EnterHandlerDelegate.Result.Continue
 
     val document = editor.document
     val project = file.project
@@ -39,7 +38,8 @@ class EnterInEditorConfigFileHandler : EnterHandlerDelegateAdapter() {
     val psiElementStart = psiUnderCaret?.text?.firstOrNull()
     val charUnderCaret = document.text.elementAtOrNull(caretOffset)
 
-    if (elementType != EditorConfigElementTypes.LINE_COMMENT || isCommentStart(charUnderCaret)) return Result.Continue
+    if (elementType != EditorConfigElementTypes.LINE_COMMENT || isCommentStart(charUnderCaret))
+      return EnterHandlerDelegate.Result.Continue
 
     val (text, offset) = if (isWhitespace(charUnderCaret)) "\n$psiElementStart" to 3 else "\n$psiElementStart " to 3
 
@@ -47,7 +47,7 @@ class EnterInEditorConfigFileHandler : EnterHandlerDelegateAdapter() {
     editor.caretModel.moveToOffset(caretOffset + offset)
     editor.scrollingModel.scrollToCaret(ScrollType.RELATIVE)
     editor.selectionModel.removeSelection()
-    return Result.Stop
+    return EnterHandlerDelegate.Result.Stop
   }
 
   private companion object {

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/actions/intention/EditorConfigInvertValueIntention.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/actions/intention/EditorConfigInvertValueIntention.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.actions.intention
 
 import com.intellij.codeInsight.intention.IntentionAction
@@ -53,12 +53,12 @@ class EditorConfigInvertValueIntention : IntentionAction {
     EditorConfigPsiTreeUtil.findIdentifierUnderCaret(editor, file)?.getParentOfType()
 
   private fun getText(descriptor: EditorConfigDescriptor): String? {
-    descriptor as? EditorConfigConstantDescriptor ?: return null
+    if (descriptor !is EditorConfigConstantDescriptor) return null
     return descriptor.text
   }
 
   private fun constantMatches(descriptor: EditorConfigDescriptor, value: String): Boolean {
-    descriptor as? EditorConfigConstantDescriptor ?: return false
+    if (descriptor !is EditorConfigConstantDescriptor) return false
     return EditorConfigTextMatchingUtil.textMatchesToIgnoreCase(descriptor.text, value)
   }
 

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/completion/templates/EditorConfigTemplateLineBuildAssistant.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/completion/templates/EditorConfigTemplateLineBuildAssistant.kt
@@ -1,8 +1,6 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.completion.templates
 
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.codeInsight.template.TextResult
 import com.intellij.codeInsight.template.impl.ConstantNode
 import com.intellij.codeInsight.template.impl.MacroCallNode
 import com.intellij.codeInsight.template.impl.TemplateImpl

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/completion/templates/EditorConfigTemplateSegmentBuildAssistant.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/completion/templates/EditorConfigTemplateSegmentBuildAssistant.kt
@@ -1,9 +1,7 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.completion.templates
 
 import com.intellij.codeInsight.daemon.impl.quickfix.EmptyExpression
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.codeInsight.template.TextResult
 import com.intellij.codeInsight.template.impl.ConstantNode
 import com.intellij.codeInsight.template.impl.TemplateImpl
 import com.intellij.codeInsight.template.impl.Variable

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/documentation/EditorConfigDocumentationProvider.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/documentation/EditorConfigDocumentationProvider.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.documentation
 
 import com.intellij.lang.documentation.DocumentationProviderEx
@@ -14,12 +14,12 @@ import kotlin.math.max
 
 class EditorConfigDocumentationProvider : DocumentationProviderEx() {
   override fun generateDoc(element: PsiElement, originalElement: PsiElement?): String? {
-    element as? EditorConfigDocumentationHolderElement ?: return null
+    if (element !is EditorConfigDocumentationHolderElement) return null
     return element.descriptor?.documentation
   }
 
   override fun getQuickNavigateInfo(element: PsiElement, originalElement: PsiElement?): String? {
-    element as? EditorConfigDocumentationHolderElement ?: return null
+    if (element !is EditorConfigDocumentationHolderElement) return null
     return element.descriptor?.documentation
   }
 

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/documentation/EditorConfigElementDescriptionProvider.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/documentation/EditorConfigElementDescriptionProvider.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.documentation
 
 import com.intellij.psi.ElementDescriptionLocation
@@ -13,13 +13,12 @@ import org.editorconfig.language.schema.descriptors.impl.EditorConfigReferenceDe
 
 class EditorConfigElementDescriptionProvider : ElementDescriptionProvider {
   override fun getElementDescription(element: PsiElement, location: ElementDescriptionLocation): String? {
-    element as? EditorConfigDescribableElement ?: return null
+    if (element !is EditorConfigDescribableElement) return null
     if (element is EditorConfigFlatOptionKey) {
       return EditorConfigBundle.get("usage.type.option.key", element.text, element.section.header.text)
     }
 
-    val descriptor = element.getDescriptor(false)
-    return when (descriptor) {
+    return when (element.getDescriptor(false)) {
       is EditorConfigDeclarationDescriptor,
       is EditorConfigReferenceDescriptor -> EditorConfigBundle.get(
         "usage.type.identifier",

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigDescriptorBasedFindUsagesHandler.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigDescriptorBasedFindUsagesHandler.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.findusages
 
 import com.intellij.find.findUsages.FindUsagesHandler
@@ -17,7 +17,7 @@ import org.editorconfig.language.util.EditorConfigVfsUtil
 
 class EditorConfigDescriptorBasedFindUsagesHandler(element: EditorConfigDescribableElement) : FindUsagesHandler(element) {
   override fun processElementUsages(element: PsiElement, processor: Processor<UsageInfo>, options: FindUsagesOptions) = runReadAction {
-    element as? EditorConfigDescribableElement ?: return@runReadAction false
+    if (element !is EditorConfigDescribableElement) return@runReadAction false
     val descriptor = element.getDescriptor(false) ?: return@runReadAction false
     EditorConfigVfsUtil
       .getEditorConfigFiles(project)
@@ -33,8 +33,8 @@ class EditorConfigDescriptorBasedFindUsagesHandler(element: EditorConfigDescriba
   }
 
   override fun findReferencesToHighlight(target: PsiElement, searchScope: SearchScope) = runReadAction {
-    searchScope as? LocalSearchScope ?: return@runReadAction emptyList<PsiReference>()
-    target as? EditorConfigDescribableElement ?: return@runReadAction emptyList<PsiReference>()
+    if (searchScope !is LocalSearchScope) return@runReadAction emptyList<PsiReference>()
+    if (target !is EditorConfigDescribableElement) return@runReadAction emptyList<PsiReference>()
     val descriptor = target.getDescriptor(false) ?: return@runReadAction emptyList<PsiReference>()
     searchScope.scope.asSequence()
       .flatMap { PsiTreeUtil.findChildrenOfType(it, EditorConfigDescribableElement::class.java).asSequence() }

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigFindUsagesHandlerFactory.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigFindUsagesHandlerFactory.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.findusages
 
 import com.intellij.find.findUsages.FindUsagesHandler
@@ -11,7 +11,7 @@ import org.editorconfig.language.psi.interfaces.EditorConfigIdentifierElement
 class EditorConfigFindUsagesHandlerFactory : FindUsagesHandlerFactory() {
   override fun canFindUsages(element: PsiElement) = element is EditorConfigIdentifierElement
   override fun createFindUsagesHandler(element: PsiElement, forHighlightUsages: Boolean): FindUsagesHandler? {
-    element as? EditorConfigDescribableElement ?: return null
+    if (element !is EditorConfigDescribableElement) return null
     if (getId(element) != null) return EditorConfigFindVariableUsagesHandler(element)
     return EditorConfigDescriptorBasedFindUsagesHandler(element)
   }

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigFindUsagesProvider.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigFindUsagesProvider.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.findusages
 
 import com.intellij.lang.HelpID
@@ -23,8 +23,7 @@ class EditorConfigFindUsagesProvider : FindUsagesProvider {
     }
 
     val describable = element as? EditorConfigDescribableElement
-    val descriptor = describable?.getDescriptor(false)
-    return when (descriptor) {
+    return when (describable?.getDescriptor(false)) {
       is EditorConfigDeclarationDescriptor,
       is EditorConfigReferenceDescriptor -> EditorConfigBundle.get(
         "usage.type.identifier",
@@ -46,8 +45,7 @@ class EditorConfigFindUsagesProvider : FindUsagesProvider {
     }
 
     val describable = element as? EditorConfigDescribableElement
-    val descriptor = describable?.getDescriptor(false)
-    return when (descriptor) {
+    return when (describable?.getDescriptor(false)) {
       is EditorConfigDeclarationDescriptor,
       is EditorConfigReferenceDescriptor,
       is EditorConfigConstantDescriptor ->
@@ -63,8 +61,7 @@ class EditorConfigFindUsagesProvider : FindUsagesProvider {
     }
 
     val describable = element as? EditorConfigDescribableElement
-    val descriptor = describable?.getDescriptor(false)
-    return when (descriptor) {
+    return when (describable?.getDescriptor(false)) {
       is EditorConfigDeclarationDescriptor,
       is EditorConfigReferenceDescriptor,
       is EditorConfigConstantDescriptor ->

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigFindVariableUsagesHandler.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/findusages/EditorConfigFindVariableUsagesHandler.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.findusages
 
 import com.intellij.find.findUsages.FindUsagesHandler
@@ -32,7 +32,7 @@ class EditorConfigFindVariableUsagesHandler(element: EditorConfigDescribableElem
 
   override fun findReferencesToHighlight(target: PsiElement, searchScope: SearchScope) =
     runReadAction {
-      searchScope as? LocalSearchScope ?: return@runReadAction emptyList<PsiReference>()
+      if (searchScope !is LocalSearchScope) return@runReadAction emptyList<PsiReference>()
       val id = getId(target) ?: return@runReadAction emptyList<PsiReference>()
       searchScope.scope.asSequence()
         .flatMap { PsiTreeUtil.findChildrenOfType(it, EditorConfigDescribableElement::class.java).asSequence() }
@@ -49,10 +49,9 @@ class EditorConfigFindVariableUsagesHandler(element: EditorConfigDescribableElem
       .filter { matches(it, id, element) }
 
   private fun matches(element: PsiElement, id: String, template: PsiElement): Boolean {
-    element as? EditorConfigDescribableElement ?: return false
+    if (element !is EditorConfigDescribableElement) return false
     if (!textMatchesToIgnoreCase(element, template)) return false
-    val descriptor = element.getDescriptor(false)
-    return when (descriptor) {
+    return when (val descriptor = element.getDescriptor(false)) {
       is EditorConfigDeclarationDescriptor -> descriptor.id == id
       is EditorConfigReferenceDescriptor -> descriptor.id == id
       else -> false
@@ -61,9 +60,8 @@ class EditorConfigFindVariableUsagesHandler(element: EditorConfigDescribableElem
 
   companion object {
     fun getId(element: PsiElement): String? {
-      element as? EditorConfigDescribableElement ?: return null
-      val descriptor = element.getDescriptor(false)
-      return when (descriptor) {
+      if (element !is EditorConfigDescribableElement) return null
+      return when (val descriptor = element.getDescriptor(false)) {
         is EditorConfigDeclarationDescriptor -> descriptor.id
         is EditorConfigReferenceDescriptor -> descriptor.id
         else -> null

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigMissingRequiredDeclarationInspection.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigMissingRequiredDeclarationInspection.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.inspections
 
 import com.intellij.codeInspection.LocalInspectionTool
@@ -16,7 +16,7 @@ import org.editorconfig.language.util.EditorConfigIdentifierUtil
 class EditorConfigMissingRequiredDeclarationInspection : LocalInspectionTool() {
   override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : EditorConfigVisitor() {
     override fun visitPsiElement(element: PsiElement) {
-      element as? EditorConfigDescribableElement ?: return
+      if (element !is EditorConfigDescribableElement) return
       val descriptor = element.getDescriptor(false) as? EditorConfigDeclarationDescriptor ?: return
       val declarations = EditorConfigIdentifierUtil.findDeclarations(element.section, descriptor.id, element.text)
       val manager = EditorConfigOptionDescriptorManager.instance
@@ -25,9 +25,8 @@ class EditorConfigMissingRequiredDeclarationInspection : LocalInspectionTool() {
           describable.getDescriptor(false) === requiredDescriptor
         }
       }
-      val errorCount = errors.count()
 
-      val message = when (errorCount) {
+      val message = when (val errorCount = errors.count()) {
         0 -> return
         1 -> EditorConfigBundle.get("inspection.declaration.missing.singular.message", element.text)
         else -> EditorConfigBundle.get("inspection.declaration.missing.plural.message", element.text, errorCount)

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigPatternRedundancyInspection.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigPatternRedundancyInspection.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.inspections
 
 import com.intellij.codeInspection.LocalInspectionTool
@@ -48,8 +48,7 @@ class EditorConfigPatternRedundancyInspection : LocalInspectionTool() {
     allPatterns.count(pattern::textMatches) >= 2
 
   private fun findOtherPatterns(pattern: EditorConfigPattern): List<EditorConfigPattern> {
-    val parent = pattern.parent
-    val allPatterns = when (parent) {
+    val allPatterns = when (val parent = pattern.parent) {
       is EditorConfigPatternEnumeration -> parent.patternList
       else -> listOf(pattern)
     }

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigReferenceCorrectnessInspection.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigReferenceCorrectnessInspection.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.inspections
 
 import com.intellij.codeInspection.LocalInspectionTool
@@ -18,7 +18,7 @@ import org.editorconfig.language.util.EditorConfigIdentifierUtil
 class EditorConfigReferenceCorrectnessInspection : LocalInspectionTool() {
   override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : EditorConfigVisitor() {
     override fun visitPsiElement(element: PsiElement) {
-      element as? EditorConfigDescribableElement ?: return
+      if (element !is EditorConfigDescribableElement) return
       val descriptor = element.getDescriptor(false) as? EditorConfigReferenceDescriptor ?: return
       val reference = element.reference as? EditorConfigIdentifierReference ?: return
       if (reference.multiResolve(false).isNotEmpty()) return

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigUnusedDeclarationInspection.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigUnusedDeclarationInspection.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.inspections
 
 import com.intellij.codeInspection.LocalInspectionTool
@@ -15,7 +15,7 @@ import org.editorconfig.language.util.EditorConfigIdentifierUtil
 class EditorConfigUnusedDeclarationInspection : LocalInspectionTool() {
   override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : EditorConfigVisitor() {
     override fun visitPsiElement(element: PsiElement) {
-      element as? EditorConfigDescribableElement ?: return
+      if (element !is EditorConfigDescribableElement) return
       val descriptor = element.getDescriptor(false) as? EditorConfigDeclarationDescriptor ?: return
       if (!descriptor.needsReferences) return
       val references = EditorConfigIdentifierUtil.findReferences(element.section, descriptor.id, element.text)

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigValueUniquenessInspection.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/inspections/EditorConfigValueUniquenessInspection.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.inspections
 
 import com.intellij.codeInspection.LocalInspectionTool
@@ -21,7 +21,7 @@ class EditorConfigValueUniquenessInspection : LocalInspectionTool() {
       values.groupByNotNull {
         val descriptor = it.getDescriptor(false) ?: return@groupByNotNull null
         findListChildDescriptor(descriptor)
-      }.values.filter { it.size > 1 }.flatMap { it }.forEach {
+      }.values.filter { it.size > 1 }.flatten().forEach {
         holder.registerProblem(it, message, EditorConfigRemoveListValueQuickFix())
       }
     }

--- a/plugins/editorconfig/src/org/editorconfig/language/codeinsight/refactoring/EditorConfigRenameHandler.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codeinsight/refactoring/EditorConfigRenameHandler.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.codeinsight.refactoring
 
 import com.intellij.openapi.editor.Editor
@@ -14,10 +14,9 @@ import org.editorconfig.language.schema.descriptors.impl.EditorConfigReferenceDe
 
 class EditorConfigRenameHandler : VariableInplaceRenameHandler() {
   override fun isAvailable(element: PsiElement?, editor: Editor, file: PsiFile): Boolean {
-    element as? EditorConfigDescribableElement ?: return false
+    if (element !is EditorConfigDescribableElement) return false
     if (PsiElementRenameHandler.isVetoed(element)) return false
-    val descriptor = element.getDescriptor(false)
-    return when (descriptor) {
+    return when (element.getDescriptor(false)) {
       is EditorConfigDeclarationDescriptor,
       is EditorConfigReferenceDescriptor ->
         editor.settings.isVariableInplaceRenameEnabled

--- a/plugins/editorconfig/src/org/editorconfig/language/codestyle/EditorConfigCodeStyleSettings.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/codestyle/EditorConfigCodeStyleSettings.kt
@@ -1,9 +1,0 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
-package org.editorconfig.language.codestyle
-
-import com.intellij.psi.codeStyle.CodeStyleSettings
-import com.intellij.psi.codeStyle.CustomCodeStyleSettings
-import org.editorconfig.language.EditorConfigLanguage
-
-class EditorConfigCodeStyleSettings(container: CodeStyleSettings)
-  : CustomCodeStyleSettings(EditorConfigLanguage.id, container)

--- a/plugins/editorconfig/src/org/editorconfig/language/extensions/EditorConfigJsonFileOptionDescriptorProviderBase.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/extensions/EditorConfigJsonFileOptionDescriptorProviderBase.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.extensions
 
 import com.google.gson.JsonSyntaxException

--- a/plugins/editorconfig/src/org/editorconfig/language/highlighting/EditorConfigSyntaxHighlighter.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/highlighting/EditorConfigSyntaxHighlighter.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.highlighting
 
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
@@ -42,7 +42,7 @@ object EditorConfigSyntaxHighlighter : SyntaxHighlighterBase() {
 
   override fun getHighlightingLexer() = EditorConfigLexerFactory.getAdapter()
 
-  override fun getTokenHighlights(tokenType: IElementType) = when (tokenType) {
+  override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> = when (tokenType) {
     EditorConfigElementTypes.SEPARATOR,
     EditorConfigElementTypes.COLON -> SEPARATOR_KEYS
     EditorConfigElementTypes.L_BRACKET,

--- a/plugins/editorconfig/src/org/editorconfig/language/index/EditorConfigIdentifierIndex.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/index/EditorConfigIdentifierIndex.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.index
 
 import com.intellij.psi.PsiPolyVariantReference
@@ -44,9 +44,8 @@ class EditorConfigIdentifierIndex : FileBasedIndexExtension<String, Int>() {
     val editorconfigInputFilter = DefaultFileTypeSpecificInputFilter(EditorConfigFileType)
 
     private fun isValidReference(identifier: EditorConfigDescribableElement): Boolean {
-      identifier.getDescriptor(false) as? EditorConfigReferenceDescriptor ?: return false
-      val reference = identifier.reference
-      return when (reference) {
+      if (identifier.getDescriptor(false) !is EditorConfigReferenceDescriptor) return false
+      return when (val reference = identifier.reference) {
         is PsiPolyVariantReference -> reference.multiResolve(false).isNotEmpty()
         is PsiReference -> reference.resolve() != null
         else -> false

--- a/plugins/editorconfig/src/org/editorconfig/language/messages/EditorConfigBundle.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/messages/EditorConfigBundle.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.messages
 
 import com.intellij.CommonBundle
@@ -24,7 +24,7 @@ object EditorConfigBundle {
   fun message(key : String) = EditorConfigBundle[key]
 
   @JvmStatic
-  fun message(key: String, param: String) = EditorConfigBundle.get(key, param)
+  fun message(key: String, param: String) = get(key, param)
 
   private fun getBundle() = SoftReference.dereference(bundleReference) ?: run {
     val bundle = ResourceBundle.getBundle(BUNDLE)

--- a/plugins/editorconfig/src/org/editorconfig/language/messages/EditorConfigWrongFileEncodingNotificationProvider.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/messages/EditorConfigWrongFileEncodingNotificationProvider.kt
@@ -26,7 +26,7 @@ class EditorConfigWrongFileEncodingNotificationProvider : EditorNotifications.Pr
   override fun getKey() = KEY
 
   override fun createNotificationPanel(file: VirtualFile, fileEditor: FileEditor, project: Project): EditorNotificationPanel? {
-    fileEditor as? TextEditor ?: return null
+    if (fileEditor !is TextEditor) return null
     val editor = fileEditor.editor
     if (editor.getUserData(HIDDEN_KEY) != null) return null
     if (PropertiesComponent.getInstance().isTrueValue(DISABLE_KEY)) return null

--- a/plugins/editorconfig/src/org/editorconfig/language/messages/EditorConfigWrongFileNameNotificationProvider.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/messages/EditorConfigWrongFileNameNotificationProvider.kt
@@ -22,7 +22,7 @@ import java.io.IOException
 class EditorConfigWrongFileNameNotificationProvider : EditorNotifications.Provider<EditorNotificationPanel>(), DumbAware {
   override fun getKey() = KEY
   override fun createNotificationPanel(file: VirtualFile, fileEditor: FileEditor, project: Project): EditorNotificationPanel? {
-    fileEditor as? TextEditor ?: return null
+    if (fileEditor !is TextEditor) return null
     val editor = fileEditor.editor
     if (editor.getUserData(HIDDEN_KEY) != null) return null
     if (PropertiesComponent.getInstance().isTrueValue(DISABLE_KEY)) return null

--- a/plugins/editorconfig/src/org/editorconfig/language/parser/EditorConfigParserDefinition.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/parser/EditorConfigParserDefinition.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.parser
 
 import com.intellij.lang.ASTNode
@@ -13,12 +13,11 @@ import com.intellij.psi.tree.IFileElementType
 import com.intellij.psi.tree.TokenSet
 import org.editorconfig.configmanagement.lexer.EditorConfigLexerFactory
 import org.editorconfig.language.EditorConfigLanguage
-import org.editorconfig.language.lexer.EditorConfigLexerAdapter
 import org.editorconfig.language.psi.EditorConfigElementTypes
 import org.editorconfig.language.psi.EditorConfigPsiFile
 
 class EditorConfigParserDefinition : ParserDefinition {
-  override fun createLexer(project: Project) = EditorConfigLexerFactory.getAdapter();
+  override fun createLexer(project: Project) = EditorConfigLexerFactory.getAdapter()
   override fun createParser(project: Project): PsiParser = EditorConfigParser()
 
   override fun getCommentTokens() = COMMENTS

--- a/plugins/editorconfig/src/org/editorconfig/language/psi/EditorConfigPsiFile.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/psi/EditorConfigPsiFile.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.psi
 
 import com.intellij.extapi.psi.PsiFileBase
@@ -7,7 +7,6 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.editorconfig.language.EditorConfigLanguage
 import org.editorconfig.language.filetype.EditorConfigFileConstants
 import org.editorconfig.language.filetype.EditorConfigFileType
-import org.editorconfig.language.util.matches
 
 class EditorConfigPsiFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, EditorConfigLanguage) {
   override fun getFileType() = EditorConfigFileType
@@ -20,11 +19,4 @@ class EditorConfigPsiFile(viewProvider: FileViewProvider) : PsiFileBase(viewProv
 
   val sections: List<EditorConfigSection>
     get() = PsiTreeUtil.getChildrenOfTypeAsList(this, EditorConfigSection::class.java)
-
-  fun findRelevantNavigatable() =
-    sections.lastOrNull { section ->
-      val header = section.header
-      if (header.isValidGlob) header matches virtualFile
-      else false
-    } ?: this
 }

--- a/plugins/editorconfig/src/org/editorconfig/language/psi/base/EditorConfigDescribableElementBase.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/psi/base/EditorConfigDescribableElementBase.kt
@@ -1,11 +1,10 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.psi.base
 
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.vfs.newvfs.VfsPresentationUtil
-import com.intellij.psi.PsiReference
 import org.editorconfig.language.psi.EditorConfigOption
 import org.editorconfig.language.psi.EditorConfigSection
 import org.editorconfig.language.psi.interfaces.EditorConfigDescribableElement
@@ -39,23 +38,20 @@ abstract class EditorConfigDescribableElementBase(node: ASTNode) : ASTWrapperPsi
     }
 
 
-  override fun getReference(): PsiReference? {
-    val descriptor = getDescriptor(false)
-    return when (descriptor) {
-      is EditorConfigDeclarationDescriptor -> EditorConfigDeclarationReference(this)
-      is EditorConfigReferenceDescriptor -> EditorConfigIdentifierReference(this, descriptor.id)
-      is EditorConfigConstantDescriptor -> EditorConfigConstantReference(this)
-      is EditorConfigUnionDescriptor -> {
-        if (EditorConfigDescriptorUtil.isConstant(descriptor)) {
-          EditorConfigConstantReference(this)
-        }
-        else {
-          logger<EditorConfigDescribableElementBase>().warn("Got non-constant union")
-          null
-        }
+  override fun getReference() = when (val descriptor = getDescriptor(false)) {
+    is EditorConfigDeclarationDescriptor -> EditorConfigDeclarationReference(this)
+    is EditorConfigReferenceDescriptor -> EditorConfigIdentifierReference(this, descriptor.id)
+    is EditorConfigConstantDescriptor -> EditorConfigConstantReference(this)
+    is EditorConfigUnionDescriptor -> {
+      if (EditorConfigDescriptorUtil.isConstant(descriptor)) {
+        EditorConfigConstantReference(this)
       }
-      else -> null
+      else {
+        logger<EditorConfigDescribableElementBase>().warn("Got non-constant union")
+        null
+      }
     }
+    else -> null
   }
 
   final override fun toString(): String = text

--- a/plugins/editorconfig/src/org/editorconfig/language/psi/base/EditorConfigFlatOptionKeyBase.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/psi/base/EditorConfigFlatOptionKeyBase.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.psi.base
 
 import com.intellij.icons.AllIcons
@@ -6,7 +6,6 @@ import com.intellij.ide.projectView.PresentationData
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import org.editorconfig.language.psi.EditorConfigFlatOptionKey
-import org.editorconfig.language.psi.interfaces.EditorConfigDescribableElement
 import org.editorconfig.language.psi.reference.EditorConfigFlatOptionKeyReference
 
 abstract class EditorConfigFlatOptionKeyBase(node: ASTNode) : EditorConfigIdentifierElementBase(node), EditorConfigFlatOptionKey {
@@ -16,7 +15,6 @@ abstract class EditorConfigFlatOptionKeyBase(node: ASTNode) : EditorConfigIdenti
   final override fun getPresentation() = PresentationData(text, declarationSite, AllIcons.Nodes.Property, null)
 
   final override fun definesSameOption(element: EditorConfigFlatOptionKey): Boolean {
-    element as? EditorConfigDescribableElement ?: return false
     val descriptor = option.getDescriptor(false)
     val otherDescriptor = element.option.getDescriptor(false)
 

--- a/plugins/editorconfig/src/org/editorconfig/language/psi/reference/EditorConfigFlatOptionKeyReference.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/psi/reference/EditorConfigFlatOptionKeyReference.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.psi.reference
 
 import com.intellij.openapi.vfs.VirtualFile
@@ -7,17 +7,18 @@ import org.editorconfig.language.psi.EditorConfigFlatOptionKey
 import org.editorconfig.language.psi.EditorConfigOption
 import org.editorconfig.language.psi.EditorConfigPsiFile
 import org.editorconfig.language.psi.EditorConfigSection
+import org.editorconfig.language.psi.interfaces.EditorConfigDescribableElement
 import org.editorconfig.language.util.EditorConfigPsiTreeUtil
 import org.editorconfig.language.util.isSubcaseOf
 
-class EditorConfigFlatOptionKeyReference(element: EditorConfigFlatOptionKey)
-  : PsiReferenceBase<EditorConfigFlatOptionKey>(element) {
-  private val virtualFile: VirtualFile get() = myElement.containingFile.virtualFile
-  private val option get() = myElement.option
+class EditorConfigFlatOptionKeyReference(private val element: EditorConfigFlatOptionKey)
+  : PsiReferenceBase<EditorConfigDescribableElement>(element) {
+  private val virtualFile: VirtualFile get() = element.containingFile.virtualFile
+  private val option get() = element.option
   private val section get() = option.section
   private val psiFile: EditorConfigPsiFile?
     get() {
-      val file = myElement.containingFile as? EditorConfigPsiFile
+      val file = element.containingFile as? EditorConfigPsiFile
       return EditorConfigPsiTreeUtil.getOriginalFile(file)
     }
 
@@ -65,7 +66,7 @@ class EditorConfigFlatOptionKeyReference(element: EditorConfigFlatOptionKey)
    * Most importantly, disallows to have parent in same file downwards
    */
   private fun isAllowedToContainParentIn(section: EditorConfigSection) =
-    section.containsKey(myElement)
+    section.containsKey(element)
     && (section.containingFile.virtualFile != virtualFile || section.textRange.endOffset < this.section.textRange.startOffset)
 
   override fun resolve() = element
@@ -90,10 +91,10 @@ class EditorConfigFlatOptionKeyReference(element: EditorConfigFlatOptionKey)
     child.option.section.header.isSubcaseOf(option.section.header)
 
   private fun isDistantParentOf(child: EditorConfigFlatOptionKey) =
-    child !== myElement && isDistantParentOfRecursion(child)
+    child !== element && isDistantParentOfRecursion(child)
 
   private fun isDistantParentOfRecursion(child: EditorConfigFlatOptionKey): Boolean {
-    if (child === myElement) return true
+    if (child === element) return true
     val parents = child.reference.findParents()
     return parents.any(::isDistantParentOfRecursion)
   }

--- a/plugins/editorconfig/src/org/editorconfig/language/schema/descriptors/impl/EditorConfigNumberDescriptor.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/schema/descriptors/impl/EditorConfigNumberDescriptor.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.schema.descriptors.impl
 
 import com.intellij.psi.PsiElement
@@ -22,6 +22,7 @@ data class EditorConfigNumberDescriptor(
     private val NUMBER_REGEX = "-?\\d+".toRegex()
 
     private fun String.asEditorConfigInt(): Int? {
+      @Suppress("ConstantConditionIf")
       val regex =
         if (ALLOW_NEGATIVE_INTEGERS) NUMBER_REGEX
         else POSITIVE_NUMBER_REGEX

--- a/plugins/editorconfig/src/org/editorconfig/language/schema/descriptors/impl/EditorConfigQualifiedKeyDescriptor.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/schema/descriptors/impl/EditorConfigQualifiedKeyDescriptor.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.schema.descriptors.impl
 
 import com.intellij.psi.PsiElement
@@ -23,7 +23,7 @@ data class EditorConfigQualifiedKeyDescriptor(
   override fun accept(visitor: EditorConfigDescriptorVisitor) = visitor.visitQualifiedKey(this)
 
   override fun matches(element: PsiElement): Boolean {
-    element as? EditorConfigQualifiedOptionKey ?: return false
+    if (element !is EditorConfigQualifiedOptionKey) return false
     val parts = element.qualifiedKeyPartList
     if (children.size != parts.size) return false
     return children.zip(parts).all { (descriptor, part) -> matches(descriptor, part) }

--- a/plugins/editorconfig/src/org/editorconfig/language/schema/descriptors/impl/EditorConfigStringDescriptor.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/schema/descriptors/impl/EditorConfigStringDescriptor.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.schema.descriptors.impl
 
 import com.intellij.openapi.util.text.StringUtil
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiElement
 import org.editorconfig.language.schema.descriptors.EditorConfigDescriptor
 import org.editorconfig.language.schema.descriptors.EditorConfigDescriptorVisitor
 import org.editorconfig.language.schema.descriptors.EditorConfigMutableDescriptor
-import java.util.regex.Pattern
 
 data class EditorConfigStringDescriptor(
   override val documentation: String?,

--- a/plugins/editorconfig/src/org/editorconfig/language/services/EditorConfigOptionDescriptorManager.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/services/EditorConfigOptionDescriptorManager.kt
@@ -17,6 +17,6 @@ interface EditorConfigOptionDescriptorManager {
 
   companion object {
     val instance: EditorConfigOptionDescriptorManager
-      get() = ServiceManager.getService(EditorConfigOptionDescriptorManager::class.java)
+      get() = ServiceManager.getService(EditorConfigOptionDescriptorManagerProvider::class.java).descriptorManager
   }
 }

--- a/plugins/editorconfig/src/org/editorconfig/language/services/EditorConfigOptionDescriptorManagerProvider.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/services/EditorConfigOptionDescriptorManagerProvider.kt
@@ -1,0 +1,6 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.editorconfig.language.services
+
+interface EditorConfigOptionDescriptorManagerProvider {
+  val descriptorManager: EditorConfigOptionDescriptorManager
+}

--- a/plugins/editorconfig/src/org/editorconfig/language/services/impl/EditorConfigOptionDescriptorManagerProviderImpl.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/services/impl/EditorConfigOptionDescriptorManagerProviderImpl.kt
@@ -1,0 +1,8 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.editorconfig.language.services.impl
+
+import org.editorconfig.language.services.EditorConfigOptionDescriptorManagerProvider
+
+class EditorConfigOptionDescriptorManagerProviderImpl : EditorConfigOptionDescriptorManagerProvider {
+  override val descriptorManager by lazy(::EditorConfigOptionDescriptorManagerImpl)
+}

--- a/plugins/editorconfig/src/org/editorconfig/language/util/EditorConfigPsiTreeUtil.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/util/EditorConfigPsiTreeUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.util
 
 import com.intellij.openapi.editor.Editor
@@ -82,8 +82,7 @@ object EditorConfigPsiTreeUtil {
     }
 
     val service = EditorConfigFileHierarchyService.getInstance(file.project)
-    val serviceResult = service.getParentEditorConfigFiles(virtualFile)
-    return when (serviceResult) {
+    return when (val serviceResult = service.getParentEditorConfigFiles(virtualFile)) {
       is EditorConfigServiceLoaded -> serviceResult.list
       is EditorConfigServiceLoading -> findParentFilesUsingIndex(file, virtualFile)
     }

--- a/plugins/editorconfig/src/org/editorconfig/language/util/EditorConfigTemplateUtil.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/util/EditorConfigTemplateUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.util
 
 import com.intellij.codeInsight.template.impl.TemplateImpl
@@ -95,19 +95,19 @@ object EditorConfigTemplateUtil {
 
     companion object {
       fun from(descriptor: EditorConfigDescriptor): DescriptorType = when (descriptor) {
-        is EditorConfigConstantDescriptor -> DescriptorType.Constant
-        is EditorConfigDeclarationDescriptor -> DescriptorType.Variable(descriptor.id)
+        is EditorConfigConstantDescriptor -> Constant
+        is EditorConfigDeclarationDescriptor -> Variable(descriptor.id)
         is EditorConfigUnionDescriptor -> {
           val types = descriptor.children.map { from(it) }
-          if (types.all { it is DescriptorType.Constant }) DescriptorType.Constant
+          if (types.all { it is Constant }) Constant
           else {
-            val variables = types.mapNotNull { it as? DescriptorType.Variable }
+            val variables = types.mapNotNull { it as? Variable }
             if (variables.size == types.size && variables.isNotEmpty()) {
               val id = variables[0].id
-              if (variables.all { it.id == id }) DescriptorType.Variable(id)
+              if (variables.all { it.id == id }) Variable(id)
             }
 
-            DescriptorType.Inconsistent
+            Inconsistent
           }
         }
         else -> throw IllegalStateException()

--- a/plugins/editorconfig/src/org/editorconfig/language/util/EditorConfigVfsUtil.kt
+++ b/plugins/editorconfig/src/org/editorconfig/language/util/EditorConfigVfsUtil.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.editorconfig.language.util
 
 import com.intellij.openapi.application.ApplicationManager
@@ -11,7 +11,7 @@ import org.editorconfig.language.filetype.EditorConfigFileType
 object EditorConfigVfsUtil {
   /**
    * This very fast method does not take into account non-project files.
-   * If you are finding all parent .editorcong`s and precision matters more than speed,
+   * If you are finding all parent .editorconfig`s and precision matters more than speed,
    * Consider using EditorConfigFileHierarchyService or EditorConfigPsiTreeUtil#findAllParetnsPsi()
    */
   fun getEditorConfigFiles(project: Project): Collection<VirtualFile> {


### PR DESCRIPTION
A descriptor is an internal structure used by the plugin. It is not required until an editorconfig file is opened, so it can be initialized lazily. This should slightly speed up startup