### PR TITLE
Hg Tags get from hg tags command instead of read from tags file

### DIFF
--- a/plugins/hg4idea/src/org/zmlx/hg4idea/command/HgTagsCommand.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/command/HgTagsCommand.java
@@ -1,0 +1,33 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+package org.zmlx.hg4idea.command;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.zmlx.hg4idea.execution.HgCommandExecutor;
+import org.zmlx.hg4idea.execution.HgCommandResult;
+
+import java.util.Collections;
+import java.util.List;
+
+/*
+ * @author bala guru
+ *
+ */
+public class HgTagsCommand {
+
+  private static final String TAGS_OPERATION = "tags";
+  private static final List<String> ARGUMENTS = Collections.singletonList("-v");
+
+  private final Project project;
+  private final VirtualFile repo;
+
+  public HgTagsCommand(Project project, VirtualFile repo) {
+    this.project = project;
+    this.repo = repo;
+  }
+
+  public HgCommandResult collectTags(){
+    return new HgCommandExecutor(project).executeInCurrentThread(repo, TAGS_OPERATION, ARGUMENTS);
+  }
+}

--- a/plugins/hg4idea/src/org/zmlx/hg4idea/repo/HgRepositoryImpl.java
+++ b/plugins/hg4idea/src/org/zmlx/hg4idea/repo/HgRepositoryImpl.java
@@ -51,7 +51,7 @@ public final class HgRepositoryImpl extends RepositoryImpl implements HgReposito
     myVcs = vcs;
     myHgDir = rootDir.findChild(HgUtil.DOT_HG);
     assert myHgDir != null : ".hg directory wasn't found under " + rootDir.getPresentableUrl();
-    myReader = new HgRepositoryReader(vcs, VfsUtilCore.virtualToIoFile(myHgDir));
+    myReader = new HgRepositoryReader(vcs, VfsUtilCore.virtualToIoFile(myHgDir), rootDir);
     myConfig = HgConfig.getInstance(getProject(), rootDir);
     myLocalIgnoredHolder = new HgLocalIgnoredHolder(this, HgUtil.getRepositoryManager(getProject()));
     myLocalIgnoredHolder.setupListeners();

--- a/plugins/hg4idea/testSrc/hg4idea/test/repo/HgRealRepositoryReaderTest.java
+++ b/plugins/hg4idea/testSrc/hg4idea/test/repo/HgRealRepositoryReaderTest.java
@@ -24,7 +24,7 @@ public class HgRealRepositoryReaderTest extends HgPlatformTest {
   public void setUp() throws Exception {
     super.setUp();
     createBranchesAndTags();
-    myRepositoryReader = new HgRepositoryReader(myVcs, myRepository.toNioPath().resolve(".hg").toFile());
+    myRepositoryReader = new HgRepositoryReader(myVcs, myRepository.toNioPath().resolve(".hg").toFile(), myRepository);
   }
 
   public void testMergeState() {

--- a/plugins/hg4idea/testSrc/hg4idea/test/repo/HgRepositoryReaderTest.java
+++ b/plugins/hg4idea/testSrc/hg4idea/test/repo/HgRepositoryReaderTest.java
@@ -45,25 +45,6 @@ public class HgRepositoryReaderTest extends HgPlatformTest {
     super.setUp();
     myHgDir = new File(myRepository.getPath(), ".hg");
     assertTrue(myHgDir.exists());
-    //File pluginRoot = new File(PluginPathManager.getPluginHomePath("hg4idea"));
-
-    //String pathToHg = "testData/repo/dot_hg";
-    //File testHgDir = new File(pluginRoot, FileUtil.toSystemDependentName(pathToHg));
-
-    //File cacheDir = new File(testHgDir, "cache");
-    //File testDirStateFile = new File(testHgDir, "dirstate");
-    //File testBranchFile = new File(testHgDir, "branch");
-    //File testBookmarkFile = new File(testHgDir, "bookmarks");
-    //File testCurrentBookmarkFile = new File(testHgDir, "bookmarks.current");
-    //File testTagFile = new File(testHgDir.getParentFile(), ".hgtags");
-    //File testLocalTagFile = new File(testHgDir, "localtags");
-    //FileUtil.copyDir(cacheDir, new File(myHgDir, "cache"));
-    //FileUtil.copy(testBranchFile, new File(myHgDir, "branch"));
-    //FileUtil.copy(testDirStateFile, new File(myHgDir, "dirstate"));
-    //FileUtil.copy(testBookmarkFile, new File(myHgDir, "bookmarks"));
-    //FileUtil.copy(testCurrentBookmarkFile, new File(myHgDir, "bookmarks.current"));
-    //FileUtil.copy(testTagFile, new File(myHgDir.getParentFile(), ".hgtags"));
-    //FileUtil.copy(testLocalTagFile, new File(myHgDir, "localtags"));
 
     myRepositoryReader = new HgRepositoryReader(myVcs, myHgDir, myRepository);
     myBranches = setUpBranches();
@@ -216,35 +197,10 @@ public class HgRepositoryReaderTest extends HgPlatformTest {
     VcsTestUtil.assertEqualCollections(localTags, myLocalTags);
   }
 
-  //@NotNull
-  //private Collection<String> readBranches() throws IOException {
-  //  Collection<String> branches = new HashSet<>();
-  //  File branchHeads = new File(new File(myHgDir, "cache"), "branchheads-served");
-  //  String[] branchesWithHashes = FileUtil.loadFile(branchHeads).split("\n");
-  //  for (int i = 1; i < branchesWithHashes.length; ++i) {
-  //    String[] refAndName = branchesWithHashes[i].trim().split(" ");
-  //    assertEquals(2, refAndName.length);
-  //    branches.add(refAndName[1]);
-  //  }
-  //  return branches;
-  //}
-
-
   public void testCurrentBookmark() {
     String bookmarkName = "bookmark_2";
     updateRepoTo(bookmarkName);
     assertEquals(bookmarkName, myRepositoryReader.readCurrentBookmark());
   }
 
-  //@NotNull
-  //private static Collection<String> readRefs(@NotNull File refFile) throws IOException {
-  //  Collection<String> refs = new HashSet<>();
-  //  String[] refsWithHashes = FileUtil.loadFile(refFile).split("\n");
-  //  for (String str : refsWithHashes) {
-  //    String[] refAndName = str.trim().split(" ");
-  //    assertEquals(2, refAndName.length);
-  //    refs.add(refAndName[1]);
-  //  }
-  //  return refs;
-  //}
 }

--- a/plugins/hg4idea/testSrc/hg4idea/test/repo/HgRepositoryReaderTest.java
+++ b/plugins/hg4idea/testSrc/hg4idea/test/repo/HgRepositoryReaderTest.java
@@ -15,10 +15,10 @@
  */
 package hg4idea.test.repo;
 
-import com.intellij.dvcs.DvcsUtil;
 import com.intellij.openapi.application.PluginPathManager;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vcs.VcsTestUtil;
+import hg4idea.test.HgExecutor;
 import hg4idea.test.HgPlatformTest;
 import org.jetbrains.annotations.NotNull;
 import org.zmlx.hg4idea.repo.HgRepositoryReader;
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 
-import static com.intellij.openapi.vcs.Executor.debug;
+import static com.intellij.openapi.vcs.Executor.*;
 
 public class HgRepositoryReaderTest extends HgPlatformTest {
 
@@ -45,49 +45,155 @@ public class HgRepositoryReaderTest extends HgPlatformTest {
     super.setUp();
     myHgDir = new File(myRepository.getPath(), ".hg");
     assertTrue(myHgDir.exists());
-    File pluginRoot = new File(PluginPathManager.getPluginHomePath("hg4idea"));
+    //File pluginRoot = new File(PluginPathManager.getPluginHomePath("hg4idea"));
 
-    String pathToHg = "testData/repo/dot_hg";
-    File testHgDir = new File(pluginRoot, FileUtil.toSystemDependentName(pathToHg));
+    //String pathToHg = "testData/repo/dot_hg";
+    //File testHgDir = new File(pluginRoot, FileUtil.toSystemDependentName(pathToHg));
 
-    File cacheDir = new File(testHgDir, "cache");
-    File testDirStateFile = new File(testHgDir, "dirstate");
-    File testBranchFile = new File(testHgDir, "branch");
-    File testBookmarkFile = new File(testHgDir, "bookmarks");
-    File testCurrentBookmarkFile = new File(testHgDir, "bookmarks.current");
-    File testTagFile = new File(testHgDir.getParentFile(), ".hgtags");
-    File testLocalTagFile = new File(testHgDir, "localtags");
-    FileUtil.copyDir(cacheDir, new File(myHgDir, "cache"));
-    FileUtil.copy(testBranchFile, new File(myHgDir, "branch"));
-    FileUtil.copy(testDirStateFile, new File(myHgDir, "dirstate"));
-    FileUtil.copy(testBookmarkFile, new File(myHgDir, "bookmarks"));
-    FileUtil.copy(testCurrentBookmarkFile, new File(myHgDir, "bookmarks.current"));
-    FileUtil.copy(testTagFile, new File(myHgDir.getParentFile(), ".hgtags"));
-    FileUtil.copy(testLocalTagFile, new File(myHgDir, "localtags"));
+    //File cacheDir = new File(testHgDir, "cache");
+    //File testDirStateFile = new File(testHgDir, "dirstate");
+    //File testBranchFile = new File(testHgDir, "branch");
+    //File testBookmarkFile = new File(testHgDir, "bookmarks");
+    //File testCurrentBookmarkFile = new File(testHgDir, "bookmarks.current");
+    //File testTagFile = new File(testHgDir.getParentFile(), ".hgtags");
+    //File testLocalTagFile = new File(testHgDir, "localtags");
+    //FileUtil.copyDir(cacheDir, new File(myHgDir, "cache"));
+    //FileUtil.copy(testBranchFile, new File(myHgDir, "branch"));
+    //FileUtil.copy(testDirStateFile, new File(myHgDir, "dirstate"));
+    //FileUtil.copy(testBookmarkFile, new File(myHgDir, "bookmarks"));
+    //FileUtil.copy(testCurrentBookmarkFile, new File(myHgDir, "bookmarks.current"));
+    //FileUtil.copy(testTagFile, new File(myHgDir.getParentFile(), ".hgtags"));
+    //FileUtil.copy(testLocalTagFile, new File(myHgDir, "localtags"));
 
-    myRepositoryReader = new HgRepositoryReader(myVcs, myHgDir);
-    myBranches = readBranches();
-    myBookmarks = readRefs(testBookmarkFile);
-    myTags = readRefs(testTagFile);
-    myLocalTags = readRefs(testLocalTagFile);
+    myRepositoryReader = new HgRepositoryReader(myVcs, myHgDir, myRepository);
+    myBranches = setUpBranches();
+    myBookmarks = setUpBookmarks();
+    myTags = setUpTags();
+    myLocalTags = setUpLocalTags();
   }
 
-  public void testCurrentRecision() {
-    assertEquals("33ef48b940a9797973c3becd9d3a181593f5b57a", myRepositoryReader.readCurrentRevision());
+  /**
+   * create local tags in test repo
+   * @return created local tags
+   */
+  @NotNull
+  private Collection<String> setUpLocalTags(){
+    cd(myRepository);
+    touch("file_for_tag_local_1.txt");
+    HgExecutor.hg("add file_for_tag_local_1.txt");
+    HgExecutor.hg("commit -m 'commit for tag_local_1'");
+    HgExecutor.hg("tag -l tag_local_1");
+    touch("file_for_tag_local_2.txt");
+    HgExecutor.hg("add file_for_tag_local_2.txt");
+    HgExecutor.hg("commit -m 'commit for tag_local_2'");
+    HgExecutor.hg("tag -l tag_local_2");
+    Collection<String> tags = new HashSet<>();
+    tags.add("tag_local_1");
+    tags.add("tag_local_2");
+    return tags;
+  }
+
+  /**
+   * create tags in test repo
+   * @return created tags
+   */
+  @NotNull
+  private Collection<String> setUpTags(){
+    cd(myRepository);
+    touch("file_for_tag_1.txt");
+    HgExecutor.hg("add file_for_tag_1.txt");
+    HgExecutor.hg("commit -m 'commit for tag_1'");
+    HgExecutor.hg("tag tag_1");
+    touch("file_for_tag_2.txt");
+    HgExecutor.hg("add file_for_tag_2.txt");
+    HgExecutor.hg("commit -m 'commit for tag_2'");
+    HgExecutor.hg("tag tag_2");
+    Collection<String> tags = new HashSet<>();
+    tags.add("tag_1");
+    tags.add("tag_2");
+    return tags;
+  }
+
+  /**
+   * create bookmark in test repo
+   * @return created bookmark
+   */
+  @NotNull
+  private Collection<String> setUpBookmarks(){
+    cd(myRepository);
+    touch("file_for_bookmark_1.txt");
+    HgExecutor.hg("add file_for_bookmark_1.txt");
+    HgExecutor.hg("commit -m 'commit for bookmark_1'");
+    HgExecutor.hg("bookmark bookmark_1");
+    touch("file_for_bookmark_2.txt");
+    HgExecutor.hg("add file_for_bookmark_2.txt");
+    HgExecutor.hg("commit -m 'commit for bookmark_2'");
+    HgExecutor.hg("bookmark bookmark_2");
+    Collection<String> bookmarks = new HashSet<>();
+    bookmarks.add("bookmark_1");
+    bookmarks.add("bookmark_2");
+    return bookmarks;
+  }
+
+  /**
+   * create branch in test repo
+   * @return created branch
+   */
+  @NotNull
+  private Collection<String> setUpBranches(){
+    cd(myRepository);
+    HgExecutor.hg("update default");
+    HgExecutor.hg("branch branch_1");
+    touch("file_for_branch_1.txt");
+    HgExecutor.hg("add file_for_branch_1.txt");
+    HgExecutor.hg("commit -m 'commit for branch_1'");
+    HgExecutor.hg("branch branch_2");
+    touch("file_for_branch_2.txt");
+    HgExecutor.hg("add file_for_branch_2.txt");
+    HgExecutor.hg("commit -m 'commit for branch_2'");
+    Collection<String> branches = new HashSet<>();
+    branches.add("default");
+    branches.add("branch_1");
+    branches.add("branch_2");
+    return branches;
+  }
+
+  /**
+   * update current repo to branch/bookmark/tag
+   * @param updateToName BranchName/TagName/Bookmark
+   */
+  private void updateRepoTo(String updateToName){
+    cd(myRepository);
+    HgExecutor.hg("update "+updateToName);
+  }
+
+  /**
+   * get revision hash from repo for hg operation
+   * @param operation it can be any that return revision
+   * @return full revision hash
+   */
+  private String revisionFullHashForCommand(String operation){
+    cd(myRepository);
+    String output = HgExecutor.hg(String.format("%s --template '{node}'", operation));
+    output = output.trim().strip();
+    return output;
+  }
+
+  public void testCurrentRevision() {
+    String currentRevision = revisionFullHashForCommand("parent");
+    assertEquals(currentRevision, myRepositoryReader.readCurrentRevision());
   }
 
   public void testTip() {
-    File cacheDir = new File(myHgDir, "cache");
-    assertTrue(cacheDir.exists());
-    File branchFile = new File(cacheDir, "branchheads-served");
-    assertTrue(branchFile.exists());
-    debug(DvcsUtil.tryLoadFileOrReturn(branchFile, ""));
-    assertEquals("25e44c95b2612e3cdf29a704dabf82c77066cb67", myRepositoryReader.readCurrentTipRevision());
+    String tipRevision = revisionFullHashForCommand("tip");
+    assertEquals(tipRevision, myRepositoryReader.readCurrentTipRevision());
   }
 
   public void testCurrentBranch() {
+    String myCurrentBranch = "branch_1";
+    updateRepoTo(myCurrentBranch);
     String currentBranch = myRepositoryReader.readCurrentBranch();
-    assertEquals("firstBranch", currentBranch);
+    assertEquals(myCurrentBranch, currentBranch);
   }
 
   public void testBranches() {
@@ -110,33 +216,35 @@ public class HgRepositoryReaderTest extends HgPlatformTest {
     VcsTestUtil.assertEqualCollections(localTags, myLocalTags);
   }
 
-  @NotNull
-  private Collection<String> readBranches() throws IOException {
-    Collection<String> branches = new HashSet<>();
-    File branchHeads = new File(new File(myHgDir, "cache"), "branchheads-served");
-    String[] branchesWithHashes = FileUtil.loadFile(branchHeads).split("\n");
-    for (int i = 1; i < branchesWithHashes.length; ++i) {
-      String[] refAndName = branchesWithHashes[i].trim().split(" ");
-      assertEquals(2, refAndName.length);
-      branches.add(refAndName[1]);
-    }
-    return branches;
-  }
+  //@NotNull
+  //private Collection<String> readBranches() throws IOException {
+  //  Collection<String> branches = new HashSet<>();
+  //  File branchHeads = new File(new File(myHgDir, "cache"), "branchheads-served");
+  //  String[] branchesWithHashes = FileUtil.loadFile(branchHeads).split("\n");
+  //  for (int i = 1; i < branchesWithHashes.length; ++i) {
+  //    String[] refAndName = branchesWithHashes[i].trim().split(" ");
+  //    assertEquals(2, refAndName.length);
+  //    branches.add(refAndName[1]);
+  //  }
+  //  return branches;
+  //}
 
 
   public void testCurrentBookmark() {
-    assertEquals("B_BookMark", myRepositoryReader.readCurrentBookmark());
+    String bookmarkName = "bookmark_2";
+    updateRepoTo(bookmarkName);
+    assertEquals(bookmarkName, myRepositoryReader.readCurrentBookmark());
   }
 
-  @NotNull
-  private static Collection<String> readRefs(@NotNull File refFile) throws IOException {
-    Collection<String> refs = new HashSet<>();
-    String[] refsWithHashes = FileUtil.loadFile(refFile).split("\n");
-    for (String str : refsWithHashes) {
-      String[] refAndName = str.trim().split(" ");
-      assertEquals(2, refAndName.length);
-      refs.add(refAndName[1]);
-    }
-    return refs;
-  }
+  //@NotNull
+  //private static Collection<String> readRefs(@NotNull File refFile) throws IOException {
+  //  Collection<String> refs = new HashSet<>();
+  //  String[] refsWithHashes = FileUtil.loadFile(refFile).split("\n");
+  //  for (String str : refsWithHashes) {
+  //    String[] refAndName = str.trim().split(" ");
+  //    assertEquals(2, refAndName.length);
+  //    refs.add(refAndName[1]);
+  //  }
+  //  return refs;
+  //}
 }


### PR DESCRIPTION
Read tags from file works perfectly but it will not work if tags stored in another branch "tags_branch".

if repo maintains tags in another branch like "tags" then it will always produce empty in current implementation.
To overcome above issue by getting tags from hg command itself. it will handle every formats.

Because of above Implementation I need to change Unit test that involves in this file. 
existing unit test implementation involves by coping existing stored hg files but it leads to hg repo corruption. so i can not able to query using hg command in that repo. so i changed to new format by manually creating repo for all unit test use cases in that file.