### PR TITLE
Make map (Collection) always return a mutable list

### DIFF
--- a/platform/util/src/com/intellij/util/containers/ContainerUtil.java
+++ b/platform/util/src/com/intellij/util/containers/ContainerUtil.java
@@ -2097,12 +2097,11 @@ public class ContainerUtil extends ContainerUtilRt {
   /**
    * @param collection an input collection to process
    * @param mapping a side-effect free function which transforms iterable elements
-   * @return read-only list consisting of the elements from the input collection converted by mapping
+   * @return a list consisting of the elements from the input collection converted by mapping
    */
   @NotNull
   @Contract(pure=true)
   public static <T,V> List<V> map(@NotNull Collection<? extends T> collection, @NotNull Function<? super T, ? extends V> mapping) {
-    if (collection.isEmpty()) return emptyList();
     List<V> list = new ArrayList<>(collection.size());
     for (final T t : collection) {
       list.add(mapping.fun(t));


### PR DESCRIPTION
There is a fairly new linter warning and refactoring proposing to replace `collection.stream().map(...).collect(Collectors.toList())` to `ContainerUtil.map(collection, ...)`. 

This changes behaviour -> dangerous!

The problem is that `ContainerUtil.map` is supposed to return a read-only map, while `.collect(Collectors.toList())` returns a mutable map. 
However, actually `ContainerUtil.map` returns a mutable map in all cases, except when the given collection is empty. It makes situation even worse!

We should change either map's or linter's behaviour.