### PR TITLE
visually separate DUMMY_IDENTIFIER text from the main text

### DIFF
--- a/platform/core-api/src/com/intellij/codeInsight/completion/CompletionUtilCore.java
+++ b/platform/core-api/src/com/intellij/codeInsight/completion/CompletionUtilCore.java
@@ -24,6 +24,6 @@ public class CompletionUtilCore {
   /**
    * A default string that is inserted to the file before completion to guarantee that there'll always be some non-empty element there
    */
-  public static @NonNls final String DUMMY_IDENTIFIER = "IntellijIdeaRulezzz ";
-  public static @NonNls final String DUMMY_IDENTIFIER_TRIMMED = "IntellijIdeaRulezzz";
+  public static @NonNls final String DUMMY_IDENTIFIER = "_IntellijIdeaRulezzz ";
+  public static @NonNls final String DUMMY_IDENTIFIER_TRIMMED = "_IntellijIdeaRulezzz";
 }


### PR DESCRIPTION
For the debuging pupose:
![image](https://user-images.githubusercontent.com/14268320/66096589-7512bd80-e569-11e9-8ff4-1c7dc05e7b8a.png)
![image](https://user-images.githubusercontent.com/14268320/66096603-86f46080-e569-11e9-9066-03f8e8b0a1f6.png)

PS Also more `zzz` might need to be added at the end. ;)
