### PR TITLE
[EXAMPLE] Partially fix data model deserialization slowness

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ExternalProjectsDataStorage.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/ExternalProjectsDataStorage.java
@@ -27,11 +27,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.SimpleModificationTracker;
+import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.serialization.ObjectSerializer;
 import com.intellij.serialization.SerializationException;
 import com.intellij.serialization.VersionedFile;
+import com.intellij.util.TimeoutUtil;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.MultiMap;
 import com.intellij.util.io.PathKt;
@@ -405,7 +407,12 @@ public final class ExternalProjectsDataStorage extends SimpleModificationTracker
       LOG.debug("External projects data storage was invalidated");
       return null;
     }
-    return cacheFile.readList(InternalExternalProjectInfo.class, SerializationKt.createCacheReadConfiguration(LOG));
+
+    Ref<List<InternalExternalProjectInfo>> infos = new Ref();
+    long millis = TimeoutUtil.measureExecutionTime(
+      () -> infos.set(cacheFile.readList(InternalExternalProjectInfo.class, SerializationKt.createCacheReadConfiguration(LOG))));
+    System.out.printf("Data node infos loaded in %d%n", millis);
+    return infos.get();
   }
 
   private static boolean isInvalidated(@NotNull Path configurationFile, @NotNull BasicFileAttributes fileAttributes) throws IOException {


### PR DESCRIPTION
@nskvortsov This is the simple part which handles the case when the whole object is deserializaed via the constructor instantiation. See my comments in the issue itself for how it can be extended to other caces. 