### PR TITLE
Add invokeLater helper

### DIFF
--- a/platform/util-ex/src/com/intellij/openapi/application/actions.kt
+++ b/platform/util-ex/src/com/intellij/openapi/application/actions.kt
@@ -22,6 +22,10 @@ inline fun <T> runReadAction(crossinline runnable: () -> T): T {
   return ApplicationManager.getApplication().runReadAction(Computable { runnable() })
 }
 
+inline fun invokeLater(crossinline runnable: () -> Unit) {
+  ApplicationManager.getApplication().invokeLater(Runnable { runnable() })
+}
+
 /**
  * @suppress Internal use only
  */


### PR DESCRIPTION
Hi,

I am Android Studio developer and I have found myself using ApplicationManager.getApplication().invokeLater quite often, so I think it deserves a helper function.