### PR TITLE
IDEA-215838 Fix memory leak in FindPopupPanel

### DIFF
--- a/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java
+++ b/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java
@@ -33,6 +33,8 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.DumbAwareToggleAction;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.ui.*;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
@@ -224,9 +226,9 @@ public class FindPopupPanel extends JBPanel implements FindUI {
       };
       myDialog.setUndecorated(!Registry.is("ide.find.as.popup.decorated"));
 
-      Disposer.register(myProject, new Disposable() {
+      myProject.getMessageBus().connect(myDialog.getDisposable()).subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
         @Override
-        public void dispose() {
+        public void projectClosed(Project project) {
           closeImmediately();
         }
       });


### PR DESCRIPTION
To ensure that the popup is closed when the corresponding project is
closed, a Disposable was registered with the project that closes the
popup. When the popup closes normally, this Disposable is not removed.
Since it is an inner class, it retains the popup. Opening this popup is
a fairly frequent operation, so a significant amount of memory can be
leaked (on the order of 100MB was seen in some heap reports).

This change instead subscribes a ProjectManagerListener which will close
the popup if the project is closed. It uses the dialog's disposable for
the message bus connection, so if the popup is closed normally, the
connection is closed and nothing holds on to the popup.