### PR TITLE
reuse Gradle connections slightly less

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleConnectorService.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/GradleConnectorService.kt
@@ -110,7 +110,27 @@ internal class GradleConnectorService(@Suppress("UNUSED_PARAMETER") project: Pro
     val wrapperPropertyFile: String?,
     val verboseProcessing: Boolean?,
     val ttlMs: Int?
-  )
+  ) {
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other == null || this.javaClass != other.javaClass) return false
+      val otherConnectorParams = other as ConnectorParams
+
+      // don't cache connections for not-yet-installed gradle versions
+      if (this.gradleHome == null || otherConnectorParams.gradleHome == null) return false
+
+      return this.projectPath == otherConnectorParams.projectPath &&
+             this.serviceDirectory == otherConnectorParams.serviceDirectory &&
+             this.distributionType == otherConnectorParams.distributionType &&
+             this.gradleHome == otherConnectorParams.gradleHome &&
+             this.javaHome == otherConnectorParams.javaHome &&
+             this.wrapperPropertyFile == otherConnectorParams.wrapperPropertyFile &&
+             this.verboseProcessing == otherConnectorParams.verboseProcessing &&
+             this.ttlMs == other.ttlMs
+    }
+    // default data class hashCode() implementation is fine: our equals() is strictly more
+    // stringent than the default equals()
+  }
 
   companion object {
     private val LOG = logger<GradleConnectorService>()


### PR DESCRIPTION
If we attempt to make a connection with a Gradle version which is not
currently installed, `gradleHome` in the connector parameters is null,
no matter which version of Gradle is requested.  The connector will
then download and suitably install the version of Gradle requested,
but the null value of `gradleHome` forms parts of the key for looking
up existing connections.

If there is a subsequent request to make a connection with a different
Gradle version which is also not installed, the existing stored
connection (with a different Gradle version) will be re-used rather
than installing and using the requested version.

To fix this, consider ConnectorParameter objects as different (not
equals()) if either of them has a `gradleHome` that is null.