### PR TITLE
HTTP Proxy Preferences: Store the check url while dialog is open

### DIFF
--- a/platform/platform-api/src/com/intellij/util/net/HttpProxySettingsUi.java
+++ b/platform/platform-api/src/com/intellij/util/net/HttpProxySettingsUi.java
@@ -51,6 +51,7 @@ class HttpProxySettingsUi implements ConfigurableUi<HttpConfigurable> {
   private JButton myClearPasswordsButton;
   private JLabel myErrorLabel;
   private JButton myCheckButton;
+  private String myCheckConnectionUrl = "http://";
   private JLabel myOtherWarning;
   private JLabel myProxyExceptionsLabel;
   private RawCommandLineEditor myProxyExceptions;
@@ -125,11 +126,11 @@ class HttpProxySettingsUi implements ConfigurableUi<HttpConfigurable> {
       }
 
       final String title = IdeBundle.message("dialog.title.check.proxy.settings");
-      final String answer =
+      myCheckConnectionUrl =
         Messages.showInputDialog(myMainPanel,
                                  IdeBundle.message("message.text.enter.url.to.check.connection"),
-                                 title, Messages.getQuestionIcon(), "http://", null);
-      if (StringUtil.isEmptyOrSpaces(answer)) {
+                                 title, Messages.getQuestionIcon(), myCheckConnectionUrl, null);
+      if (StringUtil.isEmptyOrSpaces(myCheckConnectionUrl)) {
         return;
       }
 
@@ -144,7 +145,7 @@ class HttpProxySettingsUi implements ConfigurableUi<HttpConfigurable> {
       final AtomicReference<IOException> exceptionReference = new AtomicReference<>();
       ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
         try {
-          HttpRequests.request(answer).readTimeout(3 * 1000).tryConnect();
+          HttpRequests.request(myCheckConnectionUrl).readTimeout(3 * 1000).tryConnect();
         }
         catch (IOException e) {
           exceptionReference.set(e);


### PR DESCRIPTION
The proxy preference page has a button to check the connection with the
settings entered in the page. Every time the button is pressed the user
is prompted for a check url. The field is always reset to 'http://'.
Sometimes proxy settings are not correct on the first attempt or one
can make a small typo in the check url. In these cases one has to
press check repeatedly and it is inconvenient to reenter the url
every time. This change stores the url for the time the preference
page is open.