### PR TITLE
Handle Note Javac output lines

### DIFF
--- a/platform/lang-impl/src/com/intellij/build/output/JavacOutputParser.java
+++ b/platform/lang-impl/src/com/intellij/build/output/JavacOutputParser.java
@@ -27,6 +27,7 @@ public class JavacOutputParser implements BuildOutputParser {
 
   private static final char COLON = ':';
   private static final String WARNING_PREFIX = "warning:"; // default value
+  private static final String INFO_PREFIX = "info:";
   private static final String ERROR_PREFIX = "error:";
   private final String[] myFileExtensions;
 
@@ -96,6 +97,10 @@ public class JavacOutputParser implements BuildOutputParser {
           if (text.startsWith(WARNING_PREFIX)) {
             text = text.substring(WARNING_PREFIX.length()).trim();
             kind = MessageEvent.Kind.WARNING;
+          }
+          else if (text.startsWith(INFO_PREFIX)) {
+            text = text.substring(INFO_PREFIX.length()).trim();
+            kind = MessageEvent.Kind.INFO;
           }
           else if (text.startsWith(ERROR_PREFIX)) {
             text = text.substring(ERROR_PREFIX.length()).trim();

--- a/platform/lang-impl/src/com/intellij/build/output/JavacOutputParser.java
+++ b/platform/lang-impl/src/com/intellij/build/output/JavacOutputParser.java
@@ -27,7 +27,7 @@ public class JavacOutputParser implements BuildOutputParser {
 
   private static final char COLON = ':';
   private static final String WARNING_PREFIX = "warning:"; // default value
-  private static final String INFO_PREFIX = "info:";
+  private static final String NOTE_PREFIX = "note:";
   private static final String ERROR_PREFIX = "error:";
   private final String[] myFileExtensions;
 
@@ -98,8 +98,8 @@ public class JavacOutputParser implements BuildOutputParser {
             text = text.substring(WARNING_PREFIX.length()).trim();
             kind = MessageEvent.Kind.WARNING;
           }
-          else if (text.startsWith(INFO_PREFIX)) {
-            text = text.substring(INFO_PREFIX.length()).trim();
+          else if (text.startsWith(NOTE_PREFIX)) {
+            text = text.substring(NOTE_PREFIX.length()).trim();
             kind = MessageEvent.Kind.INFO;
           }
           else if (text.startsWith(ERROR_PREFIX)) {


### PR DESCRIPTION
## Before this PR

In the javac output produced by gradle, "Note" log lines like

```
<file path>:<line number>: Note: ...
```

get interpreted as errors when compiling through gradle (either by running `classes` as a task, or having the Gradle integration configured to "Build and run using" Gradle.

It's doubly annoying because it also jumps the editor to the first "error" whenever I build.

![image](https://user-images.githubusercontent.com/222827/71979373-76611f80-3215-11ea-9222-d247d287e333.png)

These types of messages come up when compiling using the errorprone compiler, and you get a hit on an errorprone check with severity [SUGGESTION](https://github.com/google/error-prone/blob/v2.3.4/annotation/src/main/java/com/google/errorprone/BugPattern.java#L171).

## After this PR

Javac output lines of the shape `<file>:<line>: Note:` get interpreted as as info messages in the structured output when compiling with gradle.