### PR TITLE
launcher: behave identically whether or not IDE is already running

### DIFF
--- a/platform/platform-resources/src/launcher.py
+++ b/platform/platform-resources/src/launcher.py
@@ -133,9 +133,11 @@ def start_new_instance(args):
             args.insert(0, '-W')
         os.execv('/usr/bin/open', ['open', '-na', RUN_PATH] + args)
     else:
-        bin_file = os.path.split(RUN_PATH)[1]
-        os.execv(RUN_PATH, [bin_file] + args)
-
+        if '--wait' in args:
+            bg = 'bg'
+        else:
+            bg = ''
+        os.execv('/bin/sh', ['sh', '-c', 'exec "$@" 2>/dev/null ' + bg, '-', RUN_PATH] + args)
 
 ide_args = process_args(sys.argv)
 if not try_activate_instance(ide_args):


### PR DESCRIPTION
When the IDE is not already running the launcher always waits until it exits.  This patch runs it in the background unless the --wait flag is passed.

Also redirect stderr to /dev/null to keep IDE noise from interfering with the console.
Uses the shell, but safe from any string or quoting issues as arguments are forwarded as a vector.

See IDEA-249381 (MacOS specific)