### PR TITLE
Add Invoker#forBackgroundPoolWithoutReadAction to allow parallel exec…

### DIFF
--- a/platform/platform-impl/src/com/intellij/util/concurrency/Invoker.java
+++ b/platform/platform-impl/src/com/intellij/util/concurrency/Invoker.java
@@ -571,6 +571,11 @@ public abstract class Invoker implements Disposable {
   }
 
   @NotNull
+  public static Invoker forBackgroundPoolWithoutReadAction(@NotNull Disposable parent) {
+    return new Background(parent, ThreeState.NO, 8);
+  }
+
+  @NotNull
   public static Invoker forBackgroundThreadWithReadAction(@NotNull Disposable parent) {
     return new Background(parent, ThreeState.YES, 1);
   }


### PR DESCRIPTION
…ution without locks

We populate a few of our AsyncTreeModels with data populated from network calls, so we do not want to run it under a read lock, but we do want the calls to execute in parallel.

8 threads was chosen to match the other backgroundPool method