### PR TITLE
Bad conversion of Ellipsis method parameter receiving a migrated array

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationLabeler.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationLabeler.java
@@ -1017,7 +1017,10 @@ public class TypeMigrationLabeler {
               final PsiExpression actual = expressions[idx];
               final PsiType type = getTypeEvaluator().evaluateType(actual);
               if (type != null) {
-                migrateExpressionType(actual, strippedType, parent, TypeConversionUtil.isAssignable(strippedType, type), true);
+                PsiType argumentMigrationType =
+                  type instanceof PsiArrayType && migrationType instanceof PsiEllipsisType ? strippedType.createArrayType() : strippedType;
+                migrateExpressionType(actual, argumentMigrationType, parent,
+                                      TypeConversionUtil.isAssignable(argumentMigrationType, type), true);
               }
             }
           }

--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationStatementProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationStatementProcessor.java
@@ -536,12 +536,15 @@ class TypeMigrationStatementProcessor extends JavaRecursiveElementVisitor {
 
       case TypeInfection.RIGHT_INFECTED:
         PsiType psiType = migrationType != null ? migrationType : right.getType();
+        PsiType initialType = left.getType();
+        if (initialType instanceof PsiEllipsisType && psiType instanceof PsiArrayType) {
+          psiType = new PsiEllipsisType(((PsiArrayType)psiType).getComponentType());
+        }
         if (psiType != null) {
           if (canBeVariableType(psiType)) {
             if (declarationType != null &&
                 !myLabeler.addMigrationRoot(variable, psiType, myStatement, TypeConversionUtil.isAssignable(declarationType, psiType), true) &&
                 !TypeConversionUtil.isAssignable(left.getType(), psiType)) {
-              PsiType initialType = left.getType();
               if (initialType instanceof PsiEllipsisType) {
                 initialType = ((PsiEllipsisType)initialType).getComponentType();
               }

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
@@ -879,6 +879,10 @@ public class TypeMigrationTest extends TypeMigrationTestBase {
   public void testTypeParameterMigrationInInvalidCode() {
     doTestFieldType("migrationField", myFactory.createTypeFromText("Test<Short>", null));
   }
+  
+  public void testArrayTypeUsedInEllipsisParameter(){
+    doTestFirstLocalVariableType("migrationVariable", PsiType.LONG.createArrayType());
+  }
 
   private void doTestReturnType(final String methodName, final String migrationType) {
     start(new RulesProvider() {

--- a/java/typeMigration/testData/refactoring/typeMigration/arrayTypeUsedInEllipsisParameter/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/arrayTypeUsedInEllipsisParameter/after/Test.items
@@ -1,0 +1,16 @@
+Types:
+PsiLocalVariable:migrationVariable : long[]
+PsiNewExpression:new int[]{0,0} : long[]
+PsiParameter:values : long...
+PsiReferenceExpression:migrationVariable : long[]
+
+Conversions:
+0 -> $
+0 -> $
+0 -> $
+0 -> $
+migrationVariable -> $
+
+New expression type changes:
+new int[]{0,0} -> long[]
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigration/arrayTypeUsedInEllipsisParameter/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/arrayTypeUsedInEllipsisParameter/after/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+public class Test {
+
+    public void bar(){
+        long[] migrationVariable = new long[]{0,0};
+        baz(migrationVariable);
+        baz(0, 0);
+    }
+
+    public void baz(long... values){}
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/arrayTypeUsedInEllipsisParameter/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/arrayTypeUsedInEllipsisParameter/before/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+public class Test {
+
+    public void bar(){
+        int[] migrationVariable = new int[]{0,0};
+        baz(migrationVariable);
+        baz(0, 0);
+    }
+
+    public void baz(int... values){}
+}


### PR DESCRIPTION
Let be

```java
public class Foo {
  public void bar(){
    int[] array = new int[]{0,0};
    baz(array);
    baz(0, 0);
  }

  public void baz(int... values){}
}
```

When asking type migration of array from `int[]` to `long[]`, the conversion fails.