### PR TITLE
Remove final keyword from JavaPsiFacadeImpl

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
@@ -28,7 +28,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 
-public final class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
+public class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
   private static final Logger LOG = Logger.getInstance(JavaPsiFacadeImpl.class);
 
   private final PsiConstantEvaluationHelper myConstantEvaluationHelper;


### PR DESCRIPTION
This was added incidentally by commit 6f766623
breaking compilation of existing subclasses.