### PR TITLE
Remove no longer used getDetectedFileTypes

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileTypes/impl/HashBangFileTypeDetector.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileTypes/impl/HashBangFileTypeDetector.kt
@@ -31,4 +31,5 @@ open class HashBangFileTypeDetector @JvmOverloads constructor(
   }
 
   override fun getVersion() = _version
+
 }


### PR DESCRIPTION
Since https://github.com/JetBrains/intellij-community/commit/e9cd494b63ed53dc6cb4e9a81140431a49cd469c#diff-a2590eb4630da07c27f3010a7688c35b `getDetectedFileTypes` method in `FileTypeDetector`
is no longer being used. 

Despite that fact people might still try to implement it for their own FileTypeDetectors, which will be a waste of time and might lead to potential confusion when changes to the method are not reflected in how the plugins function. I think it's better to be completely explicit about the method removal.

This is just a proposal, so let me know what you think! This will cause compilation errors in plugins implementing the method, but I view it as better than just ignoring the method altogether.

This came up when investigating an issue in the pants intellij plugin: https://github.com/pantsbuild/intellij-pants-plugin/issues/431 