### PR TITLE
[IDEA-230602] UI Thread Blocked when open a special .class file

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
@@ -62,10 +62,15 @@ public class ImportCollector {
         }
       }
 
+      StructClass preClass = currentClass;
       // .. and traverse through parent.
       currentClass = !queue.isEmpty() ? classes.get(queue.removeFirst()) : null;
       while (currentClass == null && !queue.isEmpty()) {
         currentClass = classes.get(queue.removeFirst());
+      }
+
+      if (preClass.equals(currentClass) && queue.isEmpty()) {
+        break;
       }
     }
   }


### PR DESCRIPTION
by my debug , I found the reason why  UI Thread Blocked is  [ImportCollector.java #L43](https://github.com/JetBrains/intellij-community/blob/9c616208230524a5a467ab907c32bdd04c4039cc/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java#L43)  

the `currentClass` always not null by given .class file in  [IDEA-230602](https://youtrack.jetbrains.com/issue/IDEA-230602)

so I try to fix it 

when  `preClass.equals(currentClass) && queue.isEmpty()`  , the loop should be break