### PR TITLE
[IDEA-263027] Gradle Test - JUnit No StartTime in test output

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemRunnableState.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemRunnableState.java
@@ -178,21 +178,20 @@ public class ExternalSystemRunnableState extends UserDataHolderBase implements R
       .forEachExtensionSafe(extension -> extension.attachToProcess(myConfiguration, processHandler, myEnv.getRunnerSettings()));
 
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      final String startDateTime = DateFormatUtil.formatTimeWithSeconds(System.currentTimeMillis());
-      final String greeting;
       final String settingsDescription = StringUtil.isEmpty(mySettings.toString()) ? "" : String.format(" '%s'", mySettings.toString());
-      if (mySettings.getTaskNames().size() > 1) {
-        greeting = ExternalSystemBundle.message("run.text.starting.multiple.task", startDateTime, settingsDescription) + "\n";
-      }
-      else {
-        greeting = ExternalSystemBundle.message("run.text.starting.single.task", startDateTime, settingsDescription) + "\n";
-      }
-      processHandler.notifyTextAvailable(greeting + "\n", ProcessOutputTypes.SYSTEM);
       try (BuildEventDispatcher eventDispatcher = new ExternalSystemEventDispatcher(task.getId(), progressListener, false)) {
         ExternalSystemTaskNotificationListenerAdapter taskListener = new ExternalSystemTaskNotificationListenerAdapter() {
           @Override
           public void onStart(@NotNull ExternalSystemTaskId id, String workingDir) {
             if (progressListener != null) {
+              final String startDateTime = DateFormatUtil.formatTimeWithSeconds(System.currentTimeMillis());
+              final String greeting;
+              if (mySettings.getTaskNames().size() > 1) {
+                greeting = ExternalSystemBundle.message("run.text.starting.multiple.task", startDateTime, settingsDescription) + "\n";
+              }
+              else {
+                greeting = ExternalSystemBundle.message("run.text.starting.single.task", startDateTime, settingsDescription) + "\n";
+              }
               AnAction rerunTaskAction = new ExternalSystemRunConfiguration.MyTaskRerunAction(progressListener, myEnv, myContentDescriptor);
               BuildViewSettingsProvider viewSettingsProvider =
                 consoleView instanceof BuildViewSettingsProvider ?
@@ -209,6 +208,7 @@ public class ExternalSystemRunnableState extends UserDataHolderBase implements R
               progressListener.onEvent(id,
                                        new StartBuildEventImpl(buildDescriptor, BuildBundle.message("build.status.running"))
                                          .withBuildViewSettingsProvider(viewSettingsProvider));
+              processHandler.notifyTextAvailable(greeting + "\n", ProcessOutputTypes.SYSTEM);
             }
           }
 


### PR DESCRIPTION
The greeting message has been moved to the `onStart` method in order to make sure it also gets printed when running in a test environment. 

Correct me if I'm wrong, but I have the suspicion that it did not print the greeting message before because either the `conosleView` wasn't ready to accept output or the `foldGreetingOrFarewell` was causing problems and causing the line to become blank. 

See the [issue](https://youtrack.jetbrains.com/issue/IDEA-263027) for how the test output is now currently printed. 