### PR TITLE
Invoke the "which mvn" using the default shell in the distro to enable finding Maven installed through SDKMAN

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenWslUtil.kt
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenWslUtil.kt
@@ -107,7 +107,10 @@ object MavenWslUtil : MavenUtil() {
       MavenLog.LOG.debug("Maven home found at /usr/share/maven2")
       return home
     }
-    val processOutput = this.executeOnWsl(listOf("which", "mvn"), WSLCommandLineOptions().setExecuteCommandInLoginShell(true), 10000, null)
+    val options = WSLCommandLineOptions()
+      .setExecuteCommandInLoginShell(true)
+      .setShellPath(this.shellPath)
+    val processOutput = this.executeOnWsl(listOf("which", "mvn"), options, 10000, null)
     if (processOutput.exitCode == 0) {
       val path = processOutput.stdout.lines().find { it.isNotEmpty() }?.let(this::resolveSymlink)?.let(this::getWindowsPath)?.let(::File)
       if (path != null) {


### PR DESCRIPTION
Hello,

The sdkman-init.sh script not only initializes SDKMAN but also includes in the PATH any of the installed tools like Java and Maven. This script only works with bash and zsh. It will fail if it is invoked with /bin/sh.

This addition will invoke the command which mvn using the default shell that likely will be bash or zsh. Even if the default shell is fish, it can be invoked using the bass extension.

This gives to the user the flexibility to install through SDKMAN not only Java but also Maven.

Regards