### PR TITLE
Faster DebuggerUtilsImpl.readBytesArray

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/impl/DebuggerUtilsImpl.java
+++ b/java/debugger/impl/src/com/intellij/debugger/impl/DebuggerUtilsImpl.java
@@ -11,6 +11,7 @@ import com.intellij.debugger.engine.evaluation.CodeFragmentKind;
 import com.intellij.debugger.engine.evaluation.EvaluateException;
 import com.intellij.debugger.engine.evaluation.TextWithImports;
 import com.intellij.debugger.engine.evaluation.TextWithImportsImpl;
+import com.intellij.debugger.engine.jdi.ThreadReferenceProxy;
 import com.intellij.debugger.impl.attach.PidRemoteConnection;
 import com.intellij.debugger.ui.impl.watch.DebuggerTreeNodeExpression;
 import com.intellij.debugger.ui.tree.render.BatchEvaluator;
@@ -289,7 +290,11 @@ public class DebuggerUtilsImpl extends DebuggerUtilsEx{
   // - DebuggerUtilsImpl.readBytesArray (getValues+boxing per element at least x8 memory usage and potential GC pressure): 14.3s
   // This should use COMPACT_STRINGS on newer java versions, thus String could be backed by a plain byte[], greatly reducing memory usage too
   @Nullable
-  static public byte[] fastReadBytesArray(Value that, ThreadReference thread) {
+  static public byte[] fastReadBytesArray(Value that, @Nullable ThreadReference thread) {
+    if (thread == null) {
+      return readBytesArray(that);
+    }
+
     try {
       final VirtualMachine vm = that.virtualMachine();
       final Type type = that.type();
@@ -309,4 +314,12 @@ public class DebuggerUtilsImpl extends DebuggerUtilsEx{
     }
   }
 
+  @Nullable
+  static public byte[] fastReadBytesArray(Value that, @Nullable ThreadReferenceProxy thread) {
+    if (thread == null) {
+      return readBytesArray(that);
+    } else {
+      return fastReadBytesArray(that, thread.getThreadReference());
+    }
+  }
 }

--- a/java/debugger/impl/src/com/intellij/debugger/ui/tree/render/ByteArrayAsStringRenderer.java
+++ b/java/debugger/impl/src/com/intellij/debugger/ui/tree/render/ByteArrayAsStringRenderer.java
@@ -24,7 +24,7 @@ final class ByteArrayAsStringRenderer extends CompoundReferenceRenderer {
           Value value = descriptor.getValue();
           if (value instanceof ArrayReference) {
             // TODO: read charset from the target vm
-            byte[] bytes = DebuggerUtilsImpl.readBytesArray(value);
+            byte[] bytes = DebuggerUtilsImpl.fastReadBytesArray(value, evaluationContext.getSuspendContext().getThread());
             if (bytes != null) {
               return new String(bytes, StandardCharsets.UTF_8);
             }

--- a/java/debugger/impl/src/com/intellij/debugger/ui/tree/render/ImageObjectRenderer.java
+++ b/java/debugger/impl/src/com/intellij/debugger/ui/tree/render/ImageObjectRenderer.java
@@ -63,7 +63,7 @@ class ImageObjectRenderer extends CompoundReferenceRenderer implements FullValue
   static ImageIcon getIcon(EvaluationContext evaluationContext, Value obj, String methodName) {
     try {
       Value bytes = getImageBytes(evaluationContext, obj, methodName);
-      byte[] data = DebuggerUtilsImpl.readBytesArray(bytes);
+      byte[] data = DebuggerUtilsImpl.fastReadBytesArray(bytes, evaluationContext.getSuspendContext().getThread());
       if (data != null) {
         return new ImageIcon(data);
       }


### PR DESCRIPTION
By doing an intellij extension for a custom Image library, I wanted to read the image payload.
Since I was not aware this was already done I did my own approach by serializing and deserializing to Base64, then simplified it to use the just `String` class + `getBytes` method.

Then noticed that byte reading was already implemented here. But looking at the implementation noticed that it was using the jdi `ArrayReference.getValues` that is creating a boxed item for every single element in the array, by requiring one instance per element it requires at least 8x the memory and potentially adds a lot of GC overhead.

This version serializes the byte[] into a String, then loads that string into the current process, and decodes it there. Since newer java versions can use byte[] for storing non-unicode strings, potentially could not use additional memory.