### PR TITLE
[git] migration to Java 11: use explicit 'setUI' call instead of 'ui' property

### DIFF
--- a/plugins/git4idea/src/git4idea/merge/GitMergeDialog.kt
+++ b/plugins/git4idea/src/git4idea/merge/GitMergeDialog.kt
@@ -313,7 +313,7 @@ class GitMergeDialog(private val project: Project,
     return ComboBox(model).apply {
       item = defaultRoot.name
       isSwingPopup = false
-      ui = FlatComboBoxUI(outerInsets = Insets(BW.get(), BW.get(), BW.get(), 0))
+      setUI(FlatComboBoxUI(outerInsets = Insets(BW.get(), BW.get(), BW.get(), 0)))
 
       addItemListener { e ->
         if (e.stateChange == ItemEvent.SELECTED
@@ -346,9 +346,9 @@ class GitMergeDialog(private val project: Project,
         }
       }
 
-      ui = FlatComboBoxUI(
+      setUI(FlatComboBoxUI(
         outerInsets = Insets(BW.get(), 0, BW.get(), BW.get()),
-        popupEmptyText = GitBundle.message("merge.branch.popup.empty.text"))
+        popupEmptyText = GitBundle.message("merge.branch.popup.empty.text")))
     }
   }
 


### PR DESCRIPTION
...to fix "Val cannot be reassigned" error when compiling IntelliJ sources under Java 11 (see KT-31926).