### PR TITLE
enhancement: javadoc inspection "unexpected param tag order"

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/InspectionGadgetsBundle.properties
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/InspectionGadgetsBundle.properties
@@ -2304,4 +2304,4 @@ inspection.case.mismatch.message=Method ''{0}()'' always returns {1}: the argume
 
 inspection.unexpected.param.tag.order.quickfix=Fix '@param' tag order
 inspection.unexpected.param.tag.order.display.name=Unexpected '@param' tag order
-inspection.unexpected.param.tag.order.problem='@param' tags are not in the right order
+inspection.unexpected.param.tag.order.problem='@param' tags doesn't match parameter-declaration order

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/InspectionGadgetsBundle.properties
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/InspectionGadgetsBundle.properties
@@ -2301,3 +2301,7 @@ inspection.if.statement.missing.break.in.loop.quickfix=Add 'break'
 
 inspection.case.mismatch.display.name=Mismatched case in String operation
 inspection.case.mismatch.message=Method ''{0}()'' always returns {1}: the argument contains {2} symbol while the qualifier is {3}-only
+
+inspection.unexpected.param.tag.order.quickfix=Fix '@param' tag order
+inspection.unexpected.param.tag.order.display.name=Unexpected '@param' tag order
+inspection.unexpected.param.tag.order.problem='@param' tags are not in the right order

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspection.java
@@ -1,0 +1,247 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.siyeh.ig.javadoc;
+
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.*;
+import com.intellij.psi.impl.source.javadoc.PsiDocParamRef;
+import com.intellij.psi.javadoc.PsiDocComment;
+import com.intellij.psi.javadoc.PsiDocTag;
+import com.intellij.psi.javadoc.PsiDocTagValue;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.SmartList;
+import com.siyeh.InspectionGadgetsBundle;
+import com.siyeh.ig.BaseInspection;
+import com.siyeh.ig.BaseInspectionVisitor;
+import com.siyeh.ig.InspectionGadgetsFix;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Inspects the order of the @param tags mentioned in a javadoc comment. Only javadoc comments which belongs to a {@link PsiMethod} or
+ * {@link PsiClass} are inspected.
+ * <p>
+ * The inspection expects at least one parameter or generic type provided by the inspected {@link PsiJavaDocumentedElement} AND at least one
+ * documented @param tag. If one of these preconditions isn't met the inspection will not report anything.
+ *
+ * @see <a href="https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#multiple@param">How to Write Doc Comments for the Javadoc Tool</a>
+ */
+public class UnexpectedParamTagOrderInspection extends BaseInspection {
+  @Nls
+  @NotNull
+  @Override
+  public String getDisplayName() {
+    return InspectionGadgetsBundle.message("inspection.unexpected.param.tag.order.display.name");
+  }
+
+  @NotNull
+  @Override
+  protected String buildErrorString(Object... infos) {
+    return InspectionGadgetsBundle.message("inspection.unexpected.param.tag.order.problem");
+  }
+
+  @Nullable
+  @Override
+  protected InspectionGadgetsFix buildFix(Object... infos) {
+    return new UnexpectedParamTagOrderFix();
+  }
+
+  private static class UnexpectedParamTagOrderFix extends InspectionGadgetsFix {
+
+    @Override
+    protected void doFix(@NotNull final Project project, @NotNull final ProblemDescriptor descriptor) {
+      final PsiDocComment docComment = PsiTreeUtil.getParentOfType(descriptor.getPsiElement(), PsiDocComment.class);
+      if (docComment == null) return;
+
+      final PsiJavaDocumentedElement owner = docComment.getOwner();
+      if (!(owner instanceof PsiMethod || owner instanceof PsiClass)) return;
+
+      final PsiDocTag[] paramTags = docComment.findTagsByName("param");
+      if (paramTags.length == 0) return;
+
+      final List<String> expectedTagNameOrder = createExpectedTagNameOrder(owner);
+      final PsiElementFactory elementFactory = JavaPsiFacade.getElementFactory(project);
+      final List<PsiDocTag> orderedParamTags = createOrderedParamTags(paramTags, expectedTagNameOrder, elementFactory);
+      if (orderedParamTags.isEmpty()) return;
+
+      replaceParamTags(docComment, paramTags, orderedParamTags);
+
+      // workaround:
+      //
+      // Adding new created PsiDocTags (created via elementFactory.createParamTag()) to the docComment (via "docComment.addAfter()") results
+      // in a falsely indented @param tag. Such tags have one space more/less as the other @param tags.
+      // This can be fixed by replacing the "content" of the docComment with a new created docComment instance from the text of the docComment.
+      docComment.replace(elementFactory.createDocCommentFromText(docComment.getText(), docComment.getContext()));
+    }
+
+    private static void replaceParamTags(@NotNull final PsiDocComment docComment,
+                                         @NotNull final PsiDocTag[] currentParamTags,
+                                         @NotNull final List<PsiDocTag> newParamTags) {
+      // use first param tag as initial anchor, it is guaranteed that currentParamTags isn't empty
+      PsiElement anchor = currentParamTags[0];
+      for (final PsiDocTag paramTag : newParamTags) {
+        anchor = docComment.addAfter(paramTag, anchor);
+      }
+      // remove duplicates
+      for (final PsiDocTag paramTag : currentParamTags) {
+        paramTag.delete();
+      }
+    }
+
+    @NotNull
+    private static List<PsiDocTag> createOrderedParamTags(@NotNull final PsiDocTag[] paramTags,
+                                                          @NotNull final List<String> expectedTagNameOrder,
+                                                          @NotNull final PsiElementFactory elementFactory) {
+      final List<PsiDocTag> result = new SmartList<>();
+      final Map<String, PsiDocTag> nameToTag = createNameToTag(paramTags);
+
+      int i = -1;
+      final int paramTagCount = paramTags.length;
+      for (final String expectedTagName : expectedTagNameOrder) {
+        i++;
+        if (i < paramTagCount) {
+          final PsiDocTag paramTag = paramTags[i];
+          if (expectedTagName.equals(NameUtil.getName(paramTag))) {
+            result.add(paramTag);
+            continue;
+          }
+        }
+
+        final PsiDocTag matchingTag = nameToTag.get(expectedTagName);
+        if (matchingTag != null) {
+          result.add(matchingTag);
+        }
+        else {
+          result.add(elementFactory.createParamTag(expectedTagName, ""));
+        }
+      }
+
+      return result;
+    }
+
+    @NotNull
+    private static Map<String, PsiDocTag> createNameToTag(@NotNull final PsiDocTag[] paramTags) {
+      final Map<String, PsiDocTag> result = new HashMap<>();
+      for (int i = paramTags.length - 1; i >= 0; i--) {
+        final PsiDocTag tag = paramTags[i];
+        final String paramTagName = NameUtil.getName(tag);
+        if (paramTagName != null) {
+          result.put(paramTagName, tag);
+        }
+      }
+      return result;
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Sentence)
+    @NotNull
+    @Override
+    public String getFamilyName() {
+      return InspectionGadgetsBundle.message("inspection.unexpected.param.tag.order.quickfix");
+    }
+  }
+
+  @Override
+  public BaseInspectionVisitor buildVisitor() {
+    return new UnexpectedParamTagOrderVisitor();
+  }
+
+  private static class UnexpectedParamTagOrderVisitor extends BaseInspectionVisitor {
+
+    @Override
+    public void visitDocComment(@NotNull final PsiDocComment docComment) {
+      super.visitDocComment(docComment);
+      final PsiJavaDocumentedElement owner = docComment.getOwner();
+
+      if (owner instanceof PsiMethod || owner instanceof PsiClass) {
+        checkParamTagOrder(docComment, owner);
+      }
+    }
+
+    private void checkParamTagOrder(@NotNull final PsiDocComment docComment, @NotNull final PsiJavaDocumentedElement owner) {
+      final PsiDocTag[] paramTags = docComment.findTagsByName("param");
+      if (paramTags.length == 0) {
+        // no parameters documented:
+        // therefore nothing to check
+        return;
+      }
+
+      final List<String> expectedNameOrder = createExpectedTagNameOrder(owner);
+      if (expectedNameOrder.isEmpty()) {
+        // method without parameters/type-parameters:
+        // there could be @param tags defined, but in that case there is no expected order
+        // these @param tags should not exist (not handled by this inspection)
+        return;
+      }
+
+      if (expectedNameOrder.size() != paramTags.length) {
+        registerError(docComment.getFirstChild(), owner);
+        return;
+      }
+
+      for (int i = 0; i < paramTags.length; i++) {
+        final String tagName = NameUtil.getName(paramTags[i]);
+        final String parameterName = expectedNameOrder.get(i);
+        if (!parameterName.equals(tagName)) {
+          registerError(docComment.getFirstChild(), owner);
+          return;
+        }
+      }
+    }
+  }
+
+  @NotNull
+  private static List<String> createExpectedTagNameOrder(@NotNull final PsiJavaDocumentedElement owner) {
+    final List<String> result = new SmartList<>();
+
+    if (owner instanceof PsiParameterListOwner) {
+      final PsiParameter[] parameters = ((PsiParameterListOwner)owner).getParameterList().getParameters();
+      for (final PsiParameter p : parameters) {
+        result.add(NameUtil.getName(p));
+      }
+    }
+
+    if (owner instanceof PsiTypeParameterListOwner) {
+      final PsiTypeParameter[] parameters = ((PsiTypeParameterListOwner)owner).getTypeParameters();
+      for (final PsiTypeParameter p : parameters) {
+        result.add(NameUtil.getName(p));
+      }
+    }
+
+    return result;
+  }
+
+  private static class NameUtil {
+
+    @Nullable
+    static String getName(@NotNull final PsiDocTag paramTag) {
+      final PsiDocTagValue value = paramTag.getValueElement();
+      if (value instanceof PsiDocParamRef) {
+        final PsiReference reference = value.getReference();
+        if (reference != null) {
+          final String paramTagName = reference.getCanonicalText();
+          if (((PsiDocParamRef)value).isTypeParamRef()) {
+            return "<" + paramTagName + ">";
+          }
+          return paramTagName;
+        }
+      }
+
+      return null;
+    }
+
+    @NotNull
+    static String getName(@NotNull final PsiParameter parameter) {
+      return parameter.getName();
+    }
+
+    @NotNull
+    static String getName(@NotNull final PsiTypeParameter parameter) {
+      return "<" + parameter.getName() + ">";
+    }
+  }
+}

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspection.java
@@ -75,8 +75,8 @@ public class UnexpectedParamTagOrderInspection extends BaseInspection {
       //
       // Adding new created PsiDocTags (created via elementFactory.createParamTag()) to the docComment (via "docComment.addAfter()") results
       // in a falsely indented @param tag. Such tags have one space more/less as the other @param tags.
-      // This can be fixed by replacing the "content" of the docComment with a new created docComment instance from the text of the docComment.
-      docComment.replace(elementFactory.createDocCommentFromText(docComment.getText(), docComment.getContext()));
+      // This can be solved by replacing the docComment with itself.
+      docComment.replace(docComment);
     }
 
     private static void replaceParamTags(@NotNull final PsiDocComment docComment,

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspection.java
@@ -18,9 +18,7 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Inspects the order of the @param tags mentioned in a javadoc comment. Only javadoc comments which belongs to a {@link PsiMethod} or
@@ -178,15 +176,17 @@ public class UnexpectedParamTagOrderInspection extends BaseInspection {
         return;
       }
 
-      if (expectedNameOrder.size() != paramTags.length) {
-        registerError(docComment.getFirstChild(), owner);
-        return;
-      }
-
+      // keep track of duplicates
+      final Set<String> checkedNames = new HashSet<>();
       for (int i = 0; i < paramTags.length; i++) {
         final String tagName = NameUtil.getName(paramTags[i]);
-        final String parameterName = expectedNameOrder.get(i);
-        if (!parameterName.equals(tagName)) {
+        // don't check duplicates
+        if(checkedNames.contains(tagName)) continue;
+        checkedNames.add(tagName);
+        final int declaredIndex = expectedNameOrder.indexOf(tagName);
+        // don't report non existing parameters
+        if(declaredIndex == -1) continue;
+        if (declaredIndex != i) {
           registerError(docComment.getFirstChild(), owner);
           return;
         }

--- a/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
+++ b/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
@@ -1265,6 +1265,10 @@
                      key="package.dot.html.may.be.package.info.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING"
                      implementationClass="com.siyeh.ig.javadoc.PackageDotHtmlMayBePackageInfoInspection"/>
+    <localInspection groupPath="Java" language="JAVA" shortName="UnexpectedParamTagOrder" bundle="com.siyeh.InspectionGadgetsBundle"
+                     key="inspection.unexpected.param.tag.order.display.name" groupBundle="messages.InspectionsBundle"
+                     groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING"
+                     implementationClass="com.siyeh.ig.javadoc.UnexpectedParamTagOrderInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryJavaDocLink" bundle="com.siyeh.InspectionGadgetsBundle"
                      key="unnecessary.javadoc.link.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING"

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnexpectedParamTagOrder.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnexpectedParamTagOrder.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+Reports Javadoc <b>@param</b> tags if they have an unexpected order.
+The quickfix will put the <b>@param</b> tags in parameter-declaration order.
+Nonexistent <b>@param</b> tags will be created and invalid <b>@param</b> tags will be removed.
+<!-- tooltip end -->
+<p>Multiple param tags should be listed in parameter-declaration order. This makes it easier to visually match the list to the declaration.</p>
+<p>
+<b>Note:</b> The 'javadoc' tool will use the order defined in the Javadoc comment and not the parameter-declaration order when listing the parameters.
+</body>
+</html>

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassJavadocTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassJavadocTags.after.java
@@ -1,0 +1,11 @@
+/**
+ * @author me
+ * @version 1.0
+ * @param <X> description for type parameter X
+ * @param <Y> description for type parameter Y
+ * @param <Z> description for type parameter Z
+ * @see wiki
+ * @since 1.0
+ * @serial
+ */
+class AdditionalClassJavadocTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassJavadocTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassJavadocTags.java
@@ -1,0 +1,12 @@
+/*<caret>*
+ * @author me
+ * @version 1.0
+ * @param <NON_EXISTING_TYPE_PARAMETER> random description
+ * @param <X> description for type parameter X
+ * @param <Y> description for type parameter Y
+ * @param <Z> description for type parameter Z
+ * @see wiki
+ * @since 1.0
+ * @serial
+ */
+class AdditionalClassJavadocTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassParamTags.after.java
@@ -1,0 +1,6 @@
+/**
+ * @param <X> description for type parameter X
+ * @param <Y> description for type parameter Y
+ * @param <Z> description for type parameter Z
+ */
+class AdditionalClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalClassParamTags.java
@@ -1,0 +1,10 @@
+/*<caret>*
+ * @param <NON_EXISTING_TYPE_PARAMETER_1> random description
+ * @param <X> description for type parameter X
+ * @param <Y> description for type parameter Y
+ * @param <NON_EXISTING_TYPE_PARAMETER_2> random description
+ * @param <Z> description for type parameter Z
+ * @param <NON_EXISTING_TYPE_PARAMETER_3> random description
+ * @param
+ */
+class AdditionalClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodJavadocTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodJavadocTags.after.java
@@ -1,0 +1,17 @@
+class AdditionalMethodJavadocTags {
+  /**
+   * @param a description for parameter a
+   * @param b description for parameter b
+   * @param c description for parameter c
+   * @param <X> description for type parameter X
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   * @return always null
+   * @throws an exception
+   * @see wiki
+   * @since 1.0
+   * @serial
+   * @deprecated
+   */
+  static <X, Y, Z> Z foo(X a, Y b, Z c) throws Exception {return null;}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodJavadocTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodJavadocTags.java
@@ -1,0 +1,19 @@
+class AdditionalMethodJavadocTags {
+  /*<caret>*
+   * @param a description for parameter a
+   * @param nonExistingParameter random description
+   * @param b description for parameter b
+   * @param c description for parameter c
+   * @param <X> description for type parameter X
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   * @param <NON_EXISTING_TYPE_PARAMETER> random description
+   * @return always null
+   * @throws an exception
+   * @see wiki
+   * @since 1.0
+   * @serial
+   * @deprecated
+   */
+  static <X, Y, Z> Z foo(X a, Y b, Z c) throws Exception {return null;}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodParamTags.after.java
@@ -1,0 +1,11 @@
+class AdditionalMethodParamTags {
+  /**
+   * @param a description for parameter a
+   * @param b description for parameter b
+   * @param c description for parameter c
+   * @param <X> description for type parameter X
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   */
+  static <X, Y, Z> Z foo(X a, Y b, Z c) throws Exception {return null;}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/AdditionalMethodParamTags.java
@@ -1,0 +1,14 @@
+class AdditionalMethodParamTags {
+  /*<caret>*
+   * @param a description for parameter a
+   * @param nonExistingParameter random description
+   * @param b description for parameter b
+   * @param c description for parameter c
+   * @param <X> description for type parameter X
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   * @param <NON_EXISTING_TYPE_PARAMETER> random description
+   * @param
+   */
+  static <X, Y, Z> Z foo(X a, Y b, Z c) throws Exception {return null;}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateClassParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateClassParamTags.after.java
@@ -1,0 +1,6 @@
+/**
+ * @param <X> description for type parameter X
+ * @param <Y> description for type parameter Y
+ * @param <Z> description for type parameter Z
+ */
+class DuplicateClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateClassParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateClassParamTags.java
@@ -1,0 +1,8 @@
+/*<caret>*
+ * @param <X> description for type parameter X
+ * @param <X> another description for type parameter X
+ * @param <Y> description for type parameter Y
+ * @param <Z> description for type parameter Z
+ * @param <Z> another description for type parameter Z
+ */
+class DuplicateClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateMethodParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateMethodParamTags.after.java
@@ -1,0 +1,11 @@
+class DuplicateMethodParamTags {
+  /**
+   * @param a description for parameter a
+   * @param b description for parameter b
+   * @param c description for parameter c
+   * @param <X> description for type parameter X
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   */
+  static <X, Y, Z> void foo(X a, Y b, Z c) {}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateMethodParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/DuplicateMethodParamTags.java
@@ -1,0 +1,15 @@
+class DuplicateMethodParamTags {
+  /*<caret>*
+   * @param a description for parameter a
+   * @param a another description for parameter a
+   * @param b description for parameter b
+   * @param c description for parameter c
+   * @param c another description for parameter c
+   * @param <X> description for type parameter X
+   * @param <X> another description for type parameter X
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   * @param <Z> another description for type parameter Z
+   */
+  static <X, Y, Z> void foo(X a, Y b, Z c) {}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingClassParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingClassParamTags.after.java
@@ -1,0 +1,6 @@
+/**
+ * @param <X> description for type parameter X
+ * @param <Y>
+ * @param <Z> description for type parameter Z
+ */
+class MissingClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingClassParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingClassParamTags.java
@@ -1,0 +1,5 @@
+/*<caret>*
+ * @param <X> description for type parameter X
+ * @param <Z> description for type parameter Z
+ */
+class MissingClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingMethodParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingMethodParamTags.after.java
@@ -1,0 +1,11 @@
+class MissingMethodParamTags {
+  /**
+   * @param a description for parameter a
+   * @param b
+   * @param c description for parameter c
+   * @param <X>
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   */
+  static <X, Y, Z> void foo(X a, Y b, Z c) {}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingMethodParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/MissingMethodParamTags.java
@@ -1,0 +1,9 @@
+class MissingMethodParamTags {
+  /*<caret>*
+   * @param a description for parameter a
+   * @param c description for parameter c
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   */
+  static <X, Y, Z> void foo(X a, Y b, Z c) {}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedClassParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedClassParamTags.after.java
@@ -1,0 +1,6 @@
+/**
+ * @param <X> description for type parameter X
+ * @param <Y> description for type parameter Y
+ * @param <Z> description for type parameter Z
+ */
+class WrongOrderedClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedClassParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedClassParamTags.java
@@ -1,0 +1,6 @@
+/*<caret>*
+ * @param <Z> description for type parameter Z
+ * @param <Y> description for type parameter Y
+ * @param <X> description for type parameter X
+ */
+class WrongOrderedClassParamTags<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedMethodParamTags.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedMethodParamTags.after.java
@@ -1,0 +1,11 @@
+class WrongOrderedMethodParamTags {
+  /**
+   * @param a description for parameter a
+   * @param b description for parameter b
+   * @param c description for parameter c
+   * @param <X> description for type parameter X
+   * @param <Y> description for type parameter Y
+   * @param <Z> description for type parameter Z
+   */
+  static <X, Y, Z> void foo(X a, Y b, Z c) {}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedMethodParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/javadoc/unexpected_param_tag_order/WrongOrderedMethodParamTags.java
@@ -1,0 +1,11 @@
+class WrongOrderedMethodParamTags {
+  /*<caret>*
+   * @param c description for parameter c
+   * @param b description for parameter b
+   * @param a description for parameter a
+   * @param <Z> description for type parameter Z
+   * @param <Y> description for type parameter Y
+   * @param <X> description for type parameter X
+   */
+  static <X, Y, Z> void foo(X a, Y b, Z c) {}
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/AdditionalParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/AdditionalParamTags.java
@@ -11,7 +11,7 @@ class AdditionalParamTags {
    */
   <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
 
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
    * @param a
    * @param b
    * @param c
@@ -42,7 +42,7 @@ class AdditionalParamTags {
  */
 class Foo1<X, Y, Z> {}
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+<warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
  * @param <NON_EXISTING_GENERIC_PARAMETER>
  * @param <X>
  * @param <Y>

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/AdditionalParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/AdditionalParamTags.java
@@ -1,0 +1,51 @@
+class AdditionalParamTags {
+
+  <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param a
+   * @param b
+   * @param c
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   * @param <NON_EXISTING_GENERIC_PARAMETER>
+   */
+  <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
+
+  <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param a
+   * @param b
+   * @param c
+   * @param nonExistingParameter
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   */
+  <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+
+  <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param a
+   * @param b
+   * @param c
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   * @param
+   */
+  <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
+}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <X>
+ * @param <Y>
+ * @param <Z>
+ * @param <NON_EXISTING_GENERIC_PARAMETER>
+ */
+class Foo1<X, Y, Z> {}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <NON_EXISTING_GENERIC_PARAMETER>
+ * @param <X>
+ * @param <Y>
+ * @param <Z>
+ */
+interface Foo2<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/AdditionalParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/AdditionalParamTags.java
@@ -1,6 +1,6 @@
 class AdditionalParamTags {
 
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  /**
    * @param a
    * @param b
    * @param c
@@ -22,7 +22,7 @@ class AdditionalParamTags {
    */
   <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
 
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  /**
    * @param a
    * @param b
    * @param c
@@ -34,7 +34,7 @@ class AdditionalParamTags {
   <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
 }
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+/**
  * @param <X>
  * @param <Y>
  * @param <Z>

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/DuplicatedParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/DuplicatedParamTags.java
@@ -10,7 +10,7 @@ class DuplicatedParamTags {
    */
   <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
 
-    <warning descr="'@param' tags are not in the right order">/**</warning>
+  <warning descr="'@param' tags are not in the right order">/**</warning>
    * @param a
    * @param b
    * @param c
@@ -20,6 +20,17 @@ class DuplicatedParamTags {
    * @param <Z>
    */
   <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+
+  /**
+   * @param a
+   * @param b
+   * @param c
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   * @param <Z>
+   */
+  <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
 }
 
 <warning descr="'@param' tags are not in the right order">/**</warning>
@@ -30,7 +41,7 @@ class DuplicatedParamTags {
  */
 class Foo1<X, Y, Z> {}
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+/**
  * @param <X>
  * @param <Y>
  * @param <Z>

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/DuplicatedParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/DuplicatedParamTags.java
@@ -1,0 +1,39 @@
+class DuplicatedParamTags {
+  <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param a
+   * @param b
+   * @param b
+   * @param c
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   */
+  <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
+
+    <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param a
+   * @param b
+   * @param c
+   * @param <X>
+   * @param <Y>
+   * @param <Y>
+   * @param <Z>
+   */
+  <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <X>
+ * @param <X>
+ * @param <Y>
+ * @param <Z>
+ */
+class Foo1<X, Y, Z> {}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <X>
+ * @param <Y>
+ * @param <Z>
+ * @param <Z>
+ */
+interface Foo2<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/DuplicatedParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/DuplicatedParamTags.java
@@ -1,5 +1,5 @@
 class DuplicatedParamTags {
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
    * @param a
    * @param b
    * @param b
@@ -10,7 +10,7 @@ class DuplicatedParamTags {
    */
   <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
 
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
    * @param a
    * @param b
    * @param c
@@ -33,7 +33,7 @@ class DuplicatedParamTags {
   <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
 }
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+<warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
  * @param <X>
  * @param <X>
  * @param <Y>

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/MissingParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/MissingParamTags.java
@@ -11,14 +11,14 @@ class MissingParamTags {
    */
   <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
 
-   <warning descr="'@param' tags are not in the right order">/**</warning>
+   <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
   * @param <X>
   * @param <Y>
   * @param <Z>
   */
  <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
 
-   <warning descr="'@param' tags are not in the right order">/**</warning>
+   <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
   * @param b
   */
  <X, Y, Z> Z foo4(X a, Y b, Z c) {return null;}
@@ -38,7 +38,7 @@ class MissingParamTags {
  */
 class Foo1<X, Y, Z> {}
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+<warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
  * @param <Z>
  */
 interface Foo2<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/MissingParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/MissingParamTags.java
@@ -1,25 +1,39 @@
 class MissingParamTags {
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  /**
   * @param a
   * @param b
   * @param c
   */
  <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
 
+  /**
+   * @param a
+   */
+  <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+
    <warning descr="'@param' tags are not in the right order">/**</warning>
   * @param <X>
   * @param <Y>
   * @param <Z>
   */
- <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+ <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
 
    <warning descr="'@param' tags are not in the right order">/**</warning>
-  * @param a
+  * @param b
   */
- <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
+ <X, Y, Z> Z foo4(X a, Y b, Z c) {return null;}
+
+  /**
+   * @param a
+   * @param b
+   * @param c
+   * @param <X>
+   * @param <Y>
+   */
+  <X, Y, Z> Z foo5(X a, Y b, Z c) {return null;}
 }
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+/**
  * @param <X>
  */
 class Foo1<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/MissingParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/MissingParamTags.java
@@ -1,0 +1,30 @@
+class MissingParamTags {
+  <warning descr="'@param' tags are not in the right order">/**</warning>
+  * @param a
+  * @param b
+  * @param c
+  */
+ <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
+
+   <warning descr="'@param' tags are not in the right order">/**</warning>
+  * @param <X>
+  * @param <Y>
+  * @param <Z>
+  */
+ <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+
+   <warning descr="'@param' tags are not in the right order">/**</warning>
+  * @param a
+  */
+ <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
+}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <X>
+ */
+class Foo1<X, Y, Z> {}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <Z>
+ */
+interface Foo2<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/ParamTagsForNonExistingParameters.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/ParamTagsForNonExistingParameters.java
@@ -1,0 +1,32 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+class ParamTagsForNonExistingParameters {
+
+  /**
+   * @param x
+   * @param y
+   * @param z
+   * @param <A>
+   * @param <B>
+   * @param <C>
+   */
+  <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
+
+  /**
+   * @param x
+   */
+  <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+}
+
+/**
+ * @param <A>
+ * @param <B>
+ * @param <C>
+ */
+class Foo1<X, Y, Z> {}
+
+/**
+ * @param <A>
+ * @param <B>
+ * @param <C>
+ */
+interface Foo2<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/ValidOrderedParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/ValidOrderedParamTags.java
@@ -1,0 +1,36 @@
+class ValidOrderedParamTags {
+  /**
+   * @param nonExistingParameter
+   */
+  void foo1() {}
+
+  /**
+   * @param a
+   * @param b
+   * @param c
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   */
+  <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+
+  /**
+   */
+  <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
+}
+
+/**
+ * @param <NON_EXISTING_GENERIC_PARAMETER>
+ */
+class Foo1 {}
+
+/**
+ * @param <X>
+ * @param <Y>
+ * @param <Z>
+ */
+class Foo2<X, Y, Z> {}
+
+/**
+ */
+interface Foo3<X, Y, Z> {}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/WrongOrderedParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/WrongOrderedParamTags.java
@@ -1,5 +1,5 @@
 class WrongOrderedParamTags {
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
    * @param a
    * @param <X>
    * @param b
@@ -9,7 +9,7 @@ class WrongOrderedParamTags {
    */
   <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
 
-  <warning descr="'@param' tags are not in the right order">/**</warning>
+  <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
    * @param <X>
    * @param <Y>
    * @param <Z>
@@ -19,7 +19,7 @@ class WrongOrderedParamTags {
    */
   <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
 
-   <warning descr="'@param' tags are not in the right order">/**</warning>
+   <warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
    * @param c
    * @param a
    * @param b
@@ -30,14 +30,14 @@ class WrongOrderedParamTags {
   <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
 }
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+<warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
  * @param <X>
  * @param <Z>
  * @param <Y>
  */
 class Foo1<X, Y, Z> {}
 
-<warning descr="'@param' tags are not in the right order">/**</warning>
+<warning descr="'@param' tags doesn't match parameter-declaration order">/**</warning>
  * @param <Z>
  * @param <X>
  * @param <Y>

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/WrongOrderedParamTags.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/javadoc/unexpected_param_tag_order/WrongOrderedParamTags.java
@@ -1,0 +1,45 @@
+class WrongOrderedParamTags {
+  <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param a
+   * @param <X>
+   * @param b
+   * @param <Y>
+   * @param c
+   * @param <Z>
+   */
+  <X, Y, Z> Z foo1(X a, Y b, Z c) {return null;}
+
+  <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   * @param a
+   * @param b
+   * @param c
+   */
+  <X, Y, Z> Z foo2(X a, Y b, Z c) {return null;}
+
+   <warning descr="'@param' tags are not in the right order">/**</warning>
+   * @param c
+   * @param a
+   * @param b
+   * @param <X>
+   * @param <Y>
+   * @param <Z>
+   */
+  <X, Y, Z> Z foo3(X a, Y b, Z c) {return null;}
+}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <X>
+ * @param <Z>
+ * @param <Y>
+ */
+class Foo1<X, Y, Z> {}
+
+<warning descr="'@param' tags are not in the right order">/**</warning>
+ * @param <Z>
+ * @param <X>
+ * @param <Y>
+ */
+interface Foo2<X, Y, Z> {}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/javadoc/UnexpectedParamTagOrderInspectionFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/javadoc/UnexpectedParamTagOrderInspectionFixTest.java
@@ -1,0 +1,37 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.siyeh.ig.fixes.javadoc;
+
+import com.siyeh.InspectionGadgetsBundle;
+import com.siyeh.ig.IGQuickFixesTestCase;
+import com.siyeh.ig.javadoc.UnexpectedParamTagOrderInspection;
+
+public class UnexpectedParamTagOrderInspectionFixTest extends IGQuickFixesTestCase {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    myFixture.enableInspections(new UnexpectedParamTagOrderInspection());
+    myRelativePath = "javadoc/unexpected_param_tag_order";
+    myDefaultHint = InspectionGadgetsBundle.message("inspection.unexpected.param.tag.order.quickfix");
+  }
+
+  public void testAdditionalMethodJavadocTags() { doTest(); }
+
+  public void testAdditionalMethodParamTags() { doTest(); }
+
+  public void testMissingMethodParamTags() { doTest(); }
+
+  public void testDuplicateMethodParamTags() { doTest(); }
+
+  public void testWrongOrderedMethodParamTags() { doTest(); }
+
+  public void testAdditionalClassJavadocTags() { doTest(); }
+
+  public void testAdditionalClassParamTags() { doTest(); }
+
+  public void testMissingClassParamTags() { doTest(); }
+
+  public void testDuplicateClassParamTags() { doTest(); }
+
+  public void testWrongOrderedClassParamTags() { doTest(); }
+}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspectionTest.java
@@ -31,4 +31,8 @@ public class UnexpectedParamTagOrderInspectionTest extends LightJavaInspectionTe
   public void testWrongOrderedParamTags() {
     doTest();
   }
+
+  public void testParamTagsForNonExistingParameters() {
+    doTest();
+  }
 }

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/javadoc/UnexpectedParamTagOrderInspectionTest.java
@@ -1,0 +1,34 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.siyeh.ig.javadoc;
+
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.siyeh.ig.LightJavaInspectionTestCase;
+import org.jetbrains.annotations.Nullable;
+
+public class UnexpectedParamTagOrderInspectionTest extends LightJavaInspectionTestCase {
+  @Nullable
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new UnexpectedParamTagOrderInspection();
+  }
+
+  public void testValidOrderedParamTags() {
+    doTest();
+  }
+
+  public void testAdditionalParamTags() {
+    doTest();
+  }
+
+  public void testDuplicatedParamTags() {
+    doTest();
+  }
+
+  public void testMissingParamTags() {
+    doTest();
+  }
+
+  public void testWrongOrderedParamTags() {
+    doTest();
+  }
+}


### PR DESCRIPTION
This PR adds a new javadoc inspection.

From the inspection description:

> Reports Javadoc @param tags if they have an unexpected order.
> The quickfix will put the @param tags in parameter-declaration order.
> Nonexistent @param tags will be created and invalid @param tags will be removed.

The main reason for creating this inspection was, that javadoc lists parameters in the order they are documented inside the javadoc comment.
However the IntelliJ "Quick Documentation" displays the parameters in the parameter-declaration order. Therefore the problem is only present/visible in the generated javadocs. 