### PR TITLE
FIX: double apostrophe typo

### DIFF
--- a/plugins/maven/src/main/resources/messages/MavenConfigurableBundle.properties
+++ b/plugins/maven/src/main/resources/messages/MavenConfigurableBundle.properties
@@ -105,7 +105,7 @@ maven.settings.repositories.title=Indexed Maven Repositories:
 maven.settings.repositories.no=No remote repositories"
 
 
-maven.settings.generated.folder.ignore=Don''t detect
+maven.settings.generated.folder.ignore=Don't detect
 maven.settings.generated.folder.autodetect=Detect automatically
 maven.settings.generated.folder.targerdir=target/generated-sources
 maven.settings.generated.folder.targersubdir=subdirectories of "target/generated-sources"


### PR DESCRIPTION
Fixes a typo under Preferences > Build, Execution, Deployment > Build Tools > Maven > Importing

<img width="1049" alt="Screen Shot 2021-01-11 at 11 58 41 AM" src="https://user-images.githubusercontent.com/16148766/104347918-02a3c380-54b6-11eb-83d2-caed27c05e8a.png">
