### PR TITLE
Fix sdkman detection in WSL

### DIFF
--- a/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
+++ b/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
@@ -230,7 +230,7 @@ public class JavaHomeFinderBasic {
     }
 
     // finally, try the usual location in UNIX
-    if (!SystemInfo.isWindows) {
+    if (!SystemInfo.isWindows || this instanceof JavaHomeFinderWsl) {
       Path candidates = getPathInUserHome(".sdkman/candidates");
       if (candidates != null && isDirectory(candidates)) {
         return candidates;


### PR DESCRIPTION
The java home detection in the case of sdkman, first look for the environment variables: SDKMAN_CANDIDATES_DIR, SDKMAN_DIR

In WSL it executes: 

`wsl.exe --distribution WLinux --exec /bin/sh -c printenv SDKMAN_CANDIDATES_DIR` 

It won't work because these variables in the standard installation are initialized calling a script in .bashrc. So the command should change to bash --login. Even with this change, the script is not executed before printenv

The solution is to look for the default path in Linux home, but the code checks if we are in Windows, so I added a small check telling that this piece of code is valid also in WSL
