### PR TITLE
Add back log message for Gradle Java

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleManager.java
@@ -137,6 +137,9 @@ public final class GradleManager
                                                                    settings.isOfflineWork());
       final String rootProjectPath = projectLevelSettings != null ? projectLevelSettings.getExternalProjectPath() : projectPath;
       final String javaHome = gradleInstallationManager.getGradleJvmPath(project, rootProjectPath);
+      if (!StringUtil.isEmpty(javaHome)) {
+        LOG.info("Instructing gradle to use java from " + javaHome);
+      }
       result.setJavaHome(javaHome);
       String ideProjectPath;
       if (project.getBasePath() == null ||


### PR DESCRIPTION
This was removed by a previous commit but those messages are useful when
debugging issues related to the JDK location that Gradle uses.

https://youtrack.jetbrains.com/issue/IDEA-249386