### PR TITLE
PY-40863 Highlight "{{", "}}" as escape sequence in fstrings

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/lexer/PyFStringLiteralLexer.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/lexer/PyFStringLiteralLexer.kt
@@ -1,6 +1,7 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.jetbrains.python.lexer
 
+import com.intellij.psi.StringEscapesTokenTypes
 import com.intellij.psi.tree.IElementType
 import com.intellij.util.text.CharArrayUtil
 import com.jetbrains.python.PyTokenTypes
@@ -10,17 +11,15 @@ class PyFStringLiteralLexer(fStringTextToken: IElementType) : PyStringLiteralLex
     assert(PyTokenTypes.FSTRING_TEXT_TOKENS.contains(fStringTextToken))
   }
 
-  override fun locateToken(start: Int): Int {
-    if (start >= myBufferEnd) {
-      return myBufferEnd
-    }
-    
-    if (myBuffer[start] == '\\') {
-      return locateEscapeSequence(start)
-    }
-    else {
+  override fun locateToken(start: Int): Int = when {
+    start >= myBufferEnd -> myBufferEnd
+    myBuffer[start] == '\\' -> locateEscapeSequence(start)
+    isDoubleCurley() -> start + 2
+    else -> {
       val nextBackslashOffset = CharArrayUtil.indexOf(myBuffer, "\\", start + 1, myBufferEnd)
-      return if (nextBackslashOffset >= 0) nextBackslashOffset else myBufferEnd
+      val nextLCurleyOffset = CharArrayUtil.indexOf(myBuffer, "{{", start + 1, myBufferEnd)
+      val nextRCurleyOffset = CharArrayUtil.indexOf(myBuffer, "}}", start + 1, myBufferEnd)
+      setOf(nextBackslashOffset, nextLCurleyOffset, nextRCurleyOffset).filter { it >= 0 }.minOrNull() ?: myBufferEnd
     }
   }
 
@@ -29,4 +28,13 @@ class PyFStringLiteralLexer(fStringTextToken: IElementType) : PyStringLiteralLex
   override fun isUnicodeMode(): Boolean = true
 
   override fun getState(): Int = myBaseLexerState
+
+  override fun isEscape() = isDoubleCurley() || super.isEscape()
+
+  override fun getEscapeSequenceType(): IElementType =
+    if (isDoubleCurley()) StringEscapesTokenTypes.VALID_STRING_ESCAPE_TOKEN else super.getEscapeSequenceType()
+
+  private fun isDoubleCurley() =
+    myBufferEnd > myStart + 1 &&
+    ((myBuffer[myStart] == '{' && myBuffer[myStart + 1] == '{') || (myBuffer[myStart] == '}' && myBuffer[myStart + 1] == '}'))
 }

--- a/python/python-psi-impl/src/com/jetbrains/python/lexer/PyStringLiteralLexerBase.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/lexer/PyStringLiteralLexerBase.java
@@ -47,7 +47,7 @@ public abstract class PyStringLiteralLexerBase extends LexerBase {
     if (myStart >= myEnd) return null;
 
     // skip non-escapes immediately
-    if (myBuffer.charAt(myStart) != '\\' || (isRaw() && !(isUnicodeMode() && nextIsUnicodeEscape()))) {
+    if (!isEscape()) {
       mySeenEscapedSpacesOnly = false;
       return myOriginalLiteralToken;
     }
@@ -57,7 +57,7 @@ public abstract class PyStringLiteralLexerBase extends LexerBase {
   }
 
   @NotNull
-  public final IElementType getEscapeSequenceType() {
+  public IElementType getEscapeSequenceType() {
     if (myStart + 1 >= myEnd) return StringEscapesTokenTypes.INVALID_CHARACTER_ESCAPE_TOKEN; // escape ends too early
     char nextChar = myBuffer.charAt(myStart + 1);
     mySeenEscapedSpacesOnly &= nextChar == ' ';
@@ -117,6 +117,10 @@ public abstract class PyStringLiteralLexerBase extends LexerBase {
 
     // other unrecognized escapes are just part of string, not an error
     return myOriginalLiteralToken;
+  }
+
+  protected boolean isEscape() {
+    return myBuffer.charAt(myStart) == '\\' && (!isRaw() || isUnicodeMode() && nextIsUnicodeEscape());
   }
 
   private boolean nextIsUnicodeEscape() {

--- a/python/testSrc/com/jetbrains/python/PyStringLiteralLexerTest.java
+++ b/python/testSrc/com/jetbrains/python/PyStringLiteralLexerTest.java
@@ -3,6 +3,7 @@ package com.jetbrains.python;
 
 import com.jetbrains.python.PyTokenTypes;
 import com.jetbrains.python.fixtures.PyLexerTestCase;
+import com.jetbrains.python.lexer.PyFStringLiteralLexer;
 import com.jetbrains.python.lexer.PyStringLiteralLexer;
 
 /**
@@ -42,5 +43,11 @@ public class PyStringLiteralLexerTest extends PyLexerTestCase {
     doLexerTest("'\\N{F\\')", new PyStringLiteralLexer(PyTokenTypes.SINGLE_QUOTED_UNICODE),
                 "Py:SINGLE_QUOTED_UNICODE", "INVALID_UNICODE_ESCAPE_TOKEN", "VALID_STRING_ESCAPE_TOKEN",
                 "Py:SINGLE_QUOTED_UNICODE");
+  }
+
+  // PY-40863
+  public void testFStringDoubleCurleyBrace() {
+    doLexerTest("a{{b", new PyFStringLiteralLexer(PyTokenTypes.FSTRING_TEXT), true, "a", "{{", "b");
+    doLexerTest("a\\}}b", new PyFStringLiteralLexer(PyTokenTypes.FSTRING_RAW_TEXT), true, "a", "\\", "}}", "b");
   }
 }


### PR DESCRIPTION
Update locateToken to consider double curly braces and override getEscapeSequenceType accordingly to return StringEscapesTokenTypes.VALID_STRING_ESCAPE_TOKEN for such tokens.