### PR TITLE
Open a project by launcher.py when other window is already open

### DIFF
--- a/platform/platform-resources/src/launcher.py
+++ b/platform/platform-resources/src/launcher.py
@@ -4,6 +4,7 @@
 import os
 import socket
 import struct
+import subprocess
 import sys
 
 # see com.intellij.idea.SocketLock for the server side of this interface
@@ -124,7 +125,7 @@ def start_new_instance(args):
     if sys.platform == 'darwin':
         if len(args) > 0:
             args.insert(0, '--args')
-        os.execvp('/usr/bin/open', ['-a', RUN_PATH] + args)
+        subprocess.call(['/usr/bin/open', '-na', RUN_PATH] + args)
     else:
         bin_file = os.path.split(RUN_PATH)[1]
         os.execv(RUN_PATH, [bin_file] + args)


### PR DESCRIPTION
Hi developers. Thank you very much for the wonderful project! 

The `launcher.py` opens a project properly when no IntelliJ window is running. However, when some IntelliJ windows are running, the `launcher.py` doesn't open properly in macOS. This PR fixes the problem.

I provide the following two demo video about before-PR and after-PR.

## Before PR
![idea-open-before-pr mp4 opt](https://user-images.githubusercontent.com/10933561/64998845-a744de00-d920-11e9-9eac-9c54b2f7d567.gif)


## After PR

![idea-open-after-pr mp4 opt](https://user-images.githubusercontent.com/10933561/64998940-fe4ab300-d920-11e9-9086-c857fecf0d67.gif)
