### PR TITLE
Add linux-ppc64le check-condition to support fsnotifier-ppc64le binary usage

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/impl/local/NativeFileWatcherImpl.java
@@ -144,6 +144,7 @@ public class NativeFileWatcherImpl extends PluggableFileWatcher {
       if ("linux-x86".equals(Platform.RESOURCE_PREFIX)) names = new String[]{"fsnotifier"};
       else if ("linux-x86-64".equals(Platform.RESOURCE_PREFIX)) names = new String[]{"fsnotifier64"};
       else if ("linux-arm".equals(Platform.RESOURCE_PREFIX)) names = new String[]{"fsnotifier-arm"};
+      else if ("linux-ppc64le".equals(Platform.RESOURCE_PREFIX)) names = new String[]{"fsnotifier-ppc64le"};
     }
     if (names == null) return PLATFORM_NOT_SUPPORTED;
 


### PR DESCRIPTION
fsnotifier (which lives under `native/fsNotifier/linux` for Linux platforms) can be compiled on various linux platforms. 

For Linux based 64-bit platforms, NativeFileWatcherImpl.java only knows about `x86_64` and `arm`. This tiny pull-request adds `ppc64le` to the mix. 

This will give people on Little-Endian Power systems the ability to run IntelliJ and its deratives with a fast filesystem changes notifier.