### PR TITLE
Replace size zero check with 'isEmpty'

### DIFF
--- a/java/idea-ui/src/com/intellij/jarRepository/syncLoading.kt
+++ b/java/idea-ui/src/com/intellij/jarRepository/syncLoading.kt
@@ -28,7 +28,7 @@ internal class LoadResult(val artifacts: Collection<Artifact>?,
 
 internal fun loadDependenciesSync(project: Project) {
   val toSync = RepositoryLibrarySynchronizer.collectLibrariesToSync(project)
-  if (toSync.size == 0) return
+  if (toSync.isEmpty()) return
   val queue = ArrayBlockingQueue<LoadResult>(toSync.size)
   val submitted = submitLoadJobs(project, toSync, queue)
   LOG.info("Submitted $submitted jobs for downloading maven dependencies")

--- a/java/java-impl/src/com/intellij/codeInspection/optionalToIf/OptionalToIfInspection.java
+++ b/java/java-impl/src/com/intellij/codeInspection/optionalToIf/OptionalToIfInspection.java
@@ -41,7 +41,7 @@ public class OptionalToIfInspection extends AbstractBaseJavaLocalInspectionTool 
         String methodName = terminalCall.getMethodExpression().getReferenceName();
         if (methodName == null || !SUPPORTED_TERMINALS.contains(methodName)) return;
         List<Operation> operations = extractOperations(terminalCall, true);
-        if (operations == null || operations.size() < 1 || !(operations.get(0) instanceof SourceOperation)) return;
+        if (operations == null || operations.isEmpty() || !(operations.get(0) instanceof SourceOperation)) return;
         OptionalToIfContext context = OptionalToIfContext.create(terminalCall);
         if (context == null) return;
         holder.registerProblem(terminalCall, JavaBundle.message("inspection.message.replace.optional.with.if.statements"), new ReplaceOptionalWithIfFix());

--- a/java/java-impl/src/com/intellij/codeInspection/streamMigration/JoiningMigration.java
+++ b/java/java-impl/src/com/intellij/codeInspection/streamMigration/JoiningMigration.java
@@ -945,7 +945,7 @@ public class JoiningMigration extends BaseStreamApiMigration {
                                                                          @Nullable List<PsiVariable> nonFinalVariables) {
         if (nonFinalVariables != null && !nonFinalVariables.isEmpty()) return null;
         List<PsiStatement> statements = Arrays.asList(terminalBlock.getStatements());
-        if (statements.size() < 1) return null;
+        if (statements.isEmpty()) return null;
         PsiVariable targetBuilder = extractStringBuilder(statements.get(0));
         if(!(targetBuilder instanceof PsiLocalVariable)) return null;
         List<PsiExpression> joinParts = extractJoinParts(statements);

--- a/java/java-runtime/src/com/intellij/rt/execution/testFrameworks/ProcessBuilder.java
+++ b/java/java-runtime/src/com/intellij/rt/execution/testFrameworks/ProcessBuilder.java
@@ -67,7 +67,7 @@ public class ProcessBuilder {
   //
   // If either of these becomes an issue, please refer to [util] CommandLineUtil.addToWindowsCommandLine() for a possible implementation.
   public Process createProcess() throws IOException {
-    if (myParameters.size() < 1) {
+    if (myParameters.isEmpty()) {
       throw new IllegalArgumentException("Executable name not specified");
     }
 

--- a/platform/docs/build.main.kts
+++ b/platform/docs/build.main.kts
@@ -35,7 +35,7 @@ Files.newDirectoryStream(Paths.get(".").toAbsolutePath(), "*.puml").use { inFile
 
     val sourceFileReader = SourceFileReader(inFile.toFile(), outDir.toFile(), svgFileFormat)
     val result = sourceFileReader.getGeneratedImages()
-    if (result.size == 0) {
+    if (result.isEmpty()) {
       System.err.println("warning: no image in $inFile")
       continue
     }

--- a/platform/platform-impl/src/com/intellij/diagnostic/hprof/analysis/AnalyzeGraph.kt
+++ b/platform/platform-impl/src/com/intellij/diagnostic/hprof/analysis/AnalyzeGraph.kt
@@ -341,7 +341,7 @@ open class AnalyzeGraph(protected val analysisContext: AnalysisContext) {
       toVisit2 = tmp
 
       // Handle state transitions
-      while (toVisit.size == 0 && phase != WalkGraphPhase.Finished) {
+      while (toVisit.isEmpty && phase != WalkGraphPhase.Finished) {
         // Next state
         phase = WalkGraphPhase.values()[phase.ordinal + 1]
 

--- a/platform/platform-impl/src/com/intellij/openapi/editor/textarea/TextComponentCaretModel.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/textarea/TextComponentCaretModel.java
@@ -112,7 +112,7 @@ class TextComponentCaretModel implements CaretModel {
 
   @Override
   public void setCaretsAndSelections(@NotNull List<? extends CaretState> caretStates) {
-    if (caretStates.size() < 1) throw new IllegalArgumentException("Empty list");
+    if (caretStates.isEmpty()) throw new IllegalArgumentException("Empty list");
     CaretState state = caretStates.get(0);
     if (state != null) {
       if (state.getCaretPosition() != null) moveToLogicalPosition(state.getCaretPosition());

--- a/platform/script-debugger/debugger-ui/src/FunctionScopesValueGroup.kt
+++ b/platform/script-debugger/debugger-ui/src/FunctionScopesValueGroup.kt
@@ -17,7 +17,7 @@ internal class FunctionScopesValueGroup(private val functionValue: FunctionValue
     functionValue.resolve()
       .onSuccess(node) {
           val scopes = it.scopes
-          if (scopes == null || scopes.size == 0) {
+          if (scopes == null || scopes.isEmpty()) {
             node.addChildren(XValueChildrenList.EMPTY, true)
           }
           else {

--- a/platform/script-debugger/protocol/protocol-reader/src/InterfaceReader.kt
+++ b/platform/script-debugger/protocol/protocol-reader/src/InterfaceReader.kt
@@ -173,7 +173,7 @@ internal class InterfaceReader(val typeToTypeHandler: LinkedHashMap<Class<*>, Ty
         var argumentType = type.actualTypeArguments[if (isList) 0 else 1]
         if (argumentType is WildcardType) {
           val wildcard = argumentType
-          if (wildcard.lowerBounds.size == 0 && wildcard.upperBounds.size == 1) {
+          if (wildcard.lowerBounds.isEmpty() && wildcard.upperBounds.size == 1) {
             argumentType = wildcard.upperBounds[0]
           }
         }

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/FilePathHolder.kt
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/FilePathHolder.kt
@@ -44,7 +44,7 @@ class FilePathHolder(private val project: Project) : FileHolder {
       ProgressManager.checkCanceled()
       if (files.isEmpty()) return
 
-      if (scope.recursivelyDirtyDirectories.size == 0) {
+      if (scope.recursivelyDirtyDirectories.isEmpty()) {
         // `files` set is case-sensitive depending on OS, `scope.dirtyFiles` set is always case-sensitive
         // `AbstractSet.removeAll()` chooses collection to iterate through depending on its size
         // so we explicitly iterate through `scope.dirtyFiles` here

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/VirtualFileHolder.kt
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/VirtualFileHolder.kt
@@ -46,7 +46,7 @@ class VirtualFileHolder(private val myProject: Project) : FileHolder {
       ProgressManager.checkCanceled()
       if (files.isEmpty()) return
 
-      if (scope.recursivelyDirtyDirectories.size == 0) {
+      if (scope.recursivelyDirtyDirectories.isEmpty()) {
         val dirtyFiles = scope.dirtyFiles
         var cleanDroppedFiles = false
 

--- a/plugins/github/src/org/jetbrains/plugins/github/util/GithubGitHelper.kt
+++ b/plugins/github/src/org/jetbrains/plugins/github/util/GithubGitHelper.kt
@@ -56,7 +56,7 @@ class GithubGitHelper {
     fun findGitRepository(project: Project, file: VirtualFile? = null): GitRepository? {
       val manager = GitUtil.getRepositoryManager(project)
       val repositories = manager.repositories
-      if (repositories.size == 0) {
+      if (repositories.isEmpty()) {
         return null
       }
       if (repositories.size == 1) {

--- a/plugins/package-search/src/com/jetbrains/packagesearch/intellij/plugin/ui/toolwindow/panels/management/right/PackagesTargetModulesControl.kt
+++ b/plugins/package-search/src/com/jetbrains/packagesearch/intellij/plugin/ui/toolwindow/panels/management/right/PackagesTargetModulesControl.kt
@@ -348,7 +348,7 @@ class PackagesTargetModulesControl(private val viewModel: PackageSearchToolWindo
 
         // Compare previous packageOperationTargets with current.
         // If the underlying dependencies have not changed, there is no need to update them.
-        val shouldUpdateItems = items.size == 0 ||
+        val shouldUpdateItems = items.isEmpty() ||
             items.size != projectModules.size ||
             items.any { it.packageSearchDependency != selectedDependency } ||
             installationSummary != selectedDependency?.buildInstallationSummary()

--- a/plugins/repository-search/src/main/java/org/jetbrains/idea/maven/onlinecompletion/model/MavenRepositoryArtifactInfo.kt
+++ b/plugins/repository-search/src/main/java/org/jetbrains/idea/maven/onlinecompletion/model/MavenRepositoryArtifactInfo.kt
@@ -27,7 +27,7 @@ class MavenRepositoryArtifactInfo(private val groupId: String,
 
   @NlsSafe
   override fun getVersion(): String? {
-    return if (items.size < 1) {
+    return if (items.isEmpty()) {
       null
     }
     else items[0].version!!

--- a/plugins/repository-search/src/main/java/org/jetbrains/idea/reposearch/DependencySearchService.kt
+++ b/plugins/repository-search/src/main/java/org/jetbrains/idea/reposearch/DependencySearchService.kt
@@ -88,7 +88,7 @@ class DependencySearchService(private val myProject: Project) {
     localResultSet.forEach(consumer)
 
 
-    if (parameters.isLocalOnly || remoteProviders.size == 0) {
+    if (parameters.isLocalOnly || remoteProviders.isEmpty()) {
       return resolvedPromise(0)
     }
 

--- a/python/src/com/jetbrains/python/debugger/PySuspendContext.java
+++ b/python/src/com/jetbrains/python/debugger/PySuspendContext.java
@@ -54,7 +54,7 @@ public class PySuspendContext extends XSuspendContext {
   @Override
   public XExecutionStack @NotNull [] getExecutionStacks() {
     final Collection<PyThreadInfo> threads = myDebugProcess.getThreads();
-    if (threads.size() < 1) {
+    if (threads.isEmpty()) {
       return XExecutionStack.EMPTY_ARRAY;
     }
     else {


### PR DESCRIPTION
This change removes the suggestion to use `isEmpty` in kotlin.

This change is also applied to `.java`