### PR TITLE
TypeMigration tries to convert Map<String, Object> to Map<String, String> without valid reason

### DIFF
--- a/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationStatementProcessor.java
+++ b/java/java-impl/src/com/intellij/refactoring/typeMigration/TypeMigrationStatementProcessor.java
@@ -539,8 +539,8 @@ class TypeMigrationStatementProcessor extends JavaRecursiveElementVisitor {
         if (psiType != null) {
           if (canBeVariableType(psiType)) {
             if (declarationType != null &&
-                !myLabeler.addMigrationRoot(variable, psiType, myStatement, TypeConversionUtil.isAssignable(declarationType, psiType), true) &&
-                !TypeConversionUtil.isAssignable(left.getType(), psiType)) {
+                !myLabeler.addMigrationRoot(variable, psiType, myStatement, TypeConversionUtil.isAssignable(declarationType, psiType, true, true), true) &&
+                !TypeConversionUtil.isAssignable(left.getType(), psiType, true, true)) {
               PsiType initialType = left.getType();
               if (initialType instanceof PsiEllipsisType) {
                 initialType = ((PsiEllipsisType)initialType).getComponentType();

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTest.java
@@ -464,7 +464,7 @@ public class TypeMigrationTest extends TypeMigrationTestBase {
                      myFactory.createTypeFromText("java.util.List<java.lang.String>", null));
   }
 
-   public void testT87() {
+  public void testT87() {
     doTestMethodType("getArray",
                      myFactory.createTypeFromText("java.lang.String", null).createArrayType());
   }
@@ -558,7 +558,7 @@ public class TypeMigrationTest extends TypeMigrationTestBase {
                          myFactory.createTypeFromText("java.lang.Integer", null).createArrayType());
   }
 
-   //raw list type now should not be changed
+  //raw list type now should not be changed
   public void testT104() {
     doTestFirstParamType("method",
                          myFactory.createTypeFromText("java.lang.String", null).createArrayType());
@@ -615,9 +615,9 @@ public class TypeMigrationTest extends TypeMigrationTestBase {
   }
 
   public void testT114() {
-      doTestFirstParamType("method",
-                           new PsiEllipsisType(myFactory.createTypeFromText("java.lang.String", null)));
-    }
+    doTestFirstParamType("method",
+                         new PsiEllipsisType(myFactory.createTypeFromText("java.lang.String", null)));
+  }
 
   //varargs && ArrayList
   public void testT118() {
@@ -878,6 +878,10 @@ public class TypeMigrationTest extends TypeMigrationTestBase {
 
   public void testTypeParameterMigrationInInvalidCode() {
     doTestFieldType("migrationField", myFactory.createTypeFromText("Test<Short>", null));
+  }
+
+  public void testMapStringStringInMapStringObject() {
+    doTestMethodType("migrationMethod", PsiType.LONG);
   }
 
   private void doTestReturnType(final String methodName, final String migrationType) {

--- a/java/typeMigration/testData/refactoring/typeMigration/mapStringStringInMapStringObject/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/mapStringStringInMapStringObject/after/Test.items
@@ -1,0 +1,9 @@
+Types:
+PsiMethod:migrationMethod : long
+PsiMethodCallExpression:migrationMethod() : long
+
+Conversions:
+1 -> $
+
+New expression type changes:
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigration/mapStringStringInMapStringObject/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/mapStringStringInMapStringObject/after/test.java
@@ -1,0 +1,17 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+import java.util.*;
+
+class Test {
+    public void foo() {
+        setMap(Collections.singletonMap("first", Long.toString(migrationMethod())));
+        setMap(Collections.singletonMap("second", new Object()));
+    }
+
+    private long migrationMethod() {
+        return 1;
+    }
+
+    private void setMap(Map<String, Object> map) {
+
+    }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/mapStringStringInMapStringObject/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/mapStringStringInMapStringObject/before/test.java
@@ -1,0 +1,17 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+import java.util.*;
+
+class Test {
+    public void foo() {
+        setMap(Collections.singletonMap("first", Long.toString(migrationMethod())));
+        setMap(Collections.singletonMap("second", new Object()));
+    }
+
+    private int migrationMethod() {
+        return 1;
+    }
+
+    private void setMap(Map<String, Object> map) {
+
+    }
+}


### PR DESCRIPTION
Let be:
```java
public class Scratch {
    public void foo() {
        setMap(Collections.singletonMap("key", Long.toString(number())));
    }

    private int number() {
        return 1;
    }

    private void setMap(Map<String, Object> map) {

    }
}
```

When asking type migration to convert method `int number()` from `int` to `long`, it tries to convert PsiParameter `Map<String, Object> map` from `Map<String, Object>` to `Map<String, String>`.

This PR should fix the behaviour.