### PR TITLE
[intellij sh] Allow 3rd-party plugins to access Shellcheck inspection and settings

### DIFF
--- a/plugins/sh/src/com/intellij/sh/shellcheck/ShShellcheckInspection.java
+++ b/plugins/sh/src/com/intellij/sh/shellcheck/ShShellcheckInspection.java
@@ -70,7 +70,7 @@ public class ShShellcheckInspection extends LocalInspectionTool implements Exter
   }
 
   @NotNull
-  Set<String> getDisabledInspections() {
+  public Set<String> getDisabledInspections() {
     return new HashSet<>(myDisabledInspections);
   }
 
@@ -88,7 +88,7 @@ public class ShShellcheckInspection extends LocalInspectionTool implements Exter
   }
 
   @NotNull
-  static ShShellcheckInspection findShShellcheckInspection(@NotNull PsiElement element) {
+  public static ShShellcheckInspection findShShellcheckInspection(@NotNull PsiElement element) {
     InspectionProfile profile = InspectionProjectProfileManager.getInstance(element.getProject()).getCurrentProfile();
     ShShellcheckInspection tool = (ShShellcheckInspection)profile.getUnwrappedTool(SHORT_NAME, element);
     return tool == null ? new ShShellcheckInspection() : tool;


### PR DESCRIPTION
3rd-party plugins like BashSupport Pro have their own inspections and quickfixes. This PR allows these plugins to disable shellcheck checks programmatically, e.g. with a quickfix to allow the user to prefer the plugins's inspection instead of Shellchecks validation.