### PR TITLE
Dependency resolution fixes in Gradle composite builds.

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverUtil.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolverUtil.java
@@ -604,8 +604,7 @@ public final class GradleProjectResolverUtil {
         final ExternalProjectDependency projectDependency = (ExternalProjectDependency)mergedDependency;
 
         Collection<ProjectDependencyInfo> projectDependencyInfos = new ArrayList<>();
-        String selectionReason = projectDependency.getSelectionReason();
-        if ("composite build substitution".equals(selectionReason) && resolverCtx.getSettings() != null) {
+        if (resolverCtx.getSettings() != null) {
           GradleExecutionWorkspace executionWorkspace = resolverCtx.getSettings().getExecutionWorkspace();
           ModuleData moduleData = executionWorkspace.findModuleDataByArtifacts(projectDependency.getProjectDependencyArtifacts());
           if (moduleData != null) {

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
@@ -266,7 +266,7 @@ public class DependencyResolverImpl implements DependencyResolver {
 
           ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier)artifact.getId().getComponentIdentifier();
           String projectPath = projectComponentIdentifier.getProjectPath();
-          String key = projectPath + "_" + resolvedDependency.getConfiguration();
+          String key = projectComponentIdentifier.getProjectName() + "_" + resolvedDependency.getConfiguration();
           DefaultExternalProjectDependency projectDependency = resolvedProjectDependencies.get(key);
           if (projectDependency != null) {
             Set<File> projectDependencyArtifacts = new LinkedHashSet<File>(projectDependency.getProjectDependencyArtifacts());


### PR DESCRIPTION
The PR is going to fix two issues.

The first one - https://youtrack.jetbrains.com/issue/IDEA-232283 is solved by removing "composite build substitution" string check. I guess it was left after new resolution algorithm was implemented.

The second one - https://youtrack.jetbrains.com/issue/IDEA-196240. Where transitive dependency (project3) is not added to (project1).

I'm not sure about total correctness of the fixes but please take a look :)