### PR TITLE
[intellij sh] Allow ShSupport to control the error filtering of shell scripts

### DIFF
--- a/plugins/sh/src/com/intellij/sh/ShErrorFilter.java
+++ b/plugins/sh/src/com/intellij/sh/ShErrorFilter.java
@@ -17,6 +17,7 @@ public class ShErrorFilter extends HighlightErrorFilter implements HighlightInfo
   @Override
   public boolean shouldHighlightErrorElement(@NotNull PsiErrorElement element) {
     if (ApplicationManager.getApplication().isInternal()) return true;
+    if (!ShSupport.getInstance().isErrorFilterEnabled()) return true;
     return !(element.getContainingFile() instanceof ShFile);
   }
 
@@ -25,6 +26,7 @@ public class ShErrorFilter extends HighlightErrorFilter implements HighlightInfo
     if (ApplicationManager.getApplication().isInternal()) return true;
     if (UpdateHighlightersUtil.isFileLevelOrGutterAnnotation(highlightInfo)) return true;
     if (!(file instanceof ShFile)) return true;
+    if (!ShSupport.getInstance().isErrorFilterEnabled()) return true;
     return highlightInfo.getSeverity().compareTo(HighlightSeverity.WARNING) < 0;
   }
 }

--- a/plugins/sh/src/com/intellij/sh/ShSupport.java
+++ b/plugins/sh/src/com/intellij/sh/ShSupport.java
@@ -45,6 +45,11 @@ public interface ShSupport {
   String getName(@NotNull ShLiteral l);
 
   /**
+   * @return {@code true} if {@code com.intellij.sh.ShErrorFilter} should suppress errors.
+   */
+  boolean isErrorFilterEnabled();
+
+  /**
    * Retrieve the name identifier of this literal, if it's used as a variable declaration.
    *
    * @param l The literal
@@ -89,6 +94,11 @@ public interface ShSupport {
     @Override
     public @Nullable PsiElement getNameIdentifier(@NotNull ShLiteral l) {
       return null;
+    }
+
+    @Override
+    public boolean isErrorFilterEnabled() {
+      return true;
     }
   }
 }


### PR DESCRIPTION
Currently all syntax errors and highlighting infos >= HighlightSeverity.WARNING files are suppressed in Shell script files.
This PR adds a method to `ShSupport`, which allows to control the filter, e.g. via setting. 