### PR TITLE
Remove final keyword from MockPsiManager

### DIFF
--- a/platform/lang-impl/src/com/intellij/mock/MockPsiManager.java
+++ b/platform/lang-impl/src/com/intellij/mock/MockPsiManager.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class MockPsiManager extends PsiManagerEx {
+public class MockPsiManager extends PsiManagerEx {
   private final Project myProject;
   private final Map<VirtualFile,PsiDirectory> myDirectories = new HashMap<>();
   private MockFileManager myMockFileManager;


### PR DESCRIPTION
This was added by commit 8beaf00, breaking existing tests.