### PR TITLE
Fix SourceFolderManagerImpl.rescanAndUpdateSourceFolders

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/SourceFolderManagerImpl.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/SourceFolderManagerImpl.kt
@@ -160,9 +160,8 @@ class SourceFolderManagerImpl(private val project: Project) : SourceFolderManage
         sourceFoldersToChange.computeIfAbsent(sourceFolder.module) { ArrayList() }.add(Pair(sourceFolderFile, sourceFolder))
         removeSourceFolder(sourceFolder.url)
       }
-
-      updateSourceFolders(sourceFoldersToChange)
     }
+    updateSourceFolders(sourceFoldersToChange)
   }
 
   private fun updateSourceFolders(sourceFoldersToChange: Map<Module, List<Pair<VirtualFile, SourceFolderModel>>>) {


### PR DESCRIPTION
`rescanAndUpdateSourceFolders` is supposed to collect folders whose state
has change and then update then in a batch by calling
`updateSourceFolders` which will in turn send on `PROJECT_ROOTS`
notification.  However, the call seems to have been accidentally moved
inside the loop.