### PR TITLE
IDEA-231405 Fix `getGradleVersion` for wrapper distribution type

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/GradleInstallationManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/GradleInstallationManager.java
@@ -640,7 +640,7 @@ public class GradleInstallationManager {
       GradleInstallationManager installationManager = ServiceManager.getService(GradleInstallationManager.class);
       File gradleHome = installationManager.getWrappedGradleHome(settings.getExternalProjectPath(), wrapperConfiguration);
       if (gradleHome != null) {
-        String gradleVersion = getGradleVersion(settings.getGradleHome());
+        String gradleVersion = getGradleVersion(gradleHome.getAbsolutePath());
         if (gradleVersion != null) {
           version = getGradleVersionSafe(gradleVersion);
         }


### PR DESCRIPTION
- The previous implementation was not using found gradle wrapper location to detect gradle version correctly; it used `last.used.gradle.home` property instead
- This caused plugins that used this function (like Kotlin Plugin) to incorrectly detect gradle version, which led to incorrect behavior (for example, generating `build.gradle.kts` with old API usages)
- ^IDEA-231405 Fixed