### PR TITLE
Remove TooltipManager registrations on dispose

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/lookup/impl/LookupImpl.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/lookup/impl/LookupImpl.java
@@ -1152,6 +1152,7 @@ public class LookupImpl extends LightweightHint implements LookupEx, Disposable,
         super.hide();
 
         Disposer.dispose(this);
+        ToolTipManager.sharedInstance().unregisterComponent(myList);
 
         assert myDisposed;
       }


### PR DESCRIPTION
... otherwise we can potentially hold on to large data structures.