### PR TITLE
[KTIJ-11532] Create member function removes selected code in target Java file

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/createFromUsage/callableBuilder/CallableBuilder.kt
@@ -895,6 +895,7 @@ class CallableBuilder(val config: CallableBuilderConfiguration) {
 
             val descriptor = OpenFileDescriptor(project, targetClass.containingFile.virtualFile)
             val targetEditor = FileEditorManager.getInstance(project).openTextEditor(descriptor, true)!!
+            targetEditor.selectionModel.removeSelection()
 
             when (newJavaMember) {
                 is PsiMethod -> CreateFromUsageUtils.setupEditor(newJavaMember, targetEditor)

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.after.Dependency.java
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.after.Dependency.java
@@ -1,0 +1,10 @@
+public class Foo {
+
+    public void test1() {
+
+    }
+
+    public void test2() {
+
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.after.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.after.kt
@@ -1,0 +1,8 @@
+// "Create member function 'Foo.test2'" "true"
+// ERROR: Unresolved reference: test2
+class Bar {
+
+    fun test(foo: Foo) {
+        foo.<selection><caret></selection>test2()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.before.Dependency.java
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.before.Dependency.java
@@ -1,0 +1,6 @@
+public class Foo {
+
+    public void <selection>test1() {
+
+    }</selection>
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.before.Main.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createFunction/fromKotlin/memberFunction.before.Main.kt
@@ -1,0 +1,8 @@
+// "Create member function 'Foo.test2'" "true"
+// ERROR: Unresolved reference: test2
+class Bar {
+
+    fun test(foo: Foo) {
+        foo.<caret>test2()
+    }
+}


### PR DESCRIPTION
Added selection removal before setting up target editor. 

I wanted to add few test cases but I noticed that all quickfix tests are `kotlin` to `kotlin`. When I try to mix `Create member function` from `kotlin` to `java` my tests are failing (I'm trying to add test data for ` QuickFixMultiModuleTestGenerated`). 

Issue: https://youtrack.jetbrains.com/issue/KTIJ-11532