### PR TITLE
Subscribe for fewer Gradle events

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
@@ -197,8 +197,6 @@ public class GradleExecutionHelper {
     GradleProgressListener gradleProgressListener = new GradleProgressListener(listener, id, buildRootDir);
     operation.addProgressListener((ProgressListener)gradleProgressListener);
     operation.addProgressListener(gradleProgressListener,
-                                  OperationType.GENERIC,
-                                  OperationType.PROJECT_CONFIGURATION,
                                   OperationType.TASK,
                                   OperationType.TEST);
     operation.setStandardOutput(standardOutput);


### PR DESCRIPTION
Subscribe for fewer Gradle events (~8x fewer for Android projects)

1. Replace missing events with synthetic events reconstructed from
    those we still subscribe to.

2. Replace partially implemented build phase detection with a simple
    based on text matching mechanism to update the text of the root node.

3. Do not unnecessary update the root node if nothing has changed.
