### PR TITLE
Revert usage of keymap.current.os.only key but set it to true by default

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/keymap/impl/DefaultKeymap.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/keymap/impl/DefaultKeymap.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.keymap.KeymapManager
 import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.registry.Registry
 import org.jdom.Element
 import java.util.*
 
@@ -35,7 +36,7 @@ open class DefaultKeymap {
 
   init {
     val filterKeymaps = !ApplicationManager.getApplication().isHeadlessEnvironment
-                        //&& Registry.`is`("keymap.current.os.only")
+                        && Registry.`is`("keymap.current.os.only")
     val filteredBeans = mutableListOf<BundledKeymapBean>()
 
     var macosParentKeymapFound = false

--- a/platform/util/resources/misc/registry.properties
+++ b/platform/util/resources/misc/registry.properties
@@ -638,7 +638,7 @@ keymap.show.alias.actions=false
 keymap.windows.as.meta=false
 keymap.windows.as.meta.description='Windows' key press/release events would be processed as 'Meta' modifier for shortcuts
 
-keymap.current.os.only=false
+keymap.current.os.only=true
 keymap.current.os.only.description=Filter out built-in keymaps designed for other OSes
 keymap.current.os.only.restartRequired=true
 


### PR DESCRIPTION
This doesn't change the default behavior, but reverts the feature of showing keymaps of foreign OSes via overriding Registry key.