### PR TITLE
[IDEA-257985] Update Darcula python syntax highlighting

### DIFF
--- a/python/pluginResources/colorSchemes/PythonDefault.xml
+++ b/python/pluginResources/colorSchemes/PythonDefault.xml
@@ -29,7 +29,7 @@
   </option>
   <option name="PY.KEYWORD_ARGUMENT">
     <value>
-      <option name="FOREGROUND" value="660099" />
+      <option name="FOREGROUND" value="34B8A7" />
     </value>
   </option>
   <option name="PY.PREDEFINED_DEFINITION">


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IDEA-257985

Due to the potential confusion between error highlighting and keyword argument highlighting for python in the Darcula theme. This colour has been updated from [#AA4926](https://www.color-hex.com/color/aa4926) to [#34B8A7](https://www.color-hex.com/color/34b8a7) in order to have a better contrast. 

### Screenshot 
![image](https://user-images.githubusercontent.com/8796831/109009438-d67f8300-76ae-11eb-8957-c9375a9b10d0.png)


