### PR TITLE
IDEA-253543: Include annotations in ChangeParametersRequest

### DIFF
--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/AnnotationAttributeValueRequest.kt
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/AnnotationAttributeValueRequest.kt
@@ -55,7 +55,7 @@ fun attributeValueRequest(attribValue: JvmAnnotationAttributeValue,
     val referenceText = (attribute as? PsiNameValuePair)?.value?.text ?: (attribValue.field as? PsiElement)?.text
     referenceText?.let { AnnotationAttributeValueRequest.ConstantValue(attribValue.field, it) }
   }
-  is JvmNestedAnnotationValue -> AnnotationAttributeValueRequest.NestedAnnotation(annotationRequest(attribValue.value))
+  is JvmNestedAnnotationValue -> annotationRequest(attribValue.value)?.let(AnnotationAttributeValueRequest::NestedAnnotation)
   else -> null
 }
 

--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/AnnotationAttributeValueRequest.kt
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/AnnotationAttributeValueRequest.kt
@@ -1,24 +1,81 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.lang.jvm.actions
 
+import com.intellij.lang.jvm.JvmAnnotation
+import com.intellij.lang.jvm.JvmField
+import com.intellij.lang.jvm.annotation.*
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiNameValuePair
+
 
 sealed class AnnotationAttributeValueRequest {
   data class PrimitiveValue(val value: Any) : AnnotationAttributeValueRequest()
   data class StringValue(val value: String) : AnnotationAttributeValueRequest()
-  /*
-  There also could be additional cases namely:
-  ```
-     data class ClassValue(val clazz: JvmClass) : AnnotationAttributeValueRequest()
-     data class ConstantValue(val reference: JvmField) : AnnotationAttributeValueRequest()
-     data class NestedAnnotation(val annotationRequest: AnnotationRequest) : AnnotationAttributeValueRequest()
-     data class ArrayValue(val members: List<AnnotationAttributeValueRequest>) : AnnotationAttributeValueRequest()
-  ```
-  they are skipped until become necessary
-   */
-
+  data class ClassValue(val classFqn: String) : AnnotationAttributeValueRequest()
+  data class ConstantValue(val reference: JvmField?, val text: String) : AnnotationAttributeValueRequest()
+  data class NestedAnnotation(val annotationRequest: AnnotationRequest) : AnnotationAttributeValueRequest()
+  data class ArrayValue(val members: List<AnnotationAttributeValueRequest>) : AnnotationAttributeValueRequest()
 }
 
 data class AnnotationAttributeRequest(val name: String, val value: AnnotationAttributeValueRequest)
 
-fun stringAttribute(name: String, value: String): AnnotationAttributeRequest = AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.StringValue(value))
-fun intAttribute(name: String, value: Int): AnnotationAttributeRequest = AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.PrimitiveValue(value))
+fun stringAttribute(name: String, value: String): AnnotationAttributeRequest =
+  AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.StringValue(value))
+
+fun intAttribute(name: String, value: Int): AnnotationAttributeRequest =
+  AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.PrimitiveValue(value))
+
+fun classAttribute(name: String, classFqn: String): AnnotationAttributeRequest =
+  AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.ClassValue(classFqn))
+
+fun constantAttribute(name: String, reference: JvmField): AnnotationAttributeRequest =
+  AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.ConstantValue(reference, (reference as PsiElement).text))
+
+fun constantAttribute(name: String, refText: String): AnnotationAttributeRequest =
+  AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.ConstantValue(null, refText))
+
+fun nestedAttribute(name: String, annotation: AnnotationRequest): AnnotationAttributeRequest =
+  AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.NestedAnnotation(annotation))
+
+fun arrayAttribute(name: String, members: List<AnnotationAttributeValueRequest>): AnnotationAttributeRequest =
+  AnnotationAttributeRequest(name, AnnotationAttributeValueRequest.ArrayValue(members))
+
+fun JvmAnnotationAttributeValue.toAttributeValueRequest(attribute: JvmAnnotationAttribute? = null): AnnotationAttributeValueRequest? = when (this) {
+  is JvmAnnotationArrayValue -> AnnotationAttributeValueRequest.ArrayValue(
+    this.values.mapNotNull { it.toAttributeValueRequest(attribute) })
+  is JvmAnnotationClassValue -> {
+    val referenceText = this.clazz?.qualifiedName ?: run {
+      // Try to preserve unresolved class literal
+      val classLiteralExpression = ((attribute as? PsiNameValuePair)?.value as? PsiExpression)?.type
+      val genericParameter = (classLiteralExpression as? PsiClassType)?.parameters?.firstOrNull()
+      genericParameter?.canonicalText
+    }
+    referenceText?.let(AnnotationAttributeValueRequest::ClassValue)
+  }
+  is JvmAnnotationConstantValue -> when (val constantVal = this.constantValue) {
+    is String -> AnnotationAttributeValueRequest.StringValue(constantVal)
+    is Any -> AnnotationAttributeValueRequest.PrimitiveValue(constantVal)
+    else -> {
+      // Try to preserve original reference text
+      val referenceText = (attribute as? PsiNameValuePair)?.value?.text
+      referenceText?.let { AnnotationAttributeValueRequest.ConstantValue(null, it) }
+    }
+  }
+  is JvmAnnotationEnumFieldValue -> {
+    // Try to preserve the original text, otherwise fallback to field name
+    val referenceText = (attribute as? PsiNameValuePair)?.value?.text ?: (this.field as? PsiElement)?.text
+    referenceText?.let { AnnotationAttributeValueRequest.ConstantValue(this.field, it) }
+  }
+  is JvmNestedAnnotationValue -> AnnotationAttributeValueRequest.NestedAnnotation(this.value.toRequest())
+  else -> null
+}
+
+fun JvmAnnotationAttribute.toAttributeRequest(): AnnotationAttributeRequest? {
+  val valueRequest = this.attributeValue?.toAttributeValueRequest(this) ?: return null
+  return AnnotationAttributeRequest(this.attributeName, valueRequest)
+}
+
+fun JvmAnnotation.getAttributeRequests(): List<AnnotationAttributeRequest> =
+  attributes.mapNotNull(JvmAnnotationAttribute::toAttributeRequest)

--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/ChangeParametersRequest.java
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/ChangeParametersRequest.java
@@ -47,7 +47,7 @@ public interface ChangeParametersRequest extends ActionRequest {
     @NotNull
     @Override
     public Collection<AnnotationRequest> getExpectedAnnotations() {
-      return ContainerUtil.map(myExistingParameter.getAnnotations(), AnnotationRequestsKt::annotationRequest);
+      return ContainerUtil.mapNotNull(myExistingParameter.getAnnotations(), AnnotationRequestsKt::annotationRequest);
     }
   }
 }

--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/ChangeParametersRequest.java
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/ChangeParametersRequest.java
@@ -2,6 +2,7 @@
 package com.intellij.lang.jvm.actions;
 
 import com.intellij.lang.jvm.JvmParameter;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -42,6 +43,11 @@ public interface ChangeParametersRequest extends ActionRequest {
     public JvmParameter getExistingParameter() {
       return myExistingParameter;
     }
-  }
 
+    @NotNull
+    @Override
+    public Collection<AnnotationRequest> getExpectedAnnotations() {
+      return ContainerUtil.map(myExistingParameter.getAnnotations(), AnnotationRequestsKt::toRequest);
+    }
+  }
 }

--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/ChangeParametersRequest.java
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/ChangeParametersRequest.java
@@ -47,7 +47,7 @@ public interface ChangeParametersRequest extends ActionRequest {
     @NotNull
     @Override
     public Collection<AnnotationRequest> getExpectedAnnotations() {
-      return ContainerUtil.map(myExistingParameter.getAnnotations(), AnnotationRequestsKt::toRequest);
+      return ContainerUtil.map(myExistingParameter.getAnnotations(), AnnotationRequestsKt::annotationRequest);
     }
   }
 }

--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/annotationRequests.kt
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/annotationRequests.kt
@@ -6,8 +6,8 @@ import com.intellij.lang.jvm.JvmAnnotation
 fun annotationRequest(fqn: String, vararg parameters: AnnotationAttributeRequest): AnnotationRequest =
   SimpleAnnotationRequest(fqn, parameters.asList())
 
-fun annotationRequest(annotation: JvmAnnotation): AnnotationRequest =
-  SimpleAnnotationRequest(annotation.qualifiedName ?: throw IllegalStateException(), attributeRequests(annotation))
+fun annotationRequest(annotation: JvmAnnotation): AnnotationRequest? =
+  annotation.qualifiedName?.let { SimpleAnnotationRequest(it, attributeRequests(annotation)) }
 
 private class SimpleAnnotationRequest(private val fqn: String,
                                       private val attributes: List<AnnotationAttributeRequest>) : AnnotationRequest {

--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/annotationRequests.kt
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/annotationRequests.kt
@@ -1,11 +1,19 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.lang.jvm.actions
 
-fun annotationRequest(fqn: String, vararg parameters: AnnotationAttributeRequest): AnnotationRequest = object : AnnotationRequest {
+import com.intellij.lang.jvm.JvmAnnotation
+
+fun annotationRequest(fqn: String, vararg parameters: AnnotationAttributeRequest): AnnotationRequest =
+  SimpleAnnotationRequest(fqn, parameters.asList())
+
+fun JvmAnnotation.toRequest(): AnnotationRequest =
+  SimpleAnnotationRequest(qualifiedName ?: throw IllegalStateException(), getAttributeRequests())
+
+private class SimpleAnnotationRequest(private val fqn: String,
+                                      private val attributes: List<AnnotationAttributeRequest>) : AnnotationRequest {
   override fun getQualifiedName(): String = fqn
 
-  override fun getAttributes(): List<AnnotationAttributeRequest> = parameters.asList()
+  override fun getAttributes(): List<AnnotationAttributeRequest> = attributes
 
   override fun isValid(): Boolean = true
-
 }

--- a/java/java-analysis-api/src/com/intellij/lang/jvm/actions/annotationRequests.kt
+++ b/java/java-analysis-api/src/com/intellij/lang/jvm/actions/annotationRequests.kt
@@ -6,8 +6,8 @@ import com.intellij.lang.jvm.JvmAnnotation
 fun annotationRequest(fqn: String, vararg parameters: AnnotationAttributeRequest): AnnotationRequest =
   SimpleAnnotationRequest(fqn, parameters.asList())
 
-fun JvmAnnotation.toRequest(): AnnotationRequest =
-  SimpleAnnotationRequest(qualifiedName ?: throw IllegalStateException(), getAttributeRequests())
+fun annotationRequest(annotation: JvmAnnotation): AnnotationRequest =
+  SimpleAnnotationRequest(annotation.qualifiedName ?: throw IllegalStateException(), attributeRequests(annotation))
 
 private class SimpleAnnotationRequest(private val fqn: String,
                                       private val attributes: List<AnnotationAttributeRequest>) : AnnotationRequest {

--- a/java/java-impl/src/com/intellij/lang/java/actions/ChangeMethodParameters.kt
+++ b/java/java-impl/src/com/intellij/lang/java/actions/ChangeMethodParameters.kt
@@ -53,7 +53,9 @@ internal class ChangeMethodParameters(target: PsiMethod, override val request: C
       val psiType = helper.convertType(expectedHead.expectedTypes.first().theType)
       val newParameter = factory.createParameter(name, psiType)
 
-      for (annotationRequest in expectedHead.expectedAnnotations) {
+      // #addAnnotationToModifierList adds annotations to the start of the modifier list instead of its end,
+      // reversing the list "nullifies" this behaviour, thus preserving the original annotations order
+      for (annotationRequest in expectedHead.expectedAnnotations.reversed()) {
         CreateAnnotationAction.addAnnotationToModifierList(newParameter.modifierList!!, annotationRequest)
       }
 

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/quickFix/CreateAnnotationTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/quickFix/CreateAnnotationTest.kt
@@ -64,5 +64,136 @@ class CreateAnnotationTest : LightJavaCodeInsightFixtureTestCase() {
     """.trimIndent())
   }
 
+  fun `test add annotation with class access literal`() {
+    myFixture.addClass("""
+      public @interface Anno {
+        Class<?> value();
+      }
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {}
+    """.trimIndent())
+
+    val modifierListOwner = myFixture.findElementByText("A", PsiJvmModifiersOwner::class.java)
+
+    myFixture.launchAction(createAnnotationAction(modifierListOwner,
+                                                  annotationRequest(
+                                                    "Anno",
+                                                    classAttribute("value", "A"),
+                                                  )
+    )
+    )
+    myFixture.checkResult("""
+      @Anno(A.class)
+      class A {}
+    """.trimIndent())
+  }
+
+  fun `test add annotation with field reference`() {
+    myFixture.addClass("""
+      public @interface Anno {
+        int field1();
+        int field2();
+        int field3();
+      }
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {
+        private static final int CONSTANT = 1;
+      }
+    """.trimIndent())
+
+    val modifierListOwner = myFixture.findElementByText("A", PsiJvmModifiersOwner::class.java)
+
+    val annotation = annotationRequest("Anno",
+                                       constantAttribute("field1", "A.CONSTANT"),
+                                       constantAttribute("field2", "A.INVALID_CONSTANT"),
+                                       constantAttribute("field3", "CONSTANT"))
+    myFixture.launchAction(createAnnotationAction(modifierListOwner, annotation))
+    myFixture.checkResult("""
+      @Anno(field1 = A.CONSTANT, field2 = A.INVALID_CONSTANT, field3 = CONSTANT)
+      class A {
+        private static final int CONSTANT = 1;
+      }
+    """.trimIndent())
+  }
+
+  fun `test add annotation with array value`() {
+    myFixture.addClass("""
+      public @interface Anno {
+        String[] value();
+      }
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {}
+    """.trimIndent())
+
+    val modifierListOwner = myFixture.findElementByText("A", PsiJvmModifiersOwner::class.java)
+
+    val arrayMembers = listOf(
+      AnnotationAttributeValueRequest.StringValue("member 1"),
+      AnnotationAttributeValueRequest.StringValue("member 2"),
+      AnnotationAttributeValueRequest.StringValue("member 3")
+    )
+    val annotation = annotationRequest("Anno", arrayAttribute("value", arrayMembers))
+    myFixture.launchAction(createAnnotationAction(modifierListOwner, annotation))
+    myFixture.checkResult("""
+      @Anno({"member 1", "member 2", "member 3"})
+      class A {}
+    """.trimIndent())
+  }
+
+  fun `test add annotation with deep nesting`() {
+    myFixture.addClass("""
+      public @interface Root {
+        Nested1 value();
+      }
+    """.trimIndent())
+    myFixture.addClass("""
+      public @interface Nested1 {
+        Nested2[] value() default {};
+      }
+    """.trimIndent())
+    myFixture.addClass("""
+      public @interface Nested2 {
+        Nested1 single();
+        Nested3[] array() default {};
+      }
+    """.trimIndent())
+    myFixture.addClass("""
+      public @interface Nested3 {}
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {}
+    """.trimIndent())
+
+    val modifierListOwner = myFixture.findElementByText("A", PsiJvmModifiersOwner::class.java)
+
+    val nested2_1 = annotationRequest(
+      "Nested2",
+      nestedAttribute("single", annotationRequest("Nested1")),
+      arrayAttribute("array", listOf(
+        AnnotationAttributeValueRequest.NestedAnnotation(annotationRequest("Nested3")),
+        AnnotationAttributeValueRequest.NestedAnnotation(annotationRequest("Nested3"))
+      ))
+    )
+    val nested2_2 = annotationRequest(
+      "Nested2",
+      nestedAttribute("single", annotationRequest("Nested1", arrayAttribute("value", listOf(
+        AnnotationAttributeValueRequest.NestedAnnotation(
+          annotationRequest("Nested2", nestedAttribute("single", annotationRequest("Nested1"))))
+      ))))
+    )
+    val nested1 = annotationRequest("Nested1", arrayAttribute("value", listOf(
+      AnnotationAttributeValueRequest.NestedAnnotation(nested2_1),
+      AnnotationAttributeValueRequest.NestedAnnotation(nested2_2)
+    )))
+    val root = annotationRequest("Root", nestedAttribute("value", nested1))
+    myFixture.launchAction(createAnnotationAction(modifierListOwner, root))
+    myFixture.checkResult("""
+      @Root(@Nested1({@Nested2(single = @Nested1, array = {@Nested3, @Nested3}), @Nested2(single = @Nested1({@Nested2(single = @Nested1)}))}))
+      class A {}
+    """.trimIndent())
+  }
 
 }

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/quickFix/UpdateMethodParametersTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/quickFix/UpdateMethodParametersTest.kt
@@ -1,0 +1,138 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.java.codeInsight.daemon.quickFix
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.idea.Bombed
+import com.intellij.lang.jvm.JvmMethod
+import com.intellij.lang.jvm.actions.ChangeParametersRequest
+import com.intellij.lang.jvm.actions.createChangeParametersActions
+import com.intellij.lang.jvm.actions.expectedParameter
+import com.intellij.lang.jvm.actions.updateMethodParametersRequest
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import java.util.function.Supplier
+
+class UpdateMethodParametersTest : LightJavaCodeInsightFixtureTestCase() {
+  private fun updateParametersAction(method: JvmMethod, request: ChangeParametersRequest): IntentionAction =
+    createChangeParametersActions(method, request).single()
+
+  fun `test simple annotation preservation`() {
+    myFixture.addClass("""
+      public @interface Anno {
+        int num();
+        String str();
+      }
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {
+        void bar(@Nls String param1, @Anno(num = 10, str = "value 1") String param2) {}
+      }
+    """.trimIndent())
+
+    val method = myFixture.findElementByText("bar", PsiMethod::class.java)
+
+    val request = updateMethodParametersRequest(Supplier { method }) { existing ->
+      val oldParam = existing[1]
+      val newParam = expectedParameter(PsiPrimitiveType.INT, oldParam.semanticNames.first(), oldParam.expectedAnnotations)
+      existing.toMutableList().also { it[1] = newParam }
+    }
+    myFixture.launchAction(updateParametersAction(method, request))
+    myFixture.checkResult("""
+      class A {
+        void bar(@Nls String param1, @Anno(num = 10, str = "value 1") int param2) {}
+      }
+    """.trimIndent())
+  }
+
+  // I can't fine a way to keep unresolved references without modifying some Jvm classes :'(
+  fun `test annotation preservation with unresolved references`() {
+    myFixture.addClass("""
+      public @interface Anno {
+        int num();
+        Class<?> clazz();
+      }
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {
+        void bar(@Nls String param1, @Anno(num = CONST, clazz = Unknown.class) String param2) {}
+      }
+    """.trimIndent())
+
+    val method = myFixture.findElementByText("bar", PsiMethod::class.java)
+
+    val request = updateMethodParametersRequest(Supplier { method }) { existing ->
+      val oldParam = existing[1]
+      val newParam = expectedParameter(PsiPrimitiveType.INT, oldParam.semanticNames.first(), oldParam.expectedAnnotations)
+      existing.toMutableList().also { it[1] = newParam }
+    }
+    myFixture.launchAction(updateParametersAction(method, request))
+    myFixture.checkResult("""
+      class A {
+        void bar(@Nls String param1, @Anno(num = CONST, clazz = Unknown.class) int param2) {}
+      }
+    """.trimIndent())
+  }
+
+  fun `test complex annotation preservation`() {
+    myFixture.addClass("""
+      public @interface Anno {
+        String str();
+        int[] nums();
+        Class<?>[] classes();
+      }
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {
+        void bar(@Nls String param1, @Anno(str = "text", nums = {1, 2, 3, 4, 1000}, classes = {A.class, String.class}) String param2) {}
+      }
+    """.trimIndent())
+
+    val method = myFixture.findElementByText("bar", PsiMethod::class.java)
+
+    val request = updateMethodParametersRequest(Supplier { method }) { existing ->
+      val oldParam = existing[1]
+      val newParam = expectedParameter(PsiPrimitiveType.INT, oldParam.semanticNames.first(), oldParam.expectedAnnotations)
+      existing.toMutableList().also { it[1] = newParam }
+    }
+    myFixture.launchAction(updateParametersAction(method, request))
+    myFixture.checkResult("""
+      class A {
+        void bar(@Nls String param1, @Anno(str = "text", nums = {1, 2, 3, 4, 1000}, classes = {A.class, String.class}) int param2) {}
+      }
+    """.trimIndent())
+  }
+
+  fun `test nested annotation preservation`() {
+    myFixture.addClass("""
+      public @interface Anno {
+        Nested nested();
+        Nested[] array();
+      }
+    """.trimIndent())
+    myFixture.addClass("""
+      public @interface Nested {
+        int value() default 0;
+      }
+    """.trimIndent())
+    myFixture.configureByText("A.java", """
+      class A {
+        void bar(@Nls String param1, @Anno(nested = @Nested(10), array = {@Nested, @Nested(1), @Nested(2)}) String param2) {}
+      }
+    """.trimIndent())
+
+    val method = myFixture.findElementByText("bar", PsiMethod::class.java)
+
+    val request = updateMethodParametersRequest(Supplier { method }) { existing ->
+      val oldParam = existing[1]
+      val newParam = expectedParameter(PsiPrimitiveType.INT, oldParam.semanticNames.first(), oldParam.expectedAnnotations)
+      existing.toMutableList().also { it[1] = newParam }
+    }
+    myFixture.launchAction(updateParametersAction(method, request))
+    myFixture.checkResult("""
+      class A {
+        void bar(@Nls String param1, @Anno(nested = @Nested(10), array = {@Nested, @Nested(1), @Nested(2)}) int param2) {}
+      }
+    """.trimIndent())
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/quickFix/UpdateMethodParametersTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/quickFix/UpdateMethodParametersTest.kt
@@ -45,35 +45,6 @@ class UpdateMethodParametersTest : LightJavaCodeInsightFixtureTestCase() {
     """.trimIndent())
   }
 
-  // I can't fine a way to keep unresolved references without modifying some Jvm classes :'(
-  fun `test annotation preservation with unresolved references`() {
-    myFixture.addClass("""
-      public @interface Anno {
-        int num();
-        Class<?> clazz();
-      }
-    """.trimIndent())
-    myFixture.configureByText("A.java", """
-      class A {
-        void bar(@Nls String param1, @Anno(num = CONST, clazz = Unknown.class) String param2) {}
-      }
-    """.trimIndent())
-
-    val method = myFixture.findElementByText("bar", PsiMethod::class.java)
-
-    val request = updateMethodParametersRequest(Supplier { method }) { existing ->
-      val oldParam = existing[1]
-      val newParam = expectedParameter(PsiPrimitiveType.INT, oldParam.semanticNames.first(), oldParam.expectedAnnotations)
-      existing.toMutableList().also { it[1] = newParam }
-    }
-    myFixture.launchAction(updateParametersAction(method, request))
-    myFixture.checkResult("""
-      class A {
-        void bar(@Nls String param1, @Anno(num = CONST, clazz = Unknown.class) int param2) {}
-      }
-    """.trimIndent())
-  }
-
   fun `test complex annotation preservation`() {
     myFixture.addClass("""
       public @interface Anno {


### PR DESCRIPTION
I tried to handle unresolved references but I could not find a better way than using Java PSI, a solution I'm not really happy about but the JVM elements do not give enough information for it to be possible AFAIK.

Something I haven't done yet is keeping primitive literals presentation (like `10_000`) and resolved field references (`Math.PI`), I'm afraid that the only solution is the same than for unresolved references: use the text from `PsiElement`.

I only implemented the Java action, I tried with the Kotlin plugin but:
```
kotlin.NoWhenBranchMatchedException
	at org.jetbrains.kotlin.idea.quickfix.crossLanguage.KotlinElementActionsFactoryKt.renderAttributeValue(KotlinElementActionsFactory.kt:464)
```

I hope the tests are meaningful enough, if not let me know I can add more for whatever needs to be covered.