### PR TITLE
Started tackling NotNull anotation issue

### DIFF
--- a/java/java-impl/src/com/intellij/codeInspection/inferNullity/NullityInferrer.java
+++ b/java/java-impl/src/com/intellij/codeInspection/inferNullity/NullityInferrer.java
@@ -699,7 +699,7 @@ public class NullityInferrer {
       if (field instanceof PsiEnumConstant) {
         return;
       }
-      if (field.getType() instanceof PsiPrimitiveType ||
+      if ((field.getType() instanceof PsiPrimitiveType && !(field.getType() instanceof PsiArrayType)) ||
           isNotNull(field) || isNullable(field)) {
         return;
       }


### PR DESCRIPTION
I know that this pr is probably incomplete but i just wanted to start tackling the issue with JetBrains annotations that if you try to annotate a primitive array with NotNull or Nullable it will tell you that "Primitive type members cannot be annotated" which is obviously incorrect because arrays of primitives aren't primitive themselves. This poses a major issue for a project i am working on and trying to annotate primitive array method parameters with NotNull but Intelij just tells me that it's a primitive type.
Edits and suggestions are welcome :)