### PR TITLE
Less noise in logs

### DIFF
--- a/platform/execution-impl/src/com/intellij/execution/impl/RCInArbitraryFileManager.kt
+++ b/platform/execution-impl/src/com/intellij/execution/impl/RCInArbitraryFileManager.kt
@@ -126,7 +126,7 @@ internal class RCInArbitraryFileManager(private val project: Project) {
     }
 
     if (element.name != "component" || element.getAttributeValue("name") != "ProjectRunConfigurationManager") {
-      LOG.info("Unexpected root element ${element.name} with name=${element.getAttributeValue("name")} in $filePath")
+      LOG.trace("Unexpected root element ${element.name} with name=${element.getAttributeValue("name")} in $filePath")
       return DeletedAndAddedRunConfigs(previouslyLoadedRunConfigs, emptyList())
     }
 


### PR DESCRIPTION
In some our projects we have dozens of *.run.xml files which are not run configuration and this causes noise in logs.