### PR TITLE
IDEA-252328: Consider Java installations from Gradle

### DIFF
--- a/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
+++ b/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
@@ -36,6 +36,7 @@ public class JavaHomeFinderBasic {
     myFinders.add(this::findInPATH);
     myFinders.add(() -> findInSpecifiedPaths(paths));
     myFinders.add(this::findJavaInstalledBySdkMan);
+    myFinders.add(this::findJavaInstalledByGradle);
 
     if (forceEmbeddedJava || Registry.is("java.detector.include.embedded", false)) {
       myFinders.add(() -> scanAll(getJavaHome(), false));
@@ -218,4 +219,19 @@ public class JavaHomeFinderBasic {
     // no chances
     return null;
   }
+
+  private @NotNull Set<String> findJavaInstalledByGradle() {
+    // TODO: Decide if this is good enough. We actually want the configured GradleSystemSettings
+    //       but that would introduce a cycle 
+    //File gradleHome = GradleSystemSettings.getInstance().getServiceDirectoryPath();
+    String homePath = System.getProperty("user.home");
+    if(homePath != null) {
+      File homeDir = new File(homePath);
+      File gradleHome = new File(homeDir, ".gradle");
+      File jdks = new File(gradleHome, "jdks");
+      return jdks.isDirectory() ? scanAll(jdks.toPath(), true) : Collections.emptySet();  
+    }
+    return Collections.emptySet();
+  }
+  
 }


### PR DESCRIPTION
Gradle 6.7 introduced support for toolchains. This allows Gradle builds to define the environment required to run the build. In case there is no matching JDK, Gradle may download a matching JDK and install it. If this happens and a project is loaded in IntelliJ, the respective JDK is not found and requires the user to manually point IntelliJ to the Gradle JDK folder.