### PR TITLE
Restore module intellij.jsp.base to java-api.jar

### DIFF
--- a/platform/build-scripts/groovy/org/jetbrains/intellij/build/JavaPluginLayout.groovy
+++ b/platform/build-scripts/groovy/org/jetbrains/intellij/build/JavaPluginLayout.groovy
@@ -37,6 +37,7 @@ class JavaPluginLayout {
         "intellij.java.indexing",
         "intellij.java.psi",
         "intellij.java",
+        "intellij.jsp.base",
         "intellij.jsp",
         "intellij.platform.uast"
       ].each {


### PR DESCRIPTION
This was removed by commit 4438460 but runtime dependencies on it remain
for example in module intellij.jsp where JspFile extends BaseJspFile.