### PR TITLE
Enable configurable spotlight border.

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/options/ex/GlassPanel.java
+++ b/platform/platform-impl/src/com/intellij/openapi/options/ex/GlassPanel.java
@@ -21,6 +21,8 @@ public class GlassPanel extends JComponent {
   private final Set<JComponent> myLightComponents = new HashSet<>();
   private final JComponent myPanel;
   private static final Insets EMPTY_INSETS = new Insets(0, 0, 0, 0);
+  private static final JBColor SPOTLIGHT_BORDER_COLOR = JBColor.namedColor("Settings.Spotlight.borderColor",
+                                                                                   ColorUtil.toAlpha(JBColor.ORANGE, 100));
 
 
   public GlassPanel(JComponent containingPanel) {
@@ -75,7 +77,7 @@ public class GlassPanel extends JComponent {
         g2.fill(mask);
 
         g2.setStroke(new BasicStroke(stroke));
-        g2.setColor(ColorUtil.toAlpha(JBColor.ORANGE, 100));
+        g2.setColor(SPOTLIGHT_BORDER_COLOR);
         g2.draw(mask);
       }
       finally {

--- a/platform/platform-resources/src/themes/metadata/IntelliJPlatform.themeMetadata.json
+++ b/platform/platform-resources/src/themes/metadata/IntelliJPlatform.themeMetadata.json
@@ -623,6 +623,10 @@
       "key": "SearchMatch.startBackground"
     },
     {
+      "key": "Settings.Spotlight.borderColor",
+      "description": "The border around highlighted items when searching in the Settings menu."
+    },
+    {
       "key": "SidePanel.background",
       "description": "Left-side tree background in the Settings and Project Structure dialogs"
     },


### PR DESCRIPTION
## Description

Enables others to be able to customize the border around highlighted items when searching in the Settings menu.

## Screens
----
| Before Configuration | After Configuration |
|---------- | ------- |
| ![Screenshot from 2020-04-28 18-05-59](https://user-images.githubusercontent.com/15972415/80546895-6e6feb80-897c-11ea-9237-15f85d731f62.png) | ![Screenshot from 2020-04-28 18-04-33](https://user-images.githubusercontent.com/15972415/80546908-7d569e00-897c-11ea-8aa7-bf38f58a31a9.png) |

## More Info

I was able to build and run locally to test that my changes worked as expected, however I was not able to figure out how to run the tests. I don't know if I broke any tests.

Thanks!