### PR TITLE
Disable Mnemonics check for context menu on macOS

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionPopupMenuImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionPopupMenuImpl.java
@@ -115,7 +115,7 @@ final class ActionPopupMenuImpl implements ActionPopupMenu, ApplicationActivatio
 
       myContext = myDataContextProvider != null ? myDataContextProvider.get() : DataManager.getInstance().getDataContext(component, x2, y2);
       long time = -System.currentTimeMillis();
-      Utils.fillMenu(myGroup, this, true, myPresentationFactory, myContext, myPlace, false, LaterInvocator.isInModalContext(), false);
+      Utils.fillMenu(myGroup, this, !UISettings.getInstance().getDisableMnemonics(), myPresentationFactory, myContext, myPlace, false, LaterInvocator.isInModalContext(), false);
       time += System.currentTimeMillis();
       if (time > 1000) LOG.warn(time + "ms to fill popup menu " + myPlace);
       if (getComponentCount() == 0) {


### PR DESCRIPTION
In the issue reported at IDEA-242047, context menu on macOS does not show with error because of failing on finding location/index of Mnemonic character, which is already stripped by the change introduced in https://github.com/JetBrains/intellij-community/commit/d14e2d658b6a295cd53e2d72ee49204a7ebe491f, while Mnemonic handling should not be done on macOS.
To avoid/fix this error, necessity of Mnemonic handling should be determined by calling "UISettings.getInstance().getDisableMnemonics()" like done in other places.