### PR TITLE
Add pep8 codes to suppression map

### DIFF
--- a/python/src/com/jetbrains/python/inspections/flake8/Flake8InspectionSuppressor.java
+++ b/python/src/com/jetbrains/python/inspections/flake8/Flake8InspectionSuppressor.java
@@ -51,6 +51,20 @@ public class Flake8InspectionSuppressor implements InspectionSuppressor {
       .put("F831", "PyUnusedLocal")
       .put("F841", "PyUnusedLocal")
       .put("C90", "PyUnusedLocal")
+      .put("N801", "PyPep8Naming")  // class names should use CapWords convention
+      .put("N802", "PyPep8Naming")  // function name should be lowercase
+      .put("N803", "PyPep8Naming")  // argument name should be lowercase
+      .put("N804", "PyPep8Naming")  // first argument of a classmethod should be named 'cls'
+      .put("N805", "PyPep8Naming")  // first argument of a method should be named 'self'
+      .put("N806", "PyPep8Naming")  // variable in function should be lowercase
+      .put("N807", "PyPep8Naming")  // function name should not start and end with '__'
+      .put("N811", "PyPep8Naming")  // constant imported as non constant
+      .put("N812", "PyPep8Naming")  // lowercase imported as non lowercase
+      .put("N813", "PyPep8Naming")  // camelcase imported as lowercase
+      .put("N814", "PyPep8Naming")  // camelcase imported as constant
+      .put("N815", "PyPep8Naming")  // mixedCase variable in class scope
+      .put("N816", "PyPep8Naming")  // mixedCase variable in global scope
+      .put("N817", "PyPep8Naming")  // camelcase imported as acronym
       // pycodestyle.py specific code
       .put("E711", "PyComparisonWithNone")
       .build()

--- a/python/src/com/jetbrains/python/inspections/flake8/Flake8InspectionSuppressor.java
+++ b/python/src/com/jetbrains/python/inspections/flake8/Flake8InspectionSuppressor.java
@@ -51,20 +51,20 @@ public class Flake8InspectionSuppressor implements InspectionSuppressor {
       .put("F831", "PyUnusedLocal")
       .put("F841", "PyUnusedLocal")
       .put("C90", "PyUnusedLocal")
-      .put("N801", "PyPep8Naming")  // class names should use CapWords convention
-      .put("N802", "PyPep8Naming")  // function name should be lowercase
-      .put("N803", "PyPep8Naming")  // argument name should be lowercase
-      .put("N804", "PyPep8Naming")  // first argument of a classmethod should be named 'cls'
-      .put("N805", "PyPep8Naming")  // first argument of a method should be named 'self'
-      .put("N806", "PyPep8Naming")  // variable in function should be lowercase
-      .put("N807", "PyPep8Naming")  // function name should not start and end with '__'
-      .put("N811", "PyPep8Naming")  // constant imported as non constant
-      .put("N812", "PyPep8Naming")  // lowercase imported as non lowercase
-      .put("N813", "PyPep8Naming")  // camelcase imported as lowercase
-      .put("N814", "PyPep8Naming")  // camelcase imported as constant
-      .put("N815", "PyPep8Naming")  // mixedCase variable in class scope
-      .put("N816", "PyPep8Naming")  // mixedCase variable in global scope
-      .put("N817", "PyPep8Naming")  // camelcase imported as acronym
+      .put("N801", "PyPep8Naming")
+      .put("N802", "PyPep8Naming")
+      .put("N803", "PyPep8Naming")
+      .put("N804", "PyPep8Naming")
+      .put("N805", "PyPep8Naming")
+      .put("N806", "PyPep8Naming")
+      .put("N807", "PyPep8Naming")
+      .put("N811", "PyPep8Naming")
+      .put("N812", "PyPep8Naming")
+      .put("N813", "PyPep8Naming")
+      .put("N814", "PyPep8Naming")
+      .put("N815", "PyPep8Naming")
+      .put("N816", "PyPep8Naming")
+      .put("N817", "PyPep8Naming")
       // pycodestyle.py specific code
       .put("E711", "PyComparisonWithNone")
       .build()


### PR DESCRIPTION
This PR adds support for suppression of PEP8 naming checks with `noqa`.

* 1st commit adds codes, each with a comment describing their cause.
* 2nd commit removes the inline comments.