### PR TITLE
Fix beforeRun handler for `GradleTask` with `JarApplication`

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/settings/RunConfigurationHandler.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/settings/RunConfigurationHandler.kt
@@ -53,7 +53,7 @@ internal class RunConfigurationHandler : ConfigurationHandler {
         }
 
         (cfg["beforeRun"] as? List<*>)?.let {
-          var tasksList = runnerAndConfigurationSettings.configuration.getBeforeRunTasks()
+          var tasksList = runnerAndConfigurationSettings.configuration.getBeforeRunTasks().toMutableList()
           for (beforeRunConfig in it.filterIsInstance(Map::class.java)) {
             val typeName = beforeRunConfig["type"] as? String ?: continue
             importerForType(typeName)?.let { importer ->


### PR DESCRIPTION
The BeforeRun `GradleTask` with `JarApplication` will cause below error.

<details>
<summary>Error logs</summary>

```
java.lang.UnsupportedOperationException: Operation is not supported for read-only collection
	at kotlin.collections.EmptyList.add(Collections.kt)
	at org.jetbrains.plugins.gradle.service.project.GradleBeforeRunTaskImporter.process(GradleExternalSettingsImporter.kt:44)
	at com.intellij.openapi.externalSystem.service.project.settings.RunConfigurationHandler.apply(RunConfigurationHandler.kt:60)
	at com.intellij.openapi.externalSystem.service.project.settings.ConfigurationHandler.apply(ConfigurationHandler.java:44)
	at com.intellij.openapi.externalSystem.service.project.settings.ConfigurationDataService$importData$1.invoke(ConfigurationDataService.kt:41)
	at com.intellij.openapi.externalSystem.service.project.settings.ConfigurationDataService$importData$1.invoke(ConfigurationDataService.kt:29)
	at com.intellij.openapi.externalSystem.service.project.settings.ConfigurationDataService$Companion.withConfigurationData(ConfigurationDataService.kt:93)
	at com.intellij.openapi.externalSystem.service.project.settings.ConfigurationDataService$Companion.access$withConfigurationData(ConfigurationDataService.kt:55)
	at com.intellij.openapi.externalSystem.service.project.settings.ConfigurationDataService.importData(ConfigurationDataService.kt:39)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.doImportData(ProjectDataManagerImpl.java:253)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.importData(ProjectDataManagerImpl.java:121)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.importData(ProjectDataManagerImpl.java:207)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.importData(ProjectDataManagerImpl.java:214)
	at org.jetbrains.plugins.gradle.service.project.open.GradleOpenProjectProvider.importData(GradleOpenProjectProvider.kt:99)
	at org.jetbrains.plugins.gradle.service.project.open.GradleOpenProjectProvider.access$importData(GradleOpenProjectProvider.kt:33)
	at org.jetbrains.plugins.gradle.service.project.open.GradleOpenProjectProvider$createFinalImportCallback$1.onSuccess(GradleOpenProjectProvider.kt:74)
	at com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback.onSuccess(ExternalProjectRefreshCallback.java:40)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$2.handExecutionResult(ExternalSystemUtil.java:542)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$2.executeImpl(ExternalSystemUtil.java:522)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$2.lambda$execute$1(ExternalSystemUtil.java:372)
	at com.intellij.openapi.project.DumbServiceHeavyActivities.suspendIndexingAndRun(DumbServiceHeavyActivities.java:20)
	at com.intellij.openapi.project.DumbServiceImpl.suspendIndexingAndRun(DumbServiceImpl.java:154)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$2.execute(ExternalSystemUtil.java:372)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$4.run(ExternalSystemUtil.java:627)
	at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:957)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsync$5(CoreProgressManager.java:467)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:235)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:178)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:653)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:605)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:62)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:165)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:235)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run$$$capture(CompletableFuture.java:1604)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:652)
	at java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:649)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:649)
	at java.lang.Thread.run(Thread.java:748)
```
</details>

This caused by adding an element into the empty(immutable) list.
So, I wrapped it to `ArrayList` using `toMutableList()`, also added a test case for this.
IMO, the reason why it occurs with only `JarApplication`, it has no default `before run task`, Therefore it returns just an empty list. The others will return a mutable list with the default even there's no user defined `before run`.

The adding place: [GradleExternalSettingsImporter.kt#L44](https://github.com/JetBrains/intellij-community/blob/master/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleExternalSettingsImporter.kt#L44)
The empty list: [RunConfigurationBase.java#L49](https://github.com/EntryPointKR/intellij-community/blob/master/platform/lang-api/src/com/intellij/execution/configurations/RunConfigurationBase.java#L49)