### PR TITLE
[Sh] Allow 3rd-party plugins to override the ShRunConfigurationProfileState

### DIFF
--- a/plugins/sh/src/com/intellij/sh/ShSupport.java
+++ b/plugins/sh/src/com/intellij/sh/ShSupport.java
@@ -1,7 +1,12 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.sh;
 
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.components.ServiceManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface ShSupport {
   static ShSupport getInstance() { return ServiceManager.getService(ShSupport.class); }
@@ -10,11 +15,20 @@ public interface ShSupport {
 
   boolean isRenameEnabled();
 
+  @Nullable
+  RunProfileState createRunProfileState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment);
+
   class Impl implements ShSupport {
     @Override
     public boolean isExternalFormatterEnabled() { return true; }
 
     @Override
     public boolean isRenameEnabled() { return true; }
+
+    @Nullable
+    @Override
+    public RunProfileState createRunProfileState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) {
+      return null;
+    }
   }
 }

--- a/plugins/sh/src/com/intellij/sh/run/ShRunConfiguration.java
+++ b/plugins/sh/src/com/intellij/sh/run/ShRunConfiguration.java
@@ -15,6 +15,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiUtilCore;
 import com.intellij.refactoring.listeners.RefactoringElementAdapter;
 import com.intellij.refactoring.listeners.RefactoringElementListener;
+import com.intellij.sh.ShSupport;
 import com.intellij.sh.psi.ShFile;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -64,6 +65,10 @@ public class ShRunConfiguration extends LocatableConfigurationBase implements Re
   @Nullable
   @Override
   public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) {
+    RunProfileState profileState = ShSupport.getInstance().createRunProfileState(executor, environment);
+    if (profileState != null) {
+      return profileState;
+    }
     return new ShRunConfigurationProfileState(getProject(), this);
   }
 


### PR DESCRIPTION
Allow 3rd-party plugins to override the `ShRunConfigurationProfileState`, for example to add debug support while reusing `ShRunConfiguration`.

Such a plugin would reuse the run configuration and add debug support  on top. Its implementation would most likely use a runner based on `BaseProgramRunner`, which retrieves a new `RunProfileState` from the run configuration ([source](https://github.com/JetBrains/intellij-community/blob/master/platform/lang-api/src/com/intellij/execution/runners/BaseProgramRunner.java#L40)). 

This PR allows to customize the RunProfileState to allow this kind of enhancement.