### PR TITLE
[IDEA-241080] Fix issue with 'I do mind' showing up as path

### DIFF
--- a/plugins/sh/src/com/intellij/sh/formatter/ShExternalFormatter.java
+++ b/plugins/sh/src/com/intellij/sh/formatter/ShExternalFormatter.java
@@ -73,7 +73,7 @@ public class ShExternalFormatter implements ExternalFormatProcessor {
 
     ShCodeStyleSettings shSettings = settings.getCustomSettings(ShCodeStyleSettings.class);
     String shFmtExecutable = ShSettings.getShfmtPath();
-    if (ShSettings.I_DO_MIND.equals(shFmtExecutable)) return;
+    if (ShSettings.PLACEHOLDER.equals(shFmtExecutable)) return;
 
     if (!ShShfmtFormatterUtil.isValidPath(shFmtExecutable)) {
       String groupId = NotificationGroup.createIdWithTitle("Shell Script", ShBundle.message("sh.title.case"));
@@ -93,7 +93,7 @@ public class ShExternalFormatter implements ExternalFormatProcessor {
         }));
       notification.addAction(NotificationAction.createSimple(ShBundle.messagePointer("sh.fmt.no.thanks"), () -> {
         notification.expire();
-        ShSettings.setShfmtPath(ShSettings.I_DO_MIND);
+        ShSettings.setShfmtPath(ShSettings.PLACEHOLDER);
       }));
       Notifications.Bus.notify(notification);
       return;

--- a/plugins/sh/src/com/intellij/sh/formatter/ShShfmtFormatterUtil.java
+++ b/plugins/sh/src/com/intellij/sh/formatter/ShShfmtFormatterUtil.java
@@ -104,7 +104,7 @@ public class ShShfmtFormatterUtil {
 
   public static boolean isValidPath(@Nullable String path) {
     if (path == null) return false;
-    if (ShSettings.I_DO_MIND.equals(path)) return true;
+    if (ShSettings.PLACEHOLDER.equals(path)) return true;
     File file = new File(path);
     if (!file.canExecute()) return false;
     return file.getName().contains(SHFMT);

--- a/plugins/sh/src/com/intellij/sh/settings/ShSettings.java
+++ b/plugins/sh/src/com/intellij/sh/settings/ShSettings.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ShSettings {
-  public static final String I_DO_MIND = "I do mind";
+  public static final String PLACEHOLDER = "Placeholder";
 
   private static final String SHELLCHECK_PATH = "SHELLCHECK.PATH";
   private static final String SHFMT_PATH = "SHFMT.PATH";

--- a/plugins/sh/src/com/intellij/sh/shellcheck/ShShellcheckUtil.java
+++ b/plugins/sh/src/com/intellij/sh/shellcheck/ShShellcheckUtil.java
@@ -113,14 +113,14 @@ class ShShellcheckUtil {
   }
 
   static boolean isExecutionValidPath(@Nullable String path) {
-    if (path == null || ShSettings.I_DO_MIND.equals(path)) return false;
+    if (path == null || ShSettings.PLACEHOLDER.equals(path)) return false;
     File file = new File(path);
     return file.canExecute() && file.getName().contains(SHELLCHECK);
   }
 
   static boolean isValidPath(@Nullable String path) {
     if (path == null) return false;
-    if (ShSettings.I_DO_MIND.equals(path)) return true;
+    if (ShSettings.PLACEHOLDER.equals(path)) return true;
     File file = new File(path);
     return file.canExecute() && file.getName().contains(SHELLCHECK);
 
@@ -134,6 +134,11 @@ class ShShellcheckUtil {
 //      LOG.debug("Exception in process execution", e);
 //    }
 //    return false;
+  }
+
+  static boolean isPlaceholder(@Nullable String path) {
+    if (ShSettings.PLACEHOLDER.equals(path)) return true;
+    return false;
   }
 
   @NotNull

--- a/plugins/sh/src/com/intellij/sh/shellcheck/ShellcheckOptionsPanel.java
+++ b/plugins/sh/src/com/intellij/sh/shellcheck/ShellcheckOptionsPanel.java
@@ -48,14 +48,17 @@ public class ShellcheckOptionsPanel {
       protected void textChanged(@NotNull DocumentEvent documentEvent) {
         String shellcheckPath = myShellcheckSelector.getText();
         ShSettings.setShellcheckPath(shellcheckPath);
-        myWarningPanel.setVisible(!ShShellcheckUtil.isValidPath(shellcheckPath));
+        myWarningPanel.setVisible(!ShShellcheckUtil.isValidPath(shellcheckPath) || ShShellcheckUtil.isPlaceholder(shellcheckPath));
         myErrorLabel.setVisible(false);
       }
     });
 
     String shellcheckPath = ShSettings.getShellcheckPath();
-    myShellcheckSelector.setText(shellcheckPath);
-    myWarningPanel.setVisible(!ShShellcheckUtil.isValidPath(shellcheckPath));
+    boolean validPath = ShShellcheckUtil.isValidPath(shellcheckPath) && !ShShellcheckUtil.isPlaceholder(shellcheckPath);
+    String shellcheckSelectorText = validPath ? shellcheckPath : "";
+    myShellcheckSelector.setText(shellcheckSelectorText);
+    myWarningPanel.setVisible(!validPath);
+
     myErrorLabel.setForeground(JBColor.RED);
 
     ShShellcheckUtil.SHELLCHECK_CODES.forEach((key, value) -> myInspectionsCheckboxPanel.addCheckbox(key + " " + value, key));

--- a/plugins/sh/src/com/intellij/sh/shellcheck/ShellcheckSetupNotificationProvider.java
+++ b/plugins/sh/src/com/intellij/sh/shellcheck/ShellcheckSetupNotificationProvider.java
@@ -49,7 +49,7 @@ public class ShellcheckSetupNotificationProvider extends EditorNotifications.Pro
       }, () -> Notifications.Bus.notify(new Notification("Shell Script", "", "Can't download sh shellcheck. Please install it manually",
                                                          NotificationType.ERROR))));
       panel.createActionLabel("No, thanks", () -> {
-        ShSettings.setShellcheckPath(ShSettings.I_DO_MIND);
+        ShSettings.setShellcheckPath(ShSettings.PLACEHOLDER);
         EditorNotifications.getInstance(project).updateAllNotifications();
       });
       return panel;


### PR DESCRIPTION
Link to issue: https://youtrack.jetbrains.com/issue/IDEA-241080

Renamed an oddly named variable and added a method that checks if a given path equals the placeholder path which is assigned when the user clicks "No, thanks". Also added some logic for when to display the error message that notifies the user that the path is invalid, as well as when to show the path-string (which is what caused the original issue).