### PR TITLE
Shell: Implement missing functionality to allow resolving and usage highlighting

### DIFF
--- a/plugins/sh/gen/com/intellij/sh/psi/ShAssignmentCommand.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShAssignmentCommand.java
@@ -4,8 +4,9 @@ package com.intellij.sh.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
 
-public interface ShAssignmentCommand extends ShCommand {
+public interface ShAssignmentCommand extends ShCommand, PsiNameIdentifierOwner {
 
   @Nullable
   ShArrayExpression getArrayExpression();
@@ -18,5 +19,14 @@ public interface ShAssignmentCommand extends ShCommand {
 
   @Nullable
   PsiElement getPlusAssign();
+
+  int getTextOffset();
+
+  @Nullable
+  String getName();
+
+  PsiElement setName(String name);
+
+  PsiElement getNameIdentifier();
 
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/ShAssignmentExpression.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShAssignmentExpression.java
@@ -4,8 +4,9 @@ package com.intellij.sh.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
 
-public interface ShAssignmentExpression extends ShBinaryExpression {
+public interface ShAssignmentExpression extends ShBinaryExpression, PsiNameIdentifierOwner {
 
   @Nullable
   PsiElement getAssign();
@@ -39,5 +40,21 @@ public interface ShAssignmentExpression extends ShBinaryExpression {
 
   @Nullable
   PsiElement getShiftRightAssign();
+
+  @NotNull
+  ShExpression getLeft();
+
+  @Nullable
+  ShExpression getRight();
+
+  int getTextOffset();
+
+  @Nullable
+  String getName();
+
+  PsiElement setName(String name);
+
+  @Nullable
+  PsiElement getNameIdentifier();
 
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/ShFunctionDefinition.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShFunctionDefinition.java
@@ -4,8 +4,9 @@ package com.intellij.sh.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
 
-public interface ShFunctionDefinition extends ShCommand {
+public interface ShFunctionDefinition extends ShCommand, PsiNameIdentifierOwner {
 
   @Nullable
   ShBlock getBlock();
@@ -21,5 +22,15 @@ public interface ShFunctionDefinition extends ShCommand {
 
   @Nullable
   PsiElement getWord();
+
+  int getTextOffset();
+
+  @Nullable
+  String getName();
+
+  PsiElement setName(String name);
+
+  @Nullable
+  PsiElement getNameIdentifier();
 
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/ShLiteralExpression.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShLiteralExpression.java
@@ -4,6 +4,7 @@ package com.intellij.sh.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
 
 public interface ShLiteralExpression extends ShExpression {
 
@@ -27,5 +28,7 @@ public interface ShLiteralExpression extends ShExpression {
 
   @NotNull
   List<ShVariable> getVariableList();
+
+  PsiReference[] getReferences();
 
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/ShVisitor.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShVisitor.java
@@ -3,6 +3,7 @@ package com.intellij.sh.psi;
 
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiNameIdentifierOwner;
 
 public class ShVisitor extends PsiElementVisitor {
 
@@ -24,6 +25,7 @@ public class ShVisitor extends PsiElementVisitor {
 
   public void visitAssignmentCommand(@NotNull ShAssignmentCommand o) {
     visitCommand(o);
+    // visitPsiNameIdentifierOwner(o);
   }
 
   public void visitAssignmentCondition(@NotNull ShAssignmentCondition o) {
@@ -32,6 +34,7 @@ public class ShVisitor extends PsiElementVisitor {
 
   public void visitAssignmentExpression(@NotNull ShAssignmentExpression o) {
     visitBinaryExpression(o);
+    // visitPsiNameIdentifierOwner(o);
   }
 
   public void visitAssignmentList(@NotNull ShAssignmentList o) {
@@ -156,6 +159,7 @@ public class ShVisitor extends PsiElementVisitor {
 
   public void visitFunctionDefinition(@NotNull ShFunctionDefinition o) {
     visitCommand(o);
+    // visitPsiNameIdentifierOwner(o);
   }
 
   public void visitGenericCommandDirective(@NotNull ShGenericCommandDirective o) {

--- a/plugins/sh/gen/com/intellij/sh/psi/impl/ShAssignmentCommandImpl.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/impl/ShAssignmentCommandImpl.java
@@ -49,4 +49,25 @@ public class ShAssignmentCommandImpl extends ShCommandImpl implements ShAssignme
     return findChildByType(PLUS_ASSIGN);
   }
 
+  @Override
+  public int getTextOffset() {
+    return ShPsiImplUtil.getTextOffset(this);
+  }
+
+  @Override
+  @Nullable
+  public String getName() {
+    return ShPsiImplUtil.getName(this);
+  }
+
+  @Override
+  public PsiElement setName(String name) {
+    return ShPsiImplUtil.setName(this, name);
+  }
+
+  @Override
+  public PsiElement getNameIdentifier() {
+    return ShPsiImplUtil.getNameIdentifier(this);
+  }
+
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/impl/ShAssignmentExpressionImpl.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/impl/ShAssignmentExpressionImpl.java
@@ -91,4 +91,40 @@ public class ShAssignmentExpressionImpl extends ShBinaryExpressionImpl implement
     return findChildByType(SHIFT_RIGHT_ASSIGN);
   }
 
+  @Override
+  @NotNull
+  public ShExpression getLeft() {
+    List<ShExpression> p1 = PsiTreeUtil.getChildrenOfTypeAsList(this, ShExpression.class);
+    return p1.get(0);
+  }
+
+  @Override
+  @Nullable
+  public ShExpression getRight() {
+    List<ShExpression> p1 = PsiTreeUtil.getChildrenOfTypeAsList(this, ShExpression.class);
+    return p1.size() < 2 ? null : p1.get(1);
+  }
+
+  @Override
+  public int getTextOffset() {
+    return ShPsiImplUtil.getTextOffset(this);
+  }
+
+  @Override
+  @Nullable
+  public String getName() {
+    return ShPsiImplUtil.getName(this);
+  }
+
+  @Override
+  public PsiElement setName(String name) {
+    return ShPsiImplUtil.setName(this, name);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getNameIdentifier() {
+    return ShPsiImplUtil.getNameIdentifier(this);
+  }
+
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/impl/ShFunctionDefinitionImpl.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/impl/ShFunctionDefinitionImpl.java
@@ -55,4 +55,26 @@ public class ShFunctionDefinitionImpl extends ShCommandImpl implements ShFunctio
     return findChildByType(WORD);
   }
 
+  @Override
+  public int getTextOffset() {
+    return ShPsiImplUtil.getTextOffset(this);
+  }
+
+  @Override
+  @Nullable
+  public String getName() {
+    return ShPsiImplUtil.getName(this);
+  }
+
+  @Override
+  public PsiElement setName(String name) {
+    return ShPsiImplUtil.setName(this, name);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getNameIdentifier() {
+    return ShPsiImplUtil.getNameIdentifier(this);
+  }
+
 }

--- a/plugins/sh/gen/com/intellij/sh/psi/impl/ShLiteralExpressionImpl.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/impl/ShLiteralExpressionImpl.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
 import static com.intellij.sh.ShTypes.*;
 import com.intellij.sh.psi.*;
+import com.intellij.psi.PsiReference;
 
 public class ShLiteralExpressionImpl extends ShExpressionImpl implements ShLiteralExpression {
 
@@ -65,6 +66,11 @@ public class ShLiteralExpressionImpl extends ShExpressionImpl implements ShLiter
   @NotNull
   public List<ShVariable> getVariableList() {
     return PsiTreeUtil.getChildrenOfTypeAsList(this, ShVariable.class);
+  }
+
+  @Override
+  public PsiReference[] getReferences() {
+    return ShPsiImplUtil.getReferences(this);
   }
 
 }

--- a/plugins/sh/grammar/sh.bnf
+++ b/plugins/sh/grammar/sh.bnf
@@ -217,7 +217,11 @@ private pipeline_command_list ::= pipeline_command (pipeline_command_list_separa
 } // todo with pin
 private pipeline_command_list_separator ::= ('&&'|  '||' |  '&' |  ';' |  '\n') newlines
 
-function_definition ::= &(function | word '(') function_definition_inner {extends=command}
+function_definition ::= &(function | word '(') function_definition_inner {
+  extends=command
+  implements="com.intellij.psi.PsiNameIdentifierOwner"
+  methods=[getTextOffset getName setName getNameIdentifier]
+}
 private function_definition_inner ::=           word argument_list  newlines block
                                      | function (word | <<keywordsRemapped>>) argument_list? newlines block {pin(".*")="function|argument_list"}
 private argument_list ::= '(' ')' {recoverWhile = argument_list_recover}
@@ -288,7 +292,11 @@ private end_of_list ::= '\n' | ';' | '&'
 shell_parameter_expansion ::= '{' parameter_expansion_body (composed_var parameter_expansion_body?)* '}' {pin=1}
 
 left assignment_command ::= array_expression? ('='|"+=") [assignment_list | <<parseUntilSpace (literal | composed_var)>>]
-                            {'=' <<parseUntilSpace literal >>}* {pin=0}
+                            {'=' <<parseUntilSpace literal >>}* {
+  pin=0
+  implements="com.intellij.psi.PsiNameIdentifierOwner"
+  methods=[getTextOffset getName setName getNameIdentifier]
+}
 assignment_list ::= '(' (<<backslash>> | array_assignment)* ')'
 array_assignment ::= newlines '='? expression newlines
 
@@ -333,7 +341,10 @@ expression ::=
   | parentheses_expression
 
 comma_expression ::= expression ',' expression
-assignment_expression ::= expression ('=' |'*=' |'/=' |'%=' |'+=' |'-=' |'<<=' |'>>=' |'&=' |'^=' |'|=') expression
+assignment_expression ::= expression ('=' |'*=' |'/=' |'%=' |'+=' |'-=' |'<<=' |'>>=' |'&=' |'^=' |'|=') expression {
+  implements="com.intellij.psi.PsiNameIdentifierOwner"
+  methods=[left="expression[0]" right="expression[1]" getTextOffset getName setName getNameIdentifier]
+}
 conditional_expression ::= expression '?' expression ':' expression
 logical_or_expression ::= expression '||' expression
 logical_and_expression ::= expression '&&' expression
@@ -356,7 +367,9 @@ index_expression ::= expression '[' expression ']'
 array_expression ::= '[' expression ']'
 parentheses_expression ::= '(' expression ')' {pin=1}
 
-literal_expression ::= w+
+literal_expression ::= w+ {
+  methods=[getReferences]
+}
 
 condition ::=
     assignment_condition

--- a/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
+++ b/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
@@ -1,15 +1,111 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.sh.psi.impl;
 
+import com.intellij.psi.ElementManipulator;
+import com.intellij.psi.ElementManipulators;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.sh.ShSupport;
-import com.intellij.sh.psi.ShLiteral;
-import com.intellij.sh.psi.ShString;
-import com.intellij.sh.psi.ShVariable;
+import com.intellij.sh.ShTypes;
+import com.intellij.sh.psi.*;
+import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ShPsiImplUtil {
+  static int getTextOffset(ShAssignmentCommand cmd) {
+    return cmd.getLiteral().getNode().getStartOffset();
+  }
+
+  @Nullable
+  static String getName(ShAssignmentCommand o) {
+    PsiElement nameIdentifier = o.getNameIdentifier();
+    return nameIdentifier == null ? null : nameIdentifier.getText();
+  }
+
+  static PsiElement setName(@NotNull ShAssignmentCommand o, String name) {
+    ElementManipulator<ShAssignmentCommand> manipulator = ElementManipulators.getManipulator(o);
+    if (manipulator != null) {
+      return manipulator.handleContentChange(o, name);
+    }
+    throw new IncorrectOperationException();
+  }
+
+  static PsiElement getNameIdentifier(@NotNull ShAssignmentCommand o) {
+    return o.getLiteral();
+  }
+
+  static int getTextOffset(@NotNull ShAssignmentExpression o) {
+    return o.getLeft().getNode().getStartOffset();
+  }
+
+  static PsiElement setName(@NotNull ShAssignmentExpression o, String name) {
+    ElementManipulator<ShAssignmentExpression> manipulator = ElementManipulators.getManipulator(o);
+    if (manipulator != null) {
+      return manipulator.handleContentChange(o, name);
+    }
+    throw new IncorrectOperationException();
+  }
+
+  @Nullable
+  static String getName(@NotNull ShAssignmentExpression o) {
+    PsiElement nameIdentifier = o.getNameIdentifier();
+    return nameIdentifier == null ? null : nameIdentifier.getText();
+  }
+
+  /**
+   * Retrieve the name identifier of the assignment expression.
+   * An identifier on the left-hand-side is only valid,
+   * if it contains a single leaf element with element type WORD.
+   *
+   * @param o the current expression
+   * @return the name identifier of the assignment expression, if available
+   */
+  @Nullable
+  static PsiElement getNameIdentifier(@NotNull ShAssignmentExpression o) {
+    PsiElement left = o.getLeft();
+    if (left instanceof ShLiteralExpression) {
+      PsiElement first = left.getFirstChild();
+      if (first instanceof LeafPsiElement
+          && first.getNextSibling() == null
+          && first.getNode().getElementType() == ShTypes.WORD) {
+        return left;
+      }
+    }
+
+    return null;
+  }
+
+  static int getTextOffset(@NotNull ShFunctionDefinition o) {
+    PsiElement word = o.getWord();
+    return word == null ? o.getNode().getStartOffset() : word.getNode().getStartOffset();
+  }
+
+  static PsiElement setName(@NotNull ShFunctionDefinition o, String name) {
+    ElementManipulator<ShFunctionDefinition> manipulator = ElementManipulators.getManipulator(o);
+    if (manipulator != null) {
+      return manipulator.handleContentChange(o, name);
+    }
+    throw new IncorrectOperationException();
+  }
+
+  @Nullable
+  static String getName(@NotNull ShFunctionDefinition o) {
+    PsiElement word = o.getNameIdentifier();
+    return word == null ? null : word.getText();
+  }
+
+  @Nullable
+  static PsiElement getNameIdentifier(@NotNull ShFunctionDefinition o) {
+    return o.getWord();
+  }
+
+  static PsiReference @NotNull [] getReferences(@NotNull ShLiteralExpression o) {
+    return ReferenceProvidersRegistry.getReferencesFromProviders(o);
+  }
+
   static PsiReference @NotNull [] getReferences(@NotNull ShLiteral o) {
     return o instanceof ShString || o.getWord() != null
            ? ReferenceProvidersRegistry.getReferencesFromProviders(o)


### PR DESCRIPTION
This extends the grammar definition of `SFunctionDefinition`, `ShAssignmentCommand` and `ShAssignmentExpression` to implement `PsiNamedIdentifierOwner`. This is needed to allow implementations of reference resolving for Shell PSI elements, e.g. by 3rd-party plugins.

`getName()`, etc. are needed for highlighting references and the target element in the editor.

`setName` delegates to an ElementManipulator, the default implementation is unavailable (as before). The implementor of reference resolving is also able to implement rename by providing an element manipulator.

`ShLiteralExpression` now supports references in identifiers and `PsiNamedIdentifierOwner` for the `ShAssignmentExpression`. Shell arithmetic expressions contain variable definitions and references. This wasn't possible to resolve so far.

- I tried to follow the existing coding style and also applied the shared code style formatting
- I generated the ShPsi sources from the sh.bnf grammar, only needed changes are included
- Tests of the Shell plugin are passing

Please let me know if changes are needed.