### PR TITLE
PY-45894 - fix wrong rendered cell background

### DIFF
--- a/python/src/com/jetbrains/python/debugger/array/ArrayTableCellRenderer.java
+++ b/python/src/com/jetbrains/python/debugger/array/ArrayTableCellRenderer.java
@@ -8,6 +8,7 @@ import com.jetbrains.python.debugger.dataframe.DataViewCellRenderer;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.awt.*;
 
 /**
  * @author amarch
@@ -37,16 +38,20 @@ class ArrayTableCellRenderer extends DataViewCellRenderer implements ColoredCell
 
   @Override
   protected void colorize(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+    Color background = null;
+
     if (myMax != myMin) {
       if (myColored && value != null) {
         try {
           double rangedValue = PyNumericViewUtil.getRangedValue(value.toString(), myType, myMin, myMax, myComplexMax, myComplexMin);
-          this.setBackground(PyNumericViewUtil.rangedValueToColor(rangedValue));
+          background = PyNumericViewUtil.rangedValueToColor(rangedValue);
         }
         catch (NumberFormatException ignored) {
         }
       }
     }
+
+    this.setBackground(background);
   }
 
   public void setMin(double min) {

--- a/python/src/com/jetbrains/python/debugger/dataframe/DataFrameTableCellRenderer.java
+++ b/python/src/com/jetbrains/python/debugger/dataframe/DataFrameTableCellRenderer.java
@@ -5,6 +5,7 @@ import com.jetbrains.python.debugger.containerview.ColoredCellRenderer;
 import com.jetbrains.python.debugger.containerview.PyNumericViewUtil;
 
 import javax.swing.*;
+import java.awt.*;
 
 
 class DataFrameTableCellRenderer extends DataViewCellRenderer implements ColoredCellRenderer {
@@ -26,21 +27,25 @@ class DataFrameTableCellRenderer extends DataViewCellRenderer implements Colored
   @Override
   protected void colorize(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
     if (!(value instanceof TableValueDescriptor)) {
+      this.setBackground(null);
       return;
     }
 
+    Color background = null;
     TableValueDescriptor descriptor = (TableValueDescriptor)value;
 
     if (myColored) {
       try {
         double rangedValue = descriptor.getRangedValue();
         if (!Double.isNaN(rangedValue)) {
-          this.setBackground(PyNumericViewUtil.rangedValueToColor(rangedValue));
+          background = PyNumericViewUtil.rangedValueToColor(rangedValue);
         }
       }
       catch (NumberFormatException ignored) {
 
       }
     }
+
+    this.setBackground(background);
   }
 }

--- a/python/src/com/jetbrains/python/debugger/dataframe/DataViewCellRenderer.java
+++ b/python/src/com/jetbrains/python/debugger/dataframe/DataViewCellRenderer.java
@@ -8,11 +8,10 @@ import java.awt.*;
 public class DataViewCellRenderer extends DefaultTableCellRenderer {
   @Override
   public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
-    super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-
     if (!isSelected)
       colorize(table, value, isSelected, hasFocus, row, column);
 
+    super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
     return this;
   }
 


### PR DESCRIPTION
A DefaultTableCellRenderer doesn't automatically reset the foreground/background color before painting the next cell. The renderer re-uses these colors for each unselected cell, if they are not explicitly overwritten.

To fix this problem, the "colorize" method is called before "super.getTableCellRendererComponent" so that the super implementation can apply a default background color in case that "colorize" cleared the background by setting it to "null".