### PR TITLE
[python] Don't annotate type: ignore[error-code] syntax

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/codeInsight/typing/PyTypingTypeProvider.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/codeInsight/typing/PyTypingTypeProvider.java
@@ -101,7 +101,7 @@ public class PyTypingTypeProvider extends PyTypeProviderBase {
   private static final String PY3_TEXT_FILE_TYPE = "typing.TextIO";
 
   private static final Pattern TYPE_COMMENT_PATTERN = Pattern.compile("# *type: *([^#]+) *(#.*)?");
-  public static final String IGNORE = "ignore";
+  public static final Pattern IGNORE_PATTERN = Pattern.compile("^ignore(\\[ *[^ ,\\]]+ *(, *[^ ,\\]]+ *)*\\])?$");
 
   public static final ImmutableMap<String, String> BUILTIN_COLLECTION_CLASSES = ImmutableMap.<String, String>builder()
     .put(LIST, "list")

--- a/python/python-psi-impl/src/com/jetbrains/python/inspections/PyTypeHintsInspection.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/inspections/PyTypeHintsInspection.kt
@@ -133,7 +133,7 @@ class PyTypeHintsInspection : PyInspection() {
 
       if (node is PyTypeCommentOwner &&
           node is PyAnnotationOwner &&
-          node.typeCommentAnnotation.let { it != null && it != PyTypingTypeProvider.IGNORE }) {
+          node.typeCommentAnnotation.let { it != null && !PyTypingTypeProvider.IGNORE_PATTERN.matcher(it).matches() }) {
         val message = PyPsiBundle.message("INSP.type.hints.type.specified.both.in.type.comment.and.annotation")
 
         if (node is PyFunction) {

--- a/python/src/com/jetbrains/python/codeInsight/typing/PyTypingAnnotationInjector.java
+++ b/python/src/com/jetbrains/python/codeInsight/typing/PyTypingAnnotationInjector.java
@@ -85,7 +85,7 @@ public class PyTypingAnnotationInjector extends PyInjectorBase {
     final String annotationText = PyTypingTypeProvider.getTypeCommentValue(text);
     if (annotationText != null) {
       final Language language;
-      if (PyTypingTypeProvider.IGNORE.equals(annotationText)) {
+      if (PyTypingTypeProvider.IGNORE_PATTERN.matcher(annotationText).matches()) {
         language = null;
       }
       else if (isFunctionTypeComment(host)) {

--- a/python/testSrc/com/jetbrains/python/inspections/PyTypeHintsInspectionTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/PyTypeHintsInspectionTest.java
@@ -891,6 +891,8 @@ public class PyTypeHintsInspectionTest extends PyInspectionTestCase {
     runWithLanguageLevel(
       LanguageLevel.PYTHON36,
       () -> doTestByText("def foo(a: str):  # type: ignore\n" +
+                         "    pass\n" +
+                         "def bar(a: Unknown):  # type: ignore[no-untyped-def, name-defined]\n" +
                          "    pass")
     );
   }


### PR DESCRIPTION
This follows up on 9d34a41ee58e058e577e625fe9b21ff7d77bc9ea and c1e63b4b424b8ab830c1ae43293bebe7e112a333, which made it so that `# type: ignore` isn't annotated (eg so the IDE doesn't complain about "ignore" not being found). This extends that for the new [error code specific](https://mypy.readthedocs.io/en/stable/error_codes.html#silencing-errors-based-on-error-codes) ignore syntax, eg `# type: ignore[no-untyped-def]`. Without this change the error code is highlighted as an error itself.

This should fix PY-38213.