### PR TITLE
Improve Method's param count evaluation

### DIFF
--- a/java/java-psi-api/src/com/intellij/codeInsight/AnnotationInvocationHandler.java
+++ b/java/java-psi-api/src/com/intellij/codeInsight/AnnotationInvocationHandler.java
@@ -41,8 +41,7 @@ class AnnotationInvocationHandler implements InvocationHandler {
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) {
-    Class<?>[] paramTypes = method.getParameterTypes();
-    assert paramTypes.length == 0: Arrays.toString(paramTypes);
+    assert method.getParameterCount() == 0: Arrays.toString(method.getParameterTypes());
 
     String member = method.getName();
     if (member.equals("toString")) {

--- a/platform/extensions/src/com/intellij/util/pico/CachingConstructorInjectionComponentAdapter.java
+++ b/platform/extensions/src/com/intellij/util/pico/CachingConstructorInjectionComponentAdapter.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.util.pico;
 
+import com.intellij.util.ArrayUtil;
 import com.intellij.util.ExceptionUtil;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
@@ -100,6 +101,9 @@ public final class CachingConstructorInjectionComponentAdapter extends Instantia
 
   @NotNull
   private Object[] getConstructorArguments(PicoContainer container, @NotNull Constructor<?> ctor) {
+    if (ctor.getParameterCount() == 0) {
+      return ArrayUtil.EMPTY_OBJECT_ARRAY;
+    }
     Class<?>[] parameterTypes = ctor.getParameterTypes();
     Object[] result = new Object[parameterTypes.length];
     Parameter[] currentParameters = parameters != null ? parameters : createDefaultParameters(parameterTypes);
@@ -190,14 +194,14 @@ public final class CachingConstructorInjectionComponentAdapter extends Instantia
     List<Constructor<?>> matchingConstructors = new ArrayList<>();
     // filter out all constructors that will definitely not match
     for (Constructor<?> constructor : getConstructors()) {
-      if ((parameters == null || constructor.getParameterTypes().length == parameters.length) &&
+      if ((parameters == null || constructor.getParameterCount() == parameters.length) &&
           (allowNonPublicClasses || (constructor.getModifiers() & Modifier.PUBLIC) != 0)) {
         matchingConstructors.add(constructor);
       }
     }
     // optimize list of constructors moving the longest at the beginning
     if (parameters == null) {
-      matchingConstructors.sort((arg0, arg1) -> arg1.getParameterTypes().length - arg0.getParameterTypes().length);
+      matchingConstructors.sort((arg0, arg1) -> arg1.getParameterCount() - arg0.getParameterCount());
     }
     return matchingConstructors;
   }

--- a/platform/lang-api/src/com/intellij/ide/projectView/ProjectViewNode.java
+++ b/platform/lang-api/src/com/intellij/ide/projectView/ProjectViewNode.java
@@ -111,7 +111,7 @@ public abstract class ProjectViewNode <Value> extends AbstractTreeNode<Value> im
                                                 ViewSettings settings) throws InstantiationException {
     Object[] parameters = {project, value, settings};
     for (Constructor<? extends AbstractTreeNode> constructor : (Constructor<? extends AbstractTreeNode>[])nodeClass.getConstructors()) {
-      if (constructor.getParameterTypes().length != 3) continue;
+      if (constructor.getParameterCount() != 3) continue;
       try {
         return constructor.newInstance(parameters);
       }

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/X11UiUtil.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/X11UiUtil.java
@@ -381,7 +381,7 @@ public class X11UiUtil {
 
   private static Method method(Class<?> aClass, String name, int parameters) throws Exception {
     for (Method method : aClass.getDeclaredMethods()) {
-      if (name.equals(method.getName()) && method.getParameterTypes().length == parameters) {
+      if (method.getParameterCount() == parameters && name.equals(method.getName())) {
         method.setAccessible(true);
         return method;
       }

--- a/platform/platform-impl/src/com/intellij/patterns/compiler/PatternCompilerImpl.java
+++ b/platform/platform-impl/src/com/intellij/patterns/compiler/PatternCompilerImpl.java
@@ -319,8 +319,8 @@ public class PatternCompilerImpl<T> implements PatternCompiler<T> {
   private static Method findMethod(final String methodName, final Object[] arguments, final Collection<Method> methods, Ref<? super Boolean> convertVarArgs) {
     main: for (Method method : methods) {
       if (!methodName.equals(method.getName())) continue;
+      if (method.getParameterCount() != arguments.length && !method.isVarArgs()) continue;
       final Class<?>[] parameterTypes = method.getParameterTypes();
-      if (!method.isVarArgs() && parameterTypes.length != arguments.length) continue;
       convertVarArgs.set(false);
       for (int i = 0, parameterTypesLength = parameterTypes.length; i < arguments.length; i++) {
         final Class<?> type = ReflectionUtil

--- a/platform/platform-impl/src/net/sf/cglib/proxy/AdvancedProxy.java
+++ b/platform/platform-impl/src/net/sf/cglib/proxy/AdvancedProxy.java
@@ -147,8 +147,8 @@ public class AdvancedProxy {
     if (constructorArgs.length == 0) return ArrayUtil.EMPTY_CLASS_ARRAY;
 
     loop: for (final Constructor constructor : aClass.getDeclaredConstructors()) {
-      final Class[] parameterTypes = constructor.getParameterTypes();
-      if (parameterTypes.length == constructorArgs.length) {
+      if (constructor.getParameterCount() == constructorArgs.length) {
+        final Class[] parameterTypes = constructor.getParameterTypes();
         for (int i = 0; i < parameterTypes.length; i++) {
           Class parameterType = parameterTypes[i];
           final Object constructorArg = constructorArgs[i];
@@ -156,7 +156,7 @@ public class AdvancedProxy {
             continue loop;
           }
         }
-        return constructor.getParameterTypes();
+        return parameterTypes;
       }
     }
     throw new AssertionError("Cannot find constructor for arguments: " + Arrays.asList(constructorArgs));

--- a/platform/util/src/com/intellij/execution/rmi/RemoteUtil.java
+++ b/platform/util/src/com/intellij/execution/rmi/RemoteUtil.java
@@ -46,10 +46,10 @@ public class RemoteUtil {
         Method m = null;
         main:
         for (Method candidate : key.first.getMethods()) {
+          if (candidate.getParameterCount() != method.getParameterCount()) continue;
           if (!candidate.getName().equals(method.getName())) continue;
           Class<?>[] cpts = candidate.getParameterTypes();
           Class<?>[] mpts = method.getParameterTypes();
-          if (cpts.length != mpts.length) continue;
           for (int i = 0; i < mpts.length; i++) {
             Class<?> mpt = mpts[i];
             Class<?> cpt = castArgumentClassToLocal(cpts[i]);
@@ -117,10 +117,10 @@ public class RemoteUtil {
   @Nullable
   private static Object[] fixArgs(@Nullable Object[] args, @NotNull Method method) {
     if (args == null) return null;
+    if (method.getParameterCount() != args.length) return args;
     Object[] result = new Object[args.length];
     try {
       Class<?>[] methodArgs = method.getParameterTypes();
-      if (methodArgs.length != args.length) return args;
       for (int i = 0; i < args.length; i++) {
         result[i] = fixArg(args[i], methodArgs[i]);
       }

--- a/platform/util/src/com/intellij/serialization/PropertyCollector.java
+++ b/platform/util/src/com/intellij/serialization/PropertyCollector.java
@@ -44,8 +44,7 @@ public class PropertyCollector {
    */
   @NotNull
   public List<MutableAccessor> collect(@NotNull Class<?> aClass) {
-    List<MutableAccessor> accessors;
-    accessors = new ArrayList<>();
+    List<MutableAccessor> accessors = new ArrayList<>();
 
     Map<String, Couple<Method>> nameToAccessors;
     // special case for Rectangle.class to avoid infinite recursion during serialization due to bounds() method
@@ -138,8 +137,8 @@ public class PropertyCollector {
       }
 
       NameAndIsSetter propertyData = getPropertyData(method.getName());
-      if (propertyData == null || propertyData.name.equals("class") ||
-          method.getParameterTypes().length != (propertyData.isSetter ? 1 : 0)) {
+      if (propertyData == null || method.getParameterCount() != (propertyData.isSetter ? 1 : 0) ||
+          propertyData.name.equals("class")) {
         continue;
       }
 

--- a/platform/util/src/com/intellij/util/ReflectionUtil.java
+++ b/platform/util/src/com/intellij/util/ReflectionUtil.java
@@ -242,7 +242,7 @@ public final class ReflectionUtil {
   @Nullable
   public static Method findMethod(@NotNull Collection<Method> methods, @NonNls @NotNull String name, @NotNull Class<?>... parameters) {
     for (final Method method : methods) {
-      if (name.equals(method.getName()) && Arrays.equals(parameters, method.getParameterTypes())) {
+      if (parameters.length == method.getParameterCount() && name.equals(method.getName()) && Arrays.equals(parameters, method.getParameterTypes())) {
         return makeAccessible(method);
       }
     }
@@ -460,6 +460,11 @@ public final class ReflectionUtil {
             constructor.setAccessible(true);
           }
           catch (Throwable ignored) {
+          }
+
+          if (constructor.getParameterCount() == 0) {
+            //noinspection unchecked
+            return (T) constructor.newInstance();
           }
 
           Class<?>[] parameterTypes = constructor.getParameterTypes();

--- a/xml/dom-impl/src/com/intellij/util/xml/impl/StaticGenericInfo.java
+++ b/xml/dom-impl/src/com/intellij/util/xml/impl/StaticGenericInfo.java
@@ -163,12 +163,11 @@ public class StaticGenericInfo extends DomGenericInfoEx {
   }
 
   private static Function<Object[], Type> getTypeGetter(final JavaMethod method) {
-    final Class<?>[] parameterTypes = method.getParameterTypes();
-    if (parameterTypes.length >= 1 && parameterTypes[0].equals(Class.class)) {
+    if (method.getParameterCount() >= 1 && method.getParameterTypes()[0].equals(Class.class)) {
       return s -> (Type)s[0];
     }
 
-    if (parameterTypes.length == 2 && parameterTypes[1].equals(Class.class)) {
+    if (method.getParameterCount() == 2 && method.getParameterTypes()[1].equals(Class.class)) {
       return s -> (Type)s[1];
     }
 
@@ -177,12 +176,11 @@ public class StaticGenericInfo extends DomGenericInfoEx {
 
 
   private static Function<Object[], Integer> getIndexGetter(final JavaMethod method) {
-    final Class<?>[] parameterTypes = method.getParameterTypes();
-    if (parameterTypes.length >= 1 && parameterTypes[0].equals(int.class)) {
+    if (method.getParameterCount() >= 1 && method.getParameterTypes()[0].equals(int.class)) {
       return s -> (Integer)s[0];
     }
 
-    if (parameterTypes.length == 2 && parameterTypes[1].equals(int.class)) {
+    if (method.getParameterCount() == 2 && method.getParameterTypes()[1].equals(int.class)) {
       return s -> (Integer)s[1];
     }
 

--- a/xml/dom-impl/src/com/intellij/util/xml/impl/StaticGenericInfoBuilder.java
+++ b/xml/dom-impl/src/com/intellij/util/xml/impl/StaticGenericInfoBuilder.java
@@ -167,6 +167,8 @@ public class StaticGenericInfoBuilder {
     final Type type = myCollectionChildrenTypes.get(tagName);
     if (type == null || !ReflectionUtil.getRawType(type).isAssignableFrom(method.getReturnType())) return false;
 
+    if (method.getParameterCount() == 0) return true;
+
     return ADDER_PARAMETER_TYPES.containsAll(Arrays.asList(method.getParameterTypes()));
   }
 

--- a/xml/dom-impl/src/com/intellij/util/xml/impl/VisitorDescription.java
+++ b/xml/dom-impl/src/com/intellij/util/xml/impl/VisitorDescription.java
@@ -35,10 +35,10 @@ public class VisitorDescription {
   public VisitorDescription(final Class<? extends DomElementVisitor> visitorClass) {
     myVisitorClass = visitorClass;
     for (final Method method : ReflectionUtil.getClassPublicMethods(visitorClass)) {
-      final Class<?>[] parameterTypes = method.getParameterTypes();
-      if (parameterTypes.length != 1) {
+      if (method.getParameterCount() != 1) {
         continue;
       }
+      final Class<?>[] parameterTypes = method.getParameterTypes();
       final Class<?> domClass = parameterTypes[0];
       if (!ReflectionUtil.isAssignable(DomElement.class, domClass)) {
         continue;

--- a/xml/dom-openapi/src/com/intellij/util/xml/JavaMethod.java
+++ b/xml/dom-openapi/src/com/intellij/util/xml/JavaMethod.java
@@ -134,4 +134,8 @@ public final class JavaMethod implements AnnotatedElement {
   public Class<?>[] getParameterTypes() {
     return myMethod.getParameterTypes();
   }
+
+  public int getParameterCount() {
+    return myMethod.getParameterCount();
+  }
 }


### PR DESCRIPTION
I've investigated usage of `java.lang.reflect.Method.getParameterTypes();` and found that it's frequently called from parts of the application responsible for startup, indexing and PSI:

![](https://habrastorage.org/webt/i4/nw/lr/i4nwlrsk813i4eatvxrdoxwa2sg.png)

![](https://habrastorage.org/webt/yi/2y/x1/yi2yx1rqbonm52yiqlalidln1hc.png)

![](https://habrastorage.org/webt/8t/bg/ny/8tbgnyr7qxmyhazmch4mzk8xv_c.png)

Each call to `Method.getParameterTypes()` clones underlying array, and in many cases the copy is used only to get it's length i.e. number of method params. So I propose to use `Method.getParameterCount()` which returns number of method's arguments without cloning of underlying array.

In some cases it also allows to make a decision about constructor's param count and if it's 0 then we can call `Constructor.newInstance()` without using vararg.