### PR TITLE
Fix disabled slider thumb border color

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaSliderUI.kt
+++ b/platform/platform-impl/src/com/intellij/ide/ui/laf/darcula/ui/DarculaSliderUI.kt
@@ -60,7 +60,7 @@ public open class DarculaSliderUI(b: JComponent? = null) : BasicSliderUI(b as JS
         theme.buttonBorderColor
       }
       else {
-        theme.disabledButtonColor
+        theme.disabledButtonBorderColor
       }
 
       g2d.stroke = BasicStroke(theme.borderThickness.toFloat())


### PR DESCRIPTION
Previously it was the same as the color of the thumb itself, which is
also the same as the default background color for toolbars.