### PR TITLE
update values in wsl distribution descriptor

### DIFF
--- a/platform/platform-impl/src/com/intellij/execution/wsl/WSLDistributionService.java
+++ b/platform/platform-impl/src/com/intellij/execution/wsl/WSLDistributionService.java
@@ -46,6 +46,8 @@ final class WSLDistributionService implements PersistentStateComponent<WSLDistri
     new WslDistributionDescriptor("OPENSUSE42", "openSUSE-42", "opensuse-42.exe", "openSUSE Leap 42"),
     new WslDistributionDescriptor("SLES12", "SLES-12", "sles-12.exe", "SUSE Linux Enterprise Server 12"),
     new WslDistributionDescriptor("SLES15", "SLES-15", "sles-15.exe", "SUSE Linux Enterprise Server 15"),
+    new WslDistributionDescriptor("SLES15-SP1", "SLES-15-SP1", "SLES-15-SP1.exe", "SUSE Linux Enterprise Server 15 SP1"),
+    new WslDistributionDescriptor("SLES15-SP2", "SUSE-Linux-Enterprise-Server-15-SP2", "SUSE-Linux-Enterprise-Server-15-SP2.exe", "SUSE Linux Enterprise Server 15 SP2"),
     new WslDistributionDescriptor("OPENSUSE15", "openSUSE-Leap-15", "openSUSE-Leap-15.exe", "openSUSE Leap 15"),
     new WslDistributionDescriptor("OPENSUSE15-1", "openSUSE-Leap-15-1", "openSUSE-Leap-15-1.exe", "openSUSE Leap 15.1"),
     new WslDistributionDescriptor("OPENSUSE15.2", "openSUSE-Leap-15.2", "openSUSE-Leap-15.2.exe", "openSUSE Leap 15.2"),
@@ -53,9 +55,10 @@ final class WSLDistributionService implements PersistentStateComponent<WSLDistri
     new WslDistributionDescriptor("UBUNTU1604", "Ubuntu-16.04", "ubuntu1604.exe", "Ubuntu 16.04"),
     new WslDistributionDescriptor("UBUNTU1804", "Ubuntu-18.04", "ubuntu1804.exe", "Ubuntu 18.04"),
     new WslDistributionDescriptor("UBUNTU2004", "Ubuntu-20.04", "ubuntu2004.exe", "Ubuntu 20.04"),
-    new WslDistributionDescriptor("WLINUX", "WLinux", "wlinux.exe", "WLinux"),
-    new WslDistributionDescriptor("PENGWIN", "Pengwin", "pengwin.exe", "Pengwin"),
+    new WslDistributionDescriptor("UBUNTUPREVIEW", "Ubuntu-CommPrev", "ubuntupreview.exe", "Ubuntu on Windows Community Preview"),
+    new WslDistributionDescriptor("PENGWIN", "WLinux", "pengwin.exe", "Pengwin"),
     new WslDistributionDescriptor("PENGWIN_ENTERPRISE", "WLE", "wle.exe", "Pengwin Enterprise"),
+    new WslDistributionDescriptor("FEDORA_REMIX_FOR_WSL", "fedoraremix", "fedoraremix.exe", "Fedora Remix for WSL"),
     new WslDistributionDescriptor("ARCH", "Arch", "Arch.exe", "Arch Linux")
   );
 


### PR DESCRIPTION
fixing the wrong msdi value for PENGWIN distribution, this error generate error to user when they try to connect to wsl PENGWIN distribution. This bug is present on several tools of intellij. 

Removing unsupported wsl distribution "WLINUX" . this distribution was renamed as PENGWIN by WhitewaterFoundry project, to avoid problems with different distributions with same msdi.  (this is the root cause of wrong msdi value for PENGWIN)

adding some missed distribution. to allow to users work with Intellij on theses wsl linux distributions.  



