### PR TITLE
Use a Supplier to get EditorComposite's focusComponent

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorComposite.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorComposite.java
@@ -37,6 +37,7 @@ import com.intellij.util.ArrayUtil;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -106,22 +107,22 @@ public class EditorComposite implements Disposable {
     myProviders = providers;
     if (ArrayUtil.contains(null, editors)) throw new IllegalArgumentException("Must not pass null editors in " + Arrays.asList(editors));
     myFileEditorManager = fileEditorManager;
-    myInitialFileTimeStamp     = myFile.getTimeStamp();
+    myInitialFileTimeStamp = myFile.getTimeStamp();
 
     Project project = fileEditorManager.getProject();
     Disposer.register(project, this);
 
-    if(editors.length > 1){
+    if (editors.length > 1) {
       myTabbedPaneWrapper = createTabbedPaneWrapper(editors);
       JComponent component = myTabbedPaneWrapper.getComponent();
-      myComponent = new MyComponent(component, component);
+      myComponent = new MyComponent(component, () -> component);
     }
-    else if(editors.length==1){
-      myTabbedPaneWrapper=null;
+    else if (editors.length == 1) {
+      myTabbedPaneWrapper = null;
       FileEditor editor = editors[0];
-      myComponent = new MyComponent(createEditorComponent(editor), editor.getPreferredFocusedComponent());
+      myComponent = new MyComponent(createEditorComponent(editor), editor::getPreferredFocusedComponent);
     }
-    else{
+    else {
       throw new IllegalArgumentException("editors array cannot be empty");
     }
 
@@ -453,10 +454,10 @@ public class EditorComposite implements Disposable {
   }
 
   private class MyComponent extends JPanel implements DataProvider{
-    @Nullable
-    private JComponent myFocusComponent;
+    @NotNull
+    private Supplier<JComponent> myFocusComponent;
 
-    MyComponent(@NotNull JComponent realComponent, @Nullable JComponent focusComponent){
+    MyComponent(@NotNull JComponent realComponent, @NotNull Supplier<JComponent> focusComponent) {
       super(new BorderLayout());
       myFocusComponent = focusComponent;
       add(realComponent, BorderLayout.CENTER);
@@ -464,24 +465,28 @@ public class EditorComposite implements Disposable {
 
     void setComponent(JComponent newComponent) {
       add(newComponent, BorderLayout.CENTER);
-      myFocusComponent = newComponent;
+      myFocusComponent = () -> newComponent;
     }
 
     @Override
     public boolean requestFocusInWindow() {
-      return myFocusComponent != null && myFocusComponent.requestFocusInWindow();
+      JComponent focusComponent = myFocusComponent.get();
+      return focusComponent != null && focusComponent.requestFocusInWindow();
     }
 
     @Override
     public void requestFocus() {
-      if (myFocusComponent != null) {
-        IdeFocusManager.getGlobalInstance().doWhenFocusSettlesDown(() -> IdeFocusManager.getGlobalInstance().requestFocus(myFocusComponent, true));
+      JComponent focusComponent = myFocusComponent.get();
+      if (focusComponent != null) {
+        IdeFocusManager.getGlobalInstance()
+          .doWhenFocusSettlesDown(() -> IdeFocusManager.getGlobalInstance().requestFocus(focusComponent, true));
       }
     }
 
     @Override
     public boolean requestDefaultFocus() {
-      return myFocusComponent != null && myFocusComponent.requestDefaultFocus();
+      JComponent focusComponent = myFocusComponent.get();
+      return focusComponent != null && focusComponent.requestDefaultFocus();
     }
 
     @Override


### PR DESCRIPTION
EditorComposite was setting the preferred focus component at construction
time by passing FileEditor#getPreferredFocusedComponent to the instance
of MyComponent it creates. Later on, when we request focus on the editor,
we will delegate to that component passed when creating MyComponent.

This would work fine if the preferred focus component never changes, but
that's not the case for some FileEditor implementations. For example, in
TextEditorWithPreview we return a different preferred focus component
depending on the current editor mode. In order to get the correct focus
component, we need to call FileEditor#getPreferredFocusedComponent again
whenever requesting focus on the EditorComposite.