### PR TITLE
Bug fix: virtualenv in project dir was not being auto-detected

### DIFF
--- a/python/python-sdk/src/com/jetbrains/python/sdk/BasePySdkExt.kt
+++ b/python/python-sdk/src/com/jetbrains/python/sdk/BasePySdkExt.kt
@@ -10,8 +10,8 @@ val Module.rootManager: ModuleRootManager
 
 val Module.baseDir: VirtualFile?
   get() {
-    val moduleFile = moduleFile ?: return null
     val roots = rootManager.contentRoots
+    val moduleFile = moduleFile ?: return roots.firstOrNull()
     return roots.firstOrNull { VfsUtil.isAncestor(it, moduleFile, true) } ?: roots.firstOrNull()
   }
 


### PR DESCRIPTION
If you open a directory for the first time (as a new project) in pycharm/intellij, it should auto-detect the virtualenv in that directory and set it as the project interpreter. This bug stopped that from happening. It was introduced by https://github.com/JetBrains/intellij-community/commit/fedf5828fff10d281e865cc3883a0a7d703d1cab

It would be great if this could make it into the 2020.2 release of pycharm/intellij. Thanks!
