### PR TITLE
IDEA-224062 Fixed unexpected paste behavior of Environment Variable table cell

### DIFF
--- a/platform/lang-api/src/com/intellij/execution/util/EnvVariablesTable.java
+++ b/platform/lang-api/src/com/intellij/execution/util/EnvVariablesTable.java
@@ -259,11 +259,16 @@ public class EnvVariablesTable extends ListTableWithButtons<EnvironmentVariable>
             Component component = ((DefaultCellEditor)editor).getComponent();
             if (component instanceof JTextField) {
               JTextField textField = (JTextField)component;
+
+              int selectionStart = textField.getSelectionStart();
+              int selectionEnd = textField.getSelectionEnd();
+
               try {
-                textField.getDocument().insertString(textField.getCaretPosition(), content, null);
+                textField.getDocument().remove(selectionStart, selectionEnd - selectionStart);
+                textField.getDocument().insertString(selectionStart, content, null);
               }
               catch (BadLocationException e) {
-                //just ignore, paste failed
+                // Just ignore, paste failed
               }
             }
           }


### PR DESCRIPTION
The current behavior of pasting in the cell appends the copy buffer to the end of the cell contents instead of overwriting a highlighted section and was introduced in IDEA-210252. This PR resolves IDEA-224062 by making the cell behave like a normal text field. You can insert text at any point as well as remove a highlighted section with the copy buffer as expected.