### PR TITLE
Document requirement for JavaFX in JDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Using IntelliJ IDEA **File | Open**, select the `<IDEA_HOME>` directory.
   [refresh the Gradle projects](https://www.jetbrains.com/help/idea/jetgradle-tool-window.html). 
 
 ### IntelliJ Build Configuration
-JDK version 1.8 (u162 or newer) is required for building and developing for IntelliJ IDEA Community Edition.
+JDK version 1.8 (u162 or newer) with JavaFX is required for building and developing for IntelliJ IDEA Community Edition. Note that many JDK distributions (e.g., AdoptOpenJDK) do not include JavaFX.
 1. Using IntelliJ IDEA, [configure](https://www.jetbrains.com/help/idea/sdk.html) a JDK named "**1.8**", pointing to `<JDK_18_HOME>`.
    * If not already present, add `<JDK_18_HOME>/lib/tools.jar` [to the Classpath](https://www.jetbrains.com/help/idea/sdk.html#manage_sdks) tab
      for the **1.8** JDK.


### PR DESCRIPTION
Without JavaFX, the build fails with errors like "java: package com.sun.javafx.embed does not exist".