### PR TITLE
Shell: Use resolve scope provider instead of static scope

### DIFF
--- a/plugins/sh/resources/META-INF/plugin.xml
+++ b/plugins/sh/resources/META-INF/plugin.xml
@@ -21,6 +21,7 @@ Adds support for working with shell script files
     <lang.commenter id="shCommenter" language="Shell Script" implementationClass="com.intellij.sh.ShCommenter"/>
     <lang.quoteHandler id="shQuoteHandler" language="Shell Script" implementationClass="com.intellij.sh.ShQuoteHandler"/>
     <lang.findUsagesProvider id="shFindUsagesProvider" language="Shell Script" implementationClass="com.intellij.sh.codeInsight.ShFindUsagesProvider"/>
+    <resolveScopeProvider id="shResolveScopeProvider" implementation="com.intellij.sh.psi.impl.ShResolveScopeProvider"/>
     <lang.elementManipulator id="shLiteralManipulator" forClass="com.intellij.sh.psi.ShLiteral"
                              implementationClass="com.intellij.sh.psi.manipulator.ShLiteralManipulator" />
     <editor.backspaceModeOverride id="shBackspaceModeOverride" language="Shell Script" implementationClass="com.intellij.sh.ShBackspaceModeOverride"/>

--- a/plugins/sh/src/com/intellij/sh/psi/impl/ShCompositeElementImpl.java
+++ b/plugins/sh/src/com/intellij/sh/psi/impl/ShCompositeElementImpl.java
@@ -37,11 +37,6 @@ public class ShCompositeElementImpl extends ASTWrapperPsiElement implements ShCo
   }
 
   @Override
-  public @NotNull GlobalSearchScope getResolveScope() {
-    return GlobalSearchScope.fileScope(getContainingFile());
-  }
-
-  @Override
   public @NotNull SearchScope getUseScope() {
     return GlobalSearchScope.fileScope(getContainingFile());
   }

--- a/plugins/sh/src/com/intellij/sh/psi/impl/ShResolveScopeProvider.java
+++ b/plugins/sh/src/com/intellij/sh/psi/impl/ShResolveScopeProvider.java
@@ -1,0 +1,22 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.sh.psi.impl;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.ResolveScopeProvider;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.sh.ShFileType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+
+public class ShResolveScopeProvider extends ResolveScopeProvider {
+  @Override
+  public @Nullable GlobalSearchScope getResolveScope(@NotNull VirtualFile file, Project project) {
+    if (file.getFileType() instanceof ShFileType) {
+      return GlobalSearchScope.fileScope(project, file);
+    }
+    return null;
+  }
+}

--- a/plugins/sh/tests/com/intellij/sh/psi/impl/ShResolveScopeProviderTest.java
+++ b/plugins/sh/tests/com/intellij/sh/psi/impl/ShResolveScopeProviderTest.java
@@ -1,0 +1,16 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.sh.psi.impl;
+
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.util.Collections;
+
+public class ShResolveScopeProviderTest extends BasePlatformTestCase {
+  public void testResolveScopeShell() {
+    PsiFile file = myFixture.configureByText("test.sh", "");
+    GlobalSearchScope expected = GlobalSearchScope.filesScope(getProject(), Collections.singletonList(file.getVirtualFile()));
+    assertEquals(expected, file.getResolveScope());
+  }
+}


### PR DESCRIPTION
Use a resolve scope provider to provide the resolve scope to allow other extensions to use resolve scope enlargers. 
The current implementation returned a static scope and thus disabled the use of enlargers.