### PR TITLE
Use System.lineSeparator() instead of System.getProperty("line.separator")

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/messages/SheetController.java
+++ b/platform/platform-impl/src/com/intellij/ui/messages/SheetController.java
@@ -62,7 +62,7 @@ public final class SheetController implements Disposable {
 
   private static final int GAP_BETWEEN_BUTTONS = 5;
 
-  @NonNls private static final String SPACE_OR_LINE_SEPARATOR_PATTERN = "([\\s" + System.getProperty("line.separator") + "]|(<br\\s*/?>))+";
+  @NonNls private static final String SPACE_OR_LINE_SEPARATOR_PATTERN = "([\\s" + System.lineSeparator() + "]|(<br\\s*/?>))+";
 
   // SHEET
   public int SHEET_WIDTH = 400;

--- a/platform/testGuiFramework/src/com/intellij/testGuiFramework/fixtures/IdeFrameFixture.java
+++ b/platform/testGuiFramework/src/com/intellij/testGuiFramework/fixtures/IdeFrameFixture.java
@@ -853,7 +853,7 @@ public class IdeFrameFixture extends ComponentFixture<IdeFrameFixture, IdeFrameI
   // is 1 more than their parent.
   private static void printNode(XDebuggerTreeNode node, StringBuilder builder, int level, int numIndentSpaces) {
     if (builder.length() > 0) {
-      builder.append(System.getProperty("line.separator"));
+      builder.append(System.lineSeparator());
     }
     for (int i = 0; i < level * numIndentSpaces; ++i) {
       builder.append(' ');

--- a/platform/testGuiFramework/src/com/intellij/testGuiFramework/impl/GuiTestUtilKt.kt
+++ b/platform/testGuiFramework/src/com/intellij/testGuiFramework/impl/GuiTestUtilKt.kt
@@ -403,7 +403,7 @@ object GuiTestUtilKt {
       val messageBuilder = StringBuilder(errorMessage.message ?: "")
       val additionalInfo: String? = errorMessage.additionalInfo
       if (additionalInfo != null && additionalInfo.isNotEmpty())
-        messageBuilder.append(System.getProperty("line.separator")).append("Additional Info: ").append(additionalInfo)
+        messageBuilder.append(System.lineSeparator()).append("Additional Info: ").append(additionalInfo)
       val error = Error(messageBuilder.toString(), errorMessage.throwable)
       errors.add(error)
     }

--- a/platform/util/src/com/intellij/util/SystemProperties.java
+++ b/platform/util/src/com/intellij/util/SystemProperties.java
@@ -22,7 +22,7 @@ public final class SystemProperties {
   }
 
   public static String getLineSeparator() {
-    return System.getProperty("line.separator");
+    return System.lineSeparator();
   }
 
   /** @deprecated use {@link SystemInfo#OS_NAME} */

--- a/plugins/built-in-help/src/com/jetbrains/builtInHelp/indexer/HelpIndexer.kt
+++ b/plugins/built-in-help/src/com/jetbrains/builtInHelp/indexer/HelpIndexer.kt
@@ -40,9 +40,10 @@ internal constructor(indexDir: String) {
         val parsedDocument = Jsoup.parse(f, "UTF-8")
 
         val content = StringBuilder()
+        val lineSeparator = System.lineSeparator()
         parsedDocument.body().getElementsByClass("article")[0].children()
           .filterNot { it.hasAttr("data-swiftype-index") }
-          .forEach { content.append(it.text()).append(System.getProperty("line.separator")) }
+          .forEach { content.append(it.text()).append(lineSeparator) }
 
         doc.add(TextField("contents", content.toString(), Field.Store.YES))
         doc.add(StringField("filename", f.name, Field.Store.YES))

--- a/plugins/eclipse/src/org/jdom/output/EclipseNamespaceStack.java
+++ b/plugins/eclipse/src/org/jdom/output/EclipseNamespaceStack.java
@@ -71,9 +71,6 @@ import java.util.Stack;
  */
 public class EclipseNamespaceStack {
 
-    private static final String CVS_ID =
-      "@(#) $RCSfile: NamespaceStack.java,v $ $Revision: 1.13 $ $Date: 2004/02/06 09:28:32 $ $Name: jdom_1_0 $";
-
     /** The prefixes available */
     private final Stack prefixes;
 
@@ -144,10 +141,10 @@ public class EclipseNamespaceStack {
      */
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        String sep = System.getProperty("line.separator");
-        buf.append("Stack: " + prefixes.size() + sep);
+        String sep = System.lineSeparator();
+        buf.append("Stack: ").append(prefixes.size()).append(sep);
         for (int i = 0; i < prefixes.size(); i++) {
-            buf.append(prefixes.elementAt(i) + "&" + uris.elementAt(i) + sep);
+            buf.append(prefixes.elementAt(i)).append('&').append(uris.elementAt(i)).append(sep);
         }
         return buf.toString();
     }

--- a/plugins/junit5_rt_tests/test/com/intellij/junit5/JUnit5EventsTest.java
+++ b/plugins/junit5_rt_tests/test/com/intellij/junit5/JUnit5EventsTest.java
@@ -83,7 +83,6 @@ class JUnit5EventsTest {
     myExecutionListener.executionFinished(identifier, TestExecutionResult.failed(multipleFailuresError));
 
 
-    String lineSeparator = MapSerializerUtil.escapeStr(System.getProperty("line.separator"), MapSerializerUtil.STD_ESCAPER);
     Assertions.assertEquals("##teamcity[enteredTheMatrix]\n" +
                             "##teamcity[testStarted id='|[engine:testMethod|]' name='test1()' nodeId='|[engine:testMethod|]' parentNodeId='|[engine:testClass|]' locationHint='java:test://com.intellij.junit5.JUnit5EventsTest$TestClass/test1' metainfo='']\n" +
                             "##teamcity[testStdOut id='|[engine:testMethod|]' name='test1()' nodeId='|[engine:testMethod|]' parentNodeId='|[engine:testClass|]' out = 'timestamp = " + reportEntry.getTimestamp() + ", key1 = value1, stdout = out1|n']\n" +

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenConsole.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenConsole.java
@@ -32,7 +32,7 @@ import java.text.MessageFormat;
 import java.util.List;
 
 public abstract class MavenConsole {
-  private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+  private static final String LINE_SEPARATOR = System.lineSeparator();
   private final List<ProcessListener> myProcessListeners = new SmartList<>();
   private final List<AttachProcessListener> myAttachProcessListeners = new SmartList<>();
 

--- a/uast/uast-common/src/org/jetbrains/uast/internal/internalUastUtils.kt
+++ b/uast/uast-common/src/org/jetbrains/uast/internal/internalUastUtils.kt
@@ -19,7 +19,7 @@ import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiModifierListOwner
 import com.intellij.psi.PsiType
 
-internal val LINE_SEPARATOR = System.getProperty("line.separator") ?: "\n"
+internal val LINE_SEPARATOR = System.lineSeparator() ?: "\n"
 
 val String.withMargin: String
   get() = lines().joinToString(LINE_SEPARATOR) { "    " + it }


### PR DESCRIPTION
According to JavaDoc of `System.lineSeparator()` it always returns the initial value of `System.getProperty("line.separator")`. Unlike the latter `System.lineSeparator()` returns the value of field while `System.getProperty("line.separator")` gets its value from `Properties` or `CHM` (depending on Java version).
If we take this benchmark
```java
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@BenchmarkMode(value = Mode.AverageTime)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class LineSeparatorBenchmark {

  @Benchmark
  public String getProperty() {
    return System.getProperty("line.separator");
  }

  @Benchmark
  public String lineSeparator() {
    return System.lineSeparator();
  }

}
```
then without contention it gives
```
Benchmark                                                 Mode  Cnt   Score    Error   Units
LineSeparatorBenchmark.getProperty                        avgt    5   8.246 ±  2.154   ns/op
LineSeparatorBenchmark.lineSeparator                      avgt    5   2.508 ±  1.143   ns/op
```
With contention `getProperty` becomes slower:
```
2 threads

Benchmark                                                 Mode  Cnt   Score    Error   Units
LineSeparatorBenchmark.getProperty                        avgt    5   8.890 ±  2.049   ns/op
LineSeparatorBenchmark.lineSeparator                      avgt    5   2.663 ±  0.326   ns/op

4 threads

Benchmark                                                 Mode  Cnt   Score    Error   Units
LineSeparatorBenchmark.getProperty                        avgt    5  11.539 ±  7.983   ns/op
LineSeparatorBenchmark.lineSeparator                      avgt    5   2.758 ±  0.198   ns/op

6 threads

Benchmark                                                 Mode  Cnt   Score    Error   Units
LineSeparatorBenchmark.getProperty                        avgt    5  16.271 ±  2.127   ns/op
LineSeparatorBenchmark.lineSeparator                      avgt    5   3.094 ±  1.001   ns/op
```
Itself
```java
System.getProperty("line.separator");
```
is not very widely used, but it is delegated from `SystemProperties.getLineSeparator()` so I think this change might be useful especially for the cases of concurrent use.