### PR TITLE
Fix path bug ('/' instead of ':' on osx for example)

### DIFF
--- a/platform/platform-api/src/com/intellij/execution/configurations/GeneralCommandLine.java
+++ b/platform/platform-api/src/com/intellij/execution/configurations/GeneralCommandLine.java
@@ -393,7 +393,7 @@ public class GeneralCommandLine implements UserDataHolder {
     }
 
     String exePath = myExePath;
-    if (SystemInfo.isMac && myParentEnvironmentType == ParentEnvironmentType.CONSOLE && exePath.indexOf(File.pathSeparatorChar) == -1) {
+    if (SystemInfo.isMac && myParentEnvironmentType == ParentEnvironmentType.CONSOLE && exePath.indexOf(File.separatorChar) == -1) {
       String systemPath = System.getenv("PATH"), shellPath = EnvironmentUtil.getValue("PATH");
       if (!Objects.equals(systemPath, shellPath)) {
         File exeFile = PathEnvironmentVariableUtil.findInPath(myExePath, shellPath, null);


### PR DESCRIPTION
Simple bug, but critical.  IJ shouldn't be looking on the path to find binaries
that are relative, such as `./myBinary`.  `pathSeparatorChar` actually is the 
character used to separate elements in the PATH environment variable, not
the character used to separate directories in the filesystem.

https://docs.oracle.com/javase/7/docs/api/java/io/File.html#pathSeparatorChar
vs
https://docs.oracle.com/javase/7/docs/api/java/io/File.html#separatorChar