### PR TITLE
Don't use lazy methods to obtain tasks

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalProjectBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalProjectBuilderImpl.groovy
@@ -124,7 +124,7 @@ class ExternalProjectBuilderImpl extends AbstractModelBuilderService {
 
   static void addArtifactsData(final Project project, DefaultExternalProject externalProject) {
     final List<File> artifacts = new ArrayList<File>()
-    for (Jar jar : project.getTasks().withType(Jar.class)) {
+    project.getTasks().withType(Jar.class, { Jar jar ->
       try {
         if (is51OrBetter) {
           def archiveFile = jar.getArchiveFile()
@@ -140,7 +140,7 @@ class ExternalProjectBuilderImpl extends AbstractModelBuilderService {
         // TODO add reporting for such issues
         project.getLogger().error("warning: [task $jar.path] $e.message")
       }
-    }
+    })
     externalProject.setArtifacts(artifacts)
 
     def configurationsByName = project.getConfigurations().getAsMap()

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
@@ -37,9 +37,9 @@ class ExternalTestsModelBuilderImpl implements ModelBuilderService {
 
   private static List<ExternalTestSourceMapping> getMapping(Project project) {
     def taskToClassesDirs = new LinkedHashMap<Test, Set<String>>()
-    for (task in project.tasks.withType(Test.class)) {
+    project.tasks.withType(Test.class, { Test task ->
       taskToClassesDirs.put(task, getClassesDirs(task))
-    }
+    })
 
     def sourceSetContainer = JavaPluginUtil.getSourceSetContainer(project)
     if (sourceSetContainer == null) return Collections.emptyList()


### PR DESCRIPTION
Using these withType methods can cause ConcurrentModificationExceptions
as it is possible that the list returned to modified during the body of
the loops. This is since the returned collection is lazy and doesn't
force the creation of tasks. Instead we use a different overload of the
withType method that accepts a closure which ensures that all tasks of
the given type have already been created.

Currently it is also possible for these loops to miss tasks of the wanted
type as they have not being created yet.