### PR TITLE
[IDEA-267912] Fix repaint during document change

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
@@ -1562,7 +1562,7 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
     if (myDocumentChangeInProgress) {
       // at this point soft wrap model might be in an invalid state, so the following calculations cannot be performed correctly
       if (startOffset < myRangeToRepaintStart) myRangeToRepaintStart = startOffset;
-      if (endOffset < myRangeToRepaintEnd) myRangeToRepaintEnd = endOffset;
+      if (endOffset > myRangeToRepaintEnd) myRangeToRepaintEnd = endOffset;
       return;
     }
 


### PR DESCRIPTION
Fixes [IDEA-267912]. Is there anything I need to do in order to backport this fix to earlier versions of IntelliJ?

[IDEA-267912]:
<https://youtrack.jetbrains.com/issue/IDEA-267912>
"Changes in highlighting are not repainted after document changes : IDEA-267912"