### PR TITLE
PY-41143: correct format for pydev_log call

### DIFF
--- a/python/helpers/pydev/pydevd_tracing.py
+++ b/python/helpers/pydev/pydevd_tracing.py
@@ -246,7 +246,7 @@ def set_trace_to_threads(tracing_func):
                 ctypes.py_object(None),
             )
             if result != 0:
-                pydev_log.info('Unable to set tracing for existing threads. Result: %s', result)
+                pydev_log.info('Unable to set tracing for existing threads. Result: %s' % result)
                 ret = result
     finally:
         if not IS_PY37_OR_GREATER:


### PR DESCRIPTION
Hi @avli 🙏 You forgot this occurrence while fixing similar cases. See 53bd8c07e5259407bb4029b73955c25522b4b520