### PR TITLE
IDEA-227734: report "return null" statements inside non-null methods

### DIFF
--- a/plugins/InspectionGadgets/src/com/siyeh/ig/bugs/ReturnNullInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/bugs/ReturnNullInspection.java
@@ -181,6 +181,21 @@ public class ReturnNullInspection extends BaseInspection {
         registerError(value, value);
         return;
       }
+
+      final Project project = method.getProject();
+      final NullabilityAnnotationInfo info = NullableNotNullManager.getInstance(project).findEffectiveNullabilityInfo(method);
+      if (info != null && !info.isInferred()) {
+        if (info.getNullability() == Nullability.NULLABLE) {
+          return;
+        } else if (info.getNullability() == Nullability.NOT_NULL) {
+          registerError(value, value);
+          return;
+        }
+      }
+      if (DfaPsiUtil.getTypeNullability(returnType) == Nullability.NULLABLE) {
+        return;
+      }
+
       if (lambda) {
         if (m_ignorePrivateMethods || isInNullableContext(element)) {
           return;
@@ -196,14 +211,6 @@ public class ReturnNullInspection extends BaseInspection {
             return;
           }
         }
-      }
-      final Project project = method.getProject();
-      final NullabilityAnnotationInfo info = NullableNotNullManager.getInstance(project).findEffectiveNullabilityInfo(method);
-      if (info != null && info.getNullability() == Nullability.NULLABLE && !info.isInferred()) {
-        return;
-      }
-      if (DfaPsiUtil.getTypeNullability(returnType) == Nullability.NULLABLE) {
-        return;
       }
 
       if (CollectionUtils.isCollectionClassOrInterface(returnType)) {

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/return_null/ReturnNullFromNotNullAnnotatedMethods.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/return_null/ReturnNullFromNotNullAnnotatedMethods.java
@@ -1,0 +1,85 @@
+package com.siyeh.igtest.bugs;
+
+public class ReturnNullFromNotNullAnnotatedMethods {
+
+  @NotNull
+  private Object nullInsteadOfObject() {
+    return <warning descr="Return of 'null'">null</warning>;
+  }
+
+  private Object nullInsteadOfObjectWithoutAnnotation() {
+    return null;
+  }
+
+  @NotNull
+  private int[] nullInsteadOfArray() {
+    return <warning descr="Return of 'null'">null</warning>;
+  }
+
+  private int[] nullInsteadOfArrayWithoutAnnotation() {
+    return null;
+  }
+
+  enum MyEnum{ A, B, C }
+
+  @NotNull
+  private String nullFromSwitchDefaultBranch(final MyEnum myEnum) {
+    switch(myEnum){
+      case A:
+      case B:
+        return "YES";
+      default: return <warning descr="Return of 'null'">null</warning>;
+    }
+  }
+
+  private String nullFromSwitchDefaultBranchWithoutAnnotation(final MyEnum myEnum) {
+    switch(myEnum){
+      case A:
+      case B:
+        return "YES";
+      default: return null;
+    }
+  }
+
+  @NotNull
+  private String nullFromUnreachableSwitchDefaultBranch(final MyEnum myEnum) {
+    switch(myEnum){
+      case A:
+      case B:
+      case C:
+        return "YES";
+      default: return <warning descr="Return of 'null'">null</warning>;
+    }
+  }
+
+  private String nullFromUnreachableSwitchDefaultBranchWithoutAnnotation(final MyEnum myEnum) {
+    switch(myEnum){
+      case A:
+      case B:
+      case C:
+        return "YES";
+      default: return null;
+    }
+  }
+
+  @NotNull
+  private String nullFromUnreachableReturnAfterSwitch(final MyEnum myEnum) {
+    switch(myEnum){
+      case A:
+      case B:
+      case C:
+        return "YES";
+    }
+    return <warning descr="Return of 'null'">null</warning>;
+  }
+
+  private String nullFromUnreachableReturnAfterSwitchWithoutAnnotation(final MyEnum myEnum) {
+    switch(myEnum){
+      case A:
+      case B:
+      case C:
+        return "YES";
+    }
+    return null;
+  }
+}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/ReturnNullInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/ReturnNullInspectionTest.java
@@ -21,6 +21,13 @@ public class ReturnNullInspectionTest extends LightJavaInspectionTestCase {
     doTest();
   }
 
+  public void testReturnNullFromNotNullAnnotatedMethods() {
+    final NullableNotNullManager nnnManager = NullableNotNullManager.getInstance(getProject());
+    nnnManager.setNotNulls("com.siyeh.igtest.bugs.NotNull");
+    Disposer.register(myFixture.getTestRootDisposable(), nnnManager::setNotNulls);
+    doTest();
+  }
+
   public void testWarnOptional() {
     doTest();
   }
@@ -28,9 +35,18 @@ public class ReturnNullInspectionTest extends LightJavaInspectionTestCase {
   @Nullable
   @Override
   protected InspectionProfileEntry getInspection() {
+    final String testCaseName = getTestName(false);
     final ReturnNullInspection inspection = new ReturnNullInspection();
-    inspection.m_reportObjectMethods = !"WarnOptional".equals(getTestName(false));
-    inspection.m_ignorePrivateMethods = "WarnOptional".equals(getTestName(false));
+    if ("ReturnNullFromNotNullAnnotatedMethods".equals(testCaseName)) {
+      inspection.m_ignorePrivateMethods = true;
+      inspection.m_reportObjectMethods = false;
+      inspection.m_reportArrayMethods = false;
+      inspection.m_reportCollectionMethods = false;
+    } else {
+      inspection.m_reportObjectMethods = !"WarnOptional".equals(testCaseName);
+      inspection.m_ignorePrivateMethods = "WarnOptional".equals(testCaseName);
+    }
+
     return inspection;
   }
 
@@ -47,7 +63,13 @@ public class ReturnNullInspectionTest extends LightJavaInspectionTestCase {
       "import java.lang.annotation.*;\n" +
       "@Retention(RetentionPolicy.SOURCE)\n" +
       "@Target({ElementType.TYPE_USE, ElementType.METHOD})\n" +
-      "public @interface Nullable {}"
+      "public @interface Nullable {}",
+
+      "package com.siyeh.igtest.bugs;\n" +
+      "import java.lang.annotation.*;\n" +
+      "@Retention(RetentionPolicy.SOURCE)\n" +
+      "@Target({ElementType.TYPE_USE, ElementType.METHOD})\n" +
+      "public @interface NotNull {}"
     };
   }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-227734
The `ReturnNullInspection` is enhanced to report `return null` statements inside non-null methods.
