### PR TITLE
Reverse the logic to enable the inspection configurator

### DIFF
--- a/python/pluginJava/com/jetbrains/python/inspections/PythonPluginCommandLineInspectionProjectConfigurator.java
+++ b/python/pluginJava/com/jetbrains/python/inspections/PythonPluginCommandLineInspectionProjectConfigurator.java
@@ -41,7 +41,7 @@ public class PythonPluginCommandLineInspectionProjectConfigurator implements Com
   @Override
   public boolean isApplicable(@NotNull ConfiguratorContext context) {
     List<Sdk> sdks = PythonSdkUtil.getAllSdks();
-    if (!sdks.isEmpty()) return false;
+    if (sdks.isEmpty()) return false;
 
     try {
       boolean hasAnyPythonFiles = Files.walk(context.getProjectPath()).anyMatch(f -> {
@@ -67,7 +67,7 @@ public class PythonPluginCommandLineInspectionProjectConfigurator implements Com
     for (Sdk sdk : sdks) {
       logger.reportMessage(3, sdk.getHomePath());
     }
-    if (sdks.isEmpty()) {
+    if (!sdks.isEmpty()) {
       final List<Sdk> detectedSdks = PySdkExtKt.findAllPythonSdks(context.getProjectPath());
 
       if (detectedSdks.size() > 0) {


### PR DESCRIPTION
The implementation of this class has some logic which is the wrong way around.

The `isApplicable()` method will return `false` if the sdks list **is empty**, which the opposite of what you'd expect (and I think the intention of that guard clause).

Second, the configure environment will go and detect Python SDKs, but only if the list of SDKs **is empty**, which I think is backward.

I've tested this on a CLI environment and could never get the original project configurator to pass