### PR TITLE
IDEA-231570 Support new LogBuilder API from Log4J 2

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/logging/PlaceholderCountMatchesArgumentCountInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/logging/PlaceholderCountMatchesArgumentCountInspection.java
@@ -55,7 +55,8 @@ public class PlaceholderCountMatchesArgumentCountInspection extends BaseInspecti
       }
       final PsiClass aClass = method.getContainingClass();
       if (!InheritanceUtil.isInheritor(aClass, "org.slf4j.Logger") &&
-          !InheritanceUtil.isInheritor(aClass, "org.apache.logging.log4j.Logger")) {
+          !InheritanceUtil.isInheritor(aClass, "org.apache.logging.log4j.Logger") &&
+          !InheritanceUtil.isInheritor(aClass, "org.apache.logging.log4j.LogBuilder")) {
         return;
       }
       final PsiParameter[] parameters = method.getParameterList().getParameters();

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/logging/StringConcatenationArgumentToLogCallInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/logging/StringConcatenationArgumentToLogCallInspection.java
@@ -280,7 +280,8 @@ public class StringConcatenationArgumentToLogCallInspection extends BaseInspecti
       }
       final PsiClass containingClass = method.getContainingClass();
       if (!InheritanceUtil.isInheritor(containingClass, "org.slf4j.Logger") &&
-          !InheritanceUtil.isInheritor(containingClass, "org.apache.logging.log4j.Logger")) {
+          !InheritanceUtil.isInheritor(containingClass, "org.apache.logging.log4j.Logger") &&
+          !InheritanceUtil.isInheritor(containingClass, "org.apache.logging.log4j.LogBuilder")) {
         return;
       }
       final PsiExpressionList argumentList = expression.getArgumentList();

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/logging/string_concatenation_argument_to_log_call/Log4JLogBuilder.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/logging/string_concatenation_argument_to_log_call/Log4JLogBuilder.after.java
@@ -1,0 +1,11 @@
+import org.apache.logging.log4j.*;
+
+class Log4JLogBuilder {
+
+    void foo() {
+        Logger logger = LogManager.getLogger(Log4JLogBuilder.class);
+        final String CONST = "const";
+        String var = "var";
+        logger.atInfo().withLocation().log("string {}" + CONST, var);
+    }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/logging/string_concatenation_argument_to_log_call/Log4JLogBuilder.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/logging/string_concatenation_argument_to_log_call/Log4JLogBuilder.java
@@ -1,0 +1,11 @@
+import org.apache.logging.log4j.*;
+
+class Log4JLogBuilder {
+
+    void foo() {
+        Logger logger = LogManager.getLogger(Log4JLogBuilder.class);
+        final String CONST = "const";
+        String var = "var";
+        logger.atInfo().withLocation().lo<caret>g("string " + (var) + CONST);
+    }
+}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/logging/StringConcatenationArgumentToLogCallFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/logging/StringConcatenationArgumentToLogCallFixTest.java
@@ -13,12 +13,16 @@ public class StringConcatenationArgumentToLogCallFixTest extends IGQuickFixesTes
     myDefaultHint = InspectionGadgetsBundle.message("string.concatenation.argument.to.log.call.quickfix");
     myFixture.addClass("package org.slf4j; public interface Logger { void info(String format); }");
     myFixture.addClass("package org.slf4j; public class LoggerFactory { public static Logger getLogger(Class clazz) { return null; }}");
+    myFixture.addClass("package org.apache.logging.log4j; public interface LogBuilder { void log(String format); LogBuilder withLocation(); }");
+    myFixture.addClass("package org.apache.logging.log4j; public interface Logger { LogBuilder atInfo(); }");
+    myFixture.addClass("package org.apache.logging.log4j; public class LogManager { public static Logger getLogger(Class clazz) { return null; }}");
     myFixture.enableInspections(new StringConcatenationArgumentToLogCallInspection());
   }
 
   public void testUseOfConstant() { doTest(); }
   public void testCharLiteral() { doTest(); }
   public void testQuoteCharLiteral() { doTest(); }
+  public void testLog4JLogBuilder() { doTest(); }
 
   @Override
   protected String getRelativePath() {

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/logging/PlaceholderCountMatchesArgumentCountInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/logging/PlaceholderCountMatchesArgumentCountInspectionTest.java
@@ -23,6 +23,9 @@ public class PlaceholderCountMatchesArgumentCountInspectionTest extends LightJav
       "  void info(String message, Object... params);" +
       "  void fatal(String message, Object... params);" +
       "  void error(Supplier<?> var1, Throwable var2);" +
+      "  LogBuilder atInfo();" +
+      "  LogBuilder atFatal();" +
+      "  LogBuilder atError();" +
       "}",
 
       "package org.apache.logging.log4j;" +
@@ -35,6 +38,14 @@ public class PlaceholderCountMatchesArgumentCountInspectionTest extends LightJav
       "package org.apache.logging.log4j.util;" +
       "public interface Supplier<T> {" +
       "    T get();" +
+      "}",
+
+      "package org.apache.logging.log4j;" +
+      "import org.apache.logging.log4j.util.Supplier;" +
+      "public interface LogBuilder {" +
+      "  public void log(String format, Object p0);" +
+      "  public void log(String format, Object... params);" +
+      "  public void log(String format, Supplier<?>... params);" +
       "}"
     };
   }
@@ -47,6 +58,18 @@ public class PlaceholderCountMatchesArgumentCountInspectionTest extends LightJav
            "    LOG.info(/*Fewer arguments provided (1) than placeholders specified (3)*/\"hello? {}{}{}\"/**/, i);\n" +
            "    LOG.fatal(/*More arguments provided (1) than placeholders specified (0)*/\"you got me \"/**/,  i);\n" +
            "    LOG.error(() -> \"\", new Exception());\n" +
+           "  }\n" +
+           "}");
+  }
+
+  public void testLog4j2LogBuilder() {
+    doTest("import org.apache.logging.log4j.*;\n" +
+           "class Logging {\n" +
+           "  private static final Logger LOG = LogManager.getLogger();\n" +
+           "  void m(int i) {\n" +
+           "    LOG.atInfo().log(/*Fewer arguments provided (1) than placeholders specified (3)*/\"hello? {}{}{}\"/**/, i);\n" +
+           "    LOG.atFatal().log(/*More arguments provided (2) than placeholders specified (0)*/\"you got me \"/**/, i, i);\n" +
+           "    LOG.atError().log(/*More arguments provided (1) than placeholders specified (0)*/\"what does the supplier say? \"/**/, () -> \"\");\n" +
            "  }\n" +
            "}");
   }

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/logging/StringConcatenationArgumentToLogCallInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/logging/StringConcatenationArgumentToLogCallInspectionTest.java
@@ -31,6 +31,8 @@ public class StringConcatenationArgumentToLogCallInspectionTest extends LightJav
       "public interface Logger {" +
       "  void info(String var2);" +
       "  void fatal(String var1);" +
+      "  LogBuilder atDebug();" +
+      "  LogBuilder atInfo();" +
       "}",
 
       "package org.apache.logging.log4j;" +
@@ -38,6 +40,12 @@ public class StringConcatenationArgumentToLogCallInspectionTest extends LightJav
       "  public static Logger getLogger() {" +
       "    return null;" +
       "  }" +
+      "}",
+
+      "package org.apache.logging.log4j;" +
+      "public interface LogBuilder {" +
+      "  void log(String format, Object p0);" +
+      "  void log(String format, Object... params);" +
       "}"
     };
   }
@@ -72,6 +80,17 @@ public class StringConcatenationArgumentToLogCallInspectionTest extends LightJav
            "  void m(int i) {" +
            "    LOG./*Non-constant string concatenation as argument to 'info()' logging call*/info/**/(\"hello? \" + i);" +
            "    LOG./*Non-constant string concatenation as argument to 'fatal()' logging call*/fatal/**/(\"you got me \" + i);" +
+           "  }" +
+           "}");
+  }
+
+  public void testLog4j2LogBuilder() {
+    doTest("import org.apache.logging.log4j.*;" +
+           "class Logging {" +
+           "  private static final Logger LOG = LogManager.getLogger();" +
+           "  void m(int i) {" +
+           "    LOG.atDebug()./*Non-constant string concatenation as argument to 'log()' logging call*/log/**/(\"hello? \" + i);" +
+           "    LOG.atInfo()./*Non-constant string concatenation as argument to 'log()' logging call*/log/**/(\"you got me \" + i);" +
            "  }" +
            "}");
   }


### PR DESCRIPTION
Modify logging inspections to support for Log4J 2's new [LogBuilder API](https://logging.apache.org/log4j/2.x/log4j-api/apidocs/index.html?org/apache/logging/log4j/LogBuilder.html).

In short, `LOGGER.info("My name is {}", "John")` can now be written as `LOGGER.atInfo().log("My name is {}", "John")`. The inspections will detect problems in the new `log(...)` methods now.