### PR TITLE
Expose Invoker#useReadAction to StructureTreeModel

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/tree/StructureTreeModel.java
+++ b/platform/platform-impl/src/com/intellij/ui/tree/StructureTreeModel.java
@@ -44,23 +44,30 @@ public class StructureTreeModel<Structure extends AbstractTreeStructure>
   private final Structure structure;
   private volatile Comparator<? super Node> comparator;
 
-  private StructureTreeModel(@NotNull Structure structure, boolean background, @NotNull Disposable parentDisposable) {
+  private StructureTreeModel(@NotNull Structure structure, boolean background, boolean useReadAction, @NotNull Disposable parentDisposable) {
     this.structure = structure;
     description = format(structure.toString());
     invoker = background
-              ? new Invoker.Background(this)
+              ? new Invoker.Background(this, useReadAction)
               : new Invoker.EDT(this);
     Disposer.register(parentDisposable, this);
   }
 
   public StructureTreeModel(@NotNull Structure structure, @NotNull Disposable parentDisposable) {
-    this(structure, true, parentDisposable);
+    this(structure, true, true, parentDisposable);
   }
 
   public StructureTreeModel(@NotNull Structure structure,
                             @NotNull Comparator<? super NodeDescriptor> comparator,
                             @NotNull Disposable parentDisposable) {
-    this(structure, parentDisposable);
+    this(structure, comparator, true, parentDisposable);
+  }
+
+  public StructureTreeModel(@NotNull Structure structure,
+                            @NotNull Comparator<? super NodeDescriptor> comparator,
+                            boolean useReadAction,
+                            @NotNull Disposable parentDisposable) {
+    this(structure, true, useReadAction, parentDisposable);
     this.comparator = wrapToNodeComparator(comparator);
   }
 


### PR DESCRIPTION
We load data from the network in the background using a `StructureTreeModel`, this exposes the `Invoker`'s `useReadAction` so that the read lock is not captured during the background actions of the Tree / AsyncTreeModel