### PR TITLE
Parallel Gradle sync support for Gradle 6.8+

### DIFF
--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
@@ -101,9 +101,7 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
     assert myGradleBuild != null;
     assert myModelConverter != null;
     final MyBuildController wrappedController = new MyBuildController(controller, myGradleBuild);
-    for (BasicGradleProject gradleProject : myGradleBuild.getProjects()) {
-      addProjectModels(wrappedController, myAllModels, gradleProject, isProjectsLoadedAction);
-    }
+    fetchProjectBuildModels(wrappedController, isProjectsLoadedAction, myGradleBuild);
     addBuildModels(wrappedController, myAllModels, myGradleBuild, isProjectsLoadedAction);
 
     if (myIsCompositeBuildsSupported) {
@@ -113,9 +111,7 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
           if (!isProjectsLoadedAction) {
             myAllModels.getIncludedBuilds().add(convert(includedBuild));
           }
-          for (BasicGradleProject project : includedBuild.getProjects()) {
-            addProjectModels(wrappedController, myAllModels, project, isProjectsLoadedAction);
-          }
+          fetchProjectBuildModels(wrappedController, isProjectsLoadedAction, includedBuild);
           addBuildModels(wrappedController, myAllModels, includedBuild, isProjectsLoadedAction);
         }
       });
@@ -142,6 +138,12 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
         buildConsumer.accept(includedBuild);
         queue.addAll(includedBuild.getIncludedBuilds());
       }
+    }
+  }
+
+  private void fetchProjectBuildModels(BuildController controller, final boolean isProjectsLoadedAction, GradleBuild build) {
+    for (final BasicGradleProject gradleProject : build.getProjects()) {
+      addProjectModels(controller, myAllModels, gradleProject, isProjectsLoadedAction);
     }
   }
 

--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
@@ -2,6 +2,7 @@
 package org.jetbrains.plugins.gradle.model;
 
 import com.intellij.openapi.externalSystem.model.ExternalSystemException;
+import java.util.concurrent.ConcurrentHashMap;
 import org.gradle.api.Action;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
@@ -315,9 +316,11 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
     Object convert(Object object);
   }
 
+  // Note: This class is NOT thread safe and it is supposed to be used from a single thread.
+  //       Performance logging related methods are thread safe.
   public static class AllModels extends ModelsHolder<BuildModel, ProjectModel> {
     @NotNull private final List<Build> includedBuilds = new ArrayList<Build>();
-    private final Map<String, Long> performanceTrace = new LinkedHashMap<String, Long>();
+    private final Map<String, Long> performanceTrace = new ConcurrentHashMap<String, Long>();
 
     public AllModels(@NotNull Build mainBuild) {
       super(mainBuild);


### PR DESCRIPTION
Gradle 6.8 has introduced support for querying build models in parallel. 

It can significantly reduce the time required to import a Gradle project as it allows dependency resolution to happen in parallel. 

This series of changes makes the IDE Gradle plugin to request models via a new in Gradle 6.8 API (`org.gradle.tooling.BuildController#run`), which  executes  build action in parallel if connected to Gradle 6.8 or later. The API is backward compatible and executes the requests sequentially if connected to an older version of Gradle. 

The first two commits restructures the code to separate the phase that requests models from the phase that serializes and collects models. 

The other two commits adds thread safety to performance logging methods and migrates model fetching to the new Gradle APIs.

@nskvortsov 