### PR TITLE
IDEA-124383 save dialog should edited file name

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileChooser/ex/FileSaverDialogImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileChooser/ex/FileSaverDialogImpl.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.io.File;
 import java.nio.file.Path;
@@ -57,6 +58,42 @@ public class FileSaverDialogImpl extends FileChooserDialogImpl implements FileSa
   @Override
   public @Nullable VirtualFileWrapper save(@Nullable Path baseDir, @Nullable String filename) {
     return save(baseDir == null ? null : LocalFileSystem.getInstance().refreshAndFindFileByNioFile(baseDir), filename);
+  }
+
+  @Override
+  protected void init() {
+    super.init();
+
+    // ensure that in the tree only the folder is selected once the user starts editing the file field
+    myFileName.getDocument().addDocumentListener(new DocumentListener() {
+      @Override
+      public void insertUpdate(DocumentEvent e) {
+        changed();
+      }
+
+      @Override
+      public void removeUpdate(DocumentEvent e) {
+        changed();
+      }
+
+      @Override
+      public void changedUpdate(DocumentEvent e) {
+        changed();
+      }
+
+      private void changed() {
+        // when the file name changes AND has focus, then this is the user editing and not an automatic update after selecting a file.
+        if (myFileName.hasFocus()) {
+          // if the selected item is a file (not a directory), change the selection to the parent folder.
+          // this is the symmetric logic as in FileSaverDialogImpl.getFile()
+          if (myFileSystemTree.getSelectedFile() != null && !myFileSystemTree.getSelectedFile().isDirectory()) {
+            // now switch to parent folder of the file
+            myFileSystemTree.select(myFileSystemTree.getSelectedFile().getParent(), () -> {
+            });
+          }
+        }
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
This fixes issue https://youtrack.jetbrains.com/issue/IDEA-124383

Old behavior: A selected file name in the tree view overrides any edited file name in `myFileName`. File name edited by the user is ignored.

New behavior: Once the user starts editing the file name, the tree view selects only the folder so that selected folder + edited filename lead to the result the user expects. 

I tested that adding a DocumentListener works as expected. For the AsciiDoc plugin I maintain a backport worked as expected, see https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/530

 