### PR TITLE
Do not try to migrate string binary expressions

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationStatementProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationStatementProcessor.java
@@ -32,7 +32,6 @@ import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -65,7 +64,7 @@ class TypeMigrationStatementProcessor extends JavaRecursiveElementVisitor {
     final PsiType ltype = left.getType();
     final PsiType rtype = right.getType();
     if (ltype == null || rtype == null) return;
-
+    
     if (sign != JavaTokenType.EQ) {
       final IElementType binaryOperator = TypeConversionUtil.convertEQtoOperation(sign);
       if (!TypeConversionUtil.isBinaryOperatorApplicable(binaryOperator, ltype, rtype, false)) {
@@ -77,8 +76,12 @@ class TypeMigrationStatementProcessor extends JavaRecursiveElementVisitor {
         }
         return;
       }
+      PsiClassType stringType = JavaPsiFacade.getElementFactory(expression.getProject()).createTypeByFQClassName("java.lang.String");
+      if (stringType.equals(ltype) && binaryOperator == JavaTokenType.PLUS && !left.isChanged() && right.isChanged()) {
+        return;
+      }
     }
-
+    
     switch (TypeInfection.getInfection(left, right)) {
       case TypeInfection.NONE_INFECTED:
         break;

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
@@ -879,6 +879,10 @@ public class TypeMigrationTest extends TypeMigrationTestBase {
   public void testTypeParameterMigrationInInvalidCode() {
     doTestFieldType("migrationField", myFactory.createTypeFromText("Test<Short>", null));
   }
+  
+  public void testCompatibleBinaryExpressions() {
+    doTestFieldType("migrationField", PsiType.LONG);
+  }
 
   private void doTestReturnType(final String methodName, final String migrationType) {
     start(new RulesProvider() {

--- a/java/typeMigration/testData/refactoring/typeMigration/compatibleBinaryExpressions/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/compatibleBinaryExpressions/after/Test.items
@@ -1,0 +1,9 @@
+Types:
+PsiField:migrationField : long
+PsiReferenceExpression:migrationField : long
+
+Conversions:
+5 -> $
+
+New expression type changes:
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigration/compatibleBinaryExpressions/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/compatibleBinaryExpressions/after/test.java
@@ -1,0 +1,10 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+class Test {
+    
+    private long migrationField = 5;
+    
+    public void bar() {
+        String query = "";
+        query += migrationField;
+    }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/compatibleBinaryExpressions/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/compatibleBinaryExpressions/before/test.java
@@ -1,0 +1,10 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+class Test {
+    
+    private int migrationField = 5;
+    
+    public void bar() {
+        String query = "";
+        query += migrationField;
+    }
+}


### PR DESCRIPTION
Let be

```java
public class Foo {
    public void bar() {
        int number = 5;
        String query = "";
        query += number;
    }
}
```

When asking type migration of variable number from `int` to `long`, the migration fails because it fails to convert variable `query` from `String` to `long`.

This PR makes type migration consider those kind of assignment as migration compatible, i.e. not requiring any kind of conversion.