### PR TITLE
Fix bug: environment variables of before run task can not be saved to…

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemBeforeRunTask.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemBeforeRunTask.java
@@ -2,6 +2,7 @@
 package com.intellij.openapi.externalSystem.service.execution;
 
 import com.intellij.execution.BeforeRunTask;
+import com.intellij.execution.configuration.EnvironmentVariablesComponent;
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.intellij.openapi.externalSystem.model.execution.ExternalSystemTaskExecutionSettings;
 import com.intellij.openapi.util.Key;
@@ -44,6 +45,10 @@ public class ExternalSystemBeforeRunTask extends BeforeRunTask<ExternalSystemBef
     if (myTaskExecutionSettings.getScriptParameters() != null) {
       element.setAttribute("scriptParameters", myTaskExecutionSettings.getScriptParameters());
     }
+
+    if (!myTaskExecutionSettings.getEnv().isEmpty()) {
+      EnvironmentVariablesComponent.writeExternal(element, myTaskExecutionSettings.getEnv());
+    }
   }
 
   @Override
@@ -53,6 +58,7 @@ public class ExternalSystemBeforeRunTask extends BeforeRunTask<ExternalSystemBef
     myTaskExecutionSettings.setExternalProjectPath(element.getAttributeValue("externalProjectPath"));
     myTaskExecutionSettings.setVmOptions(element.getAttributeValue("vmOptions"));
     myTaskExecutionSettings.setScriptParameters(element.getAttributeValue("scriptParameters"));
+    EnvironmentVariablesComponent.readExternal(element, myTaskExecutionSettings.getEnv());
   }
 
   @Override


### PR DESCRIPTION
Fix bug: environment variables of before run task can not be saved to xml config file.
![image](https://user-images.githubusercontent.com/18010111/67765888-28e36c00-fa88-11e9-9de7-0b2049de01ee.png)
