### PR TITLE
PY-41471: Verify that the plugin whitelist file exists before reading it

### DIFF
--- a/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/DistributionJARsBuilder.groovy
+++ b/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/DistributionJARsBuilder.groovy
@@ -683,8 +683,12 @@ class DistributionJARsBuilder {
       def pluginsDirectoryName = "${buildContext.applicationInfo.productCode}-plugins"
       def nonBundledPluginsArtifacts = "$buildContext.paths.artifacts/$pluginsDirectoryName"
       def pluginsToIncludeInCustomRepository = new ArrayList<PluginRepositorySpec>()
-      def whiteList = new File("$buildContext.paths.communityHome/../build/plugins-autoupload-whitelist.txt").readLines()
-        .stream().map { it.trim() }.filter { !it.isEmpty() && !it.startsWith("//") }.collect(Collectors.toSet())
+      def whiteListFile = new File("$buildContext.paths.communityHome/../build/plugins-autoupload-whitelist.txt")
+
+      HashSet whiteList = new HashSet()
+      if (whiteListFile.exists()) {
+        whiteList = whiteListFile.readLines().stream().map { it.trim() }.filter { !it.isEmpty() && !it.startsWith("//") }.collect(Collectors.toSet())
+      }
 
       pluginsToPublish.each { plugin ->
         def includeInCustomRepository = productLayout.prepareCustomPluginRepositoryForPublishedPlugins


### PR DESCRIPTION
Spent a bit too long using git bisect to find, this, probably should have just searched for the file in the code and found the bug. Anyway this file is not created anywhere in community builds, and i assume you didn't catch it due to already having the file on your system. This PR just checks that the file exists before trying to read it.

I have tested ant build with a linux target in the python directory and it worked.