### PR TITLE
Remove final keyword from ToolWindowHeadlessManagerImpl

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowHeadlessManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowHeadlessManagerImpl.java
@@ -32,7 +32,7 @@ import java.awt.event.InputEvent;
 import java.util.List;
 import java.util.*;
 
-public final class ToolWindowHeadlessManagerImpl extends ToolWindowManagerEx {
+public class ToolWindowHeadlessManagerImpl extends ToolWindowManagerEx {
   private final Map<String, ToolWindow> myToolWindows = new HashMap<>();
   private final Project myProject;
 


### PR DESCRIPTION
This was added incidentally by commit 983b3e7
breaking test doubles for the class.