### PR TITLE
Hides device selection from the configuration menu

### DIFF
--- a/platform/lang-api/src/com/intellij/execution/ExecutionTarget.java
+++ b/platform/lang-api/src/com/intellij/execution/ExecutionTarget.java
@@ -60,6 +60,14 @@ public abstract class ExecutionTarget {
     return true;
   }
 
+  /**
+   * Implementation-specific logic to determine if an external plugin is responsible for managing this target.
+   * @return true if the target is externally managed, or false for platform to manage
+   */
+  public boolean isExternallyManaged() {
+    return false;
+  }
+
   @Override
   public boolean equals(Object obj) {
     return obj == this || (getClass().isInstance(obj) && getId().equals(((ExecutionTarget)obj).getId()));

--- a/platform/lang-api/src/com/intellij/execution/ExecutionTargetManager.java
+++ b/platform/lang-api/src/com/intellij/execution/ExecutionTargetManager.java
@@ -6,6 +6,7 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.Topic;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,6 +34,10 @@ public abstract class ExecutionTargetManager {
   public static List<ExecutionTarget> getTargetsToChooseFor(@NotNull Project project, @Nullable RunConfiguration configuration) {
     List<ExecutionTarget> result = getInstance(project).getTargetsFor(configuration);
     if (result.size() == 1 && DefaultExecutionTarget.INSTANCE.equals(result.get(0))) return Collections.emptyList();
+    result = Collections.unmodifiableList(result.stream().filter(target -> !target.isExternallyManaged()).collect(Collectors.toList()));
+    if (result.size() == 1 && DefaultExecutionTarget.INSTANCE.equals(result.get(0))) {
+      return Collections.emptyList();
+    }
     return result;
   }
 

--- a/platform/lang-impl/src/com/intellij/execution/actions/RunConfigurationsComboBoxAction.java
+++ b/platform/lang-impl/src/com/intellij/execution/actions/RunConfigurationsComboBoxAction.java
@@ -77,7 +77,7 @@ public class RunConfigurationsComboBoxAction extends ComboBoxAction implements D
     presentation.putClientProperty(BUTTON_MODE, null);
     if (project != null && target != null && settings != null) {
       String name = Executor.shortenNameIfNeeded(settings.getName());
-      if (target != DefaultExecutionTarget.INSTANCE) {
+      if (target != DefaultExecutionTarget.INSTANCE && !target.isExternallyManaged()) {
         name += " | " + target.getDisplayName();
       } else {
         if (!ExecutionTargetManager.canRun(settings.getConfiguration(), target)) {

--- a/platform/lang-impl/src/com/intellij/execution/compound/ConfigurationSelectionUtil.java
+++ b/platform/lang-impl/src/com/intellij/execution/compound/ConfigurationSelectionUtil.java
@@ -24,7 +24,8 @@ public class ConfigurationSelectionUtil {
   @NotNull
   public static String getDisplayText(@NotNull RunConfiguration configuration, @Nullable ExecutionTarget target) {
     return configuration.getType().getDisplayName() + " '" + configuration.getName() +
-           "'" + (target != null && target != DefaultExecutionTarget.INSTANCE ? " | " + target.getDisplayName() : "");
+           "'" + (target != null && target != DefaultExecutionTarget.INSTANCE && !target.isExternallyManaged() ?
+           " | " + target.getDisplayName() : "");
   }
 
   // todo merge with ChooseRunConfigurationPopup


### PR DESCRIPTION
Android Studio externally manages execution targets, so we hide all
execution target information from the configuration combo box.

We do this by adding support for externally managed targets, and filter
out UI elements that match externally managed targets.