### PR TITLE
PyCharm: add "View as ..." for geopandas GeoDataFrame/GeoSeries to the debugger

### DIFF
--- a/python/helpers/pydev/_pydevd_bundle/pydevd_thrift.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_thrift.py
@@ -611,8 +611,13 @@ def header_data_to_thrift_struct(rows, cols, dtypes, col_bounds, col_to_format, 
     return array_headers
 
 
-TYPE_TO_THRIFT_STRUCT_CONVERTERS = {"ndarray": array_to_thrift_struct, "DataFrame": dataframe_to_thrift_struct,
-                                    "Series": dataframe_to_thrift_struct}
+TYPE_TO_THRIFT_STRUCT_CONVERTERS = {
+    "ndarray": array_to_thrift_struct,
+    "DataFrame": dataframe_to_thrift_struct,
+    "Series": dataframe_to_thrift_struct,
+    "GeoDataFrame": dataframe_to_thrift_struct,
+    "GeoSeries": dataframe_to_thrift_struct
+}
 
 
 def table_like_struct_to_thrift_struct(array, name, roffset, coffset, rows, cols, format):

--- a/python/helpers/pydev/_pydevd_bundle/pydevd_vars.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_vars.py
@@ -714,7 +714,13 @@ def is_able_to_format_number(format):
     return True
 
 
-TYPE_TO_XML_CONVERTERS = {"ndarray": array_to_xml, "DataFrame": dataframe_to_xml, "Series": dataframe_to_xml}
+TYPE_TO_XML_CONVERTERS = {
+    "ndarray": array_to_xml,
+    "DataFrame": dataframe_to_xml,
+    "Series": dataframe_to_xml,
+    "GeoDataFrame": dataframe_to_xml,
+    "GeoSeries": dataframe_to_xml
+}
 
 
 def table_like_struct_to_xml(array, name, roffset, coffset, rows, cols, format):

--- a/python/pluginResources/messages/PyBundle.properties
+++ b/python/pluginResources/messages/PyBundle.properties
@@ -834,6 +834,7 @@ debugger.data.view.resize.automatically=Resize Automatically
 debugger.data.view.colored.cells=Colored cells
 debugger.numeric.view.as.dataframe=View as DataFrame
 debugger.numeric.view.as.array=View as Array
+debugger.numeric.view.as.series=View as Series
 debugger.stepping.filter=Stepping Filter
 debugger.stepping.filter.specify.pattern=Specify glob pattern ('*', '?' and '[seq]' allowed, semicolon ';' as name separator):
 debugger.stepping.no.script.filters=No script filters configured

--- a/python/pydevSrc/com/jetbrains/python/debugger/PyDebugValue.java
+++ b/python/pydevSrc/com/jetbrains/python/debugger/PyDebugValue.java
@@ -26,7 +26,13 @@ public class PyDebugValue extends XNamedValue {
   private static final Logger LOG = Logger.getInstance(PyDebugValue.class);
   private static final String DATA_FRAME = "DataFrame";
   private static final String SERIES = "Series";
-  private static final Map<String, String> EVALUATOR_POSTFIXES = ImmutableMap.of("ndarray", "Array", DATA_FRAME, DATA_FRAME, SERIES, SERIES);
+  private static final Map<String, String> EVALUATOR_POSTFIXES = ImmutableMap.of(
+    "ndarray", "Array",
+    DATA_FRAME, DATA_FRAME,
+    SERIES, SERIES,
+    "GeoDataFrame", DATA_FRAME,
+    "GeoSeries", SERIES
+    );
   private static final int MAX_ITEMS_TO_HANDLE = 100;
   public static final int MAX_VALUE = 256;
   public static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();

--- a/python/src/com/jetbrains/python/debugger/containerview/DataViewStrategy.java
+++ b/python/src/com/jetbrains/python/debugger/containerview/DataViewStrategy.java
@@ -30,7 +30,13 @@ import java.util.Set;
 
 public abstract class DataViewStrategy {
   private static class StrategyHolder {
-    private static final Set<DataViewStrategy> STRATEGIES = ImmutableSet.of(new ArrayViewStrategy(), new DataFrameViewStrategy(), new SeriesViewStrategy());
+    private static final Set<DataViewStrategy> STRATEGIES = ImmutableSet.of(
+      new ArrayViewStrategy(),
+      DataFrameViewStrategy.createInstanceForDataFrame(),
+      DataFrameViewStrategy.createInstanceForGeoDataFrame(),
+      SeriesViewStrategy.createInstanceForSeries(),
+      SeriesViewStrategy.createInstanceForGeoSeries()
+    );
   }
 
   public abstract AsyncArrayTableModel createTableModel(int rowCount, int columnCount, @NotNull PyDataViewerPanel panel, @NotNull PyDebugValue debugValue);

--- a/python/src/com/jetbrains/python/debugger/containerview/PyViewNumericContainerAction.java
+++ b/python/src/com/jetbrains/python/debugger/containerview/PyViewNumericContainerAction.java
@@ -71,8 +71,12 @@ public class PyViewNumericContainerAction extends XDebuggerTreeActionBase {
           e.getPresentation().setText(PyBundle.message("debugger.numeric.view.as.array"));
           e.getPresentation().setVisible(true);
         }
-        else if (("DataFrame".equals(nodeType))) {
+        else if ("DataFrame".equals(nodeType) || "GeoDataFrame".equals(nodeType)) {
           e.getPresentation().setText(PyBundle.message("debugger.numeric.view.as.dataframe"));
+          e.getPresentation().setVisible(true);
+        }
+        else if ("Series".equals(nodeType) || "GeoSeries".equals(nodeType)) {
+          e.getPresentation().setText(PyBundle.message("debugger.numeric.view.as.series"));
           e.getPresentation().setVisible(true);
         }
         else {

--- a/python/src/com/jetbrains/python/debugger/dataframe/DataFrameViewStrategy.java
+++ b/python/src/com/jetbrains/python/debugger/dataframe/DataFrameViewStrategy.java
@@ -10,7 +10,22 @@ import com.jetbrains.python.debugger.containerview.PyDataViewerPanel;
 import org.jetbrains.annotations.NotNull;
 
 public class DataFrameViewStrategy extends DataViewStrategy {
-  private static final String DATA_FRAME = "DataFrame";
+
+  private final String myTypeName;
+
+  @NotNull
+  public static DataFrameViewStrategy createInstanceForDataFrame(){
+    return new DataFrameViewStrategy("DataFrame");
+  }
+
+  @NotNull
+  public static DataFrameViewStrategy createInstanceForGeoDataFrame(){
+    return new DataFrameViewStrategy("GeoDataFrame");
+  }
+
+  protected DataFrameViewStrategy(@NotNull final String typeName){
+    this.myTypeName = typeName;
+  }
 
   @Override
   public AsyncArrayTableModel createTableModel(int rowCount, int columnCount, @NotNull PyDataViewerPanel dataProvider, @NotNull PyDebugValue debugValue) {
@@ -30,6 +45,6 @@ public class DataFrameViewStrategy extends DataViewStrategy {
   @NotNull
   @Override
   public String getTypeName() {
-    return DATA_FRAME;
+    return myTypeName;
   }
 }

--- a/python/src/com/jetbrains/python/debugger/dataframe/SeriesViewStrategy.java
+++ b/python/src/com/jetbrains/python/debugger/dataframe/SeriesViewStrategy.java
@@ -18,10 +18,19 @@ package com.jetbrains.python.debugger.dataframe;
 import org.jetbrains.annotations.NotNull;
 
 public class SeriesViewStrategy extends DataFrameViewStrategy {
+
+  protected SeriesViewStrategy(@NotNull final String typeName){
+    super(typeName);
+  }
+
   @NotNull
-  @Override
-  public String getTypeName() {
-    return "Series";
+  public static SeriesViewStrategy createInstanceForSeries(){
+    return new SeriesViewStrategy("Series");
+  }
+
+  @NotNull
+  public static SeriesViewStrategy createInstanceForGeoSeries(){
+    return new SeriesViewStrategy("GeoSeries");
   }
 
   @Override


### PR DESCRIPTION
## add "View as ..." for geopandas GeoDataFrame/GeoSeries to the debugger

Allows to display `geopandas` types `GeoDataFrame` and `GeoSeries` like the `panda` types `DataFrame` and `Series` in the `PyDataView`. 
See: https://www.jetbrains.com/help/pycharm/viewing-as-array.html

There is also a feature request: https://youtrack.jetbrains.com/issue/PY-31705

## Issues
- I couldn't add new unit tests to `PythonDataViewerTest`, because I haven't found the place where I need to add `geopandas`.
- I decided to re-use the labels `View as DataFrame`/`View as Series` for `GeoDataFrame`/`GeoSeries` in the debugger view. But if required I can add the labels `View as GeoDataFrame`/`View as GeoSeries`. 
- The changes in `pydevd_thrift.py` are not tested. I added these changes to be symmetrical with the changes in `pydevd_vars.py`. Is there a way to test the changes in `pydevd_thrift.py` with the Community Edition?
- I'm unsure if more changes are required in the `_pydevd_bundle` files to fully support `GeoDataFrame` and `GeoSeries` (for example the different `shapely.geometry` types). 