### PR TITLE
IDEA-219227 adding a system property to provide optional default gradle distribution type

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleManager.java
@@ -125,15 +125,11 @@ public final class GradleManager
       DistributionType defaultDistributionType = null;
       final String defaultDistributionTypeValue = GradleEnvironment.GRADLE_DEFAULT_DISTRIBUTION_TYPE;
       if (defaultDistributionTypeValue != null) {
-        try {
-          defaultDistributionType = DistributionType.valueOf(defaultDistributionTypeValue);
-          LOG.info(String.format("Found gradle default distribution type: %s", defaultDistributionType));
-        } catch (final IllegalArgumentException e) {
-          LOG.warn(String.format(
-            "Exception occurred on attempt to parse gradle default distribution type property: %s",
-            defaultDistributionTypeValue
-          ), e);
-        }
+        defaultDistributionType = Arrays.stream(DistributionType.values())
+          .filter(v -> v.name().equals(defaultDistributionTypeValue))
+          .findFirst()
+          .orElse(null);
+        LOG.info("Found gradle default distribution type: " + defaultDistributionType);
       }
 
       final DistributionType distributionType;
@@ -151,7 +147,7 @@ public final class GradleManager
                               : defaultDistributionType)
                            : projectLevelSettings.getDistributionType();
       }
-      LOG.info(String.format("Instructing gradle to use distribution type: %s", distributionType));
+      LOG.info("Instructing gradle to use distribution type: " + distributionType);
 
       GradleExecutionSettings result = new GradleExecutionSettings(localGradlePath,
                                                                    settings.getServiceDirectoryPath(),

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleEnvironment.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleEnvironment.java
@@ -9,6 +9,7 @@ public class GradleEnvironment {
 
   @NonNls public static final boolean DEBUG_GRADLE_HOME_PROCESSING = Boolean.getBoolean("gradle.debug.home.processing");
   @NonNls public static final boolean ADJUST_USER_DIR = Boolean.getBoolean("gradle.adjust.userdir");
+  @NonNls public static final String GRADLE_DEFAULT_DISTRIBUTION_TYPE = System.getProperty("idea.gradle.default.distributionType");
 
   public static class Headless {
     @NonNls public static final String GRADLE_DISTRIBUTION_TYPE = System.getProperty("idea.gradle.distributionType");


### PR DESCRIPTION
This is a small change set to address issue mentioned in [IDEA-219227](https://youtrack.jetbrains.com/issue/IDEA-219227).

Initial idea was to adjust `org.jetbrains.plugins.gradle.service.settings.IdeaGradleSystemSettingsControlBuilder` UI component to render gradle distribution selection similar to `org.jetbrains.plugins.gradle.service.settings.IdeaGradleProjectSettingsControlBuilder`, but it turned out being pretty complicated and high risk change (to address update in message bus and listeners), as well as quite a refactoring to reuse component classes.

So instead I thought that just providing a new option system property to control default selection of distribution type which will be used if no distribution type is yet chosen, and it is absent - just fall back to previous behavior.