### PR TITLE
Null check is added for PopupChooserBuilder.myItemChosenRunnable:crea…

### DIFF
--- a/platform/platform-api/src/com/intellij/openapi/ui/popup/PopupChooserBuilder.java
+++ b/platform/platform-api/src/com/intellij/openapi/ui/popup/PopupChooserBuilder.java
@@ -324,7 +324,7 @@ public class PopupChooserBuilder<T> implements IPopupChooserBuilder<T> {
           if (myCloseOnEnter) {
             closePopup(e, true);
           }
-          else {
+          else if (myItemChosenRunnable != null) {
             myItemChosenRunnable.run();
           }
         }


### PR DESCRIPTION
Null check is added for PopupChooserBuilder.myItemChosenRunnable:createPopup

When I try to create JBPopup like:
```java
  JBPopupFactory.getInstance()
                .createPopupChooserBuilder(table)
                .setCloseOnEnter(false)
                .createPopup()
                .showInScreenCoordinates(component.getAnchor(), point);
```
I have to invoke setItemChoosenCallback with a stub to prevent NPE:
```java
  JBPopupFactory.getInstance()
                .createPopupChooserBuilder(table)
                .setItemChoosenCallback(point::toString) // Stub
                .setCloseOnEnter(false)
                .createPopup()
                .showInScreenCoordinates(component.getAnchor(), point);
```