### PR TITLE
Fixed issue IDEA-245707

### DIFF
--- a/jps/jps-builders/src/org/jetbrains/jps/incremental/java/JavaBuilder.java
+++ b/jps/jps-builders/src/org/jetbrains/jps/incremental/java/JavaBuilder.java
@@ -837,6 +837,11 @@ public final class JavaBuilder extends ModuleLevelBuilder {
           }
         }
       }
+      Pair<JpsSdk<JpsDummyElement>, Integer> sdk = getAssociatedSdk(chunk);
+      if (compilerOptions instanceof EclipseCompilerOptions && sdk != null && sdk.second > 9 && customArgs.contains("add-modules")) {
+        appender.accept(compilationOptions, "--module-path");
+        appender.accept(compilationOptions, sdk.first.getHomePath()+ "/jmods" );
+      }
     }
 
     for (ExternalJavacOptionsProvider extension : JpsServiceManager.getInstance().getExtensions(ExternalJavacOptionsProvider.class)) {

--- a/jps/jps-builders/src/org/jetbrains/jps/incremental/java/JavaBuilder.java
+++ b/jps/jps-builders/src/org/jetbrains/jps/incremental/java/JavaBuilder.java
@@ -838,7 +838,7 @@ public final class JavaBuilder extends ModuleLevelBuilder {
         }
       }
       Pair<JpsSdk<JpsDummyElement>, Integer> sdk = getAssociatedSdk(chunk);
-      if (compilerOptions instanceof EclipseCompilerOptions && sdk != null && sdk.second > 9 && customArgs.contains("add-modules")) {
+      if (compilerOptions instanceof EclipseCompilerOptions && sdk != null && sdk.second > 8 && customArgs.contains("add-modules")) {
         appender.accept(compilationOptions, "--module-path");
         appender.accept(compilationOptions, sdk.first.getHomePath()+ "/jmods" );
       }


### PR DESCRIPTION
When user choose ECJ as compiler, he may get strange error in case he adds some java modules as ECJ does not know where to search the jmods folder.

I also opened a support case at Eclipse asking them to look for this in the JAVA_HOME 
But as I don't know if they will add such feature one day, I fixed the issue inside my favorite IDE ;)

