### PR TITLE
Change installer to not show an error when no config file is provided and default to admin mode

### DIFF
--- a/build/conf/nsis/idea.nsi
+++ b/build/conf/nsis/idea.nsi
@@ -615,7 +615,7 @@ Function silentConfigReader
   ${LogText} "  config file: $R1"
 
   ${ConfigRead} "$R1" "mode=" $R0
-  IfErrors no_silent_config
+  IfErrors bad_silent_config
   ${LogText} "  mode: $R0"
   StrCpy $silentMode "user"
   IfErrors launcher_32
@@ -681,6 +681,11 @@ update_settings:
   !insertmacro INSTALLOPTIONS_WRITE "Desktop.ini" "Settings" "NumFields" "$R0"
   goto done
 no_silent_config:
+  ${LogText} "  config file was not provided"
+  ${LogText} "  defaulting to admin mode"
+  StrCpy $silentMode "admin"
+  goto done
+bad_silent_config:
   Call IncorrectSilentInstallParameters
 done:
 FunctionEnd


### PR DESCRIPTION
Resolves the issue with the installer always requiring a config file when installing in silent mode (https://github.com/microsoft/winget-pkgs/pull/179#issuecomment-630247055) 