### PR TITLE
[Gradle] Always create tooling model copy for GradleExtensions.

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/CommonGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/CommonGradleProjectResolverExtension.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.roots.DependencyScope;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
-import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.Consumer;
 import com.intellij.util.PathUtil;
@@ -215,9 +214,7 @@ public class CommonGradleProjectResolverExtension extends AbstractProjectResolve
   public void populateModuleExtraModels(@NotNull IdeaModule gradleModule, @NotNull DataNode<ModuleData> ideModule) {
     GradleExtensions gradleExtensions = resolverCtx.getExtraProject(gradleModule, GradleExtensions.class);
     if (gradleExtensions != null) {
-      boolean useCustomSerialization = Registry.is("gradle.tooling.custom.serializer", true);
-      DefaultGradleExtensions extensions = useCustomSerialization ? (DefaultGradleExtensions)gradleExtensions
-                                                                  : new DefaultGradleExtensions(gradleExtensions);
+      DefaultGradleExtensions extensions = new DefaultGradleExtensions(gradleExtensions);
       ExternalProject externalProject = getExternalProject(gradleModule, resolverCtx);
       if (externalProject != null) {
         extensions.addTasks(externalProject.getTasks().values());


### PR DESCRIPTION
With custom serialization, multiple projects can share the same instance
of tooling model after serialization, because the serialization mechanism
uses hashcode as identifier to avoid re-creating objects. While two projects
can have the same hashcode if their fields are identical.

This will cause problems if the shared tooling model is updated by one project,
and then all projects sharing that instance will get unintended change.

For example, with GradleExtensions model, each project adds their
own task list to the same instance of GradleExtensions.

Fix the problem by always making a copy of the de-serialized model.