### PR TITLE
Fix performance issues in ProgressSuspender.freezeIfNeeded

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/progress/impl/ProgressSuspender.java
+++ b/platform/platform-impl/src/com/intellij/openapi/progress/impl/ProgressSuspender.java
@@ -128,14 +128,14 @@ public final class ProgressSuspender implements AutoCloseable {
   }
 
   private boolean freezeIfNeeded(ProgressIndicator current) {
-    if (isCurrentThreadHoldingKnownLocks()) {
-      return false;
-    }
-
     if (current == null) {
       current = ProgressIndicatorProvider.getGlobalProgressIndicator();
     }
     if (current == null || !myProgresses.contains(current)) {
+      return false;
+    }
+
+    if (isCurrentThreadHoldingKnownLocks()) {
       return false;
     }
 


### PR DESCRIPTION
`freezeIfNeeded` calls `isCurrentThreadHoldingKnownLocks` which is
an expensive call since it relies on
`ManagementFactory.getThreadMXBean.getThreadInfo`. The performance
problems can be reproduced by creating a new project while the IDE
indexes a lot of files. It manifests itself as very slowly progressing
"Scanning files to index..." process (hours instead od minutes).

`freezeIfNeeded` used to test `myProgresses.contains(current)` before
calling `isCurrentThreadHoldingKnownLocks` and seems to be
unintentionally updated when making `ProgressIndicator current`
parameter nullable. This change reverts the order of tests to the
original one.