### PR TITLE
Process the mouse event if it is a click

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/popup/list/ListPopupImpl.java
+++ b/platform/platform-impl/src/com/intellij/ui/popup/list/ListPopupImpl.java
@@ -583,7 +583,7 @@ public class ListPopupImpl extends WizardPopup implements ListPopup, NextStepHan
       }
 
       boolean isClick = UIUtil.isActionClick(e, MouseEvent.MOUSE_PRESSED) || UIUtil.isActionClick(e, MouseEvent.MOUSE_RELEASED);
-      if (!isClick || myList.locationToIndex(e.getPoint()) == myList.getSelectedIndex()) {
+      if (isClick || myList.locationToIndex(e.getPoint()) == myList.getSelectedIndex()) {
         super.processMouseEvent(e);
       }
     }


### PR DESCRIPTION
Hi Kirill, this is Juan with Android Studio

One of our UI tests creates an Android Instrumented Tests configuration by opening the Run/Debug Configurations dialog, clicking the +, and selecting Android Instrumented Tests in the popup. But the Swing in IDEA never gets the simulated mouse click, the instrumented test configuration is not created, and the test fails.

I traced things to 98a868fb989a64a8cdd535d1a765b7ebbd6b67a8. If I revert the commit, things work. Did you mean for that ! to be in front of isClick? The test also passes if I remove only that.