### PR TITLE
Pass along existing progress indicator if one exists.

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/application/impl/ApplicationImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/application/impl/ApplicationImpl.java
@@ -417,7 +417,8 @@ public class ApplicationImpl extends PlatformComponentManagerImpl implements App
         LOG.debug("Starting process with progress from within write action makes no sense");
       }
       try {
-        ProgressManager.getInstance().runProcess(process, new EmptyProgressIndicator());
+        ProgressIndicator progressIndicator = ProgressManager.getInstance().getProgressIndicator();
+        ProgressManager.getInstance().runProcess(process, progressIndicator == null ? new EmptyProgressIndicator() : progressIndicator);
       }
       catch (ProcessCanceledException e) {
         // ok to ignore.

--- a/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
@@ -859,7 +859,7 @@ public class ProgressIndicatorTest extends LightPlatformTestCase {
 
   public void testProgressIndicatorNotOverriddenIn_InRunProcessWithProgressSynchronously_duringWriteAction() {
     final String progressIndicatorText = "Progress indicator text";
-    ProgressIndicator progressIndicator = new ProgressIndicatorStub() {
+    ProgressIndicator progressIndicator = new ProgressIndicatorBase() {
       String text;
 
       @Override
@@ -870,11 +870,6 @@ public class ProgressIndicatorTest extends LightPlatformTestCase {
       @Override
       public String getText() {
         return text;
-      }
-
-      @Override
-      public void processFinish() {
-        //Prevent throwing runtimeException.
       }
     };
     ApplicationManager.getApplication().runWriteAction(() -> {

--- a/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
@@ -856,4 +856,23 @@ public class ProgressIndicatorTest extends LightPlatformTestCase {
     catch (ProcessCanceledException ignored) {
     }
   }
+
+  public void testProgressIndicatorNotOverriddenIn_InRunProcessWithProgressSynchronously_duringWriteAction() {
+    ProgressIndicator progressIndicator = new ProgressIndicatorStub() {
+      @Override
+      public void processFinish() {
+
+      }
+    };
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      ProgressManager.getInstance().executeProcessUnderProgress(() -> {
+        ApplicationManagerEx.getApplicationEx().runProcessWithProgressSynchronously(() -> {
+          assertFalse(progressIndicator.isCanceled());
+          ProgressManager.getInstance().getProgressIndicator().cancel();
+        }, "NotUsed", true, null);
+      }, progressIndicator);
+    });
+
+    assertTrue(progressIndicator.isCanceled());
+  }
 }

--- a/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
@@ -859,19 +859,7 @@ public class ProgressIndicatorTest extends LightPlatformTestCase {
 
   public void testProgressIndicatorNotOverriddenIn_runProcessWithProgressSynchronously_duringWriteAction() {
     final String progressIndicatorText = "Progress indicator text";
-    ProgressIndicator progressIndicator = new ProgressIndicatorBase() {
-      String text;
-
-      @Override
-      public void setText(String text) {
-        this.text = text;
-      }
-
-      @Override
-      public String getText() {
-        return text;
-      }
-    };
+    ProgressIndicator progressIndicator = new ProgressIndicatorBase();
     ApplicationManager.getApplication().runWriteAction(() -> {
       ProgressManager.getInstance().executeProcessUnderProgress(() -> {
         ApplicationManagerEx.getApplicationEx().runProcessWithProgressSynchronously(() -> {

--- a/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
@@ -858,21 +858,34 @@ public class ProgressIndicatorTest extends LightPlatformTestCase {
   }
 
   public void testProgressIndicatorNotOverriddenIn_InRunProcessWithProgressSynchronously_duringWriteAction() {
+    final String progressIndicatorText = "Progress indicator text";
     ProgressIndicator progressIndicator = new ProgressIndicatorStub() {
+      String text;
+
+      @Override
+      public void setText(String text) {
+        this.text = text;
+      }
+
+      @Override
+      public String getText() {
+        return text;
+      }
+
       @Override
       public void processFinish() {
-
+        //Prevent throwing runtimeException.
       }
     };
     ApplicationManager.getApplication().runWriteAction(() -> {
       ProgressManager.getInstance().executeProcessUnderProgress(() -> {
         ApplicationManagerEx.getApplicationEx().runProcessWithProgressSynchronously(() -> {
           ProgressIndicator progressManagerIndicator = ProgressManager.getInstance().getProgressIndicator();
-          assertEquals(progressIndicator, progressManagerIndicator);
-          progressManagerIndicator.cancel();
+          progressManagerIndicator.setText(progressIndicatorText);
         }, "NotUsed", true, null);
       }, progressIndicator);
     });
-    assertTrue(progressIndicator.isCanceled());
+    assertEquals("Expected the progress indicator passed in to have the text the runnable set",
+                 progressIndicatorText, progressIndicator.getText());
   }
 }

--- a/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
@@ -867,12 +867,12 @@ public class ProgressIndicatorTest extends LightPlatformTestCase {
     ApplicationManager.getApplication().runWriteAction(() -> {
       ProgressManager.getInstance().executeProcessUnderProgress(() -> {
         ApplicationManagerEx.getApplicationEx().runProcessWithProgressSynchronously(() -> {
-          assertFalse(progressIndicator.isCanceled());
-          ProgressManager.getInstance().getProgressIndicator().cancel();
+          ProgressIndicator progressManagerIndicator = ProgressManager.getInstance().getProgressIndicator();
+          assertEquals(progressIndicator, progressManagerIndicator);
+          progressManagerIndicator.cancel();
         }, "NotUsed", true, null);
       }, progressIndicator);
     });
-
     assertTrue(progressIndicator.isCanceled());
   }
 }

--- a/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/progress/impl/ProgressIndicatorTest.java
@@ -857,7 +857,7 @@ public class ProgressIndicatorTest extends LightPlatformTestCase {
     }
   }
 
-  public void testProgressIndicatorNotOverriddenIn_InRunProcessWithProgressSynchronously_duringWriteAction() {
+  public void testProgressIndicatorNotOverriddenIn_runProcessWithProgressSynchronously_duringWriteAction() {
     final String progressIndicatorText = "Progress indicator text";
     ProgressIndicator progressIndicator = new ProgressIndicatorBase() {
       String text;


### PR DESCRIPTION
Running a plugin in headless mode, this is overriding my progress bar I have configured to pipe the progress to the terminal. Can't think of a reason we cant use the existing one if it exists. 