### PR TITLE
Fix memory leak in PsiFileBreadcrumbsCollector

### DIFF
--- a/platform/platform-impl/src/com/intellij/xml/breadcrumbs/PsiFileBreadcrumbsCollector.java
+++ b/platform/platform-impl/src/com/intellij/xml/breadcrumbs/PsiFileBreadcrumbsCollector.java
@@ -78,7 +78,8 @@ public class PsiFileBreadcrumbsCollector extends FileBreadcrumbsCollector {
         public boolean isAspectChangeInteresting(@NotNull PomModelAspect aspect) {
           return aspect instanceof TreeAspect;
         }
-      }
+      },
+      disposable
     );
   }
 


### PR DESCRIPTION
Pass the parent disposable to addModelListener so that the listener will
be removed when the editor tab is closed.