### PR TITLE
IDEA-207810 End align tasks input field

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemTaskSettingsControl.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemTaskSettingsControl.java
@@ -89,9 +89,7 @@ public final class ExternalSystemTaskSettingsControl implements ExternalSystemSe
     myTasksLabel = new JBLabel(ExternalSystemBundle.message("run.configuration.settings.label.tasks"));
     myTasksTextField = new EditorTextField("", myProject, PlainTextFileType.INSTANCE);
     canvas.add(myTasksLabel, ExternalSystemUiUtil.getLabelConstraints(0));
-    GridBag c = ExternalSystemUiUtil.getFillLineConstraints(0);
-    c.insets.right = myProjectPathField.getButton().getPreferredSize().width + 8 /* street magic, sorry */;
-    canvas.add(myTasksTextField, c);
+    canvas.add(myTasksTextField, ExternalSystemUiUtil.getFillLineConstraints(0));
 
     new TaskCompletionProvider(myProject, myExternalSystemId, myProjectPathField).apply(myTasksTextField);
 


### PR DESCRIPTION
Resolves https://youtrack.jetbrains.com/issue/IDEA-207810

Removes the padding at the end of the task input such that all inputs align vertically at the end in the Gradle Run Configuration UI. 
## Before
![image](https://user-images.githubusercontent.com/8796831/108724727-f2a3e880-7525-11eb-8c4b-2b05799d3574.png)


## After
![image](https://user-images.githubusercontent.com/8796831/108726411-ae194c80-7527-11eb-99cb-33b256196c29.png)
