### PR TITLE
Added checkbox for enable fixed size of editor tabs

### DIFF
--- a/platform/editor-ui-api/src/com/intellij/ide/ui/UISettingsState.kt
+++ b/platform/editor-ui-api/src/com/intellij/ide/ui/UISettingsState.kt
@@ -110,6 +110,8 @@ class UISettingsState : BaseState() {
   var hideKnownExtensionInTabs by property(false)
   var showTreeIndentGuides by property(false)
   var compactTreeIndents by property(false)
+  @get:OptionTag("USE_FIXED_SIZE_TABS")
+  var useFixedSizeTabs by property(false);
 
   @get:OptionTag("SORT_TABS_ALPHABETICALLY")
   var sortTabsAlphabetically by property(false)

--- a/platform/platform-api/resources/messages/ApplicationBundle.properties
+++ b/platform/platform-api/resources/messages/ApplicationBundle.properties
@@ -294,6 +294,7 @@ radio.editor.tabs.in.multiple.rows=Multiple rows
 tabs.close.button.placement=Close button position
 checkbox.editor.scroll.if.need=Hide tabs if there is no space
 checkbox.show.pinned.tabs.in.a.separate.row=Show pinned tabs in a separate row
+checkbox.editor.tabs.fixed.size=Enable fixed size tabs
 checkbox.show.file.icon.in.editor.tabs=Show file icon
 checkbox.show.file.extension.in.editor.tabs=Show file extension
 checkbox.show.directory.for.non.unique.files=Show directory for non-unique file names

--- a/platform/platform-api/src/com/intellij/ui/tabs/impl/table/TableLayout.java
+++ b/platform/platform-api/src/com/intellij/ui/tabs/impl/table/TableLayout.java
@@ -121,6 +121,7 @@ public class TableLayout extends TabLayout {
     int eachY = insets.top;
     TablePassInfo data = new TablePassInfo(myTabs, visibleInfos);
     boolean showPinnedTabsSeparately = UISettings.getInstance().getState().getShowPinnedTabsInASeparateRow();
+    boolean useFixedSizeTabs = UISettings.getInstance().getState().getUseFixedSizeTabs();
 
     if (!myTabs.isHideTabs()) {
       data = computeLayoutTable(visibleInfos);
@@ -145,7 +146,7 @@ public class TableLayout extends TabLayout {
           label.putClientProperty(JBTabsImpl.STRETCHED_BY_WIDTH, Boolean.valueOf(toAjust));
 
           int width;
-          if (label.isPinned() && showPinnedTabsSeparately) {
+          if ((label.isPinned() && showPinnedTabsSeparately) || useFixedSizeTabs) {
             width = label.getNotStrictPreferredSize().width;
           }
           else if (i < eachRow.myColumns.size() - 1 || !toAjust) {

--- a/platform/platform-impl/src/com/intellij/application/options/editor/EditorTabsConfigurable.kt
+++ b/platform/platform-impl/src/com/intellij/application/options/editor/EditorTabsConfigurable.kt
@@ -80,6 +80,9 @@ class EditorTabsConfigurable : BoundSearchableConfigurable(
                 checkBox(showPinnedTabsInASeparateRow).enableIf(
                   myEditorTabPlacement.selectedValueIs(SwingConstants.TOP)
                     and myMultipleRowsRadio.selected).withLargeLeftGap().component
+                checkBox(useFixedSizeTabs).enableIf(
+                  myEditorTabPlacement.selectedValueIs(SwingConstants.TOP)
+                    and myMultipleRowsRadio.selected).withLargeLeftGap().component
               })
             }
             val group = ButtonGroup()

--- a/platform/platform-impl/src/com/intellij/application/options/editor/EditorTabsOptionsModel.kt
+++ b/platform/platform-impl/src/com/intellij/application/options/editor/EditorTabsOptionsModel.kt
@@ -26,3 +26,4 @@ internal val showTabsInOneRow                    get() = CheckboxDescriptor(mess
 internal val showTabsInMultipleRows              get() = CheckboxDescriptor(message("radio.editor.tabs.in.multiple.rows"), PropertyBinding({ !ui.scrollTabLayoutInEditor }, { ui.scrollTabLayoutInEditor = !it }))
 internal val openInPreviewTabIfPossible          get() = CheckboxDescriptor(message("checkbox.smart.tab.preview"), ui::openInPreviewTabIfPossible, message("checkbox.smart.tab.preview.inline.help"))
 internal val useSmallFont                        get() = CheckboxDescriptor(message("checkbox.use.small.font.for.labels"), ui::useSmallLabelsOnTabs)
+internal val useFixedSizeTabs                    get() = CheckboxDescriptor(message("checkbox.editor.tabs.fixed.size"), ui::useFixedSizeTabs)


### PR DESCRIPTION
Hello.

I think it's nice to have an option where the width of the tabs is always equal to the label. Because when the multi-row mode is enabled, the new tab is wrapped to a next line, then it stretches to full screen, jumps, this may be inconvenient for some people.

There were several issues about current behavior of multi row tabs , main is:
https://youtrack.jetbrains.com/issue/IDEA-22546 

Thank you.
