### PR TITLE
Make ReadVariableInstruction public like other InstructionBase classes

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/controlFlow/ReadVariableInstruction.java
+++ b/java/java-psi-impl/src/com/intellij/psi/controlFlow/ReadVariableInstruction.java
@@ -18,7 +18,7 @@ package com.intellij.psi.controlFlow;
 import com.intellij.psi.PsiVariable;
 import org.jetbrains.annotations.NotNull;
 
-final class ReadVariableInstruction extends SimpleInstruction {
+public final class ReadVariableInstruction extends SimpleInstruction {
   @NotNull 
   public final PsiVariable variable;
 


### PR DESCRIPTION
Other Instruction classes inheriting `InstructionBase` are public but only ReadVariableInstruction isn't. E.g. https://github.com/JetBrains/intellij-community/blob/master/java/java-psi-impl/src/com/intellij/psi/controlFlow/WriteVariableInstruction.java#L21