### PR TITLE
PY-42270 Don't detach when 'inspect' flag is set

### DIFF
--- a/python/helpers/pydev/_pydevd_bundle/pydevd_breakpoints.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_breakpoints.py
@@ -120,8 +120,9 @@ def stop_on_unhandled_exception(py_db, thread, additional_info, arg):
     else:
         exception_breakpoint = None
 
-    original_excepthook(exctype, value, tb)
-    disable_excepthook()  # Avoid printing the exception for the second time.
+    if not sys.flags.inspect:
+        original_excepthook(exctype, value, tb)
+        disable_excepthook()  # Avoid printing the exception for the second time.
 
     if not exception_breakpoint:
         return
@@ -174,12 +175,14 @@ def _fallback_excepthook(exctype, value, tb):
             additional_info = getattr(thread, 'additional_info', None)
             if not thread or additional_info is None:
                 return
-            debugger.disable_tracing()
+            if not sys.flags.inspect:
+                debugger.disable_tracing()
             stop_on_unhandled_exception(debugger, thread, additional_info, (exctype, value, tb))
     finally:
         if sys.excepthook != dummy_excepthook:
             original_excepthook(exctype, value, tb)
-        sys.exit(1)
+        if not sys.flags.inspect:
+            sys.exit(1)
 
 
 def set_fallback_excepthook():

--- a/python/helpers/pydev/pydevd.py
+++ b/python/helpers/pydev/pydevd.py
@@ -1206,9 +1206,10 @@ class PyDB(object):
         pydevd_vars.add_additional_frame_by_id(thread_id, frames_byid)
         exctype, value, tb = arg
         tb = pydevd_utils.get_top_level_trace_in_project_scope(tb)
-        if sys.excepthook != dummy_excepthook:
-            original_excepthook(exctype, value, tb)
-        disable_excepthook()  # Avoid printing the exception for the second time.
+        if not sys.flags.inspect:
+            if sys.excepthook != dummy_excepthook:
+                original_excepthook(exctype, value, tb)
+            disable_excepthook()  # Avoid printing the exception for the second time.
         try:
             try:
                 add_exception_to_frame(frame, arg)


### PR DESCRIPTION
When handling uncaught exceptions, don't detach the debugger, exit
the process, or reset the excepthook when sys.flags.inspect (Py_InspectFlag)
is set.