### PR TITLE
Fix support for CREATE_EMPTY_DIRECTORIES

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ContentRootDataService.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ContentRootDataService.java
@@ -253,6 +253,11 @@ public class ContentRootDataService extends AbstractProjectDataService<ContentRo
                                                   @NotNull JpsModuleSourceRootType<?> sourceRootType,
                                                   boolean createEmptyContentRootDirectories) {
 
+    String path = sourceRoot.getPath();
+    if (createEmptyContentRootDirectories) {
+      createEmptyDirectory(path);
+    }
+
     SourceFolder folder = findSourceFolder(contentEntry, sourceRoot);
     if (folder != null) {
       final JpsModuleSourceRootType<?> folderRootType = folder.getRootType();
@@ -262,11 +267,7 @@ public class ContentRootDataService extends AbstractProjectDataService<ContentRo
       contentEntry.removeSourceFolder(folder);
     }
 
-    String path = sourceRoot.getPath();
     String url = pathToUrl(path);
-    if (createEmptyContentRootDirectories) {
-      createEmptyDirectory(path);
-    }
 
     if (!FileUtil.exists(path)) {
       logDebug("Source folder [%s] does not exist and will not be created, will add when dir is created", url);


### PR DESCRIPTION
When a source folder already exists in a content entry but not in
the file system, a duplicate source root is created.

This does not seem to happen in the way IDEA uses
CREATE_EMPTY_DIRECTORIES. We find it very useful in Android Studio
tests, but it produces duplicate source folders if importData
runs for an existing but empty project.

This change simply makes sure that if a directory should be created it is created 
before we test for its existence and not between the first test in findSourceFolder 
and the second test in addSourceFolder.

@vladsoroka 