### PR TITLE
Fix default layout property being unset incorrectly

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
@@ -43,7 +43,10 @@ public class TextEditorWithPreview extends UserDataHolderBase implements FileEdi
   private final String myName;
   public static final Key<Layout> DEFAULT_LAYOUT_FOR_FILE = Key.create("TextEditorWithPreview.DefaultLayout");
 
-  public TextEditorWithPreview(TextEditor editor, @NotNull FileEditor preview, @NotNull String editorName, @NotNull Layout defaultLayout) {
+  public TextEditorWithPreview(@NotNull TextEditor editor,
+                               @NotNull FileEditor preview,
+                               @NotNull String editorName,
+                               @NotNull Layout defaultLayout) {
     myEditor = editor;
     myPreview = preview;
     myName = editorName;
@@ -422,7 +425,7 @@ public class TextEditorWithPreview extends UserDataHolderBase implements FileEdi
     public void setSelected(@NotNull AnActionEvent e, boolean state) {
       if (state) {
         myLayout = myActionLayout;
-        PropertiesComponent.getInstance().setValue(getLayoutPropertyName(), myLayout.myName, Layout.SHOW_EDITOR_AND_PREVIEW.myName);
+        PropertiesComponent.getInstance().setValue(getLayoutPropertyName(), myLayout.myName, myDefaultLayout.myName);
         adjustEditorsVisibility();
       }
     }


### PR DESCRIPTION
In TextEditorWithPreview, there is a property responsible for storing
the last used layout corresponding to that editor. We get this property
when creating new files to make sure they'll be open in the last used
layout. We're supposed to set it every time we select a layout other than
the default one (in this case, we reset it). However, we were hardcoding
Layout.SHOW_EDITOR_AND_PREVIEW to reset the property, while we're supposed
to be using the myDefaultLayout to avoid a misbehavior when opening new
files.