### PR TITLE
Task/update inspection gadget descriptions

### DIFF
--- a/plugins/InspectionGadgets/src/inspectionDescriptions/AssertWithSideEffects.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/AssertWithSideEffects.html
@@ -6,7 +6,7 @@ modifications of variables and fields in the assert statement. Also methods call
 fields.
 <p>Example:</p>
 <pre>
-  assert i++ < 10;
+  assert i++ &lt; 10;
 </pre>
 </body>
 </html>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/CollectionAddedToSelf.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/CollectionAddedToSelf.html
@@ -8,7 +8,7 @@ May happen in the code with raw types as a result of copy-paste.
 
 <p>Example:</p>
 <pre>
-  ArrayList list = new ArrayList<>();
+  ArrayList list = new ArrayList&lt;&gt;();
   list.add(list);
   return list.hashCode(); // throws StackOverflowException
 </pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ComparatorMethodParameterNotUsed.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ComparatorMethodParameterNotUsed.html
@@ -11,8 +11,8 @@ Reports problems found in <code>Comparator.compare()</code> implementations:
 <!-- tooltip end -->
 <p>Sample of the code that will be reported: </p>
 <pre>
-  Comparator&lt;String&gt; lambda = (a, b) -> (a.length() > b.length() ? 0 :
-                Math.random() > 0.5 ? (-1) : (1));
+  Comparator&lt;String&gt; lambda = (a, b) -&gt; (a.length() &gt; b.length() ? 0 :
+                Math.random() &gt; 0.5 ? (-1) : (1));
 </pre>
 </body>
 </html>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ControlFlowStatementWithoutBraces.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ControlFlowStatementWithoutBraces.html
@@ -4,11 +4,11 @@ Reports any <b>if</b>, <b>while</b> or <b>for</b> statements without braces.
 Braces make the code easier to read and help prevent errors when modifying the code.
 <p>Example:</p>
 <pre>
-  if (x > 0) System.out.println("x is positive");
+  if (x &gt; 0) System.out.println("x is positive");
 </pre>
 <p>The quick fix for the inspection wraps the statement body with braces:
 <pre>
-  if (x > 0) {
+  if (x &gt; 0) {
     System.out.println("x is positive");
   }
 </pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/IfCanBeSwitch.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/IfCanBeSwitch.html
@@ -20,10 +20,10 @@ The result of transformation is usually shorter and clearer.
 <pre>
   void test(String str) {
     switch (str) {
-      case "1" -> System.out.println(1);
-      case "2" -> System.out.println(2);
-      case "3" -> System.out.println(3);
-      default -> System.out.println(4);
+      case "1" -&gt; System.out.println(1);
+      case "2" -&gt; System.out.println(2);
+      case "3" -&gt; System.out.println(3);
+      default -&gt; System.out.println(4);
     }
   }
 </pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/IfStatementWithIdenticalBranches.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/IfStatementWithIdenticalBranches.html
@@ -4,7 +4,7 @@ Reports <code>if</code> statements where common parts can be extracted from the 
 These common parts are independent from the condition and make <code>if</code> statements harder to understand.
 <p>Example:</p>
 <pre>
-  if (x > 12) {
+  if (x &gt; 12) {
     doSomethingBefore();
     doSomethingDifferent1();
     doSomethingAfter();
@@ -17,7 +17,7 @@ These common parts are independent from the condition and make <code>if</code> s
 <p>After the quick-fix is applied, the result looks like this:</p>
 <pre>
   doSomethingBefore();
-  if (x > 12) {
+  if (x &gt; 12) {
     doSomethingDifferent1();
   } else {
     doSomethingDifferent2();

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ImplicitNumericConversion.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ImplicitNumericConversion.html
@@ -7,7 +7,7 @@ of difficult to trace bugs.
 <p>
 Use the first checkbox below if you wish this inspection to ignore implicit conversion which
 can not result in loss of data (e.g.
-<b>int</b>-><b>long</b>).
+<b>int</b>-&gt;<b>long</b>).
 <p>Use the second checkbox to indicate that this inspection should ignore conversion from
 and to <b>char</b>. Conversion from floating point to <b>char</b> and vice versa will still be reported.
 <p>Use the third checkbox to let this inspection ignore conversion from literals and

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/InfiniteLoopStatement.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/InfiniteLoopStatement.html
@@ -15,7 +15,7 @@ Use the checkbox below to ignore the infinite loop statements inside <code>Threa
 It may be useful for the daemon threads.
 <p>Example:</p>
 <pre>
-  new Thread(() -> {
+  new Thread(() -&gt; {
     while (true) {
     }
   }).start();

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/KeySetIterationMayUseEntrySet.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/KeySetIterationMayUseEntrySet.html
@@ -3,9 +3,9 @@
 Reports iteration over the <b>keySet()</b> of a <b>java.util.Map</b> instance,
 where the iterated keys are used to retrieve the values from the map. Such
 iteration may be more efficiently replaced by iteration over the
-<b>entrySet()</b> or <b>values()</b> (if key is not actually used). 
-Similarly <b>keySet().forEach(key -> ...)</b>
-can be replaced with <b>forEach((key, value) -> ...)</b> if values are retrieved
+<b>entrySet()</b> or <b>values()</b> (if key is not actually used).
+Similarly <b>keySet().forEach(key -&gt; ...)</b>
+can be replaced with <b>forEach((key, value) -&gt; ...)</b> if values are retrieved
 inside lambda.
 <!-- tooltip end -->
 <p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LambdaParameterTypeCanBeSpecified.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LambdaParameterTypeCanBeSpecified.html
@@ -3,11 +3,11 @@
 Reports lambda parameters which don't have their type specified. The quick-fix adds the type declaration to the lambda parameters.
 <p>Example:</p>
 <pre>
-  Function&lt;String, Integer&gt; length = a -> a.length();
+  Function&lt;String, Integer&gt; length = a -&gt; a.length();
 </pre>
 <p>After the quick-fix is applied the result looks like:</p>
 <pre>
-  Function&lt;String, Integer&gt; length = (String a) -> a.length();
+  Function&lt;String, Integer&gt; length = (String a) -&gt; a.length();
 </pre>
 <!-- tooltip end -->
 <p>This inspection only reports if the language level of the project or module is 8 or higher</p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LambdaUnfriendlyMethodOverload.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LambdaUnfriendlyMethodOverload.html
@@ -7,8 +7,8 @@ It is preferable to give the overloaded methods different names to eliminate amb
 <p>Example:</p>
 <pre>
 interface MyExecutor {
-  void execute(Supplier<?> supplier);
-  void execute(Callable<?> callable);
+  void execute(Supplier&lt;?&gt; supplier);
+  void execute(Callable&lt;?&gt; callable);
 }
 </pre>
 <p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ListIndexOfReplaceableByContains.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ListIndexOfReplaceableByContains.html
@@ -7,7 +7,7 @@ expressions that can be replaced with the
 <pre>
   boolean hasEmptyString(List&lt;String&gt; list) {
     // Warning: can be simplified
-    return list.indexOf("") >= 0;
+    return list.indexOf("") &gt;= 0;
   }
 </pre>
 A quick-fix is provided that will replace the <code>indexOf</code> call with a <code>contains</code> call:

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LoopConditionNotUpdatedInsideLoop.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LoopConditionNotUpdatedInsideLoop.html
@@ -7,14 +7,14 @@ are probably not what was intended.
 <pre>
   void loopDoesNotLoop(boolean b) {
       while (b) {
-        System.out.println();
-        break;
+          System.out.println();
+          break;
       }
   }
 </pre>
 <!-- tooltip end -->
 <p>
-    Use the checkbox below to disable this inspection if condition can be updated indirectly (e.g. via called method
+  Use the checkbox below to disable this inspection if condition can be updated indirectly (e.g. via called method
   or concurrently from another thread).
 </p>
 

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/MethodRefCanBeReplacedWithLambda.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/MethodRefCanBeReplacedWithLambda.html
@@ -9,7 +9,7 @@ Lambda expressions can be easier to modify than method references.
 </code></pre>
 <p>After the quick fix is applied the result looks like:
 <pre><code>
-  s -> System.out.println(s)
+  s -&gt; System.out.println(s)
 </code></pre>
 <!-- tooltip end -->
 <p>By default this inspection does not highlight in the editor, but only provides a quick fix.

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/MultipleVariablesInDeclaration.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/MultipleVariablesInDeclaration.html
@@ -13,7 +13,7 @@ Some coding standards prohibit such declarations.
 </pre>
 <!-- tooltip end -->
 <p>Use the first checkbox below to ignore multiple variables declared in the initialization of a 'for' loop statement, e.g.:</p>
-<pre><b>for</b> (int i = 0, max = list.size(); i < max; i++) {}</pre>
+<pre><b>for</b> (int i = 0, max = list.size(); i &gt; max; i++) {}</pre>
 <p>Use the second checkbox below to only warn when variables with different array dimensions are declared in a single declaration, e.g.:</p>
 <pre>String s = "", array[];</pre>
 <p><small>New in 2019.2</small></p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessBitwiseExpression.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessBitwiseExpression.html
@@ -1,16 +1,21 @@
 <html>
 <body>
-Reports pointless bitwise
-expressions. Such expressions include <code>and</code>ing with zero, <code>or</code>ing by zero,
-and shifting by zero. Such expressions may be the result of automated refactorings
-not completely followed through to completion, and in any case are unlikely to be what the developer
-intended to do.
-<p>Examples:</p>
-<pre>
+  Reports pointless bitwise
+  expressions. Such expressions include <code>and</code>ing with the maximum value for the given type, 
+  <code>or</code>ing by zero, and shifting by zero. Such expressions may be the result of automated 
+  refactorings not completely followed through to completion, and in any case are unlikely to be what 
+  the developer intended to do.
+  <p>Examples:</p>
+  <pre>
 // Warning: operation is pointless and can be replaced with just `flags`
-int bits = flags & 0xFFFFFFFF;
+// 0xFFFF_FFFF is the maximum value for an integer, and both literals are treated
+// as 32 bit integer literals.
+int bits = flags & 0xFFFF_FFFF;
+
 // Warning: operation is pointless and can be replaced with just `bits`
+// OR-ing with 0 always outputs the other oprand.
 int or = bits | 0x0;
+
 // Warning: operation is pointless, as always results in 0
 int xor = or ^ or;
 </pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/SerializableRecordContainsIgnoredMembers.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/SerializableRecordContainsIgnoredMembers.html
@@ -6,20 +6,26 @@ These members are ignored during serialization/deserialization of records.
 <p>Example:</p>
 <pre>
   record R1() implements Serializable {
+    // The field is ignored during record serialization
     @Serial
-    private static final ObjectStreamField[] serialPersistentFields = new ObjectStreamField[0]; //The field is ignored during record serialization
+    private static final ObjectStreamField[] serialPersistentFields = new ObjectStreamField[0];
+
+    // The method is ignored during record serialization
     @Serial
-    private void writeObject(ObjectOutputStream out) throws IOException { //The method is ignored during record serialization
+    private void writeObject(ObjectOutputStream out) throws IOException {
     }
   }
 </pre>
 <pre>
   record R2() implements Externalizable {
+    // The method is ignored during record serialization
     @Override
-    public void writeExternal(ObjectOutput out) throws IOException { //The method is ignored during record serialization
+    public void writeExternal(ObjectOutput out) throws IOException {
     }
+
+    // The method is ignored during record serialization
     @Override
-    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException { //The method is ignored during record serialization
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
     }
   }
 </pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ShiftOutOfRange.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ShiftOutOfRange.html
@@ -9,7 +9,7 @@ a coding error.
 <pre>
   int shiftSize = 32;
   // Warning: shift by 32 bits is equivalent to shift by 0 bits, so there's no shift at all. 
-  int mask = (1 << shiftSize) - 1;
+  int mask = (1 &lt;&lt; shiftSize) - 1;
 </pre>
 <!-- tooltip end -->
 </body>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/SuspiciousInvocationHandlerImplementation.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/SuspiciousInvocationHandlerImplementation.html
@@ -5,7 +5,7 @@ Reports the implementations of <code>InvocationHandler</code> that do not proxy 
 Failing to handle these methods might cause unexpected problems upon calling them on a proxy instance.
 <p>Example:
 <pre>
-  InvocationHandler myHandler = (proxy, method, params) -> {
+  InvocationHandler myHandler = (proxy, method, params) -&gt; {
     System.out.println("Hello World!");
     <b>return</b> null;
   };

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/SwitchStatementWithTooFewBranches.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/SwitchStatementWithTooFewBranches.html
@@ -6,8 +6,8 @@ and
 <p>Example (minimum branches == 3):</p>
 <pre>
 switch (expression) {
-  case "foo" -> foo();
-  case "bar" -> bar();
+  case "foo" -&gt; foo();
+  case "bar" -&gt; bar();
 }
 </pre>
 <p>After the quick-fix is applied the result looks like:</p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryBreak.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryBreak.html
@@ -5,11 +5,11 @@ An <code>break</code> statement is unnecessary when no other statements will be 
 <p><b>Example:</b></p>
 <pre>
  switch (e) {
-    case A -> {
+    case A -&gt; {
         System.out.println("A");
         break; // reports 'break' statement is unnecessary
     }
-    default -> {
+    default -&gt; {
         System.out.println("Default");
         break; // reports 'break' statement is unnecessary
     }

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryDefault.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryDefault.html
@@ -13,9 +13,9 @@ Quick fix removes default branch.
   enum E { A, B }
   int foo(E e) {
     return switch (e) {
-      case A -> 1;
-      case B -> 2;
-      default -> 3;
+      case A -&gt; 1;
+      case B -&gt; 2;
+      default -&gt; 3;
     };
   }
 </pre>
@@ -24,8 +24,8 @@ Quick fix removes default branch.
   enum E { A, B }
   int foo(E e) {
     return switch (e) {
-      case A -> 1;
-      case B -> 2;
+      case A -&gt; 1;
+      case B -&gt; 2;
     };
   }
 </pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryLabelOnBreakStatement.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryLabelOnBreakStatement.html
@@ -4,7 +4,7 @@ Reports <code>break</code> statements with unnecessary labels. Such labels do no
 <p><b>Example:</b></p>
 <pre>
     label: 
-    for(int i = 0; i < 10; i++) {
+    for(int i = 0; i &lt; 10; i++) {
       if (shouldBreak()) break label;
       //doSmth
     }
@@ -12,7 +12,7 @@ Reports <code>break</code> statements with unnecessary labels. Such labels do no
 <p>After the quickfix is applied the result looks like:</p>
 <pre>
     label: 
-    for(int i = 0; i < 10; i++) {
+    for(int i = 0; i &lt; 10; i++) {
       if (shouldBreak()) break;
       //doSmth
     }

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryLabelOnContinueStatement.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryLabelOnContinueStatement.html
@@ -5,7 +5,7 @@ labels.
 <p>Example: </p>
 <pre>
         LABEL:
-        while (a > b) {
+        while (a &gt; b) {
             System.out.println("Hello");
             //the code below is the last statement in a loop,
             //so unnecessary label and continue can be removed


### PR DESCRIPTION
- Fixes several occurrences where `<` and `>` may be interpreted as HTML tags rather than literal symbols,
  which has manifested itself as a visual error in at least one place:

![image](https://user-images.githubusercontent.com/73482956/113519040-ce561580-9581-11eb-8893-9bdc5fef6748.png)

- Moved comments in SerializableRecordContainsIgnoredMembers.html to aid in readability and reduce content that
  scrolls horizontally or wraps in the preview/tooltip.

- Added additional comments to PointlessBitwiseExpression.html, as some semantics of how Java deals with bitwise operations
  and integral limits may be considered to be outside the range of beginner knowledge, and thus a common "gotcha" to developers.