### PR TITLE
Change "ToggleBookmarkAction" to respect selected text

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/bookmarks/actions/ToggleBookmarkAction.java
+++ b/platform/lang-impl/src/com/intellij/ide/bookmarks/actions/ToggleBookmarkAction.java
@@ -5,6 +5,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.ide.IdeBundle;
 import com.intellij.ide.bookmarks.BookmarkManager;
 import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
@@ -45,6 +46,8 @@ public class ToggleBookmarkAction extends BookmarksAction implements DumbAware, 
     final BookmarkInContextInfo info = getBookmarkInfo(e);
     if (info == null) return;
 
+    Editor editor = e.getData(CommonDataKeys.EDITOR);
+
     final boolean selected = info.getBookmarkAtPlace() != null;
     Toggleable.setSelected(e.getPresentation(), selected);
 
@@ -52,7 +55,12 @@ public class ToggleBookmarkAction extends BookmarksAction implements DumbAware, 
       BookmarkManager.getInstance(project).removeBookmark(info.getBookmarkAtPlace());
     }
     else {
-      BookmarkManager.getInstance(project).addTextBookmark(info.getFile(), info.getLine(), "");
+      if (editor != null) {
+        BookmarkManager.getInstance(project).addEditorBookmark(editor, info.getLine());
+      }
+      else {
+        BookmarkManager.getInstance(project).addTextBookmark(info.getFile(), info.getLine(), "");
+      }
     }
   }
 


### PR DESCRIPTION
When add bookmark via "Ctrl + mouse1" it uses selected text as bookmark's name. 
At the same time if you toggle bookmark with "ToggleBookmarkAction" (default hotkey 
is "F11") it doesn't respect selected text. This patch fixes this issue.

![image](https://user-images.githubusercontent.com/7687412/76173418-21f00700-61a8-11ea-9ad5-403852ee3fda.png)
