### PR TITLE
Convenient method for adding additional checkboxes to move file dialog

### DIFF
--- a/platform/lang-impl/src/com/intellij/refactoring/move/moveFilesOrDirectories/MoveFilesOrDirectoriesDialog.java
+++ b/platform/lang-impl/src/com/intellij/refactoring/move/moveFilesOrDirectories/MoveFilesOrDirectoriesDialog.java
@@ -30,6 +30,7 @@ import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -120,11 +121,27 @@ public abstract class MoveFilesOrDirectoriesDialog extends RefactoringDialog {
     myCbSearchForReferences = new NonFocusableCheckBox(RefactoringBundle.message("search.for.references"));
     myCbSearchForReferences.setSelected(RefactoringSettings.getInstance().MOVE_SEARCH_FOR_REFERENCES_FOR_FILE);
 
-    return FormBuilder.createFormBuilder().addComponent(myNameLabel)
+    FormBuilder builder = FormBuilder.createFormBuilder().addComponent(myNameLabel)
       .addLabeledComponent(RefactoringBundle.message("move.files.to.directory.label"), myTargetDirectoryField, UIUtil.LARGE_VGAP)
       .addTooltip(RefactoringBundle.message("path.completion.shortcut", shortcutText))
-      .addComponentToRightColumn(myCbSearchForReferences, UIUtil.LARGE_VGAP)
-      .getPanel();
+      .addComponentToRightColumn(myCbSearchForReferences, UIUtil.LARGE_VGAP);
+    addAdditionalCheckboxes(builder);
+    return builder.getPanel();
+  }
+
+  private void addAdditionalCheckboxes(@NotNull FormBuilder builder) {
+    JCheckBox[] checkboxes = getAdditionalCheckboxes();
+    if (checkboxes == null) return;
+    for (JCheckBox checkbox : checkboxes) {
+      builder.addComponentToRightColumn(checkbox, UIUtil.LARGE_VGAP);
+    }
+  }
+
+  /**
+   * @return additional checkboxes to be displayed under "Search for references" checkbox
+   */
+  protected @NotNull JCheckBox @Nullable [] getAdditionalCheckboxes() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
When implementing "Move file" refactoring, it may be needed to customize the dialog:

![image](https://user-images.githubusercontent.com/6505554/84365175-8331d700-abea-11ea-96b1-6719af95b61a.png)

Usually the only customization needed is to add additional checkboxes, e.g. here is the dialog for Kotlin files, where checkbox "Update package directives" is added:

![image](https://user-images.githubusercontent.com/6505554/84365162-7e6d2300-abea-11ea-9d98-267899574c9b.png)

---

If I understand correctly, currently the supposed way to add checkboxes is to copy-paste [`MoveFilesOrDirectoriesDialog`](https://github.com/JetBrains/intellij-community/blob/046e7df9a9936c6353f520d4c2a38f06ff1a2da3/platform/lang-impl/src/com/intellij/refactoring/move/moveFilesOrDirectories/MoveFilesOrDirectoriesDialog.java) file and just add checkboxes. This pull request adds a method to `MoveFilesOrDirectoriesDialog` which allows to easily add additional checkboxes