### PR TITLE
fix UnsupportedOperationException with debugger agent + retransforming agent

### DIFF
--- a/java/debugger/debugger-agent/src/com/intellij/rt/debugger/agent/CaptureAgent.java
+++ b/java/debugger/debugger-agent/src/com/intellij/rt/debugger/agent/CaptureAgent.java
@@ -165,7 +165,10 @@ public final class CaptureAgent {
                             Class<?> classBeingRedefined,
                             ProtectionDomain protectionDomain,
                             byte[] classfileBuffer) {
-      if (className != null && classBeingRedefined == null) { // we do not support redefinition or retransform
+      // While we do not support redefinition or retransform, in case another agent is active
+      // we have to re-transform again. Otherwise the other agent might not be able to instrument the class properly without the structural
+      // changes applied by this agent.
+      if (className != null) {
         List<InstrumentPoint> classPoints = myInstrumentPoints.get(className);
         if (classPoints != null) {
           try {


### PR DESCRIPTION
IDEA debugger agent instruments classes by modifying their structure, which is allowed before the classes are loaded for the first time.

However, when another agent tries to instrument by re-transforming one of the classes already instrumented by the debugger agent, we get `UnsupportedOperationException` as the modified class bytecode is not provided to the other agent.

We discovered this in the context of https://github.com/elastic/apm-agent-java/issues/1673 where `java.util.concurrent.ForkJoinTask#fork()` is instrumented both by IDEA debugger agent and Elastic APM agent.

While we can apply a simple work-around like checking if `intellij.debug.agent` system property is being set and invite anyone debugging with the debugger agent active to disable it, it is definitely just a work-around and prevents us from using this very useful debugger feature. Also, that issue will happen for every class that is [instrumented by this agent](https://github.com/JetBrains/intellij-community/blob/master/java/debugger/debugger-agent/src/com/intellij/rt/debugger/agent/CaptureAgent.java#L576)

Removing the `if` condition seems the only thing required here as:
- class transformation seems to be idempotent (not 100% sure, but I don't know how and if it's being tested).
- impact on performance is expected to be minimal as classes won't be redefined unless another agent (like ours) is active when debugging
- the agent is already declared as being able to re-transform classes ([META-INF/MANIFEST.MF](https://github.com/JetBrains/intellij-community/blob/master/java/debugger/debugger-agent/META-INF/MANIFEST.MF))