### PR TITLE
Add support for parametrized model builders injected from the IDE

### DIFF
--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/AbstractModelBuilderService.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/AbstractModelBuilderService.java
@@ -7,11 +7,12 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author Vladislav.Soroka
  */
-public abstract class AbstractModelBuilderService implements ModelBuilderService {
+public abstract class AbstractModelBuilderService implements ModelBuilderService.Ex {
   @Override
   final public Object buildAll(String modelName, Project project) {
     throw new AssertionError("The method should not be called for this service: " + getClass());
   }
 
+  @Override
   public abstract Object buildAll(@NotNull String modelName, @NotNull Project project, @NotNull ModelBuilderContext context);
 }

--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/ModelBuilderContext.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/ModelBuilderContext.java
@@ -5,6 +5,7 @@ import org.gradle.api.Project;
 import org.gradle.api.invocation.Gradle;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Vladislav.Soroka
@@ -15,6 +16,12 @@ public interface ModelBuilderContext {
    */
   @NotNull
   Gradle getRootGradle();
+
+  /**
+   * @return the value of the parameter passed to the builder, if the parametrized version of {@link BuildController#getModel} is used.
+   */
+  @Nullable
+  String getParameter();
 
   /**
    * @return cached data if it's already created, newly created data otherwise

--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/ModelBuilderService.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/ModelBuilderService.java
@@ -25,13 +25,20 @@ import java.io.Serializable;
  */
 public interface ModelBuilderService extends Serializable {
 
-  interface Parametrized extends ModelBuilderService {
-    Object buildAll(String modelName, Project project, Parameter parameter);
-  }
-
+  /**
+   * A {@link ParameterizedToolingModelBuilder}'s parameter interface to be used when requesting
+   * a parametrized model provided by an implementation of {@link ModelBuilderService.Ex}.
+   *
+   * The string value set via {@link Parameter#setValue(String)} will be passed to the model builder
+   * via the {@link ModelBuilderContext#getParameter()}.
+   */
   interface Parameter {
     String getValue();
     void setValue(String value);
+  }
+
+  interface Ex extends ModelBuilderService {
+    Object buildAll(String modelName, Project project, @NotNull ModelBuilderContext context);
   }
 
   boolean canBuild(String modelName);

--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/ModelBuilderService.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/tooling/ModelBuilderService.java
@@ -24,6 +24,16 @@ import java.io.Serializable;
  * @author Vladislav.Soroka
  */
 public interface ModelBuilderService extends Serializable {
+
+  interface Parametrized extends ModelBuilderService {
+    Object buildAll(String modelName, Project project, Parameter parameter);
+  }
+
+  interface Parameter {
+    String getValue();
+    void setValue(String value);
+  }
+
   boolean canBuild(String modelName);
 
   Object buildAll(String modelName, Project project);

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/ExtraModelBuilder.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/ExtraModelBuilder.java
@@ -10,6 +10,7 @@ import org.gradle.internal.impldep.com.google.common.collect.Lists;
 import org.gradle.internal.impldep.com.google.gson.GsonBuilder;
 import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 import org.gradle.util.GradleVersion;
 import org.jetbrains.annotations.ApiStatus;
@@ -33,6 +34,15 @@ import java.util.*;
  * @author Vladislav.Soroka
  */
 public class ExtraModelBuilder implements ToolingModelBuilder {
+
+  public static class ForGradle44 extends ExtraModelBuilder implements ParameterizedToolingModelBuilder<ModelBuilderService.Parameter> {
+    @NotNull
+    @Override
+    public Class<ModelBuilderService.Parameter> getParameterType() {
+      return ModelBuilderService.Parameter.class;
+    }
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(ExtraModelBuilder.class);
   @ApiStatus.Internal
   public static final String MODEL_BUILDER_SERVICE_MESSAGE_PREFIX = "ModelBuilderService message: ";
@@ -67,6 +77,10 @@ public class ExtraModelBuilder implements ToolingModelBuilder {
 
   @Override
   public Object buildAll(String modelName, Project project) {
+    return buildAll(modelName, null, project);
+  }
+
+  public Object buildAll(String modelName, ModelBuilderService.Parameter parameter, Project project) {
     if (DummyModel.class.getName().equals(modelName)) {
       return new DummyModel() {
       };
@@ -97,6 +111,8 @@ public class ExtraModelBuilder implements ToolingModelBuilder {
             if (service instanceof AbstractModelBuilderService) {
               return ((AbstractModelBuilderService)service).buildAll(modelName, project, myModelBuilderContext);
             }
+            else if (service instanceof ModelBuilderService.Parametrized)
+              return ((ModelBuilderService.Parametrized)service).buildAll(modelName, project, parameter);
             else {
               return service.buildAll(modelName, project);
             }

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/init.gradle
@@ -38,7 +38,11 @@ class JetGradlePlugin implements Plugin<Gradle> {
  * Thread safe.
  */
 class RegistryProcessor implements ProjectEvaluationListener {
-  def extraModelBuilderInstance = new ExtraModelBuilder()
+  def extraModelBuilderInstance =
+    GradleVersion.current() >= GradleVersion.version("4.4")
+      ? ExtraModelBuilder.class.classLoader.loadClass(ExtraModelBuilder.class.typeName + "\$ForGradle44").newInstance()
+      : new ExtraModelBuilder();
+
   CopyOnWriteArrayList<ToolingModelBuilderRegistry> processedRegistries = new CopyOnWriteArrayList<ToolingModelBuilderRegistry>()
 
   @Override


### PR DESCRIPTION
Gradle since version 4.4 supports ParameterizedToolingModelBuilder
interface which allows model builders to be configured form the IDE.
This is used by the Android plugin to import only the build variant
currently selected in the IDE.

This change make it possible to configure model builders injected from
the IDE in a similar manner. This should allow the Android plugin to
communicate the currently selected build variant to the Kotlin plugin
and thus not to import unnecessary source sets.

NOTE: `ExtraModelProvider` still implements `ModelBuilder` and its 
behavior does not change. This pull requests alters the behavior when 
the IDE has already configured a parameter only. In this case Gradle
attempts to use `ParameterizedToolingModelBuilder` instead of 
`ModelBuilder`.