### PR TITLE
Remove redundant .toString()

### DIFF
--- a/java/compiler/forms-compiler/src/com/intellij/uiDesigner/compiler/AsmCodeGenerator.java
+++ b/java/compiler/forms-compiler/src/com/intellij/uiDesigner/compiler/AsmCodeGenerator.java
@@ -146,10 +146,10 @@ public class AsmCodeGenerator {
       }
     }
     catch (IOException e) {
-      myErrors.add(new FormErrorInfo(null, "Cannot read or write class file " + classFile.getPath() + ": " + e.toString()));
+      myErrors.add(new FormErrorInfo(null, "Cannot read or write class file " + classFile.getPath() + ": " + e));
     }
     catch(IllegalStateException e) {
-      myErrors.add(new FormErrorInfo(null, "Unexpected data in form file when patching class " + classFile.getPath() + ": " + e.toString()));
+      myErrors.add(new FormErrorInfo(null, "Unexpected data in form file when patching class " + classFile.getPath() + ": " + e));
     }
   }
 

--- a/java/debugger/impl/src/com/intellij/debugger/engine/SuspendManagerImpl.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/SuspendManagerImpl.java
@@ -81,7 +81,7 @@ public class SuspendManagerImpl implements SuspendManager {
             myFrozenThreads.remove(getThread());
             getThread().resume();
             if (LOG.isDebugEnabled()) {
-              LOG.debug("Thread resumed : " + getThread().toString());
+              LOG.debug("Thread resumed : " + getThread());
             }
             break;
           case EventRequest.SUSPEND_NONE:

--- a/java/debugger/impl/src/com/intellij/debugger/memory/agent/ReferringObjectsInfo.java
+++ b/java/debugger/impl/src/com/intellij/debugger/memory/agent/ReferringObjectsInfo.java
@@ -49,7 +49,7 @@ public class ReferringObjectsInfo {
   public List<ReferringObject> getReferringObjects(@NotNull ObjectReference value, long limit) {
     Integer index = myReversedMap.get(value);
     if (index == null) {
-      LOG.error("Could not find referring object for reference " + value.toString());
+      LOG.error("Could not find referring object for reference " + value);
       return Collections.emptyList();
     }
 

--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/javadoc/PsiDocTokenImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/javadoc/PsiDocTokenImpl.java
@@ -55,6 +55,6 @@ public class PsiDocTokenImpl extends LeafPsiElement implements PsiDocToken{
 
   @Override
   public String toString(){
-    return "PsiDocToken:" + getTokenType().toString();
+    return "PsiDocToken:" + getTokenType();
   }
 }

--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/PsiJavaTokenImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/PsiJavaTokenImpl.java
@@ -44,6 +44,6 @@ public class PsiJavaTokenImpl extends LeafPsiElement implements PsiJavaToken{
 
   @Override
   public String toString(){
-    return "PsiJavaToken:" + getElementType().toString();
+    return "PsiJavaToken:" + getElementType();
   }
 }

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/impl/UnknownSdkTrackerTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/impl/UnknownSdkTrackerTest.java
@@ -291,7 +291,7 @@ public class UnknownSdkTrackerTest extends JavaCodeInsightFixtureTestCase {
 
     ArrayList<String> infos = new ArrayList<>();
     for (UnknownSdkFix notification : UnknownSdkEditorNotification.getInstance(getProject()).getNotifications()) {
-      infos.add("SdkFixInfo:" + notification.toString());
+      infos.add("SdkFixInfo:" + notification);
     }
 
     EditorNotificationPanel sdkNotification = SdkSetupNotificationTestBase.runOnText(myFixture, "Sample.java", "class Sample { java.lang.String foo; }");

--- a/java/java-tests/testSrc/com/intellij/java/openapi/projectRoots/JavaSdkVersionTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/openapi/projectRoots/JavaSdkVersionTest.java
@@ -21,7 +21,7 @@ public class JavaSdkVersionTest {
   @Test
   public void maxLanguageLevelSanity() {
     for (JavaSdkVersion version : JavaSdkVersion.values()) {
-      assertFalse("Fails for " + version.toString(), version.getMaxLanguageLevel().isPreview());
+      assertFalse("Fails for " + version, version.getMaxLanguageLevel().isPreview());
     }
   }
 

--- a/java/java-tests/testSrc/com/intellij/java/refactoring/FunctionalInterfaceSuggesterTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/refactoring/FunctionalInterfaceSuggesterTest.java
@@ -244,7 +244,7 @@ public class FunctionalInterfaceSuggesterTest extends LightJavaCodeInsightFixtur
   }
 
   private static void checkWithExpected(Collection<? extends PsiType> suggestedTypes, final String... expectedTypes) {
-    assertEquals("Suggested types: " + suggestedTypes.toString(), expectedTypes.length, suggestedTypes.size());
+    assertEquals("Suggested types: " + suggestedTypes, expectedTypes.length, suggestedTypes.size());
     assertTrue(ContainerUtil.map(suggestedTypes, PsiType::getCanonicalText).containsAll(Arrays.asList(expectedTypes)));
   }
 

--- a/java/java-tests/testSrc/com/intellij/roots/MultiModuleEditingTest.java
+++ b/java/java-tests/testSrc/com/intellij/roots/MultiModuleEditingTest.java
@@ -200,7 +200,7 @@ public class MultiModuleEditingTest extends JavaModuleTestCase {
         String[] chunk = expected[chunkIndex];
         final List<String> expectedChunkList = new ArrayList<>(Arrays.asList(chunk));
         int nextIndex = runningIndex + chunk.length;
-        assertTrue("Expected chunk " + expectedChunkList.toString(), nextIndex <= myLog.size());
+        assertTrue("Expected chunk " + expectedChunkList, nextIndex <= myLog.size());
         final List<String> actualChunkList = new ArrayList<>(myLog.subList(runningIndex, nextIndex));
         Collections.sort(expectedChunkList);
         Collections.sort(actualChunkList);

--- a/jps/jps-builders/src/org/jetbrains/jps/incremental/IncProjectBuilder.java
+++ b/jps/jps-builders/src/org/jetbrains/jps/incremental/IncProjectBuilder.java
@@ -1016,7 +1016,7 @@ public final class IncProjectBuilder {
             LOG.info(e);
           }
           finally {
-            LOG.debug("Finished compilation of " + task.getChunk().toString());
+            LOG.debug("Finished compilation of " + task.getChunk());
             myTasksCountDown.countDown();
             List<BuildChunkTask> nextTasks;
             synchronized (myQueueLock) {

--- a/jps/jps-builders/testSrc/org/jetbrains/jps/javac/APIWrappersTest.java
+++ b/jps/jps-builders/testSrc/org/jetbrains/jps/javac/APIWrappersTest.java
@@ -32,7 +32,7 @@ public class APIWrappersTest extends TestCase {
           else {
             try {
               final Method apiMethod = apiIfaceClass.getMethod(declaredMethod.getName(), declaredMethod.getParameterTypes());
-              fail("Method " + apiMethod.toString() + " in API interface " + apiIfaceClass.getName() + " should not match a non-public method in a wrapper class " + declaredMethod);
+              fail("Method " + apiMethod + " in API interface " + apiIfaceClass.getName() + " should not match a non-public method in a wrapper class " + declaredMethod);
             }
             catch (NoSuchMethodException ignored) {
               // as expected: for non-public methods there should be no corresponding methods in the API interface

--- a/json/src/com/jetbrains/jsonSchema/impl/JsonValidationError.java
+++ b/json/src/com/jetbrains/jsonSchema/impl/JsonValidationError.java
@@ -61,7 +61,7 @@ public class JsonValidationError {
     private static String getPropertyNameWithComment(MissingPropertyIssueData prop) {
       String comment = "";
       if (prop.enumItemsCount == 1) {
-        comment = " = " + prop.defaultValue.toString();
+        comment = " = " + prop.defaultValue;
       }
       return "'" + prop.propertyName + "'" + comment;
     }

--- a/json/src/com/jetbrains/jsonSchema/widget/JsonSchemaStatusWidget.java
+++ b/json/src/com/jetbrains/jsonSchema/widget/JsonSchemaStatusWidget.java
@@ -285,7 +285,7 @@ class JsonSchemaStatusWidget extends EditorBasedStatusBarPopup {
 
   @NotNull
   private static WidgetState getDownloadErrorState(@Nullable @Nls String message) {
-    String s = message == null ? "" : (": " + HtmlChunk.br().toString() + message);
+    String s = message == null ? "" : (": " + HtmlChunk.br() + message);
     MyWidgetState state = new MyWidgetState(JsonBundle.message("schema.widget.error.cant.download") + s,
                                             JsonBundle.message("schema.widget.error.label"), true);
     state.setWarning(true);

--- a/platform/build-scripts/testSrc/org/jetbrains/intellij/build/JUnitLiveTestProgressFormatter.java
+++ b/platform/build-scripts/testSrc/org/jetbrains/intellij/build/JUnitLiveTestProgressFormatter.java
@@ -40,17 +40,17 @@ public class JUnitLiveTestProgressFormatter implements JUnitResultFormatter, Ign
 
   @Override
   public void testAssumptionFailure(Test test, Throwable exception) {
-    printMessage(test, "assumption violated (" + exception.toString() + ")");
+    printMessage(test, "assumption violated (" + exception + ")");
   }
 
   @Override
   public void addError(Test test, Throwable e) {
-    printMessage(test, "error (" + e.toString() + ")");
+    printMessage(test, "error (" + e + ")");
   }
 
   @Override
   public void addFailure(Test test, AssertionFailedError e) {
-    printMessage(test, "failed (" + e.toString() + ")");
+    printMessage(test, "failed (" + e + ")");
   }
 
   @Override

--- a/platform/core-api/src/com/intellij/util/indexing/ID.java
+++ b/platform/core-api/src/com/intellij/util/indexing/ID.java
@@ -146,6 +146,6 @@ public class ID<K, V> extends IndexId<K,V> {
   }
 
   public static void dump() {
-    Logger.getInstance(ID.class).info("ID registry: " + ourRegistry.toString());
+    Logger.getInstance(ID.class).info("ID registry: " + ourRegistry);
   }
 }

--- a/platform/core-impl/src/com/intellij/extapi/psi/ASTWrapperPsiElement.java
+++ b/platform/core-impl/src/com/intellij/extapi/psi/ASTWrapperPsiElement.java
@@ -27,6 +27,6 @@ public class ASTWrapperPsiElement extends ASTDelegatePsiElement {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(" + myNode.getElementType().toString() + ")";
+    return getClass().getSimpleName() + "(" + myNode.getElementType() + ")";
   }
 }

--- a/platform/core-impl/src/com/intellij/psi/stubs/StubTreeLoader.java
+++ b/platform/core-impl/src/com/intellij/psi/stubs/StubTreeLoader.java
@@ -157,7 +157,7 @@ public abstract class StubTreeLoader {
   public static @NonNls String getFileViewProviderMismatchDiagnostics(@NotNull FileViewProvider provider) {
     Function<PsiFile, String> fileClassName = file -> file.getClass().getSimpleName();
     Function<Pair<IStubFileElementType, PsiFile>, String> stubRootToString =
-      pair -> "(" + pair.first.toString() + ", " + pair.first.getLanguage() + " -> " + fileClassName.fun(pair.second) + ")";
+      pair -> "(" + pair.first + ", " + pair.first.getLanguage() + " -> " + fileClassName.fun(pair.second) + ")";
     List<Pair<IStubFileElementType, PsiFile>> roots = StubTreeBuilder.getStubbedRoots(provider);
     return ", stubBindingRoot = " + fileClassName.fun(provider.getStubBindingRoot()) +
            ", languages = [" + StringUtil.join(provider.getLanguages(), Language::getID, ", ") +

--- a/platform/core-ui/src/ui/IconWrapperWithToolTipComposite.java
+++ b/platform/core-ui/src/ui/IconWrapperWithToolTipComposite.java
@@ -61,6 +61,6 @@ public class IconWrapperWithToolTipComposite implements IconWithToolTip, Copyabl
 
   @Override
   public String toString() {
-    return "IconWrapperWithTooltipComposite:" + myIcon.toString();
+    return "IconWrapperWithTooltipComposite:" + myIcon;
   }
 }

--- a/platform/extensions/src/org/picocontainer/defaults/CyclicDependencyException.java
+++ b/platform/extensions/src/org/picocontainer/defaults/CyclicDependencyException.java
@@ -46,6 +46,6 @@ public class CyclicDependencyException extends PicoIntrospectionException {
 
     @Override
     public @NonNls String getMessage() {
-        return "Cyclic dependency: " + stack.toString();
+        return "Cyclic dependency: " + stack;
     }
 }

--- a/platform/external-system-impl/testSrc/com/intellij/openapi/externalSystem/test/ExternalSystemTestCase.java
+++ b/platform/external-system-impl/testSrc/com/intellij/openapi/externalSystem/test/ExternalSystemTestCase.java
@@ -560,7 +560,7 @@ public abstract class ExternalSystemTestCase extends UsefulTestCase {
 
   protected static <T> void assertContain(java.util.List<? extends T> actual, T... expected) {
     java.util.List<T> expectedList = Arrays.asList(expected);
-    assertTrue("expected: " + expectedList + "\n" + "actual: " + actual.toString(), actual.containsAll(expectedList));
+    assertTrue("expected: " + expectedList + "\n" + "actual: " + actual, actual.containsAll(expectedList));
   }
 
   protected static <T> void assertDoNotContain(List<? extends T> actual, T... expected) {

--- a/platform/lang-impl/src/com/intellij/psi/stubs/CompositeBinaryBuilderMap.java
+++ b/platform/lang-impl/src/com/intellij/psi/stubs/CompositeBinaryBuilderMap.java
@@ -51,7 +51,7 @@ final class CompositeBinaryBuilderMap {
         int enumeratedId = cumulativeVersionEnumerator.enumerate(cumulativeVersion.toString());
         LOG.debug("composite binary stub builder for " + fileType + " registered:  " +
                   "id = " + enumeratedId + ", " +
-                  "value" + cumulativeVersion.toString());
+                  "value" + cumulativeVersion);
         myCumulativeVersionMap.put(fileType, enumeratedId);
       }
     }

--- a/platform/platform-api/src/com/intellij/ui/jcef/JBCefApp.java
+++ b/platform/platform-api/src/com/intellij/ui/jcef/JBCefApp.java
@@ -144,7 +144,7 @@ public final class JBCefApp {
       .getProviders()
       .stream()
       .flatMap(p -> {
-        LOG.debug("got options: [" + p.getOptions().toString() + "] from:" + p.getClass().getName());
+        LOG.debug("got options: [" + p.getOptions() + "] from:" + p.getClass().getName());
         return p.getOptions().stream();
       })
       .distinct()

--- a/platform/platform-impl/src/com/intellij/ide/ui/customization/CustomActionsSchema.java
+++ b/platform/platform-impl/src/com/intellij/ide/ui/customization/CustomActionsSchema.java
@@ -151,9 +151,9 @@ public final class CustomActionsSchema implements PersistentStateComponent<Eleme
     List<ActionUrl> storedActions = schema.getActions();
     if (ApplicationManager.getApplication().isUnitTestMode() && !storedActions.isEmpty()) {
       //noinspection UseOfSystemOutOrSystemErr
-      System.err.println("stored: " + storedActions.toString());
+      System.err.println("stored: " + storedActions);
       //noinspection UseOfSystemOutOrSystemErr
-      System.err.println("actual: " + getActions().toString());
+      System.err.println("actual: " + getActions());
     }
     if (storedActions.size() != getActions().size()) {
       return true;

--- a/platform/platform-impl/src/com/intellij/openapi/ui/playback/commands/ActionCommand.java
+++ b/platform/platform-impl/src/com/intellij/openapi/ui/playback/commands/ActionCommand.java
@@ -62,7 +62,7 @@ public class ActionCommand extends TypeCommand {
             context.error(getMessage(), getLine());
           }
         };
-        context.message("Invoking action via shortcut: " + stroke.toString(), getLine());
+        context.message("Invoking action via shortcut: " + stroke, getLine());
 
         final KeyStroke finalStroke = stroke;
 

--- a/platform/platform-impl/src/com/intellij/ui/ShowUIDefaultsAction.java
+++ b/platform/platform-impl/src/com/intellij/ui/ShowUIDefaultsAction.java
@@ -262,9 +262,9 @@ public class ShowUIDefaultsAction extends AnAction implements DumbAware {
                       for (int row : rows) {
                         Pair pair = (Pair)myTable.getModel().getValueAt(row, 0);
                         if (pair.second instanceof Color) {
-                          result.add("\"" + pair.first.toString() + "\": \"" + ColorUtil.toHtmlColor((Color)pair.second) + "\"" + tail);
+                          result.add("\"" + pair.first + "\": \"" + ColorUtil.toHtmlColor((Color)pair.second) + "\"" + tail);
                         } else {
-                          result.add("\"" + pair.first.toString() + "\": \"" + pair.second + "\"" + tail);
+                          result.add("\"" + pair.first + "\": \"" + pair.second + "\"" + tail);
                         }
                       }
 

--- a/platform/platform-impl/src/com/intellij/ui/mac/touchbar/ProjectData.java
+++ b/platform/platform-impl/src/com/intellij/ui/mac/touchbar/ProjectData.java
@@ -421,7 +421,7 @@ final class ProjectData {
       ContentData(@NotNull Content content, @NotNull BarContainer barContainer) {
         this.content = content;
         this.barContainer = barContainer;
-        contextName = toolWindowId + "_" + content.toString();
+        contextName = toolWindowId + "_" + content;
       }
 
       void setOptionalContextActions(ActionGroup group) {

--- a/platform/platform-impl/src/com/intellij/ui/messages/SheetController.java
+++ b/platform/platform-impl/src/com/intellij/ui/messages/SheetController.java
@@ -319,7 +319,7 @@ public final class SheetController implements Disposable {
               if (url != null) {
                 Desktop.getDesktop().browse(url.toURI());
               } else {
-                LOG.warn("URL is null; HyperlinkEvent: " + he.toString());
+                LOG.warn("URL is null; HyperlinkEvent: " + he);
               }
             }
             catch (IOException | URISyntaxException e) {

--- a/platform/platform-tests/testSrc/com/intellij/ui/FinderRecursivePanelSelectionUpdateTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/ui/FinderRecursivePanelSelectionUpdateTest.java
@@ -94,7 +94,7 @@ public class FinderRecursivePanelSelectionUpdateTest extends LightPlatformTestCa
     }
     catch (Exception e) {
       final IllegalStateException exception = assertInstanceOf(e, IllegalStateException.class);
-      assertEquals("failed to select idx=1: component=" + placeholder.toString() + ", pathToSelect=[a, b]", exception.getMessage());
+      assertEquals("failed to select idx=1: component=" + placeholder + ", pathToSelect=[a, b]", exception.getMessage());
     }
   }
 

--- a/platform/platform-tests/testSrc/com/intellij/util/containers/TreeTraverserTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/util/containers/TreeTraverserTest.java
@@ -530,7 +530,7 @@ public class TreeTraverserTest extends TestCase {
                  "POST_ORDER_DFS [null]\n" +
                  "PRE_ORDER_DFS [null]\n" +
                  "TRACING_BFS [null]",
-                 StringUtil.join(traversals.map(o -> o + " " + t1.traverse(o).toList().toString()), "\n"));
+                 StringUtil.join(traversals.map(o -> o + " " + t1.traverse(o).toList()), "\n"));
 
     JBTreeTraverser<Object> t2 = JBTreeTraverser.from(o -> JBIterable.of(nil, nil)).withRoots(Arrays.asList(42));
     assertEquals("BI_ORDER_DFS [42, null, null, null, null, 42]\n" +
@@ -541,7 +541,7 @@ public class TreeTraverserTest extends TestCase {
                  "POST_ORDER_DFS [null, null, 42]\n" +
                  "PRE_ORDER_DFS [42, null, null]\n" +
                  "TRACING_BFS [42, null]",
-                 StringUtil.join(traversals.map(o -> o + " " + t2.traverse(o).toList().toString()), "\n"));
+                 StringUtil.join(traversals.map(o -> o + " " + t2.traverse(o).toList()), "\n"));
   }
 
   public void testSimplePreOrderDfs() {

--- a/platform/platform-tests/testSrc/com/intellij/util/ui/TestScaleHelper.java
+++ b/platform/platform-tests/testSrc/com/intellij/util/ui/TestScaleHelper.java
@@ -154,7 +154,7 @@ public final class TestScaleHelper {
   }
 
   public static String msg(UserScaleContext ctx) {
-    return "[JRE-HiDPI " + JreHiDpiUtil.isJreHiDPIEnabled() + "], " + ctx.toString();
+    return "[JRE-HiDPI " + JreHiDpiUtil.isJreHiDPIEnabled() + "], " + ctx;
   }
 
   private static class MyGraphicsConfiguration extends GraphicsConfiguration {

--- a/platform/testFramework/core/src/com/intellij/TestClassesFilter.java
+++ b/platform/testFramework/core/src/com/intellij/TestClassesFilter.java
@@ -75,8 +75,8 @@ public abstract class TestClassesFilter {
     @Override
     public String toString() {
       return "TestClassesFilter.And{" +
-             "first: " + first.toString() + ", " +
-             "second: " + second.toString() + '}';
+             "first: " + first + ", " +
+             "second: " + second + '}';
     }
   }
 }

--- a/platform/testFramework/src/com/intellij/util/io/TestFileSystemItem.java
+++ b/platform/testFramework/src/com/intellij/util/io/TestFileSystemItem.java
@@ -61,7 +61,7 @@ public final class TestFileSystemItem {
         notFound.remove(name);
       }
     }
-    Assert.assertTrue("files " + notFound.toString() + " not found in " + relativePath, notFound.isEmpty());
+    Assert.assertTrue("files " + notFound + " not found in " + relativePath, notFound.isEmpty());
   }
 
   private void assertFileEqual(File file, String relativePath) {

--- a/platform/util/src/com/intellij/openapi/util/Dump.java
+++ b/platform/util/src/com/intellij/openapi/util/Dump.java
@@ -18,6 +18,6 @@ public final class Dump {
     Exception e = new Exception();
     StackTraceElement[] element = e.getStackTrace();
     StackTraceElement dumper = element[2];
-    ps.println(text + " at " + dumper.toString());
+    ps.println(text + " at " + dumper);
   }
 }

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ManualArrayToCollectionCopyInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ManualArrayToCollectionCopyInspection.java
@@ -334,7 +334,7 @@ public class ManualArrayToCollectionCopyInspection extends BaseInspection {
         final String negatedExpressionText = expressionText.substring(1);
         final Object lhConstant = computeConstant(negatedExpressionText, context);
         if (lhConstant != null) {
-          return " - " + lhConstant.toString();
+          return " - " + lhConstant;
         }
         return " + (" + expressionText + ")";
       }

--- a/plugins/cucumber-jvm-formatter/src/org/jetbrains/plugins/cucumber/java/run/CucumberJvm2Adapter.java
+++ b/plugins/cucumber-jvm-formatter/src/org/jetbrains/plugins/cucumber/java/run/CucumberJvm2Adapter.java
@@ -123,7 +123,7 @@ public class CucumberJvm2Adapter {
     public String getStepName() {
       String stepName;
       if (myRealStep.isHook()) {
-        stepName = "Hook: " + myRealStep.getHookType().toString();
+        stepName = "Hook: " + myRealStep.getHookType();
       } else {
         stepName = getStepKeyword() + " " + myRealStep.getStepText();
       }

--- a/plugins/cucumber-jvm-formatter3/src/org/jetbrains/plugins/cucumber/java/run/CucumberJvm3Adapter.java
+++ b/plugins/cucumber-jvm-formatter3/src/org/jetbrains/plugins/cucumber/java/run/CucumberJvm3Adapter.java
@@ -126,7 +126,7 @@ public class CucumberJvm3Adapter {
     public String getStepName() {
       String stepName;
       if (myRealStep instanceof HookTestStep) {
-        stepName = "Hook: " + ((HookTestStep)myRealStep).getHookType().toString();
+        stepName = "Hook: " + ((HookTestStep)myRealStep).getHookType();
       } else {
         stepName = getStepKeyword() + " " + ((PickleStepTestStep) myRealStep).getPickleStep().getText();
       }

--- a/plugins/eclipse/src/org/jdom/output/EclipseXMLOutputter.java
+++ b/plugins/eclipse/src/org/jdom/output/EclipseXMLOutputter.java
@@ -1499,7 +1499,7 @@ public class EclipseXMLOutputter extends BaseXmlOutputter implements Cloneable {
       "omitEncoding = " + false + ", " +
       "indent = '" + "\t" + "'" + ", " +
       "expandEmptyElements = " + userFormat.expandEmptyElements + ", " +
-      "lineSeparator = '" + buffer.toString() + "', " +
+      "lineSeparator = '" + buffer + "', " +
       "textMode = " + userFormat.mode + "]"
     );
   }

--- a/plugins/testng_rt/src/com/intellij/rt/testng/IDEATestNGRemoteListener.java
+++ b/plugins/testng_rt/src/com/intellij/rt/testng/IDEATestNGRemoteListener.java
@@ -298,7 +298,7 @@ public class IDEATestNGRemoteListener {
             }
           }
           else {
-            paramString = "[" + parameter.toString() + "]";
+            paramString = "[" + parameter + "]";
           }
         }
       }


### PR DESCRIPTION
In String concatenation, `.toString()` is not needed, since it is implicitly called by the compiler.

This PR doesn't cover all cases, but it is initial before adding more PRs.