### PR TITLE
PY-14631 Use IPython config file in Python Console

### DIFF
--- a/python/helpers/pydev/_pydev_bundle/pydev_ipython_console_011.py
+++ b/python/helpers/pydev/_pydev_bundle/pydev_ipython_console_011.py
@@ -27,6 +27,7 @@ from IPython.core.usage import default_banner_parts
 from IPython.utils.strdispatch import StrDispatch
 import IPython.core.release as IPythonRelease
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from IPython.terminal.ipapp import load_default_config
 try:
     from traitlets import CBool, Unicode
 except ImportError:
@@ -345,7 +346,7 @@ class _PyDevFrontEnd:
         if hasattr(PyDevTerminalInteractiveShell, '_instance') and PyDevTerminalInteractiveShell._instance is not None:
             self.ipython = PyDevTerminalInteractiveShell._instance
         else:
-            self.ipython = PyDevTerminalInteractiveShell.instance()
+            self.ipython = PyDevTerminalInteractiveShell.instance(config=load_default_config())
 
         self._curr_exec_line = 0
         self._curr_exec_lines = []


### PR DESCRIPTION
@Elizaveta239 
I seem to solve the [problem](https://youtrack.jetbrains.com/issue/PY-14631)
Could you help me examine if this PR indeed makes PyCharm load IPython config flie and possibly break other things? 