### PR TITLE
Shell: support variable declarations outside of an assignment command

### DIFF
--- a/plugins/sh/gen/com/intellij/sh/psi/ShLiteral.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShLiteral.java
@@ -4,9 +4,10 @@ package com.intellij.sh.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
 import com.intellij.psi.PsiReference;
 
-public interface ShLiteral extends ShSimpleCommandElement {
+public interface ShLiteral extends ShSimpleCommandElement, PsiNameIdentifierOwner {
 
   @Nullable
   PsiElement getWord();

--- a/plugins/sh/gen/com/intellij/sh/psi/ShVisitor.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/ShVisitor.java
@@ -196,6 +196,7 @@ public class ShVisitor extends PsiElementVisitor {
 
   public void visitLiteral(@NotNull ShLiteral o) {
     visitSimpleCommandElement(o);
+    // visitPsiNameIdentifierOwner(o);
   }
 
   public void visitLiteralCondition(@NotNull ShLiteralCondition o) {

--- a/plugins/sh/gen/com/intellij/sh/psi/impl/ShLiteralImpl.java
+++ b/plugins/sh/gen/com/intellij/sh/psi/impl/ShLiteralImpl.java
@@ -11,7 +11,7 @@ import static com.intellij.sh.ShTypes.*;
 import com.intellij.sh.psi.*;
 import com.intellij.psi.PsiReference;
 
-public class ShLiteralImpl extends ShSimpleCommandElementImpl implements ShLiteral {
+public class ShLiteralImpl extends ShLiteralMixin implements ShLiteral {
 
   public ShLiteralImpl(ASTNode node) {
     super(node);

--- a/plugins/sh/grammar/sh.bnf
+++ b/plugins/sh/grammar/sh.bnf
@@ -117,7 +117,7 @@
   extends("variable|string|number")=literal
   extends(".*command|function_definition")=command
 
-  implements("function_definition|assignment_command|assignment_expression")="com.intellij.psi.PsiNameIdentifierOwner"
+  implements("function_definition|assignment_command|assignment_expression|literal")="com.intellij.psi.PsiNameIdentifierOwner"
 
   extends("(comma|assignment|conditional|logical_or|logical_and|bitwise_or|bitwise_exclusive_or|bitwise_and|equality|comparison|bitwise_shift|add|mul|exp)_expression")=binary_expression
   extends(".*expression")=expression
@@ -300,6 +300,7 @@ array_assignment ::= newlines '='? expression newlines
 
 literal ::= word | string | number | variable {
   extends=simple_command_element
+  mixin="com.intellij.sh.psi.impl.ShLiteralMixin"
   methods=[getReferences]
 }
 private not_lvalue ::= '!' | vars | '$' | brace_expansion | 'file descriptor'

--- a/plugins/sh/src/com/intellij/sh/ShSupport.java
+++ b/plugins/sh/src/com/intellij/sh/ShSupport.java
@@ -5,11 +5,18 @@ import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry;
+import com.intellij.sh.codeInsight.ShFunctionReference;
+import com.intellij.sh.psi.ShLiteral;
+import com.intellij.sh.psi.ShString;
 import com.intellij.sh.psi.ShVariable;
 import com.intellij.sh.run.ShRunConfiguration;
 import com.intellij.sh.run.ShRunConfigurationProfileState;
+import com.intellij.util.ArrayUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface ShSupport {
   static ShSupport getInstance() { return ServiceManager.getService(ShSupport.class); }
@@ -24,8 +31,30 @@ public interface ShSupport {
                                         @NotNull ShRunConfiguration configuration);
 
   PsiReference @NotNull [] getVariableReferences(@NotNull ShVariable v);
-  
-  
+
+  PsiReference @NotNull [] getLiteralReferences(@NotNull ShLiteral o);
+
+  /**
+   * Retrieve the name of the literal, if it's used as a variable declaration.
+   *
+   * @param l the literal
+   * @return The name of the literal, if it's used as a variable declaration. Otherwise {@code null} is returned.
+   * @see com.intellij.psi.PsiNameIdentifierOwner
+   */
+  @Nullable
+  String getName(@NotNull ShLiteral l);
+
+  /**
+   * Retrieve the name identifier of this literal, if it's used as a variable declaration.
+   *
+   * @param l The literal
+   * @return A non-null element representing the name if the literal is used as a variable declaration. Otherwise {@code null} is returned.
+   * @see com.intellij.psi.PsiNameIdentifierOwner
+   */
+  @Nullable
+  PsiElement getNameIdentifier(@NotNull ShLiteral l);
+
+
   class Impl implements ShSupport {
     @Override
     public boolean isExternalFormatterEnabled() { return true; }
@@ -44,6 +73,23 @@ public interface ShSupport {
     @Override
     public PsiReference @NotNull [] getVariableReferences(@NotNull ShVariable v) {
       return PsiReference.EMPTY_ARRAY;
+    }
+
+    @Override
+    public PsiReference @NotNull [] getLiteralReferences(@NotNull ShLiteral o) {
+      return o instanceof ShString || o.getWord() != null
+             ? ArrayUtil.prepend(new ShFunctionReference(o), ReferenceProvidersRegistry.getReferencesFromProviders(o))
+             : PsiReference.EMPTY_ARRAY;
+    }
+
+    @Override
+    public @Nullable String getName(@NotNull ShLiteral l) {
+      return null;
+    }
+
+    @Override
+    public @Nullable PsiElement getNameIdentifier(@NotNull ShLiteral l) {
+      return null;
     }
   }
 }

--- a/plugins/sh/src/com/intellij/sh/psi/impl/ShLiteralMixin.java
+++ b/plugins/sh/src/com/intellij/sh/psi/impl/ShLiteralMixin.java
@@ -1,0 +1,49 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.sh.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.ElementManipulator;
+import com.intellij.psi.ElementManipulators;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry;
+import com.intellij.sh.ShSupport;
+import com.intellij.sh.codeInsight.ShFunctionReference;
+import com.intellij.sh.psi.ShLiteral;
+import com.intellij.sh.psi.ShString;
+import com.intellij.util.ArrayUtil;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+abstract class ShLiteralMixin extends ShSimpleCommandElementImpl implements ShLiteral {
+  ShLiteralMixin(ASTNode node) {
+    super(node);
+  }
+
+  @Override
+  public String getName() {
+    if (this instanceof ShString || this.getWord() != null) {
+      return ShSupport.getInstance().getName(this);
+    }
+    return null;
+  }
+
+  @Override
+  public @Nullable PsiElement getNameIdentifier() {
+    return this instanceof ShString || this.getWord() != null
+           ? ShSupport.getInstance().getNameIdentifier(this)
+           : null;
+  }
+
+  @Override
+  public PsiElement setName(@NotNull String name) throws IncorrectOperationException {
+    if (this instanceof ShString || this.getWord() != null) {
+      ElementManipulator<ShLiteral> manipulator = ElementManipulators.getManipulator(this);
+      if (manipulator != null) {
+        return manipulator.handleContentChange(this, name);
+      }
+    }
+    throw new IncorrectOperationException();
+  }
+}

--- a/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
+++ b/plugins/sh/src/com/intellij/sh/psi/impl/ShPsiImplUtil.java
@@ -4,19 +4,14 @@ package com.intellij.sh.psi.impl;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry;
 import com.intellij.sh.ShSupport;
-import com.intellij.sh.codeInsight.ShFunctionReference;
 import com.intellij.sh.psi.ShLiteral;
 import com.intellij.sh.psi.ShLiteralExpression;
-import com.intellij.sh.psi.ShString;
 import com.intellij.sh.psi.ShVariable;
-import com.intellij.util.ArrayUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class ShPsiImplUtil {
   static PsiReference @NotNull [] getReferences(@NotNull ShLiteral o) {
-    return o instanceof ShString || o.getWord() != null
-           ? ArrayUtil.prepend(new ShFunctionReference(o), ReferenceProvidersRegistry.getReferencesFromProviders(o))
-           : PsiReference.EMPTY_ARRAY;
+    return ShSupport.getInstance().getLiteralReferences(o);
   }
 
   static PsiReference @NotNull [] getReferences(@NotNull ShLiteralExpression o) {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IDEA-231792

Many Bash commands declare a variable, but don't assign a value. These elements are plain `ShLiteral` PsiElements.
This pull requests adds support for `getName`, `setName`, and `getNameIdentifier` to allow proper variable resolve, highlighting and rename in 3rd-party plugins. Without this, variable references resolving to a definition of such a `ShLiteral` don't highlight properly and can't be renamed.

This PR also moves the instantiation of a ShFunctionReference into ShSupport to allow plugins to provide more sophisticated function resolving, e.g. to support include files. This is related to the handling of ShLiteral , but could be split into a seperate PR.

This PR isn't restricting this to a subset of commands, because it's easy to overlook a command which declares variables and this may also be different with older versions of Bash. This allows plugins to implement this without restrictions up-front.

Some examples, there are more:
```bash
# declares two vars without value, one with a value
export var1 var2 var3=name
# declares two read-only variables
declare -r var1 var2
# declares two read-only variables
readonly var1 var2
# declares two local variables (can only be used in functions)
local localVar1 localVar2

# declares loopVar
for loopVar; do ... ; done
```

Possible improvements in the Sh plugin, if requested:
- Check that a ShLiteral isn't the the name of a function definition. At the moment it's assumed that the 3rd-party plugin takes care of this.
- Move `getReferences` to the ShLiteralMixin, I didn't want to change the existing code