### PR TITLE
Create a Comparison Failure when AssertionError is thrown by Akka's TestKit#expectMsg(Object)

### DIFF
--- a/plugins/testng_rt/src/com/intellij/rt/testng/TestNGExpectedPatterns.java
+++ b/plugins/testng_rt/src/com/intellij/rt/testng/TestNGExpectedPatterns.java
@@ -17,7 +17,8 @@ class TestNGExpectedPatterns extends AbstractExpectedPatterns {
     "expected \\[(.*)\\] but got \\[(.*)\\]",
     "expected not same with:\\<(.*)\\> but was same:\\<(.*)\\>",
     "expected \\[(.*)\\] but found \\[(.*)\\]",
-    "\nexpected: .*?\"(.*)\"\n\\s*but: .*?\"(.*)\""
+    "\nexpected: .*?\"(.*)\"\n\\s*but: .*?\"(.*)\"",
+    "assertion failed: expected (.*), found (.*)"
     };
 
   static {

--- a/plugins/testng_rt/tests/intellij.testng.rt.tests.iml
+++ b/plugins/testng_rt/tests/intellij.testng.rt.tests.iml
@@ -14,5 +14,6 @@
     <orderEntry type="module" module-name="intellij.java.execution.impl" scope="TEST" />
     <orderEntry type="module" module-name="intellij.java.aetherDependencyResolver" scope="TEST" />
     <orderEntry type="module" module-name="intellij.platform.core.ui" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.testng.rt" scope="TEST" />
   </component>
 </module>

--- a/plugins/testng_rt/tests/src/com/intellij/rt/testng/TestNGExpectedPatternsTest.java
+++ b/plugins/testng_rt/tests/src/com/intellij/rt/testng/TestNGExpectedPatternsTest.java
@@ -1,0 +1,24 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.rt.testng;
+
+import com.intellij.rt.execution.junit.ComparisonFailureData;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TestNGExpectedPatternsTest {
+
+  @Test
+  public void testExpectedButFound() {
+    ComparisonFailureData failure = createNotification("expected [foo] but found [bar]");
+
+    assertNotNull(failure);
+    assertEquals("foo", failure.getExpected());
+    assertEquals("bar", failure.getActual());
+  }
+
+  private static ComparisonFailureData createNotification(String message) {
+    return TestNGExpectedPatterns.createExceptionNotification(message);
+  }
+}

--- a/plugins/testng_rt/tests/src/com/intellij/rt/testng/TestNGExpectedPatternsTest.java
+++ b/plugins/testng_rt/tests/src/com/intellij/rt/testng/TestNGExpectedPatternsTest.java
@@ -18,6 +18,15 @@ public class TestNGExpectedPatternsTest {
     assertEquals("bar", failure.getActual());
   }
 
+  @Test
+  public void testAkkaTestKit() {
+    ComparisonFailureData failure = createNotification("assertion failed: expected foo, found bar");
+
+    assertNotNull(failure);
+    assertEquals("foo", failure.getExpected());
+    assertEquals("bar", failure.getActual());
+  }
+
   private static ComparisonFailureData createNotification(String message) {
     return TestNGExpectedPatterns.createExceptionNotification(message);
   }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-254832