### PR TITLE
[IDEA-230486] Constructor references with type parameters are not recognized as PsiMethodReferenceExpression

### DIFF
--- a/java/java-psi-impl/src/com/intellij/lang/java/parser/StatementParser.java
+++ b/java/java-psi-impl/src/com/intellij/lang/java/parser/StatementParser.java
@@ -160,16 +160,31 @@ public class StatementParser {
       skipQualifiedName(builder);
       IElementType suspectedLT = builder.getTokenType(), next = builder.lookAhead(1);
       refPos.rollbackTo();
+
       if (suspectedLT == JavaTokenType.LT || suspectedLT == JavaTokenType.DOT && next == JavaTokenType.AT) {
+        final boolean constructorRef;
+
         PsiBuilder.Marker declStatement = builder.mark();
         PsiBuilder.Marker decl = myParser.getDeclarationParser().parse(builder, DeclarationParser.Context.CODE_BLOCK);
+
         if (decl == null) {
           PsiBuilder.Marker marker = myParser.getReferenceParser().parseType(builder, 0);
-          error(builder, JavaErrorBundle.message("expected.identifier"));
-          if (marker == null) builder.advanceLexer();
+          // if the type declaration ends with "::" then it is a method reference to a constructor
+          constructorRef = builder.getTokenType() == JavaTokenType.DOUBLE_COLON;
+          if (!constructorRef) {
+            error(builder, JavaErrorBundle.message("expected.identifier"));
+            if (marker == null) builder.advanceLexer();
+          }
         }
-        done(declStatement, JavaElementType.DECLARATION_STATEMENT);
-        return declStatement;
+        else {
+          constructorRef = false;
+        }
+
+        if (!constructorRef) {
+          done(declStatement, JavaElementType.DECLARATION_STATEMENT);
+          return declStatement;
+        }
+        declStatement.rollbackTo();
       }
     }
 

--- a/java/java-tests/testData/psi/parser-partial/statements/ConstructorRef.txt
+++ b/java/java-tests/testData/psi/parser-partial/statements/ConstructorRef.txt
@@ -1,0 +1,13 @@
+PsiJavaFile:ConstructorRef.java
+  PsiExpressionStatement
+    PsiMethodReferenceExpression
+      PsiReferenceExpression:Foo
+        PsiReferenceParameterList
+          <empty list>
+        PsiIdentifier:Foo('Foo')
+      PsiJavaToken:DOUBLE_COLON('::')
+      PsiReferenceParameterList
+        <empty list>
+      PsiKeyword:new('new')
+    PsiErrorElement:';' expected
+      <empty list>

--- a/java/java-tests/testData/psi/parser-partial/statements/ConstructorWithTypeParamsRef.txt
+++ b/java/java-tests/testData/psi/parser-partial/statements/ConstructorWithTypeParamsRef.txt
@@ -1,0 +1,20 @@
+PsiJavaFile:ConstructorWithTypeParamsRef.java
+  PsiExpressionStatement
+    PsiMethodReferenceExpression
+      PsiTypeElement:Foo<Integer>
+        PsiJavaCodeReferenceElement:Foo<Integer>
+          PsiIdentifier:Foo('Foo')
+          PsiReferenceParameterList
+            PsiJavaToken:LT('<')
+            PsiTypeElement:Integer
+              PsiJavaCodeReferenceElement:Integer
+                PsiIdentifier:Integer('Integer')
+                PsiReferenceParameterList
+                  <empty list>
+            PsiJavaToken:GT('>')
+      PsiJavaToken:DOUBLE_COLON('::')
+      PsiReferenceParameterList
+        <empty list>
+      PsiKeyword:new('new')
+    PsiErrorElement:';' expected
+      <empty list>

--- a/java/java-tests/testSrc/com/intellij/java/parser/partial/StatementParserTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/parser/partial/StatementParserTest.java
@@ -185,6 +185,9 @@ public class StatementParserTest extends JavaParsingTestCase {
   public void testWhileIncomplete4() { doParserTest("while(cond)"); }
   public void testWhileIncomplete5() { doParserTest("while() foo();"); }
 
+  public void testConstructorRef() { doParserTest("Foo::new"); }
+  public void testConstructorWithTypeParamsRef() { doParserTest("Foo<Integer>::new"); }
+
   private void doBlockParserTest(String text) {
     doParserTest(text, builder -> JavaParser.INSTANCE.getStatementParser().parseCodeBlockDeep(builder, true));
   }


### PR DESCRIPTION
**`StatementParser`** used to ignore type parameters to constructor references and it prevents the tokens of such statements from being grouped under the **`PsiMethodReferenceExpression`** node in the PSI tree.

This patch adds a new check in **`StatementParser#parseStatement`** if the examined line is a constructor reference with type parameters.

Here is [the link to the issue](https://youtrack.jetbrains.com/issue/IDEA-230486)