### PR TITLE
Linux launcher script: `exec` the Java binary

### DIFF
--- a/platform/build-scripts/resources/linux/scripts/executable-template.sh
+++ b/platform/build-scripts/resources/linux/scripts/executable-template.sh
@@ -205,7 +205,7 @@ fi
 # ---------------------------------------------------------------------
 IFS="$(printf '\n\t')"
 # shellcheck disable=SC2086
-"$JAVA_BIN" \
+exec "$JAVA_BIN" \
   -classpath "$CLASSPATH" \
   ${VM_OPTIONS} \
   "-XX:ErrorFile=$HOME/java_error_in___product_uc___%p.log" \


### PR DESCRIPTION
A bit of archaeology here:
- [initial version](../blob/7460e5adae69c7b17c951f1198a6b6900721a1ee/bin/idea.sh#L53) already used `exec`
- 8ba3c2533f498c45e5c37144898aa7979a2479a4 replaced it with a `while`-loop as part of the restart implementation
- e9254bf8d6b00453edf2a15f9b6fb5cf55fd5538 replaced the restart `while`-loop with `exec`-ing the launcher script itself
- e7571b78c0591e390cc25d6a2593fdb680d2635e changed the restart mechanics, resulting in the invocation of the Java process being once again the last action in the launcher script

So the current launcher is very similar to the initial one, but `exec` got lost somewhere down the road.