### PR TITLE
Shell: Override ShFunctionDefinition.getTextOffset() to navigate to the name of the function

### DIFF
--- a/plugins/sh/gen/com/intellij/sh/psi/ShFunctionDefinition.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShFunctionDefinition.java
@@ -22,4 +22,6 @@ public interface ShFunctionDefinition extends ShCommand {
   @Nullable
   PsiElement getWord();
 
+  int getTextOffset();
+
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/impl/ShFunctionDefinitionImpl.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/impl/ShFunctionDefinitionImpl.java
@@ -55,4 +55,9 @@ public class ShFunctionDefinitionImpl extends ShCommandImpl implements ShFunctio
     return findChildByType(WORD);
   }
 
+  @Override
+  public int getTextOffset() {
+    return ShPsiImplUtil.getTextOffset(this);
+  }
+
 }

--- a/plugins/sh/grammar/sh.bnf
+++ b/plugins/sh/grammar/sh.bnf
@@ -217,7 +217,7 @@ private pipeline_command_list ::= pipeline_command (pipeline_command_list_separa
 } // todo with pin
 private pipeline_command_list_separator ::= ('&&'|  '||' |  '&' |  ';' |  '\n') newlines
 
-function_definition ::= &(function | word '(') function_definition_inner {extends=command}
+function_definition ::= &(function | word '(') function_definition_inner {extends=command methods=[getTextOffset]}
 private function_definition_inner ::=           word argument_list  newlines block
                                      | function (word | <<keywordsRemapped>>) argument_list? newlines block {pin(".*")="function|argument_list"}
 private argument_list ::= '(' ')' {recoverWhile = argument_list_recover}

--- a/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
+++ b/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
@@ -1,9 +1,11 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.sh.psi.impl;
 
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry;
 import com.intellij.sh.ShSupport;
+import com.intellij.sh.psi.ShFunctionDefinition;
 import com.intellij.sh.psi.ShLiteral;
 import com.intellij.sh.psi.ShString;
 import com.intellij.sh.psi.ShVariable;
@@ -18,5 +20,10 @@ public class ShPsiImplUtil {
 
   static PsiReference @NotNull [] getReferences(@NotNull ShVariable o) {
     return ShSupport.getInstance().getVariableReferences(o);
+  }
+
+  static int getTextOffset(@NotNull ShFunctionDefinition f) {
+    PsiElement word = f.getWord();
+    return word != null ? word.getTextOffset() : f.getNode().getStartOffset();
   }
 }


### PR DESCRIPTION
Override getTextOffset() to navigate to the name of the function. Previously navigation jumped to the start offset of the function keyword.
This allows 3rd-party plugins to implement resolving with proper navigation to the name element.