### PR TITLE
Another custom Logger.getInstance() inspection

### DIFF
--- a/.idea/inspectionProfiles/idea_default.xml
+++ b/.idea/inspectionProfiles/idea_default.xml
@@ -923,6 +923,9 @@
       <replaceConfiguration name="Logger.getInstance(&quot;#&quot; + class.getName()) can be simplified" text="com.intellij.openapi.diagnostic.Logger.getInstance(&quot;#&quot; + $c$.class.getName())" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="com.intellij.openapi.diagnostic.Logger.getInstance($c$.class)">
         <constraint name="c" within="" contains="" />
       </replaceConfiguration>
+      <replaceConfiguration name="Logger.getInstance(&quot;#&lt;class name&gt;&quot;) can be simplified" text="com.intellij.openapi.diagnostic.Logger.getInstance(&quot;#$c$&quot;)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="true" shortenFQN="true" replacement="com.intellij.openapi.diagnostic.Logger.getInstance($c$.class)">
+        <constraint name="c" within="" contains="" />
+      </replaceConfiguration>
       <replaceConfiguration name="StringUtil.indexOf(String, char) -&gt; String.indexOf(char)" text="com.intellij.openapi.util.text.StringUtil.indexOf($s$, $c$)" recursive="false" caseInsensitive="true" type="JAVA" reformatAccordingToStyle="false" shortenFQN="false" replacement="$s$.indexOf($c$)">
         <constraint name="s" nameOfExprType="java.lang.String" exprTypeWithinHierarchy="true" within="" contains="" />
         <constraint name="c" nameOfExprType="char" exprTypeWithinHierarchy="true" within="" contains="" />


### PR DESCRIPTION
I noticed some invocations like:

    Logger.getInstance("#fqn.of.Class");

And, since the actual FQNs are invariably longer than in my example, I naturally began to wonder if any of these
invocations was misspelled or out-of-date.

So here's an inspection with a quick-fix, which I made by copying the one that rewrites:

    Logger.getInstance("#" + $c$.class.getName())

to:

    Logger.getInstance($c$.class)

and then changing the search template appropriately.

(FYI, I did this directly in the XML, because the inspection settings page just felt too ... cramped and modal.)

I was pleasantly surprised that I didn't need to do anything to turn the FQN text into an expression.

P.S. There are invocations like this in, e.g., Kotlin that would need to be handled separately.

Signed-off-by: Samuel Bronson <naesten@gmail.com>