### PR TITLE
fixed DOM generation: simple enum anonymous type inside complex type

### DIFF
--- a/plugins/devkit/devkit-core/src/dom/generator/XSDModelLoader.java
+++ b/plugins/devkit/devkit-core/src/dom/generator/XSDModelLoader.java
@@ -229,13 +229,25 @@ public class XSDModelLoader implements ModelLoader {
 
   private XSComplexTypeDefinition makeTypeFromAnonymous(XSObject o) {
     final XSComplexTypeDecl ctd = new XSComplexTypeDecl();
-    if (o instanceof XSElementDeclaration && ((XSElementDeclaration) o).getTypeDefinition() instanceof XSComplexTypeDecl) {
-      final XSComplexTypeDecl ctd1 = (XSComplexTypeDecl) ((XSElementDeclaration) o).getTypeDefinition();
-      final XSObjectListImpl annotations = ctd1.getAnnotations() instanceof XSObjectListImpl ? (XSObjectListImpl) ctd1.getAnnotations() : new XSObjectListImpl();
-      ctd.setValues(o.getName(), ctd1.getNamespace(), ctd1.getBaseType(), ctd1.getDerivationMethod(),
-              ctd1.getFinal(), ctd1.getProhibitedSubstitutions(), ctd1.getContentType(),
-              ctd1.getAbstract(), ctd1.getAttrGrp(), (XSSimpleType) ctd1.getSimpleType(),
-              (XSParticleDecl) ctd1.getParticle(), annotations);
+    if (o instanceof XSElementDeclaration) {
+      XSTypeDefinition xsTypeDefinition = ((XSElementDeclaration)o).getTypeDefinition();
+      if (xsTypeDefinition instanceof XSComplexTypeDecl) {
+        final XSComplexTypeDecl ctd1 = (XSComplexTypeDecl)xsTypeDefinition;
+        final XSObjectListImpl annotations =
+          ctd1.getAnnotations() instanceof XSObjectListImpl ? (XSObjectListImpl)ctd1.getAnnotations() : new XSObjectListImpl();
+        ctd.setValues(o.getName(), ctd1.getNamespace(), ctd1.getBaseType(), ctd1.getDerivationMethod(),
+                      ctd1.getFinal(), ctd1.getProhibitedSubstitutions(), ctd1.getContentType(),
+                      ctd1.getAbstract(), ctd1.getAttrGrp(), (XSSimpleType)ctd1.getSimpleType(),
+                      (XSParticleDecl)ctd1.getParticle(), annotations);
+      }
+      else if (xsTypeDefinition instanceof XSSimpleTypeDecl) {
+        final XSSimpleTypeDecl std = (XSSimpleTypeDecl)xsTypeDefinition;
+        final XSObjectListImpl annotations =
+          std.getAnnotations() instanceof XSObjectListImpl ? (XSObjectListImpl)std.getAnnotations() : new XSObjectListImpl();
+        ctd.setValues(o.getName(), std.getNamespace(), std.getBaseType(), XSConstants.DERIVATION_RESTRICTION,
+                      std.getFinal(), (short)0, XSComplexTypeDefinition.CONTENTTYPE_SIMPLE,
+                      false, new XSAttributeGroupDecl(), std, null, annotations);
+      }
       ctd.setName(o.getName() + Util.ANONYMOUS_ELEM_TYPE_SUFFIX);
     } else if (o instanceof XSAttributeDeclaration) {
       final XSSimpleTypeDecl ctd1 = (XSSimpleTypeDecl) ((XSAttributeDeclaration) o).getTypeDefinition();


### PR DESCRIPTION
### Steps

- Go to Tools &rarr; Internal Actions &rarr; DevKit &rarr; Generate DOM Model
- Select scheme with anonymous simple enum type inside complex type.
Example:
```
<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
  <xs:complexType name="task">
    <xs:sequence>
      <xs:element name="taskState">
        <xs:simpleType>
          <xs:restriction base="xs:string">
            <xs:enumeration value="Answered"/>
            <xs:enumeration value="Works As Intended"/>
            <xs:enumeration value="To be duscussed"/>
		  </xs:restriction>
		</xs:simpleType>
	  </xs:element>
      <xs:element name="taskTitle" type="xs:string"/>
    </xs:sequence>
  </xs:complexType>
</xs:schema>
```
- Try to generate DOM Model
- Exception occurred:
```
java.lang.IllegalStateException: Model generation failed
	at org.jetbrains.idea.devkit.dom.generator.DomGenDialog.doOKAction(DomGenDialog.java:54)
...
Caused by: java.lang.IllegalArgumentException: local part cannot be "null" when creating a QName
	at java.xml/javax.xml.namespace.QName.<init>(QName.java:185)
	at java.xml/javax.xml.namespace.QName.<init>(QName.java:129)
	at org.jetbrains.idea.devkit.dom.generator.XSDModelLoader.makeTypeFromAnonymous(XSDModelLoader.java:250)
	at org.jetbrains.idea.devkit.dom.generator.XSDModelLoader.processParticles(XSDModelLoader.java:452)
	at org.jetbrains.idea.devkit.dom.generator.XSDModelLoader.processType(XSDModelLoader.java:349)
	at org.jetbrains.idea.devkit.dom.generator.XSDModelLoader.processSchemas(XSDModelLoader.java:209)
	at org.jetbrains.idea.devkit.dom.generator.XSDModelLoader.loadModel(XSDModelLoader.java:44)
	at org.jetbrains.idea.devkit.dom.generator.ModelGen.loadModel(ModelGen.java:173)
	at org.jetbrains.idea.devkit.dom.generator.ModelGen.perform(ModelGen.java:131)
	at org.jetbrains.idea.devkit.dom.generator.DomGenDialog.doOKAction(DomGenDialog.java:52)
```
### Issue
XSDModelLoader#makeTypeAnonymous don't expects that XSObject has XSSimpleTypeDeclaration type which is resulted to constructing XSComplexTypeDecl without specifying namespace and name values.