### PR TITLE
Debugger: Provide MethodsTracker from JavaExecutionStack to PositionManagerEx t…

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/engine/JavaExecutionStack.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/JavaExecutionStack.java
@@ -101,7 +101,7 @@ public class JavaExecutionStack extends XExecutionStack {
     DebugProcessImpl debugProcess = (DebugProcessImpl)descriptor.getDebugProcess();
     Location location = descriptor.getLocation();
     if (location != null) {
-      XStackFrame customFrame = debugProcess.getPositionManager().createStackFrame(stackFrameProxy, debugProcess, location);
+      XStackFrame customFrame = debugProcess.getPositionManager().createStackFrame(stackFrameProxy, debugProcess, location, myTracker);
       if (customFrame != null) {
         return customFrame;
       }

--- a/java/debugger/impl/src/com/intellij/debugger/engine/PositionManagerEx.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/PositionManagerEx.java
@@ -18,6 +18,7 @@ package com.intellij.debugger.engine;
 import com.intellij.debugger.PositionManager;
 import com.intellij.debugger.engine.evaluation.EvaluationContext;
 import com.intellij.debugger.jdi.StackFrameProxyImpl;
+import com.intellij.debugger.ui.impl.watch.MethodsTracker;
 import com.intellij.util.ThreeState;
 import com.intellij.xdebugger.frame.XStackFrame;
 import com.sun.jdi.Location;
@@ -27,6 +28,14 @@ import org.jetbrains.annotations.Nullable;
 public abstract class PositionManagerEx implements PositionManager {
   @Nullable
   public abstract XStackFrame createStackFrame(@NotNull StackFrameProxyImpl frame, @NotNull DebugProcessImpl debugProcess, @NotNull Location location);
+
+  @SuppressWarnings("UnusedDeclaration")
+  public XStackFrame createStackFrame(@NotNull StackFrameProxyImpl frame,
+                                      @NotNull DebugProcessImpl debugProcess,
+                                      @NotNull Location location,
+                                      @NotNull MethodsTracker tracker) {
+    return createStackFrame(frame, debugProcess, location);
+  }
 
   public abstract ThreeState evaluateCondition(@NotNull EvaluationContext context,
                                                @NotNull StackFrameProxyImpl frame,


### PR DESCRIPTION
In JavaExecutionStack.createFrame it tries to create a custom frame (e.g KotlinStackFrame), but PositionManager doesn't obtain MethodsTracker and there's no sane way to get it, so some functionality like recursion depth in frames view doesn't work.