### PR TITLE
[Sh] Change visibility of properties of ShRunConfiguration

### DIFF
--- a/plugins/sh/src/com/intellij/sh/run/ShRunConfiguration.java
+++ b/plugins/sh/src/com/intellij/sh/run/ShRunConfiguration.java
@@ -116,43 +116,43 @@ public class ShRunConfiguration extends LocatableConfigurationBase implements Re
     return vfile.getPath();
   }
 
-  String getScriptPath() {
+  public String getScriptPath() {
     return myScriptPath;
   }
 
-  void setScriptPath(@NotNull String scriptPath) {
+  public void setScriptPath(@NotNull String scriptPath) {
     myScriptPath = scriptPath.trim();
   }
 
-  String getScriptOptions() {
+  public String getScriptOptions() {
     return myScriptOptions;
   }
 
-  void setScriptOptions(@NotNull String scriptOptions) {
+  public void setScriptOptions(@NotNull String scriptOptions) {
     myScriptOptions = scriptOptions.trim();
   }
 
-  String getScriptWorkingDirectory() {
+  public String getScriptWorkingDirectory() {
     return myScriptWorkingDirectory;
   }
 
-  void setScriptWorkingDirectory(String scriptWorkingDirectory) {
+  public void setScriptWorkingDirectory(String scriptWorkingDirectory) {
     myScriptWorkingDirectory = scriptWorkingDirectory.trim();
   }
 
-  String getInterpreterPath() {
+  public String getInterpreterPath() {
     return myInterpreterPath;
   }
 
-  void setInterpreterPath(@NotNull String interpreterPath) {
+  public void setInterpreterPath(@NotNull String interpreterPath) {
     myInterpreterPath = interpreterPath.trim();
   }
 
-  String getInterpreterOptions() {
+  public String getInterpreterOptions() {
     return myInterpreterOptions;
   }
 
-  void setInterpreterOptions(@NotNull String interpreterOptions) {
+  public void setInterpreterOptions(@NotNull String interpreterOptions) {
     myInterpreterOptions = interpreterOptions.trim();
   }
 }


### PR DESCRIPTION
This pull request makes the properties of `ShRunConfiguration` public to allow 3rd-party plugins to use the run configuration.
This would allow 3rd-party plugins to add debug support, for example. Properties of ShRunConfiguration should be accessible to allow reuse.

It's not strictly needed to have public setter-methods. But public getter-methods and package-level setter-methods seems a bit awkward. I'm happy to change this if you want me to, though.