### PR TITLE
Simplify redundant code

### DIFF
--- a/java/java-psi-api/src/com/intellij/psi/LambdaUtil.java
+++ b/java/java-psi-api/src/com/intellij/psi/LambdaUtil.java
@@ -1108,7 +1108,7 @@ public final class LambdaUtil {
         psiType = origTypeElement.getType();
       } else {
         psiType = substitutor.substitute(parameters[i].getType());
-        if (psiType == null || !PsiTypesUtil.isDenotableType(psiType, lambdaExpression)) return null;
+        if (!PsiTypesUtil.isDenotableType(psiType, lambdaExpression)) return null;
       }
 
       PsiAnnotation[] annotations = lambdaParameter.getAnnotations();

--- a/java/java-psi-api/src/com/intellij/psi/util/PropertyUtilBase.java
+++ b/java/java-psi-api/src/com/intellij/psi/util/PropertyUtilBase.java
@@ -268,7 +268,7 @@ public class PropertyUtilBase {
     switch (flavour) {
       case GENERIC:
         PsiType returnType = method.getReturnType();
-        return returnType == null || !PsiType.VOID.equals(returnType);
+        return !PsiType.VOID.equals(returnType);
       case BOOLEAN:
         return isBoolean(method.getReturnType());
       case NOT_A_GETTER:

--- a/java/java-psi-api/src/com/intellij/psi/util/TypesDistinctProver.java
+++ b/java/java-psi-api/src/com/intellij/psi/util/TypesDistinctProver.java
@@ -196,10 +196,10 @@ public final class TypesDistinctProver {
     }
     if (boundClass1.isInterface() && boundClass2.isInterface()) return false;
     if (boundClass1.isInterface()) {
-      return !(boundClass2.hasModifierProperty(PsiModifier.FINAL) ? InheritanceUtil.isInheritorOrSelf(boundClass2, boundClass1, true) : true);
+      return !(!boundClass2.hasModifierProperty(PsiModifier.FINAL) || InheritanceUtil.isInheritorOrSelf(boundClass2, boundClass1, true));
     }
     if (boundClass2.isInterface()) {
-      return !(boundClass1.hasModifierProperty(PsiModifier.FINAL) ? InheritanceUtil.isInheritorOrSelf(boundClass1, boundClass2, true) : true);
+      return !(!boundClass1.hasModifierProperty(PsiModifier.FINAL) || InheritanceUtil.isInheritorOrSelf(boundClass1, boundClass2, true));
     }
 
     if (boundClass1 instanceof PsiTypeParameter) {


### PR DESCRIPTION
a null check followed by a method call that will definitely return false when null is passed (e.g. Class.isInstance). Such a check seems excessive as the method call always returns false