### PR TITLE
IDEA-238860 Fix the loading of some GitHub Pull Request details

### DIFF
--- a/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt
+++ b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt
@@ -32,7 +32,7 @@ class GHPRChangesProviderImpl(private val repository: GitRepository,
     diffDataByChange = THashMap(object : TObjectHashingStrategy<Change> {
       override fun equals(o1: Change?, o2: Change?) = o1 == o2 &&
                                                       o1?.beforeRevision == o2?.beforeRevision &&
-                                                      o2?.afterRevision == o2?.afterRevision
+                                                      o1?.afterRevision == o2?.afterRevision
 
       override fun computeHashCode(change: Change?) = Objects.hash(change, change?.beforeRevision, change?.afterRevision)
     })


### PR DESCRIPTION
## Problem

The [IDEA-238860](https://youtrack.jetbrains.com/issue/IDEA-238860) bug should occur when viewing [this Pull Request](https://github.com/stephaneseng/intellij-idea-238860/pull/2) when the [stephaneseng/intellij-idea-238860](https://github.com/stephaneseng/intellij-idea-238860) repository is cloned into `/tmp/stephaneseng/intellij-idea-238860` (case-sensitive path; tested on Ubuntu 18.04 with Java 1.8.0_201 x64 and on Debian 10 with Java 1.8.0_251 x64).

On master (at commit [8f29886](https://github.com/JetBrains/intellij-community/commit/8f29886f00ec138cf37dd12ad4ebb66178954a0b)), the following error message is displayed:

![master-Before](https://user-images.githubusercontent.com/2598210/80915215-2c1a2600-8d51-11ea-8bcf-2f6139a52314.png)

This error message is also displayed on 201.7223 (at commit [40e5005](https://github.com/JetBrains/intellij-community/commit/40e5005d02df57f58ac2d498867446c43d61101f)):

![201.7223-Before](https://user-images.githubusercontent.com/2598210/80915285-9763f800-8d51-11ea-85e4-23f15e7b24e9.png)

## Cause

The cause of this problem can be found by debugging into [GHPRChangesProviderImpl](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt) when Pull Request details are loaded:

### 1. At [GHPRChangesProviderImpl.kt#L32-L38](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt#L32-L38)

`diffDataByChange: THashMap<Change, GHPRChangeDiffData>` is initialized.  
This data structure will have a capacity of 7 and a maxSize of 6 at the first insertion, as determined at [TObjectHash.java#L220](https://github.com/JetBrains/intellij-deps-trove4j/blob/master/core/src/main/java/gnu/trove/TObjectHash.java#L220).

### 2. Then, at [GHPRChangesProviderImpl.kt#L46-L83](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt#L46-L83)

For each file change of each commit, a [GHPRChangeDiffData.Commit](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangeDiffData.kt#L112) is stored in `diffDataByChange`, indexed by [Change](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/platform/vcs-api/vcs-api-core/src/com/intellij/openapi/vcs/changes/Change.java#L23).

For [this Pull Request](https://github.com/stephaneseng/intellij-idea-238860/pull/2), here are the resulting 5 different `diffDataByChange` keys:

```
diffDataByChange = {THashMap@26327}  size = 5
 key = {Change@26337} "M: /tmp/stephaneseng/intellij-idea-238860/1"
  myBeforeRevision = {GitContentRevision@27022} "/tmp/stephaneseng/intellij-idea-238860/1"
   myRevision = {GitRevisionNumber@27667} "872bbef039f66e7647d52fc40e9c4ba80c02403a"
  myAfterRevision = {GitContentRevision@27023} "/tmp/stephaneseng/intellij-idea-238860/1"
   myRevision = {GitRevisionNumber@27661} "3678fa02f0d733d1aa5402129751782e49ecdaba"
 key = {Change@26339} "M: /tmp/stephaneseng/intellij-idea-238860/1"
  myBeforeRevision = {GitContentRevision@27018} "/tmp/stephaneseng/intellij-idea-238860/1"
   myRevision = {GitRevisionNumber@27675} "3678fa02f0d733d1aa5402129751782e49ecdaba"
  myAfterRevision = {GitContentRevision@27019} "/tmp/stephaneseng/intellij-idea-238860/1"
   myRevision = {GitRevisionNumber@27671} "fff374c7f24ebf30b1092919310c139f38eaa106"
 key = {Change@26341} "M: /tmp/stephaneseng/intellij-idea-238860/2"
  myBeforeRevision = {GitContentRevision@27014} "/tmp/stephaneseng/intellij-idea-238860/2"
   myRevision = {GitRevisionNumber@27679} "872bbef039f66e7647d52fc40e9c4ba80c02403a"
  myAfterRevision = {GitContentRevision@27015} "/tmp/stephaneseng/intellij-idea-238860/2"
   myRevision = {GitRevisionNumber@27683} "3678fa02f0d733d1aa5402129751782e49ecdaba"
 key = {Change@26343} "M: /tmp/stephaneseng/intellij-idea-238860/3"
  myBeforeRevision = {GitContentRevision@27010} "/tmp/stephaneseng/intellij-idea-238860/3"
   myRevision = {GitRevisionNumber@27691} "872bbef039f66e7647d52fc40e9c4ba80c02403a"
  myAfterRevision = {GitContentRevision@27011} "/tmp/stephaneseng/intellij-idea-238860/3"
   myRevision = {GitRevisionNumber@27687} "3678fa02f0d733d1aa5402129751782e49ecdaba"
 key = {Change@26345} "M: /tmp/stephaneseng/intellij-idea-238860/4"
  myBeforeRevision = {GitContentRevision@27006} "/tmp/stephaneseng/intellij-idea-238860/4"
   myRevision = {GitRevisionNumber@27699} "872bbef039f66e7647d52fc40e9c4ba80c02403a"
  myAfterRevision = {GitContentRevision@27007} "/tmp/stephaneseng/intellij-idea-238860/4"
   myRevision = {GitRevisionNumber@27695} "3678fa02f0d733d1aa5402129751782e49ecdaba"
```

### 3. Then, at [GHPRChangesProviderImpl.kt#L91-L109](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt#L91-L109)

[GHPRChangeDiffData.Cumulative](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangeDiffData.kt#L174) objects are created and stored in `diffDataByChange`, also indexed by Change.

For [this Pull Request](https://github.com/stephaneseng/intellij-idea-238860/pull/2), the first Change object to index is:

```
change = {Change@26977} "M: /tmp/stephaneseng/intellij-idea-238860/1"
 myBeforeRevision = {GitContentRevision@26993} "/tmp/stephaneseng/intellij-idea-238860/1"
  myRevision = {GitRevisionNumber@27707} "872bbef039f66e7647d52fc40e9c4ba80c02403a"
 myAfterRevision = {GitContentRevision@26994} "/tmp/stephaneseng/intellij-idea-238860/1"
  myRevision = {GitRevisionNumber@27703} "fff374c7f24ebf30b1092919310c139f38eaa106"
```

However, when this new Change key is put in `diffDataByChange` at [GHPRChangesProviderImpl.kt#L104](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt#L104), [THashMap#put(Change, GHPRChangeDiffData)](https://github.com/JetBrains/intellij-deps-trove4j/blob/master/core/src/main/java/gnu/trove/THashMap.java#L159) triggers a [THashMap#rehash(int)](https://github.com/JetBrains/intellij-deps-trove4j/blob/master/core/src/main/java/gnu/trove/THashMap.java#L334) as `diffDataByChange` now reached 6 different keys.

The goal of this rehash operation is to increase the capacity of this THashMap from 7 to 17.  
To do so, all existing THashMap entries are put into new keys and values arrays of the new capacity, at new indexes evaluated at [THashMap.java#L345](https://github.com/JetBrains/intellij-deps-trove4j/blob/c08db9d834c03142d11435369446a978056c0da3/core/src/main/java/gnu/trove/THashMap.java#L345) by [TObjectHash#insertionIndex(Change)](https://github.com/JetBrains/intellij-deps-trove4j/blob/master/core/src/main/java/gnu/trove/TObjectHash.java#L218).

Also, during this rehash operation, it is natural that all existing THashMap keys must be kept into the expanded THashMap by having distinct new indexes: This rule is enforced by this condition [THashMap.java#L346-L348](https://github.com/JetBrains/intellij-deps-trove4j/blob/c08db9d834c03142d11435369446a978056c0da3/core/src/main/java/gnu/trove/THashMap.java#L346-L348).

However, with the current Pull Request, 2 existing Changes are assignated to the same new index even though they are different:

```
{Change@26337} "M: /tmp/stephaneseng/intellij-idea-238860/1"
 myBeforeRevision = {GitContentRevision@27022} "/tmp/stephaneseng/intellij-idea-238860/1"
  myRevision = {GitRevisionNumber@27667} "872bbef039f66e7647d52fc40e9c4ba80c02403a"
 myAfterRevision = {GitContentRevision@27023} "/tmp/stephaneseng/intellij-idea-238860/1"
  myRevision = {GitRevisionNumber@27661} "3678fa02f0d733d1aa5402129751782e49ecdaba"
```

And:

```
{Change@26977} "M: /tmp/stephaneseng/intellij-idea-238860/1"
 myBeforeRevision = {GitContentRevision@26993} "/tmp/stephaneseng/intellij-idea-238860/1"
  myRevision = {GitRevisionNumber@27707} "872bbef039f66e7647d52fc40e9c4ba80c02403a"
 myAfterRevision = {GitContentRevision@26994} "/tmp/stephaneseng/intellij-idea-238860/1"
  myRevision = {GitRevisionNumber@27703} "fff374c7f24ebf30b1092919310c139f38eaa106"
```

This is because, before [TObjectHash#insertionIndex(Change)](https://github.com/JetBrains/intellij-deps-trove4j/blob/master/core/src/main/java/gnu/trove/TObjectHash.java#L218) considers that a key is already present it perfoms an equals check at [TObjectHash.java#L231](https://github.com/JetBrains/intellij-deps-trove4j/blob/c08db9d834c03142d11435369446a978056c0da3/core/src/main/java/gnu/trove/TObjectHash.java#L231) but an error in [diffDataByChange#equals(Change, Change)](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt#L33-L35) causes these 2 Changes to be wrongly considered equal.

Indeed, even though these 2 Changes have different afterRevisions (`3678fa0` and `fff374c7`), this difference is ignored by [diffDataByChange#equals(Change, Change)](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt#L33-L35).

## Resolution proposition

Fixing the [diffDataByChange#equals(Change, Change)](https://github.com/JetBrains/intellij-community/blob/8f29886f00ec138cf37dd12ad4ebb66178954a0b/plugins/github/src/org/jetbrains/plugins/github/pullrequest/data/GHPRChangesProviderImpl.kt#L33-L35) implementation is enough to solve this bug, allowing [this Pull Request](https://github.com/stephaneseng/intellij-idea-238860/pull/2) to be loaded:

![master-After](https://user-images.githubusercontent.com/2598210/80915777-c4fe7080-8d54-11ea-9a6e-a8a82f707441.png)
