### PR TITLE
Add support for Python 3.10 version string

### DIFF
--- a/python/python-psi-api/src/com/jetbrains/python/psi/LanguageLevel.java
+++ b/python/python-psi-api/src/com/jetbrains/python/psi/LanguageLevel.java
@@ -79,7 +79,8 @@ public enum LanguageLevel {
   PYTHON36(36, true, false, true, true),
   PYTHON37(37, true, false, true, true),
   PYTHON38(38, true, false, true, true),
-  PYTHON39(39, true, false, true, true);
+  PYTHON39(39, true, false, true, true),
+  PYTHON310(310, true, false, true, true);
 
   /**
    * This value is mostly bound to the compatibility of our debugger and helpers.
@@ -178,6 +179,9 @@ public enum LanguageLevel {
       if (pythonVersion.startsWith("3.0")) {
         return PYTHON30;
       }
+      if (pythonVersion.startsWith("3.10")) {
+        return PYTHON310;
+      }
       if (pythonVersion.startsWith("3.1")) {
         return PYTHON31;
       }
@@ -215,7 +219,10 @@ public enum LanguageLevel {
   public static String toPythonVersion(@Nullable LanguageLevel level) {
     if (level == null) return null;
     final int version = level.getVersion();
-    return version / 10 + "." + version % 10;
+    if (version > 300)
+      return version / 100 + "." + version % 100;
+    else
+      return version / 10 + "." + version % 10;
   }
 
   @NotNull

--- a/python/testSrc/com/jetbrains/python/psi/LanguageLevelTest.kt
+++ b/python/testSrc/com/jetbrains/python/psi/LanguageLevelTest.kt
@@ -1,0 +1,31 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python.psi
+
+import org.assertj.core.api.JUnitSoftAssertions
+import org.junit.Rule
+import org.junit.Test
+
+class LanguageLevelTest {
+  @JvmField
+  @Rule
+  val softly = JUnitSoftAssertions()
+
+  @Test
+  fun `test basic python version parsing`(){
+    softly
+      .assertThat(LanguageLevel.fromPythonVersion("3.6"))
+      .isEqualTo(LanguageLevel.PYTHON36)
+    softly
+      .assertThat(LanguageLevel.fromPythonVersion("3.7"))
+      .isEqualTo(LanguageLevel.PYTHON37)
+    softly
+      .assertThat(LanguageLevel.fromPythonVersion("3.8"))
+      .isEqualTo(LanguageLevel.PYTHON38)
+    softly
+      .assertThat(LanguageLevel.fromPythonVersion("3.9"))
+      .isEqualTo(LanguageLevel.PYTHON39)
+    softly
+      .assertThat(LanguageLevel.fromPythonVersion("3.10"))
+      .isEqualTo(LanguageLevel.PYTHON310)
+  }
+}


### PR DESCRIPTION
Current EAP incorrectly reports Python 3.10 as Python 3.1 (because of the LanguageLevel implementation)

Add support for Python 3.10 version string parsing and update the toString() method to work with version numbers beyond 3.9