### PR TITLE
Remove final keyword from InvalidDataException

### DIFF
--- a/platform/util/src/com/intellij/openapi/util/InvalidDataException.java
+++ b/platform/util/src/com/intellij/openapi/util/InvalidDataException.java
@@ -1,7 +1,7 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.openapi.util;
 
-public final class InvalidDataException extends RuntimeException {
+public class InvalidDataException extends RuntimeException {
   public InvalidDataException() {
     super();
   }


### PR DESCRIPTION
This was added incidentally by commit d504262
breaking compilation of existing subclasses.