### PR TITLE
Do not override Scope Provider return type

### DIFF
--- a/platform/indexing-impl/src/com/intellij/openapi/module/impl/scopes/ModuleScopeProviderImpl.java
+++ b/platform/indexing-impl/src/com/intellij/openapi/module/impl/scopes/ModuleScopeProviderImpl.java
@@ -44,6 +44,15 @@ public class ModuleScopeProviderImpl implements ModuleScopeProvider {
     return scope;
   }
 
+  @NotNull
+  private ModuleWithDependentsTestScope getCachedModuleTestsWithDependentsScope() {
+    ModuleWithDependentsTestScope scope = myModuleTestsWithDependentsScope;
+    if (scope == null) {
+      myModuleTestsWithDependentsScope = scope = new ModuleWithDependentsTestScope(myModule);
+    }
+    return scope;
+  }
+
   @Override
   @NotNull
   public GlobalSearchScope getModuleScope() {
@@ -91,17 +100,13 @@ public class ModuleScopeProviderImpl implements ModuleScopeProvider {
   @Override
   @NotNull
   public GlobalSearchScope getModuleWithDependentsScope() {
-    return getModuleTestsWithDependentsScope().getBaseScope();
+    return getCachedModuleTestsWithDependentsScope().getBaseScope();
   }
 
   @Override
   @NotNull
-  public ModuleWithDependentsTestScope getModuleTestsWithDependentsScope() {
-    ModuleWithDependentsTestScope scope = myModuleTestsWithDependentsScope;
-    if (scope == null) {
-      myModuleTestsWithDependentsScope = scope = new ModuleWithDependentsTestScope(myModule);
-    }
-    return scope;
+  public GlobalSearchScope getModuleTestsWithDependentsScope() {
+    return getCachedModuleTestsWithDependentsScope();
   }
 
   @Override


### PR DESCRIPTION
We have a very unique dependency graph and need to override the default behavior of moduleWithDependentsScope and moduleTestsWithDependentsScope. Since ModuleWithDependentsTestScope is package protected, this change removes the need to override the return type and instead create a new helper method. 