### PR TITLE
IDEA-242521 Fix HotSwap skipping cached gradle tasks in delegated build

### DIFF
--- a/plugins/gradle/java/src/execution/build/GradleProjectTaskRunner.java
+++ b/plugins/gradle/java/src/execution/build/GradleProjectTaskRunner.java
@@ -81,7 +81,7 @@ public class GradleProjectTaskRunner extends ProjectTaskRunner {
                                                                           "def effectiveTasks = []\n" +
                                                                           "gradle.taskGraph.addTaskExecutionListener(new TaskExecutionAdapter() {\n" +
                                                                           "    void afterExecute(Task task, TaskState state) {\n" +
-                                                                          "        if (state.didWork && task.outputs.hasOutput) {\n" +
+                                                                          "        if ((state.didWork || (state.skipped && state.skipMessage == 'FROM-CACHE')) && task.outputs.hasOutput) {\n" +
                                                                           "            effectiveTasks.add(task)\n" +
                                                                           "        }\n" +
                                                                           "    }\n" +


### PR DESCRIPTION
When build is delegated to Gradle, some tasks may run as FROM-CACHE. These tasks are currently ignored by the HotSwap code.

Cached tasks can still output modified classes, so HotSwap should deploy those changes.