### PR TITLE
[intellij sh] Use extension point instead of application service

### DIFF
--- a/plugins/sh/resources/META-INF/plugin.xml
+++ b/plugins/sh/resources/META-INF/plugin.xml
@@ -16,8 +16,13 @@ Adds support for working with shell script files
 <li>Dedicated run/debug configuration for shell scripts</li>
 <li>Integration with external tools (<a href="https://github.com/koalaman/shellcheck">ShellCheck</a>, <a href="https://github.com/mvdan/sh">Shfmt</a>, <a href="https://explainshell.com/">Explainshell</a>)
 </li></ul>]]></description>
+
+  <extensionPoints>
+    <extensionPoint qualifiedName="com.intellij.sh.shSupport" interface="com.intellij.sh.ShSupport" dynamic="true"/>
+  </extensionPoints>
+
   <extensions defaultExtensionNs="com.intellij">
-    <applicationService serviceInterface="com.intellij.sh.ShSupport" serviceImplementation="com.intellij.sh.ShSupport$Impl"/>
+    <sh.shSupport id="shSupport" implementation="com.intellij.sh.ShSupport$Impl"/>
     <fileType language="Shell Script" extensions="sh;bash;zsh" hashBangs="sh" fieldName="INSTANCE" name="Shell Script" implementationClass="com.intellij.sh.ShFileType"/>
     <lang.syntaxHighlighter language="Shell Script" implementationClass="com.intellij.sh.highlighter.ShSyntaxHighlighter"/>
     <lang.parserDefinition language="Shell Script" implementationClass="com.intellij.sh.parser.ShParserDefinition"/>

--- a/plugins/sh/src/com/intellij/sh/ShSupport.java
+++ b/plugins/sh/src/com/intellij/sh/ShSupport.java
@@ -4,7 +4,7 @@ package com.intellij.sh;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.runners.ExecutionEnvironment;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry;
@@ -19,7 +19,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface ShSupport {
-  static ShSupport getInstance() { return ServiceManager.getService(ShSupport.class); }
+  ExtensionPointName<ShSupport> EP_NAME = ExtensionPointName.create("com.intellij.sh.shSupport");
+
+  @NotNull
+  static ShSupport getInstance() {
+    return EP_NAME.findExtensionOrFail(ShSupport.class);
+  }
 
   boolean isExternalFormatterEnabled();
 


### PR DESCRIPTION
Currently `ShSupport` is an application service. Plugins, which would like to customize it, have to override it. This override prevents it from being a dynamic plugin.

This PR changes the service into an extension point. Interface `ShSupport` and method `ShSupport.getInstance()` is unchanged. It returns the first available shSupport extension.