### PR TITLE
Add `hbs` as alias for `handlebars` in markdown injections

### DIFF
--- a/plugins/markdown/resource/org/intellij/plugins/markdown/injection/alias/aliases.dat
+++ b/plugins/markdown/resource/org/intellij/plugins/markdown/injection/alias/aliases.dat
@@ -5,6 +5,7 @@ HCL-Terraform | terraform | hcl-terraform, tf
 ApacheConfig | apacheconf | aconf, apache, apacheconfig
 Batch | batch | bat, batchfile
 CoffeeScript | coffeescript | coffee, coffee-script
+Handlebars | handlebars | hbs
 JavaScript | javascript | js, node
 Markdown | markdown | md
 PowerShell | powershell | posh, pwsh


### PR DESCRIPTION
I _think_ this will allow automatic language injection for handlebars within fenced code blocks landed by `hbs`.

I wasn't sure if there was any way to do this via configuration or if it has to be built into the plugin?