### PR TITLE
add support RunConfiguration `JarApplication` for `gradle-idea-ext`.

### DIFF
--- a/java/execution/impl/src/com/intellij/execution/jar/JarApplicationRunConfigurationImporter.kt
+++ b/java/execution/impl/src/com/intellij/execution/jar/JarApplicationRunConfigurationImporter.kt
@@ -1,0 +1,40 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.execution.jar
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.ConfigurationTypeUtil
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider
+import com.intellij.openapi.externalSystem.service.project.settings.RunConfigurationImporter
+import com.intellij.openapi.project.Project
+import com.intellij.util.ObjectUtils.consumeIfCast
+
+class JarApplicationRunConfigurationImporter : RunConfigurationImporter {
+
+  override fun process(project: Project,
+                       runConfiguration: RunConfiguration,
+                       cfg: MutableMap<String, Any>,
+                       modelsProvider: IdeModifiableModelsProvider) {
+    if (runConfiguration !is JarApplicationConfiguration) {
+      throw IllegalArgumentException("Unexpected type of run configuration: ${runConfiguration::class.java}")
+    }
+    consumeIfCast(cfg["moduleName"], String::class.java) {
+      val module = modelsProvider.modifiableModuleModel.findModuleByName(it)
+      if (module != null) {
+        runConfiguration.module = module
+      }
+    }
+    consumeIfCast(cfg["jarPath"], String::class.java) { runConfiguration.jarPath = it }
+    consumeIfCast(cfg["jvmArgs"], String::class.java) { runConfiguration.vmParameters = it }
+    consumeIfCast(cfg["programParameters"], String::class.java) { runConfiguration.programParameters = it }
+    consumeIfCast(cfg["workingDirectory"], String::class.java) { runConfiguration.workingDirectory = it }
+    consumeIfCast(cfg["envs"], Map::class.java) { runConfiguration.envs = it as MutableMap<String, String> }
+  }
+
+  override fun canImport(typeName: String): Boolean = typeName == "jarApplication"
+
+  override fun getConfigurationFactory(): ConfigurationFactory =
+    ConfigurationTypeUtil.findConfigurationType<JarApplicationConfigurationType>(
+      JarApplicationConfigurationType::class.java
+    ).configurationFactories[0]
+}

--- a/java/java-impl/src/META-INF/JavaPlugin.xml
+++ b/java/java-impl/src/META-INF/JavaPlugin.xml
@@ -671,6 +671,7 @@
     <externalSystem.runConfigurationImporter implementation="com.intellij.execution.application.JavaApplicationRunConfigurationImporter"/>
     <externalSystem.runConfigurationImporter implementation="com.intellij.execution.remote.JavaRemoteDebugRunConfigurationImporter"/>
     <externalSystem.modifiableModelsProvider implementation="com.intellij.openapi.externalSystem.service.project.PackagingModifiableModelProvider"/>
+    <externalSystem.runConfigurationImporter implementation="com.intellij.execution.jar.JarApplicationRunConfigurationImporter" />
     <configuration.ModuleStructureExtension
         implementation="com.intellij.openapi.externalSystem.service.project.ExternalModuleStructureExtension"/>
 

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleSettingsImportingTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleSettingsImportingTest.java
@@ -251,6 +251,43 @@ public class GradleSettingsImportingTest extends GradleSettingsImportingTestCase
                  FileUtil.toSystemIndependentName(settings.getExternalProjectPath()));
   }
 
+  @Test
+  public void testJarApplicationRunConfigurationSettingsImport() throws Exception {
+    TestRunConfigurationImporter testExtension = new TestRunConfigurationImporter("jarApplication");
+    maskRunImporter(testExtension);
+
+    createSettingsFile("rootProject.name = 'moduleName'");
+    importProject(
+      new GradleBuildScriptBuilderEx()
+      .withGradleIdeaExtPluginIfCan("0.8.0")
+      .addPostfix(
+        "import org.jetbrains.gradle.ext.*",
+        "idea.project.settings {",
+        "  runConfigurations {",
+        "    jarApp1(JarApplication) {",
+        "      jarPath =    'my/app.jar'",
+        "      jvmArgs =    '-DvmKey=vmVal'",
+        "      moduleName = 'moduleName'",
+        "    }",
+        "    jarApp2(JarApplication) {",
+        "      jarPath =    'my/app2.jar'",
+        "      moduleName = 'moduleName'",
+        "    }",
+        "  }",
+        "}"
+      ).generate());
+
+    final Map<String, Map<String, Object>> configs = testExtension.getConfigs();
+
+    assertContain(new ArrayList<>(configs.keySet()), "jarApp1", "jarApp2");
+    Map<String, Object> jarApp1Settings = configs.get("jarApp1");
+    Map<String, Object> jarApp2Settings = configs.get("jarApp2");
+
+    assertEquals("my/app.jar", jarApp1Settings.get("jarPath"));
+    assertEquals("my/app2.jar", jarApp2Settings.get("jarPath"));
+    assertEquals("-DvmKey=vmVal", jarApp1Settings.get("jvmArgs"));
+    assertNull(jarApp2Settings.get("jvmArgs"));
+  }
 
   @Test
   public void testFacetSettingsImport() throws Exception {


### PR DESCRIPTION
It allows configuring the `JarApplication` for `gradle-ext-plugin`. Confirmed it works.
Before merge this PR, the other PR on the gradle plugin should be merged and the `0.8.0` also published for get to pass the current test.

I signed the CLA.