### PR TITLE
Add support for Gradle 6.6 in DaemonAction

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/internal/daemon/DaemonAction.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/internal/daemon/DaemonAction.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /**
  * @author Vladislav.Soroka
@@ -54,7 +55,13 @@ public abstract class DaemonAction {
   protected static DaemonParameters getDaemonParameters(BuildLayoutParameters layout) {
     // Constructors have changed for different versions of Gradle, need to use the correct version by reflection
     GradleVersion gradleBaseVersion = GradleVersion.current().getBaseVersion();
-    if (gradleBaseVersion.compareTo(GradleVersion.version("6.4")) >= 0) {
+     if (gradleBaseVersion.compareTo(GradleVersion.version("6.6-milestone-1")) >= 0) {
+      // DaemonParameters(BuildLayoutResult, FileCollectionFactory) with DefaultFileCollectionFactory using
+      // DefaultFileCollectionFactory(PathToFileResolver, TaskDependencyFactory, DirectoryFileTreeFactory, Factory<PatternSet>,
+      //   PropertyHost, FileSystem) using IdentityFileResolver()
+      return daemonParameters6Dot6(layout);
+    }
+    else if (gradleBaseVersion.compareTo(GradleVersion.version("6.4")) >= 0) {
       // DaemonParameters(BuildLayoutParameters, FileCollectionFactory) with DefaultFileCollectionFactory using
       // DefaultFileCollectionFactory(PathToFileResolver, TaskDependencyFactory, DirectoryFileTreeFactory, Factory<PatternSet>,
       //   PropertyHost, FileSystem) using IdentityFileResolver()
@@ -78,6 +85,31 @@ public abstract class DaemonAction {
     else {
       // DaemonParameters(BuildLayoutParameters)
       return daemonParametersPre5Dot3(layout);
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static DaemonParameters daemonParameters6Dot6(BuildLayoutParameters layout) {
+    try {
+      ClassLoader classLoader = DaemonAction.class.getClassLoader();
+      // Using reflection for code: "new BuildLayoutConverter().defaultValues().applyTo(BuildLayoutParameters);"
+      Class buildLayoutConvertedClass = classLoader.loadClass("org.gradle.launcher.cli.converter.BuildLayoutConverter");
+      Object buildLayoutConverter = buildLayoutConvertedClass.newInstance();
+      Method defaultValuesMethod = buildLayoutConvertedClass.getMethod("defaultValues");
+      Object buildLayoutResult = defaultValuesMethod.invoke(buildLayoutConverter);
+      Class buildLayoutResultClass = classLoader.loadClass("org.gradle.launcher.configuration.BuildLayoutResult");
+      Method applyTo = buildLayoutResultClass.getMethod("applyTo", BuildLayoutParameters.class);
+      applyTo.invoke(buildLayoutResult, layout);
+
+      Factory<PatternSet> patternSetFactory = PatternSets.getPatternSetFactory(PatternSpecFactory.INSTANCE);
+      //noinspection JavaReflectionMemberAccess
+      IdentityFileResolver identityFileResolver = IdentityFileResolver.class.getConstructor().newInstance();
+      DefaultFileCollectionFactory collectionFactory = createCollectionFactory6Dot3(identityFileResolver, patternSetFactory);
+      return DaemonParameters.class.getConstructor(buildLayoutResultClass, FileCollectionFactory.class).newInstance(buildLayoutResult, collectionFactory);
+    }
+    catch (ClassNotFoundException | NoSuchFieldException | InstantiationException | IllegalAccessException | InvocationTargetException |
+      NoSuchMethodException e) {
+      throw new RuntimeException("Cannot create DaemonParameters by reflection, gradle version " + GradleVersion.current(), e);
     }
   }
 


### PR DESCRIPTION
Constructor for DaemonParameters has changed in
Gradle 6.6-milestone-1. This chanage adds support
for creating such instance when using this verison
of Gradle. Related issue on the Android issue tracker
is https://issuetracker.google.com/161963743.