### PR TITLE
Add trusted host system property to InstallPluginService

### DIFF
--- a/platform/built-in-server/src/org/jetbrains/ide/InstallPluginService.kt
+++ b/platform/built-in-server/src/org/jetbrains/ide/InstallPluginService.kt
@@ -34,6 +34,7 @@ internal class InstallPluginService : RestService() {
   override fun isAccessible(request: HttpRequest) = true
 
   var isAvailable = true
+  private val trustedHosts = System.getProperty("idea.api.install.hosts.trusted", "").split(",")
 
   override fun execute(urlDecoder: QueryStringDecoder, request: FullHttpRequest, context: ChannelHandlerContext): String? {
     val pluginId = getStringParameter("pluginId", urlDecoder)
@@ -133,6 +134,7 @@ internal class InstallPluginService : RestService() {
 
     return (originHost != null && (
       listOf("plugins.jetbrains.com", "package-search.services.jetbrains.com", "package-search.jetbrains.com").contains(originHost) ||
+      trustedHosts.contains(originHost) ||
       originHost.endsWith(".dev.marketplace.intellij.net") ||
       NetUtils.isLocalhost(originHost))) || super.isHostTrusted(request, urlDecoder)
   }


### PR DESCRIPTION
I'm building an internal plugin repository and want a way to whitelist our repo host to use the plugin install api.