### PR TITLE
Retain @TestDataFile annotation in .class files

### DIFF
--- a/platform/testFramework/src/com/intellij/testFramework/TestDataFile.java
+++ b/platform/testFramework/src/com/intellij/testFramework/TestDataFile.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  *
  * @author yole
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.PARAMETER})
 public @interface TestDataFile {
 }


### PR DESCRIPTION
That way test data navigation still works even when IntelliJ
is on the classpath in binary form.

cc @yole since you added the annotation :-)