### PR TITLE
Fix bug: Cannot updating rendered document.

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/documentation/render/DocRenderItem.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/documentation/render/DocRenderItem.java
@@ -269,6 +269,7 @@ class DocRenderItem {
         }
         foldingModel.removeFoldRegion(foldRegion);
         foldRegion = null;
+        textToRender = null;
       };
       if (foldingTasks == null) {
         foldingModel.runBatchFoldingOperation(foldingTask, true, false);


### PR DESCRIPTION
Fixed bug:
Sample code:
```java
package com.sample;

/**
 * before
 */
public class HelloWorld {
    public static void main(String[] args) {
        System.out.println("hello world");
    }
}
```
Reproducible method:
1.Click "Toggle Renderd View" button,then the Hello class document is correctly rendered as "before".(Only the first click after openning the file will render document correctly).
2.Click  "Toggle Renderd View" button again and change document "before" to "after".like this:
```java
package com.sample;

/**
 * after
 */
public class HelloWorld {
    public static void main(String[] args) {
        System.out.println("hello world");
    }
}
```
3.Click  "Toggle Renderd View" button again, You will see the incorrect rendered document "before".(Expect result is "after").