### PR TITLE
Fixed scalability issues with static final array

### DIFF
--- a/java/java-impl/src/com/intellij/ide/fileTemplates/JavaCreateFromTemplateHandler.java
+++ b/java/java-impl/src/com/intellij/ide/fileTemplates/JavaCreateFromTemplateHandler.java
@@ -46,16 +46,16 @@ public class JavaCreateFromTemplateHandler implements CreateFromTemplateHandler 
     final PsiFile psiFile = PsiFileFactory.getInstance(project).createFileFromText(name, JavaLanguage.INSTANCE, content, false, false);
     psiFile.putUserData(PsiUtil.FILE_LANGUAGE_LEVEL_KEY, LanguageLevel.JDK_14_PREVIEW);
 
-    if (!(psiFile instanceof PsiJavaFile)){
-      throw new IncorrectOperationException("This template did not produce a Java class or an interface\n"+psiFile.getText());
+    if (!(psiFile instanceof PsiJavaFile)) {
+      throw new IncorrectOperationException("This template did not produce a Java class or an interface\n" + psiFile.getText());
     }
     PsiJavaFile psiJavaFile = (PsiJavaFile)psiFile;
     final PsiClass[] classes = psiJavaFile.getClasses();
     if (classes.length == 0) {
-      throw new IncorrectOperationException("This template did not produce a Java class or an interface\n"+psiFile.getText());
+      throw new IncorrectOperationException("This template did not produce a Java class or an interface\n" + psiFile.getText());
     }
     PsiClass createdClass = classes[0];
-    if(reformat){
+    if (reformat) {
       CodeStyleManager.getInstance(project).reformat(psiJavaFile);
     }
     String className = createdClass.getName();
@@ -82,7 +82,7 @@ public class JavaCreateFromTemplateHandler implements CreateFromTemplateHandler 
     else {
       PsiFile containingFile = addedElement.getContainingFile();
       throw new IncorrectOperationException("Selected class file name '" +
-                                            containingFile.getName() +  "' mapped to not java file type '"+
+                                            containingFile.getName() + "' mapped to not java file type '" +
                                             containingFile.getFileType().getDescription() + "'");
     }
   }
@@ -91,7 +91,7 @@ public class JavaCreateFromTemplateHandler implements CreateFromTemplateHandler 
     if (!template.isTemplateOfType(StdFileTypes.JAVA)) return;
 
     String packageName = (String)props.get(FileTemplate.ATTRIBUTE_PACKAGE_NAME);
-    if(packageName == null || packageName.length() == 0 || packageName.equals(FileTemplate.ATTRIBUTE_PACKAGE_NAME)){
+    if (packageName == null || packageName.length() == 0 || packageName.equals(FileTemplate.ATTRIBUTE_PACKAGE_NAME)) {
       PsiPackageStatement packageStatement = file.getPackageStatement();
       if (packageStatement != null) {
         packageStatement.delete();
@@ -102,7 +102,7 @@ public class JavaCreateFromTemplateHandler implements CreateFromTemplateHandler 
   @Override
   public boolean handlesTemplate(@NotNull FileTemplate template) {
     FileType fileType = FileTypeManagerEx.getInstanceEx().getFileTypeByExtension(template.getExtension());
-    return fileType.equals(StdFileTypes.JAVA) && !ArrayUtil.contains(template.getName(), JavaTemplateUtil.INTERNAL_FILE_TEMPLATES);
+    return fileType.equals(StdFileTypes.JAVA) && JavaTemplateUtil.INTERNAL_FILE_TEMPLATES.contains(template.getName());
   }
 
   @NotNull

--- a/java/java-impl/src/com/intellij/ide/fileTemplates/JavaInternalTemplatesHandler.java
+++ b/java/java-impl/src/com/intellij/ide/fileTemplates/JavaInternalTemplatesHandler.java
@@ -16,13 +16,12 @@
 package com.intellij.ide.fileTemplates;
 
 import com.intellij.psi.PsiDirectory;
-import com.intellij.util.ArrayUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class JavaInternalTemplatesHandler extends JavaCreateFromTemplateHandler {
   @Override
   public boolean handlesTemplate(@NotNull FileTemplate template) {
-    return ArrayUtil.contains(template.getName(), JavaTemplateUtil.INTERNAL_CLASS_TEMPLATES);
+    return JavaTemplateUtil.INTERNAL_CLASS_TEMPLATES.contains(template.getName());
   }
 
   @Override

--- a/java/java-impl/src/com/intellij/ide/fileTemplates/JavaTemplateUtil.java
+++ b/java/java-impl/src/com/intellij/ide/fileTemplates/JavaTemplateUtil.java
@@ -18,6 +18,8 @@ package com.intellij.ide.fileTemplates;
 import com.intellij.psi.*;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import static com.intellij.util.ObjectUtils.notNull;
@@ -42,18 +44,20 @@ public class JavaTemplateUtil {
   public static final String INTERNAL_ENUM_TEMPLATE_NAME = "Enum";
   public static final String INTERNAL_RECORD_TEMPLATE_NAME = "Record";
 
-  public static final String[] INTERNAL_CLASS_TEMPLATES = {
-    INTERNAL_CLASS_TEMPLATE_NAME, INTERNAL_INTERFACE_TEMPLATE_NAME, INTERNAL_ANNOTATION_TYPE_TEMPLATE_NAME, INTERNAL_ENUM_TEMPLATE_NAME,
-    INTERNAL_RECORD_TEMPLATE_NAME};
+  public static final List<String> INTERNAL_CLASS_TEMPLATES = Arrays
+    .asList(INTERNAL_CLASS_TEMPLATE_NAME, INTERNAL_INTERFACE_TEMPLATE_NAME, INTERNAL_ANNOTATION_TYPE_TEMPLATE_NAME,
+            INTERNAL_ENUM_TEMPLATE_NAME,
+            INTERNAL_RECORD_TEMPLATE_NAME);
 
   public static final String INTERNAL_PACKAGE_INFO_TEMPLATE_NAME = "package-info";
   public static final String INTERNAL_MODULE_INFO_TEMPLATE_NAME = "module-info";
 
-  public static final String[] INTERNAL_FILE_TEMPLATES = {INTERNAL_PACKAGE_INFO_TEMPLATE_NAME, INTERNAL_MODULE_INFO_TEMPLATE_NAME};
+  public static final List<String> INTERNAL_FILE_TEMPLATES =
+    Arrays.asList(INTERNAL_PACKAGE_INFO_TEMPLATE_NAME, INTERNAL_MODULE_INFO_TEMPLATE_NAME);
 
   private JavaTemplateUtil() { }
 
-  public static void setClassAndMethodNameProperties (@NotNull Properties properties, @NotNull PsiClass aClass, @NotNull PsiMethod method) {
+  public static void setClassAndMethodNameProperties(@NotNull Properties properties, @NotNull PsiClass aClass, @NotNull PsiMethod method) {
     properties.setProperty(FileTemplate.ATTRIBUTE_CLASS_NAME, notNull(aClass.getQualifiedName(), ""));
     properties.setProperty(FileTemplate.ATTRIBUTE_SIMPLE_CLASS_NAME, notNull(aClass.getName(), ""));
     properties.setProperty(FileTemplate.ATTRIBUTE_METHOD_NAME, method.getName());


### PR DESCRIPTION
Fixed scalability issues with static final array

If static final array is used in com.intellij.ide.fileTemplates.JavaTemplateUtil, and some judgments are made through this variable in other classes, then users will encounter some problems when creating files using file templates.

Take JavaTemplateUtil#INTERNAL_FILE_TEMPLATES as an example, in JavaCreateFromTemplateHandler#handlesTemplate, judge by INTERNAL_FILE_TEMPLATES, and then select CreateFromTemplateHandler. The final array failed to extend this judgment logic. Plugin developer users will not be able to customize package-info and module-info template files, because the return CreateFromTemplateHandler always is JavaCreateFromTemplateHandler, not DefaultCreateFromTemplateHandler that is right for  user define package-info