### PR TITLE
Allow InspectionTool description through InspectionToolEntry

### DIFF
--- a/platform/analysis-api/src/com/intellij/codeInspection/ex/InspectionToolWrapper.java
+++ b/platform/analysis-api/src/com/intellij/codeInspection/ex/InspectionToolWrapper.java
@@ -164,7 +164,7 @@ public abstract class InspectionToolWrapper<T extends InspectionProfileEntry, E 
     if (description != null) return description;
     try {
       InputStream descriptionStream = getDescriptionStream();
-      return descriptionStream != null ? ResourceUtil.loadText(descriptionStream) : null;
+      return descriptionStream != null ? ResourceUtil.loadText(descriptionStream) : getTool().loadDescription();
     }
     catch (IOException ignored) { }
 


### PR DESCRIPTION
Currently, the function loadDescription either loads the description from Resource or returns null if the variable description is not null. 
The intended use-case is when plugin authors want to describe their Inspection with HTML Strings with either 3rd party libs that render to HTML strings or else. 
This option allows maintaining those descriptions in typed values rather than maintaining a bunch of folders and files.
