### PR TITLE
Enable brace highlighting for read-only viewers

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/highlighting/BraceHighlightingHandler.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/highlighting/BraceHighlightingHandler.java
@@ -111,7 +111,7 @@ public class BraceHighlightingHandler {
 
   private static boolean isValidEditor(@NotNull Editor editor) {
     Project editorProject = editor.getProject();
-    return editorProject != null && !editorProject.isDisposed() && !editor.isDisposed() && editor.getComponent().isShowing() && !editor.isViewer();
+    return editorProject != null && !editorProject.isDisposed() && !editor.isDisposed() && editor.getComponent().isShowing();
   }
 
   @NotNull


### PR DESCRIPTION
The current implementation of brace highlighter is written in such a way that brace highlighting is disabled for editors in read-only mode (editor.isViewer()==true). There is no obvious reason to do that, so this one-liner pull-request enables brace highlighting in this situation. Brace Highlighting tests in platform.lang.test pass normally after this change.