### PR TITLE
Fix NPE in UsageViewImpl

### DIFF
--- a/platform/usageView/src/com/intellij/usages/impl/UsageViewImpl.java
+++ b/platform/usageView/src/com/intellij/usages/impl/UsageViewImpl.java
@@ -2376,7 +2376,7 @@ public class UsageViewImpl implements UsageViewEx {
     Usage toSelect = null;
     for (Usage usage : toDelete) {
       Usage next = getNextToSelect(usage);
-      if (!toDelete.contains(next)) {
+      if (next != null && !toDelete.contains(next)) {
         toSelect = next;
         break;
       }


### PR DESCRIPTION
If there is exactly one Usage, getNextToSelect(usage) returns null,
giving a null pointer exception when looking null up in the toDelete
collection.  Treating it as a successful .contains() lookup (i.e. not
updating toSelect) is safe because there will be no nodes left after
the single existing node is deleted.