### PR TITLE
Remove final keyword from IdeTooltipManager

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/IdeTooltipManager.java
+++ b/platform/platform-impl/src/com/intellij/ide/IdeTooltipManager.java
@@ -43,7 +43,7 @@ import java.awt.event.AWTEventListener;
 import java.awt.event.MouseEvent;
 import java.lang.reflect.Field;
 
-public final class IdeTooltipManager implements Disposable, AWTEventListener {
+public class IdeTooltipManager implements Disposable, AWTEventListener {
   public static final ColorKey TOOLTIP_COLOR_KEY = ColorKey.createColorKey("TOOLTIP", null);
 
   private static final Key<IdeTooltip> CUSTOM_TOOLTIP = Key.create("custom.tooltip");


### PR DESCRIPTION
This was added incidentally by commit 977a1d1
breaking tests that mock the class.