### PR TITLE
IDEA-238805 The classloader reference in a cached disabled icon prevents unloading of plugins

### DIFF
--- a/platform/util/ui/src/com/intellij/openapi/util/IconLoader.java
+++ b/platform/util/ui/src/com/intellij/openapi/util/IconLoader.java
@@ -562,7 +562,10 @@ public final class IconLoader {
     for (Map.Entry<Pair<String, Object>, CachedImageIcon> entry : new ArrayList<>(ourIconsCache.entrySet())) {
       entry.getValue().detachClassLoader(classLoader);
       if (entry.getKey().second == classLoader) {
-        ourIconsCache.remove(entry.getKey());
+        CachedImageIcon icon = ourIconsCache.remove(entry.getKey());
+        if (icon != null) {
+          ourIcon2DisabledIcon.remove(icon);
+        }
       }
     }
   }


### PR DESCRIPTION
`CachedImageIcon` has a field `myResolver` with the concrete type `MyUrlResolver`. That class has a field `myClassLoader` that is set to the plugin class loader. When the plugin creates a disabled icon for any reason, the plugin cannot be unloaded anymore.

In order to fix this, the existing `IconLoader.detachClassLoader` method is modified to remove the cached icon as well.