### PR TITLE
Add aarch64 support for macOS and jna-5.8.0

### DIFF
--- a/platform/util/src/com/intellij/openapi/util/io/FileSystemUtil.java
+++ b/platform/util/src/com/intellij/openapi/util/io/FileSystemUtil.java
@@ -285,6 +285,7 @@ public final class FileSystemUtil {
       else if ("linux-ppc".equals(Platform.RESOURCE_PREFIX)) myOffsets = LNX_PPC32;
       else if ("linux-ppc64le".equals(Platform.RESOURCE_PREFIX)) myOffsets = LNX_PPC64;
       else if ("darwin".equals(Platform.RESOURCE_PREFIX)) myOffsets = BSD_64;
+      else if ("darwin-aarch64".equals(Platform.RESOURCE_PREFIX)) myOffsets = BSD_64;
       else if ("freebsd-x86".equals(Platform.RESOURCE_PREFIX)) myOffsets = SystemInfo.isOsVersionAtLeast("12") ? BSD_32_12 : BSD_32;
       else if ("freebsd-x86-64".equals(Platform.RESOURCE_PREFIX)) myOffsets = SystemInfo.isOsVersionAtLeast("12") ? BSD_64_12 : BSD_64;
       else if ("sunos-x86".equals(Platform.RESOURCE_PREFIX)) myOffsets = SUN_OS_32;


### PR DESCRIPTION
Platform.RESOURCE_PREFIX for aarch64 macOS is "darwin-aarch64" since jna-5.8.0