### PR TITLE
TypeMigration converts some method arguments without checking compliance with the parameter declaration type

### DIFF
--- a/java/typeMigration/src/META-INF/TypeMigration.xml
+++ b/java/typeMigration/src/META-INF/TypeMigration.xml
@@ -9,6 +9,7 @@
     <conversion.rule implementation="com.intellij.refactoring.typeMigration.rules.ThreadLocalConversionRule"/>
     <conversion.rule implementation="com.intellij.refactoring.typeMigration.rules.LongAdderConversionRule"/>
     <conversion.rule implementation="com.intellij.refactoring.typeMigration.rules.VoidConversionRule"/>
+    <conversion.rule implementation="com.intellij.refactoring.typeMigration.rules.OverloadedMethodsConversionRule"/>
 
     <conversion.rule implementation="com.intellij.refactoring.typeMigration.rules.guava.GuavaOptionalConversionRule"/>
     <conversion.rule implementation="com.intellij.refactoring.typeMigration.rules.guava.GuavaFluentIterableConversionRule"/>

--- a/java/typeMigration/src/com/intellij/refactoring/typeMigration/rules/OverloadedMethodsConversionRule.java
+++ b/java/typeMigration/src/com/intellij/refactoring/typeMigration/rules/OverloadedMethodsConversionRule.java
@@ -1,0 +1,150 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.refactoring.typeMigration.rules;
+
+import com.intellij.psi.*;
+import com.intellij.psi.util.TypeConversionUtil;
+import com.intellij.refactoring.typeMigration.TypeConversionDescriptorBase;
+import com.intellij.refactoring.typeMigration.TypeEvaluator;
+import com.intellij.refactoring.typeMigration.TypeMigrationLabeler;
+import com.siyeh.ig.psiutils.MethodUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public class OverloadedMethodsConversionRule extends TypeConversionRule {
+
+  @Nullable
+  @Override
+  public TypeConversionDescriptorBase findConversion(
+    PsiType from,
+    PsiType to,
+    PsiMember member,
+    PsiExpression expression,
+    TypeMigrationLabeler labeler) {
+    if (!(expression.getContext() instanceof PsiExpressionList)) {
+      return null;
+    }
+    PsiExpressionList expressionList = (PsiExpressionList)expression.getContext();
+    if (!(expressionList.getContext() instanceof PsiMethodCallExpression)) {
+      return null;
+    }
+    PsiMethodCallExpression methodCallExpression = (PsiMethodCallExpression)expressionList.getContext();
+    PsiMethod method = methodCallExpression.resolveMethod();
+    if (method == null) {
+      return null;
+    }
+
+    if (method.isConstructor()) {
+      return null;
+    }
+    if (method.getNameIdentifier() == null) {
+      return null;
+    }
+    final PsiParameterList parameterList = method.getParameterList();
+    final int parameterCount = parameterList.getParametersCount();
+    if (parameterCount == 0) {
+      return null;
+    }
+    final PsiClass aClass = method.getContainingClass();
+    if (aClass == null) {
+      return null;
+    }
+
+    final String methodName = method.getName();
+    final PsiMethod[] sameNameMethods = aClass.findMethodsByName(methodName, false);
+    if (sameNameMethods.length == 0) {
+      return null;
+    }
+
+    PsiExpression[] arguments = expressionList.getExpressions();
+
+    int migratedArgumentIndex = Arrays.asList(arguments).indexOf(expression);
+
+    PsiType[] newArgumentTypes = new PsiType[expressionList.getExpressionCount()];
+    for (int argumentIndex = 0; argumentIndex < newArgumentTypes.length; argumentIndex++) {
+      if (argumentIndex == migratedArgumentIndex) {
+        newArgumentTypes[argumentIndex] = to;
+      }
+      else {
+        newArgumentTypes[argumentIndex] = labeler.getTypeEvaluator().getType(arguments[argumentIndex]);
+      }
+    }
+
+    for (PsiMethod sameNameMethod : sameNameMethods) {
+      if (method.equals(sameNameMethod)) {
+        continue;
+      }
+      final PsiParameterList otherParameterList = sameNameMethod.getParameterList();
+      if (parameterCount != otherParameterList.getParametersCount()) {
+        continue;
+      }
+
+      if (!areModifierListsEquivalent(method.getModifierList(), sameNameMethod.getModifierList())) {
+        continue;
+      }
+
+      PsiParameter[] sameNameMethodParameters = sameNameMethod.getParameterList().getParameters();
+      if (areArgumentTypesAssignableToParameters(labeler.getTypeEvaluator(), newArgumentTypes,
+                                                 sameNameMethodParameters)) {
+        return new TypeConversionDescriptorBase();
+      }
+    }
+
+    return null;
+  }
+
+  private boolean areArgumentTypesAssignableToParameters(TypeEvaluator typeEvaluator,
+                                                         PsiType[] argumentTypes,
+                                                         PsiParameter[] parameters) {
+    for (int parameterIndex = 0; parameterIndex < parameters.length; parameterIndex++) {
+      PsiParameter parameter = parameters[parameterIndex];
+      PsiType parameterType = typeEvaluator.getType(parameter);
+      if (parameterType == null) {
+        return false;
+      }
+      if (parameterType instanceof PsiEllipsisType) {
+        for (int argumentIndex = parameterIndex; argumentIndex < argumentTypes.length; argumentIndex++) {
+          PsiType argumentType = argumentTypes[argumentIndex];
+          if (!isArgumentTypeAssignableToParameterEllipsisType(argumentType, (PsiEllipsisType)parameterType)) {
+            return false;
+          }
+        }
+      }
+      else {
+        PsiType argumentType = argumentTypes[parameterIndex];
+        if (!TypeConversionUtil.isAssignable(parameterType, argumentType)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  private boolean isArgumentTypeAssignableToParameterEllipsisType(PsiType argumentType, PsiEllipsisType parameterType) {
+    PsiType parameterComponentType = parameterType.getComponentType();
+    if (argumentType instanceof PsiArrayType) {
+      return TypeConversionUtil
+        .isAssignable(parameterComponentType, ((PsiArrayType)argumentType).getComponentType());
+    }
+    else {
+      return TypeConversionUtil.isAssignable(parameterComponentType, argumentType);
+    }
+  }
+
+  private boolean areModifierListsEquivalent(PsiModifierList firstModifierList, PsiModifierList secondModifierList) {
+    for (int i = 0; i < PsiModifier.MODIFIERS.length; i++) {
+      String modifier = PsiModifier.MODIFIERS[i];
+      if (firstModifierList.hasModifierProperty(modifier) && !secondModifierList.hasModifierProperty(modifier)) {
+        return false;
+      }
+      if (secondModifierList.hasModifierProperty(modifier) && !firstModifierList.hasModifierProperty(modifier)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTestBase.java
+++ b/java/typeMigration/test/com/intellij/refactoring/TypeMigrationTestBase.java
@@ -8,9 +8,12 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.PostprocessReformattingAspect;
 import com.intellij.psi.search.LocalSearchScope;
+import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.refactoring.typeMigration.TypeConversionDescriptor;
 import com.intellij.refactoring.typeMigration.TypeMigrationProcessor;
 import com.intellij.refactoring.typeMigration.TypeMigrationRules;
+import com.intellij.refactoring.typeMigration.rules.TypeConversionRule;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.PlatformTestUtil;
 import com.intellij.usageView.UsageInfo;
@@ -20,6 +23,7 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 /**
  * @author anna
@@ -143,7 +147,8 @@ public abstract class TypeMigrationTestBase extends LightMultiFileTestCase {
     final PsiElement[] migrationElements = provider.victims(aClass);
     final PsiType migrationType = provider.migrationType(migrationElements[0]);
     final TypeMigrationRules rules = new TypeMigrationRules(getProject());
-    rules.setBoundScope(new LocalSearchScope(aClass.getContainingFile()));
+    rules.setBoundScope(provider.boundScope(aClass));
+    Stream.of(provider.conversionDescriptors()).forEach(rules::addConversionDescriptor);
     final TestTypeMigrationProcessor pr = new TestTypeMigrationProcessor(getProject(), migrationElements, migrationType, rules);
 
     final UsageInfo[] usages = pr.findUsages();
@@ -166,6 +171,14 @@ public abstract class TypeMigrationTestBase extends LightMultiFileTestCase {
 
     default PsiElement[] victims(PsiClass aClass) {
       return new PsiElement[] {victim(aClass)};
+    }
+    
+    default SearchScope boundScope(PsiClass aClass){
+      return new LocalSearchScope(aClass.getContainingFile());
+    }
+    
+    default TypeConversionRule[] conversionDescriptors(){
+      return new TypeConversionRule[0];
     }
   }
 

--- a/java/typeMigration/testData/refactoring/typeMigration/arrayMigrationWithEllipsisReceivingParameter/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/arrayMigrationWithEllipsisReceivingParameter/after/Test.items
@@ -1,0 +1,11 @@
+Types:
+PsiField:migrationField : long[]
+PsiNewExpression:new int[] : long[]
+PsiReferenceExpression:migrationField : long[]
+
+Conversions:
+
+New expression type changes:
+new int[] -> long[]
+Fails:
+migrationField->long[]

--- a/java/typeMigration/testData/refactoring/typeMigration/arrayMigrationWithEllipsisReceivingParameter/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/arrayMigrationWithEllipsisReceivingParameter/after/test.java
@@ -1,0 +1,16 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+
+  long[] migrationField = new long[];
+
+  public void foo() {
+    Bar.of(migrationField);
+  }
+}
+
+class Bar {
+  public static Bar of(int... args) {
+    return new Bar();
+  }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/arrayMigrationWithEllipsisReceivingParameter/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/arrayMigrationWithEllipsisReceivingParameter/before/test.java
@@ -1,0 +1,16 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+
+  int[] migrationField = new int[];
+
+  public void foo() {
+    Bar.of(migrationField);
+  }
+}
+
+class Bar {
+  public static Bar of(int... args) {
+    return new Bar();
+  }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/intToLongInStringBuffer/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/intToLongInStringBuffer/after/Test.items
@@ -1,0 +1,9 @@
+Types:
+PsiField:migrationField : long
+PsiReferenceExpression:migrationField : long
+
+Conversions:
+migrationField -> $
+
+New expression type changes:
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigration/intToLongInStringBuffer/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/intToLongInStringBuffer/after/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+
+  long migrationField;
+
+  public void foo() {
+    StringBuffer stringBuffer = new StringBuffer();
+    stringBuffer.append(migrationField);
+  }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/intToLongInStringBuffer/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/intToLongInStringBuffer/before/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+
+  int migrationField;
+
+  public void foo() {
+    StringBuffer stringBuffer = new StringBuffer();
+    stringBuffer.append(migrationField);
+  }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/nonMigratableMethodArgumentExpression/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/nonMigratableMethodArgumentExpression/after/Test.items
@@ -1,0 +1,10 @@
+Types:
+PsiMethod:migrationMethod : long
+PsiMethodCallExpression:migrationMethod() : long
+
+Conversions:
+1 -> $
+
+New expression type changes:
+Fails:
+migrationMethod()->long

--- a/java/typeMigration/testData/refactoring/typeMigration/nonMigratableMethodArgumentExpression/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/nonMigratableMethodArgumentExpression/after/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+    public void foo() {
+        Integer.toString(migrationMethod());
+    }
+
+    private long migrationMethod() {
+        return 1;
+    }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/nonMigratableMethodArgumentExpression/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/nonMigratableMethodArgumentExpression/before/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+    public void foo() {
+        Integer.toString(migrationMethod());
+    }
+
+    private int migrationMethod() {
+        return 1;
+    }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod1/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod1/after/Test.items
@@ -1,0 +1,10 @@
+Types:
+PsiMethod:migrationMethod : long
+PsiMethodCallExpression:migrationMethod() : long
+
+Conversions:
+1 -> $
+migrationMethod() -> $
+
+New expression type changes:
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod1/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod1/after/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+    public void foo() {
+        String.valueOf(migrationMethod());
+    }
+
+    private long migrationMethod() {
+        return 1;
+    }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod1/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod1/before/test.java
@@ -1,0 +1,11 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+    public void foo() {
+        String.valueOf(migrationMethod());
+    }
+
+    private int migrationMethod() {
+        return 1;
+    }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod2/after/Test.items
+++ b/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod2/after/Test.items
@@ -1,0 +1,10 @@
+Types:
+PsiMethod:migrationMethod : long
+PsiMethodCallExpression:migrationMethod() : long
+
+Conversions:
+1 -> $
+migrationMethod() -> $
+
+New expression type changes:
+Fails:

--- a/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod2/after/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod2/after/test.java
@@ -1,0 +1,21 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+    public void foo() {
+        Foo.valueOf(migrationMethod(), 1);
+    }
+
+    private long migrationMethod() {
+        return 1;
+    }
+}
+
+class Foo {
+    public static Foo valueOf(int value, int hint){
+        return null;
+    }
+
+    public static Foo valueOf(long value, long hint){
+        return null;
+    }
+}

--- a/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod2/before/test.java
+++ b/java/typeMigration/testData/refactoring/typeMigration/overloadedMethod2/before/test.java
@@ -1,0 +1,21 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+class Test {
+    public void foo() {
+        Foo.valueOf(migrationMethod(), 1);
+    }
+
+    private int migrationMethod() {
+        return 1;
+    }
+}
+
+class Foo {
+    public static Foo valueOf(int value, int hint){
+        return null;
+    }
+
+    public static Foo valueOf(long value, long hint){
+        return null;
+    }
+}


### PR DESCRIPTION
Let be:
```java
class Test {
    public void foo() {
        Integer.toString(migrationMethod());
    }

    private int migrationMethod() {
        return 1;
    }
}
```

When asking to migrate `migrationMethod` from `int` to `long` I obtain the following result:
```java
class Test {
    public void foo() {
        Integer.toString(migrationMethod()); // Does not compile
    }

    private long migrationMethod() {
        return 1;
    }
}
```
` Integer.toString(migrationMethod())` does not compile anymore.

This PR disable covariantPosition (if necessary) and adds a `OverloadedMethodsConversionRule` allowing to keep this kind of conversion working when a equivalent method accepting the new parameter type exists.