### PR TITLE
Fix the Configured Servers don't refresh components sometimes

### DIFF
--- a/plugins/tasks/tasks-core/src/com/intellij/tasks/config/TaskRepositoriesConfigurable.java
+++ b/plugins/tasks/tasks-core/src/com/intellij/tasks/config/TaskRepositoriesConfigurable.java
@@ -153,6 +153,7 @@ public class TaskRepositoriesConfigurable implements Configurable.NoScroll, Sear
           ((CardLayout)myRepositoryEditor.getLayout()).show(myRepositoryEditor, name);
           mySplitter.doLayout();
           mySplitter.repaint();
+		      myRepositoryEditor.updateUI();
         }
       }
     });


### PR DESCRIPTION
Run **Tools** -> **Tasks & Contexts** -> **Configure Servers...**.
After adding a server, the general and commit message components below will not be displayed sometimes.