### PR TITLE
Fix a typo in ProjectRootsChangeListener

### DIFF
--- a/platform/lang-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/project/ProjectRootsChangeListener.kt
+++ b/platform/lang-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/project/ProjectRootsChangeListener.kt
@@ -69,7 +69,7 @@ internal class ProjectRootsChangeListener(private val project: Project) {
         break
       }
       else if (currentRootsChangeType == ProjectRootManagerImpl.RootsChangeType.ROOTS_ADDED) {
-        result == ProjectRootManagerImpl.RootsChangeType.ROOTS_ADDED
+        result = ProjectRootManagerImpl.RootsChangeType.ROOTS_ADDED
       }
       else if (currentRootsChangeType == ProjectRootManagerImpl.RootsChangeType.ROOTS_REMOVED &&
                result != ProjectRootManagerImpl.RootsChangeType.ROOTS_ADDED) {


### PR DESCRIPTION
Typo: "==" instead of "=". This bug causes that sporadically after adding roots they are not indexed.

If we have a sequence of events there is "remove" event  before "add" even, due to a bug a final type will be `RootsChangeType.ROOTS_REMOVED` even if we have "add" event. Therefore we never trigger an indexing for these changes.