### PR TITLE
Improve hotswap class detection when build is delegated to Gradle

### DIFF
--- a/platform/platform-resources/src/META-INF/PlatformExtensions.xml
+++ b/platform/platform-resources/src/META-INF/PlatformExtensions.xml
@@ -974,6 +974,10 @@
       <description>New project wizard</description>
     </experimentalFeature>
 
+    <experimentalFeature id="gradle.improved.hotswap.detection" percentOfUsers="0">
+      <description>Improved Hotswap Detection when building with Gradle</description>
+    </experimentalFeature>
+
     <rawEditorTypedHandler implementationClass="com.intellij.openapi.editor.impl.EditorFactoryImpl$MyRawTypedHandler"/>
 
     <postStartupActivity implementation="com.intellij.diagnostic.AnalyzePendingSnapshotActivity"/>

--- a/plugins/gradle/java/src/execution/build/GradleImprovedHotswapDetection.java
+++ b/plugins/gradle/java/src/execution/build/GradleImprovedHotswapDetection.java
@@ -1,0 +1,75 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.plugins.gradle.execution.build;
+
+import com.intellij.openapi.application.Experiments;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.io.StreamUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.task.ProjectTaskContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class GradleImprovedHotswapDetection {
+  private GradleImprovedHotswapDetection() {
+    // static class cannot be constructed constructor
+  }
+
+  public static String getInitScript(File outputPathsFile) {
+    String path = FileUtil.toCanonicalPath(outputPathsFile.getAbsolutePath());
+    return String.format(InitScriptResourceHolder.INIT_SCRIPT_TEMPLATE, path);
+  }
+
+  public static String getInitScriptUsingService(File outputPathsFile) {
+    String path = FileUtil.toCanonicalPath(outputPathsFile.getAbsolutePath());
+    return String.format(InitScriptResourceHolder.INIT_SCRIPT_TEMPLATE_USING_SERVICE, path);
+  }
+
+  public static void processInitScriptOutput(ProjectTaskContext context, @Nullable File outputPathsFile) {
+    if (outputPathsFile == null || !context.isCollectionOfGeneratedFilesEnabled()) {
+      return;
+    }
+
+    Collection<GradleImprovedHotswapOutput> outputs = GradleImprovedHotswapOutput.parseOutputFile(outputPathsFile);
+
+    outputs.stream()
+      .filter(output -> !StringUtil.isEmpty(output.getPath()))
+      .forEach(output -> context.fileGenerated(output.getRoot(), output.getPath()));
+
+    Set<String> dirtyRoots = outputs.stream()
+      .map(GradleImprovedHotswapOutput::getRoot)
+      .collect(Collectors.toSet());
+
+    context.addDirtyOutputPathsProvider(() -> dirtyRoots);
+  }
+
+  public static boolean isEnabled() {
+    return Experiments.getInstance().isFeatureEnabled("gradle.improved.hotswap.detection");
+  }
+
+  // Utility class to lazily load the GradleImprovedHotswapDetectionInitScript.groovy resource
+  private static class InitScriptResourceHolder {
+    private static final String PATH_SIMPLE = "/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionInitScript.groovy";
+    private static final String PATH_USING_SERVICE = "/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionInitScriptUsingService.groovy";
+    private static final String COMMON_HASH_UTILS = "/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionUtils.groovy";
+
+    static final String COMMON_HASH_UTILS_CLASS = loadResource(COMMON_HASH_UTILS);
+    static final String INIT_SCRIPT_TEMPLATE = loadResource(PATH_SIMPLE) + COMMON_HASH_UTILS_CLASS;
+    static final String INIT_SCRIPT_TEMPLATE_USING_SERVICE = loadResource(PATH_USING_SERVICE) + COMMON_HASH_UTILS_CLASS;
+
+    private static String loadResource(String path) {
+      try (
+        InputStream stream = GradleProjectTaskRunner.class.getResourceAsStream(path);
+        Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+        return StreamUtil.readText(reader);
+      }
+      catch (IOException e) {
+        throw new IllegalStateException(String.format("Could not load resource '%s'", path), e);
+      }
+    }
+  }
+}

--- a/plugins/gradle/java/src/execution/build/GradleImprovedHotswapOutput.java
+++ b/plugins/gradle/java/src/execution/build/GradleImprovedHotswapOutput.java
@@ -1,0 +1,72 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.plugins.gradle.execution.build;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.io.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import static com.intellij.openapi.util.text.StringUtil.splitByLines;
+
+class GradleImprovedHotswapOutput {
+  private static final Logger LOG = Logger.getInstance(GradleImprovedHotswapOutput.class);
+
+  private static final String PATH_PREFIX = "path:";
+  private static final String ROOT_PREFIX = "root:";
+
+  private final String root;
+  private final String path;
+
+  private GradleImprovedHotswapOutput(String root, String path) {
+    this.root = root;
+    this.path = path;
+  }
+
+  public String getRoot() {
+    return root;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public static Collection<GradleImprovedHotswapOutput> parseOutputFile(File file) {
+    try {
+      String content = FileUtil.loadFile(file);
+
+      Iterator<String> lines = Arrays.stream(splitByLines(content, true))
+        .filter(line -> !line.isBlank())
+        .iterator();
+
+      List<GradleImprovedHotswapOutput> outputs = new ArrayList<>();
+      while (lines.hasNext()) {
+        String root = lines.next();
+        if (!lines.hasNext()) {
+          LOG.error("Expected Gradle Hotswap output to contain even number of lines");
+          LOG.debug("Gradle Hotswap output file:\n{}", content);
+          break;
+        }
+        String path = lines.next();
+
+        if (root.startsWith(ROOT_PREFIX) && path.startsWith(PATH_PREFIX)) {
+          outputs.add(new GradleImprovedHotswapOutput(
+            root.substring(ROOT_PREFIX.length()),
+            path.substring(PATH_PREFIX.length())
+          ));
+        }
+        else {
+          LOG.error(String.format("Unexpected Gradle Hotswap output format. " +
+                                  "Expected '%s' to start with '%s' and '%s' to start with '%s'",
+                                  root, ROOT_PREFIX, path, PATH_PREFIX));
+        }
+      }
+      return outputs;
+    }
+    catch (IOException e) {
+      LOG.warn("Can not create temp file to collect Gradle tasks output paths", e);
+      return Collections.emptyList();
+    }
+  }
+}

--- a/plugins/gradle/java/testSources/compiler/GradleCompilingTestCase.java
+++ b/plugins/gradle/java/testSources/compiler/GradleCompilingTestCase.java
@@ -10,13 +10,15 @@ import org.jetbrains.plugins.gradle.importing.GradleImportingTestCase;
 
 import java.io.File;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Vladislav.Soroka
  */
 public abstract class GradleCompilingTestCase extends GradleImportingTestCase {
 
   protected void assertCopied(String path) {
-    assertTrue(file(path).exists());
+    assertThat(file(path)).exists();
   }
 
   protected void assertCopied(String path, String content) {
@@ -25,7 +27,7 @@ public abstract class GradleCompilingTestCase extends GradleImportingTestCase {
   }
 
   protected void assertNotCopied(String path) {
-    assertFalse(file(path).exists());
+    assertThat(file(path)).doesNotExist();
   }
 
   @Override

--- a/plugins/gradle/java/testSources/compiler/GradleImprovedHotswapDetectionTest.java
+++ b/plugins/gradle/java/testSources/compiler/GradleImprovedHotswapDetectionTest.java
@@ -1,0 +1,391 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.plugins.gradle.compiler;
+
+import com.intellij.openapi.application.Experiments;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.task.ProjectTaskContext;
+import com.intellij.task.ProjectTaskListener;
+import com.intellij.task.ProjectTaskManager;
+import com.intellij.util.PathUtil;
+import com.intellij.util.messages.MessageBusConnection;
+import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTestCase {
+  @Language("Java")
+  public static final String APP_JAVA =
+    "package my.pack;\n" +
+    "public class App {\n" +
+    "  public int method() { return 42; }\n" +
+    "}";
+
+  // App.java with a new method added
+  @Language("Java")
+  public static final String APP_JAVA_WITH_NEW_METHOD =
+    "package my.pack;\n" +
+    "public class App extends Impl {\n" +
+    "  public int method() { return 42; }\n" +
+    "  public int methodX() { return 100_000; }\n" +
+    "}";
+
+  // App.java with new added NewInnerClass inner class
+  @Language("Java")
+  public static final String APP_JAVA_WITH_INNER_CLASS =
+    "package my.pack;\n" +
+    "public class App extends Impl {\n" +
+    "  public int method() { return 42; }\n" +
+    "  public static class NewInnerClass {\n" +
+    "    public void doNothing() {}" +
+    "  }" +
+    "}";
+
+  // the NewInnerClass method changed from 'doNothing' to 'doSomething'
+  @Language("Java")
+  public static final String APP_JAVA_WITH_MODIFIED_INNER_CLASS =
+    "package my.pack;\n" +
+    "public class App extends Impl {\n" +
+    "  public int method() { return 42; }\n" +
+    "  public static class NewInnerClass {\n" +
+    "    public boolean doSomething() { return true; }\n" +
+    "  }\n" +
+    "}";
+
+  @Language("Java")
+  public static final String IMPL_JAVA =
+    "package my.pack;\n" +
+    "import my.pack.Api;\n" +
+    "public class Impl extends Api {}";
+
+  @Language("Java")
+  public static final String IMPL_JAVA_WITH_NEW_METHOD =
+    "package my.pack;\n" +
+    "import my.pack.Api;\n" +
+    "public class Impl extends Api {\n" +
+    "  public void newImplMethod() {}\n" +
+    "}";
+
+  private String mainRoot;
+  private String testRoot;
+  private String apiMainRoot;
+  private String apiTestRoot;
+  private String implMainRoot;
+  private String implTestRoot;
+  private String apiJar;
+  private String implJar;
+
+  private boolean defaultFeatureValue;
+  private VirtualFile appFile;
+  private VirtualFile implFile;
+  private final List<String> dirtyOutputRoots = new ArrayList<>();
+  private final Map<String, Collection<String>> generatedFiles = new HashMap<>();
+
+  @Before
+  public void before() throws IOException {
+    String langPart = isGradleOlderThan("4.0") ? "build/classes" : "build/classes/java";
+
+    mainRoot = langPart + "/main";
+    testRoot = langPart + "/test";
+    apiMainRoot = "api/" + langPart + "/main";
+    apiTestRoot = "api/" + langPart + "/test";
+    implMainRoot = "impl/" + langPart + "/main";
+    implTestRoot = "impl/" + langPart + "/test";
+    apiJar = "api/build/libs/api.jar";
+    implJar = "impl/build/libs/impl.jar";
+
+    clearOutputs();
+    defaultFeatureValue = Experiments.getInstance().isFeatureEnabled("gradle.improved.hotswap.detection");
+    Experiments.getInstance().setFeatureEnabled("gradle.improved.hotswap.detection", true);
+    createProject();
+    subscribeToProject();
+  }
+
+  @After
+  public void after() {
+    Experiments.getInstance().setFeatureEnabled("gradle.improved.hotswap.detection", defaultFeatureValue);
+  }
+
+  @Test
+  public void testBuildMainProject() {
+    compileModules("project.main");
+
+    assertThat(dirtyOutputRoots).containsExactlyInAnyOrder(
+      mainRoot,
+      apiMainRoot,
+      apiJar,
+      implMainRoot,
+      implJar);
+
+    assertThat(generatedFiles).containsOnly(
+      Map.entry(mainRoot, Set.of("my/pack/App.class", "my/pack/Other.class")),
+      Map.entry(apiMainRoot, Set.of("my/pack/Api.class")),
+      Map.entry(implMainRoot, Set.of("my/pack/Impl.class"))
+    );
+
+    assertCopied(mainRoot + "/my/pack/App.class");
+    assertNotCopied(testRoot + "/my/pack/AppTest.class");
+
+    assertCopied(apiMainRoot + "/my/pack/Api.class");
+    assertNotCopied(apiTestRoot + "my/pack/ApiTest.class");
+
+    assertCopied(implMainRoot + "/my/pack/Impl.class");
+    assertNotCopied(implTestRoot + "/my/pack/ImplTest.class");
+  }
+
+
+  @Test
+  public void testBuildTestProject() {
+    compileModules("project.test");
+
+    assertThat(dirtyOutputRoots).containsExactlyInAnyOrder(
+      mainRoot,
+      testRoot,
+      apiMainRoot,
+      apiJar,
+      implMainRoot,
+      implJar);
+
+    assertThat(generatedFiles)
+      .containsOnly(
+        Map.entry(mainRoot, Set.of("my/pack/App.class", "my/pack/Other.class")),
+        Map.entry(testRoot, Set.of("my/pack/AppTest.class")),
+        Map.entry(apiMainRoot, Set.of("my/pack/Api.class")),
+        Map.entry(implMainRoot, Set.of("my/pack/Impl.class"))
+      );
+
+    assertCopied(mainRoot + "/my/pack/App.class");
+    assertCopied(testRoot + "/my/pack/AppTest.class");
+
+    assertCopied(apiMainRoot + "/my/pack/Api.class");
+    assertNotCopied(apiTestRoot + "my/pack/ApiTest.class");
+
+    assertCopied(implMainRoot + "/my/pack/Impl.class");
+    assertNotCopied(implTestRoot + "/my/pack/ImplTest.class");
+  }
+
+  @Test
+  public void testIncrementalBuildMainProjectUpdatedClass() {
+    compileModules("project.main");
+
+    setFileContent(appFile, APP_JAVA_WITH_NEW_METHOD, false);
+
+    clearOutputs();
+    compileModules("project.main");
+
+    assertThat(dirtyOutputRoots).containsExactlyInAnyOrder(mainRoot);
+    assertThat(generatedFiles)
+      .containsOnly(Map.entry(mainRoot, Set.of("my/pack/App.class")));
+  }
+
+  /**
+   * Test that adding a new inner class correctly marks
+   * the inner class *.class file as generated
+   */
+  @Test
+  public void testIncrementalBuildMainProjectNewInnerClass() {
+    compileModules("project.main");
+
+    setFileContent(appFile, APP_JAVA_WITH_INNER_CLASS, false);
+
+    clearOutputs();
+    compileModules("project.main");
+
+    assertThat(generatedFiles).as("Generated files").containsOnly(
+      Map.entry(mainRoot, Set.of("my/pack/App.class", "my/pack/App$NewInnerClass.class"))
+    );
+  }
+
+  /**
+   * Test that modifying inner class correctly marks
+   * only the inner class *.class file as generated
+   */
+  @Test
+  public void testIncrementalBuildMainProjectUpdateInnerClass() {
+    setFileContent(appFile, APP_JAVA_WITH_INNER_CLASS, false);
+    compileModules("project.main");
+
+
+    setFileContent(appFile, APP_JAVA_WITH_MODIFIED_INNER_CLASS, false);
+
+
+    clearOutputs();
+    compileModules("project.main");
+
+    assertThat(generatedFiles).as("Generated files").containsOnly(
+      Map.entry(mainRoot, Set.of("my/pack/App$NewInnerClass.class"))
+    );
+  }
+
+  @Test
+  public void testRebuildMainProjectAfterChangingImpl() {
+    compileModules("project.main");
+
+    setFileContent(implFile, IMPL_JAVA_WITH_NEW_METHOD, false);
+
+    clearOutputs();
+    compileModules("project.main");
+
+    assertThat(dirtyOutputRoots).as("Dirty output roots").containsExactlyInAnyOrder(
+      implMainRoot,
+      implJar
+    );
+
+    // note that the "implJar" is not marked as a generated file
+    // this is jar itself is marked as dirty root
+    assertThat(generatedFiles).as("Generated files").containsOnly(
+      Map.entry(implMainRoot, Set.of("my/pack/Impl.class"))
+    );
+  }
+
+  @Test
+  public void testBuildTestProjectAfterMain() {
+    compileModules("project.main");
+
+    clearOutputs();
+    compileModules("project.test");
+
+    assertThat(dirtyOutputRoots).containsExactlyInAnyOrder(testRoot);
+    assertThat(generatedFiles).as("Generated files").containsOnly(
+      Map.entry(testRoot, Set.of("my/pack/AppTest.class"))
+    );
+
+    assertCopied(testRoot + "/my/pack/AppTest.class");
+    assertNotCopied(apiTestRoot + "/my/pack/ApiTest.class");
+    assertNotCopied(implTestRoot + "/my/pack/ImplTest.class");
+  }
+
+  @Test
+  public void testRebuildMainProjectAfterUndoingChange() {
+    compileModules("project.main");
+
+    setFileContent(appFile, "package my.pack;\n" +
+                            "public class App {\n" +
+                            "  public int method() { return 42; }\n" +
+                            "  public int methodX() { return 42; }\n" +
+                            "}", false);
+
+    clearOutputs();
+    compileModules("project.main");
+
+    // revert file to previous value
+    setFileContent(appFile, APP_JAVA, false);
+
+    clearOutputs();
+    compileModules("project.main");
+
+    assertThat(dirtyOutputRoots).containsExactly(mainRoot);
+    assertThat(generatedFiles).containsOnly(Map.entry(mainRoot, Set.of("my/pack/App.class")));
+  }
+
+  @Test
+  public void testBuildProjectWithResources() throws IOException {
+    compileModules("project.main");
+    createProjectSubFile("src/main/resources/runtime.properties",
+                         "resourceString=foobar");
+
+    clearOutputs();
+    compileModules("project.main");
+
+    assertThat(dirtyOutputRoots).containsExactly("build/resources/main");
+    assertThat(generatedFiles).containsOnly(Map.entry("build/resources/main", Set.of("runtime.properties")));
+
+  }
+
+  private void subscribeToProject() {
+    MessageBusConnection connection = myProject.getMessageBus().connect(getTestRootDisposable());
+    connection.subscribe(ProjectTaskListener.TOPIC, new ProjectTaskListener() {
+      @Override
+      public void started(@NotNull ProjectTaskContext context) {
+        context.enableCollectionOfGeneratedFiles();
+      }
+
+      @Override
+      public void finished(@NotNull ProjectTaskManager.Result result) {
+        result.getContext().getDirtyOutputPaths()
+           .ifPresent(paths -> paths
+             .map(PathUtil::toSystemIndependentName)
+             .map(path -> relativePath(path))
+             .forEach(dirtyOutputRoots::add));
+
+        result.getContext().getGeneratedFilesRoots()
+          .forEach(generatedRoot -> {
+            generatedFiles.put(relativePath(generatedRoot), new HashSet<>(result.getContext().getGeneratedFilesRelativePaths(generatedRoot)));
+          });
+      }
+    });
+  }
+
+  private void createProject() throws IOException {
+    createSettingsFile("include 'api', 'impl' ");
+    createProjectSubFile("gradle.properties",
+                         "org.gradle.caching=true");
+
+    appFile = createProjectSubFile("src/main/java/my/pack/App.java", APP_JAVA);
+
+    createProjectSubFile("src/main/java/my/pack/Other.java",
+                         "package my.pack;\n" +
+                         "public class Other {\n" +
+                         "  public String method() { return \"foo\"; }\n" +
+                         "}");
+
+    createProjectSubFile("src/test/java/my/pack/AppTest.java",
+                         "package my.pack;\n" +
+                         "public class AppTest {\n" +
+                         "  public void test() { new App().method(); }\n" +
+                         "}");
+
+    createProjectSubFile("api/src/main/java/my/pack/Api.java",
+                         "package my.pack;\n" +
+                         "public class Api {\n" +
+                         "  public int method() { return 42; }\n" +
+                         "}");
+
+    createProjectSubFile("api/src/test/java/my/pack/ApiTest.java",
+                         "package my.pack;\n" +
+                         "public class ApiTest {}");
+
+    implFile = createProjectSubFile("impl/src/main/java/my/pack/Impl.java", IMPL_JAVA);
+
+    createProjectSubFile("impl/src/test/java/my/pack/ImplTest.java",
+                         "package my.pack;\n" +
+                         "import my.pack.ApiTest;\n" +
+                         "public class ImplTest extends ApiTest {}");
+
+    importProject("allprojects {\n" +
+                  "  apply plugin: 'java'\n" +
+                  "}\n" +
+                  "\n" +
+                  "dependencies {\n" +
+                  "  compile project(':impl')\n" +
+                  "}\n" +
+                  "\n" +
+                  "configure(project(':impl')) {\n" +
+                  "  dependencies {\n" +
+                  "    compile project(':api')\n" +
+                  "  }\n" +
+                  "}");
+
+    assertModules("project", "project.main", "project.test",
+                  "project.api", "project.api.main", "project.api.test",
+                  "project.impl", "project.impl.main", "project.impl.test");
+  }
+
+  private void clearOutputs() {
+    dirtyOutputRoots.clear();
+    generatedFiles.clear();
+  }
+
+  private String relativePath(String path) {
+    Path projectPath = Path.of(getProjectPath());
+    Path filePath = Path.of(path);
+    return projectPath.relativize(filePath).toString();
+  }
+}

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionInitScript.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionInitScript.groovy
@@ -1,0 +1,74 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+
+import org.gradle.BuildAdapter
+import org.gradle.BuildResult
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionAdapter
+import org.gradle.api.tasks.TaskState
+
+import java.security.MessageDigest
+
+import static groovy.io.FileType.FILES
+
+/**
+ * This init script generates a file containing a list of task output
+ * files that have been modified during the gradle run.
+ *
+ * This script hooks into Gradle task execution lifecycle. For a very
+ * similar script that uses Gradle Build Services introduced in Gradle 6.8,
+ * see GradleImprovedHotswapDetectionInitScriptUsingService.groovy
+ *
+ * The files are determined to be modified by hashing output files
+ * before and after gradle execution.
+ *
+ * We use SHA-256 to hash each file, and folder recursively
+ *
+ * If the hash is different, or the file did not exist before task was
+ * executed, we write it to "initScriptOutputFile" file (which is set
+ * from inside
+ * {@link org.jetbrains.plugins.gradle.execution.build.GradleImprovedHotswapDetection}
+ * class
+ *
+ * For each updated class we write a two lines to the output file in the format
+ *   root:<root>
+ *   path:<relative class path>
+ * e.g.
+ *   root:/repo/project/build/classes/java/main/
+ *   path:com/acme/MyClass.class
+ *
+ * Then, in
+ * {@link org.jetbrains.plugins.gradle.execution.build.GradleImprovedHotswapOutput}
+ * we read the output file and parse it
+ * Finally, {@link in org.jetbrains.plugins.gradle.execution.build.GradleImprovedHotswapDetection}
+ * we call {@link com.intellij.task.ProjectTaskContext#fileGenerated} for each generated file
+ *
+ * This fileGenerated call triggers Java hotswap
+ */
+
+Map<Task,Map<File,String>> beforeTaskFileHashes = [:]
+def effectiveTasks = []
+
+def outputFile = new File("%s")
+
+gradle.taskGraph.addTaskExecutionListener(new TaskExecutionAdapter() {
+  void beforeExecute(Task task) {
+    if (task.outputs.hasOutput) {
+      beforeTaskFileHashes.put(task, GradleImprovedHotswapDetectionUtils.hashTaskOutputs(task.outputs.files.files))
+    }
+  }
+
+  void afterExecute(Task task, TaskState state) {
+    if ((state.didWork || (state.skipped && state.skipMessage == 'FROM-CACHE')) && task.outputs.hasOutput) {
+      effectiveTasks.add(task)
+    }
+  }
+})
+
+gradle.addBuildListener(new BuildAdapter() {
+  void buildFinished(BuildResult result) {
+    effectiveTasks.each { Task task ->
+      GradleImprovedHotswapDetectionUtils.detectModifiedTaskOutputs(task, outputFile, beforeTaskFileHashes)
+    }
+  }
+})

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionInitScriptUsingService.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionInitScriptUsingService.groovy
@@ -1,0 +1,92 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionGraph
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+import java.security.MessageDigest
+
+import static groovy.io.FileType.FILES
+
+/**
+ * This init script generates a file containing a list of task output
+ * files that have been modified during the gradle run.
+ *
+ * This script is very similar to GradleImprovedHotswapDetectionInitScript.groovy
+ * The only difference is that it uses Gradle "build service" feature introduced in
+ * Grade 6.8 (see https://docs.gradle.org/current/userguide/build_services.html)
+ *
+ * The files are determined to be modified by hashing output files
+ * before and after gradle execution.
+ *
+ * We use SHA-256 to hash each file, and folder recursively
+ *
+ * If the hash is different, or the file did not exist before task was
+ * executed, we write it to "initScriptOutputFile" file (which is set
+ * from inside
+ * {@link org.jetbrains.plugins.gradle.execution.build.GradleImprovedHotswapDetection}
+ * class
+ *
+ * For each updated class we write a two lines to the output file in the format
+ *   root:<root>
+ *   path:<relative class path>
+ * e.g.
+ *   root:/repo/project/build/classes/java/main/
+ *   path:com/acme/MyClass.class
+ *
+ * Then, in
+ * {@link org.jetbrains.plugins.gradle.execution.build.GradleImprovedHotswapOutput}
+ * we read the output file and parse it
+ * Finally, {@link in org.jetbrains.plugins.gradle.execution.build.GradleImprovedHotswapDetection}
+ * we call {@link com.intellij.task.ProjectTaskContext#fileGenerated} for each generated file
+ *
+ * This fileGenerated call triggers Java hotswap
+ */
+
+def outputFile = new File("%s")
+
+abstract class OutputPathCollectorService
+  implements BuildService<Params>, AutoCloseable {
+
+  interface Params extends BuildServiceParameters {
+    Property<File> getOutputFile()
+  }
+
+  // Note that this script will hash *all* the output files for *all* executed tasks TWICE
+  //  - once before the task, and once after
+  // One possible optimization is to store the before hashes elsewhere, and only hash the output files ONCE
+  Map<Task,Map<File,String>> beforeTaskFileHashes = [:]
+  Set<Task> tasks = new HashSet<Task>()
+
+  void registerTask(Task task) {
+    tasks.add(task)
+    if (task.outputs.hasOutput) {
+      beforeTaskFileHashes.put(task, GradleImprovedHotswapDetectionUtils.hashTaskOutputs(task.outputs.files.files))
+    }
+  }
+
+  // this runs after *all* tasks have executed
+  @Override
+  void close() throws Exception {
+    def outputFile = getParameters().outputFile.get()
+    tasks.each { Task task ->
+      GradleImprovedHotswapDetectionUtils.detectModifiedTaskOutputs(task, outputFile, beforeTaskFileHashes)
+    }
+  }
+}
+
+Provider<OutputPathCollectorService> provider = gradle.sharedServices.registerIfAbsent("outputPathCollectorService",
+                                                                                       OutputPathCollectorService) { it.parameters.outputFile.set(outputFile)  }
+
+gradle.taskGraph.whenReady { TaskExecutionGraph tg ->
+  tg.allTasks.each { Task t ->
+    t.onlyIf {
+      // runs before task executes
+      provider.get().registerTask(t)
+      return true
+    }
+  }
+}

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionUtils.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/GradleImprovedHotswapDetectionUtils.groovy
@@ -1,0 +1,69 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FromString
+import org.gradle.api.Task
+
+import java.security.MessageDigest
+
+import static groovy.io.FileType.FILES
+
+class GradleImprovedHotswapDetectionUtils {
+  static void detectModifiedTaskOutputs(Task task, File outputFile, Map<Task,Map<File,String>> beforeTaskFileHashes) {
+    def state = task.state
+    def didWork = state.didWork
+    def fromCache = state.skipped && state.skipMessage == 'FROM-CACHE'
+    def hasOutput = task.outputs.hasOutput
+    if ((didWork || fromCache) && hasOutput) {
+      def beforeHashes = beforeTaskFileHashes[task]
+      task.outputs.files.files.each { File taskOutput ->
+        hashTaskOutput(taskOutput) { file, hash ->
+          def beforeHash = beforeHashes[file]
+          if (beforeHash == null || beforeHash != hash) {
+            if (taskOutput.directory) {
+              def relativePath = taskOutput.toPath().relativize(file.toPath())
+              outputFile.append("root:${taskOutput.path}\n")
+              outputFile.append("path:${relativePath}\n")
+            } else {
+              // sometimes taskOutput can be a file, such as a jar
+              // in this case we treat it as an "output root"
+              outputFile.append("root:${taskOutput.path}\n")
+              outputFile.append("path:\n")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  static Map<File,String> hashTaskOutputs(Set<File> taskOutputs) {
+    Map<File,String> hashes = [:]
+    taskOutputs.each { taskOutput ->
+      hashTaskOutput(taskOutput, { file, hash -> hashes.put(file, hash) })
+    }
+    return hashes
+  }
+
+  private static void hashTaskOutput(File taskOutput, @ClosureParams(value= FromString.class, options="File,String") Closure closure) {
+    if (taskOutput.exists()) {
+      if (taskOutput.directory) {
+        taskOutput.eachFileRecurse(FILES) {
+          hashTaskOutput(it, closure)
+        }
+      }
+      else {
+        closure.call(taskOutput, hashFile(taskOutput))
+      }
+    }
+  }
+
+  private static String hashFile(File file) {
+    file.withInputStream {
+      def digest = MessageDigest.getInstance("SHA-256")
+      it.eachByte 4096, { buffer, length ->
+        digest.update(buffer, 0, length)
+      }
+      return digest.digest().encodeHex()
+    }
+  }
+}


### PR DESCRIPTION
This PR is an improved version of https://github.com/JetBrains/intellij-community/pull/1386

### What is the problem
When IntelliJ is configured to delegate the build to Gradle, the hot swap functionality does not work as well when IntelliJ is used for compilation.

One issue is that sometimes, when gradle builds a project, the hot swap agent ends up deploying **all the classes in the project**. This is a problem for our repository because we have a project with 4000 classes, so hot swap is really slow.

### What is it caused by
I debugged the hot swap/gradle code. To me it looks like the root cause is that the `HotSwapUIImpl` class only looks at gradle output directories. When gradle builds a project, the project output paths is written to a temporary file (via a gradle init script). So, when 1 or 100 classes are changed, the input to `HotSwapUIImpl` remains the same - the `classes` folder.

The `HotSwapUIImpl` class is unable to distinguish what classes _actually_ changed so it ends up deploying _all_ the classes

### Solution proposed in this PR
Instead of gradle init script outputting the list of output folders, I changed it to output the list of actual modified classes. I created a new gradle init script. The init script hashes task outputs before and after task execution, and then compares the hashes to determine which files changed

- Add an experimental flag for improved gradle hotswap detection
- Minimal changes to `GradleProjectTaskRunner` class to use new gradle hotswap detection code
- Added tests to an new class, existing tests should pass as-is