### PR TITLE
Shell: Don't show intention "Rename all occurrences" if the rename was turned off

### DIFF
--- a/plugins/sh/src/com/intellij/sh/rename/ShRenameAllOccurrencesIntention.java
+++ b/plugins/sh/src/com/intellij/sh/rename/ShRenameAllOccurrencesIntention.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.intellij.sh.ShBundle;
+import com.intellij.sh.ShSupport;
 import com.intellij.sh.psi.ShFile;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
@@ -36,6 +37,7 @@ public class ShRenameAllOccurrencesIntention extends BaseIntentionAction impleme
   @Override
   public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
     return file instanceof ShFile && editor != null
+           && ShSupport.getInstance().isRenameEnabled()
            && ShRenameAllOccurrencesHandler.INSTANCE.isEnabled(editor, editor.getCaretModel().getPrimaryCaret(), null);
   }
 


### PR DESCRIPTION
A plugin may override the ShSupport service to disable the `Rename all occurrences` feature. The intention `Rename all occurrences` was still showing up, even if the rename was turned off. 
This PR fixes this issue.