### PR TITLE
Include libraries in use-scope

### DIFF
--- a/java/java-tests/testSrc/com/intellij/roots/ModuleScopesTest.java
+++ b/java/java-tests/testSrc/com/intellij/roots/ModuleScopesTest.java
@@ -338,4 +338,20 @@ public class ModuleScopesTest extends JavaModuleTestCase {
     assertTrue(ResolveScopeManager.getElementResolveScope(getPsiManager().findFile(libFile1)).contains(libFile2));
     assertTrue(ResolveScopeManager.getElementResolveScope(getPsiManager().findFile(libFile2)).contains(libFile1));
   }
+
+  public void testUseScopeWithLibraryUnion() throws Exception {
+    System.setProperty("idea.use.scope.include.libraries", "true");
+    try {
+      VirtualFile sourceInterface = myFixture.createFile("src/TestInterface.java", "public interface TestInterface { }");
+      VirtualFile libraryClass = myFixture.createFile("lib/classes/Test.class");
+      VirtualFile librarySrc = myFixture.createFile("lib/src/Test.java", "public class Test implements TestInterface { }");
+      PsiTestUtil.addContentRoot(myModule, sourceInterface.getParent());
+      PsiTestUtil.addProjectLibrary(myModule, "my-lib", Collections.singletonList(libraryClass.getParent()),
+                                    Collections.singletonList(librarySrc.getParent()));
+
+      assertTrue(ResolveScopeManager.getInstance(myProject).getUseScope(getPsiManager().findFile(sourceInterface)).contains(librarySrc));
+    } finally {
+      System.clearProperty("idea.use.scope.include.libraries");
+    }
+  }
 }

--- a/platform/analysis-impl/src/com/intellij/psi/impl/file/impl/ResolveScopeManagerImpl.java
+++ b/platform/analysis-impl/src/com/intellij/psi/impl/file/impl/ResolveScopeManagerImpl.java
@@ -188,9 +188,12 @@ public final class ResolveScopeManagerImpl extends ResolveScopeManager {
              ? result : GlobalSearchScope.fileScope(containingFile).uniteWith(result);
     }
     boolean isTest = TestSourcesFilter.isTestSources(vDirectory, myProject);
-    return isTest
+    GlobalSearchScope moduleWithDependents =  isTest
            ? GlobalSearchScope.moduleTestsWithDependentsScope(module)
            : GlobalSearchScope.moduleWithDependentsScope(module);
+    return Boolean.getBoolean("idea.use.scope.include.libraries")
+           ? moduleWithDependents.union(LibraryScopeCache.getInstance(myProject).getLibrariesOnlyScope())
+           : moduleWithDependents;
   }
 
   private boolean isFromAdditionalLibraries(@NotNull final VirtualFile file) {


### PR DESCRIPTION
Our projects has use-references from source contents in libraries which should be returned for users. 
I have included this change in a internal plugin which overrides ResolveManagerImpl, but this is not ideal and I would prefer this to be in IJ. 