### PR TITLE
[bug] update plantuml.jar version to avoid some bug by older version

### DIFF
--- a/plugins/markdown/resource/META-INF/plugin.xml
+++ b/plugins/markdown/resource/META-INF/plugin.xml
@@ -188,7 +188,7 @@ Includes the following features:</p>
                  defaultValue="600000"
                  description="Interval in milliseconds defining how often Markdown plugin caches (e.g. PlantUML diagrams) should be cleared"/>
     <registryKey key="markdown.plantuml.download.link"
-                 defaultValue="https://download.jetbrains.com/grazie/markdown/extensions/plantuml/plantuml-1.jar"
+                 defaultValue="https://repo1.maven.org/maven2/net/sourceforge/plantuml/plantuml/1.2021.5/plantuml-1.2021.5.jar"
                  description="Link which Markdown plugin will use to download PlantUML JAR"/>
     <registryKey key="markdown.open.link.in.external.browser"
                  defaultValue="true"


### PR DESCRIPTION
The graph that cannot be baked correctly using current plantuml.jar we used in idea is:

```plantuml
@startuml
'https://plantuml.com/component-diagram


package "Some Group" {
  HTTP - [First Component]
  [Another Component]
}

node "Other Groups" {
  FTP - [Second Component]
  [First Component] --> FTP
}

cloud {
  [Example 1]
}


database "MySql" {
  folder "This is my folder" {
    [Folder 3]
  }
  frame "Foo" {
    [Frame 4]
  }
}


[Another Component] --> [Example 1]
[Example 1] --> [Folder 3]
[Folder 3] --> [Frame 4]

@enduml
```

And after replacing the plantuml.jar in local idea folder (then clean the caches) I just can bake it.

So I do think we should upgrade the version of that jar.