### PR TITLE
Fix test filtering for test parameterized using `TestParameterInjector`.

### DIFF
--- a/.idea/libraries/com_google_testparameterinjector_test_parameter_injector_1_3.xml
+++ b/.idea/libraries/com_google_testparameterinjector_test_parameter_injector_1_3.xml
@@ -1,0 +1,22 @@
+<component name="libraryTable">
+  <library name="com.google.testparameterinjector:test-parameter-injector:1.3" type="repository">
+    <properties maven-id="com.google.testparameterinjector:test-parameter-injector:1.3" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/testparameterinjector/test-parameter-injector/1.3/test-parameter-injector-1.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/auto/value/auto-value-annotations/1.7.4/auto-value-annotations-1.7.4.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/30.1-jre/guava-30.1-jre.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/protobuf/protobuf-java/3.14.0/protobuf-java-3.14.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.13.2/junit-4.13.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/yaml/snakeyaml/1.27/snakeyaml-1.27.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/plugins/junit_rt/intellij.junit.rt.iml
+++ b/plugins/junit_rt/intellij.junit.rt.iml
@@ -4,10 +4,12 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="JUnit4" level="project" />
     <orderEntry type="module" module-name="intellij.java.rt" />
+    <orderEntry type="library" name="com.google.testparameterinjector:test-parameter-injector:1.3" level="project" />
   </component>
 </module>

--- a/plugins/junit_rt/test/com/intellij/junit4/JUnit4TestRunnerUtilTest.java
+++ b/plugins/junit_rt/test/com/intellij/junit4/JUnit4TestRunnerUtilTest.java
@@ -1,0 +1,150 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.junit4;
+
+import com.google.common.collect.ImmutableList;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.Request;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.RunNotifier;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JUnit4TestRunnerUtilTest extends TestCase {
+
+  /**
+   * {@link JUnit4TestRunnerUtil} class loaded with a custom loader.
+   *
+   * <p>This allows running this test from Intellij which will load {@link JUnit4TestRunnerUtil} to run the test itself. Custom loader lets
+   * us test the local version {@link JUnit4TestRunnerUtil} as opposed to the one shipped with Intellij running the test.
+   */
+  private static final Class<?> RUNNER_CLASS = customLoadedRunner();
+  private static final List<String> ourInvokedTests = new ArrayList<String>();
+
+  @Override
+  protected void setUp() {
+    ourInvokedTests.clear();
+  }
+
+  @RunWith(TestParameterInjector.class)
+  public static class ExampleTest {
+
+    @Test
+    public void oneParam(@TestParameter boolean value) {
+      ourInvokedTests.add(String.format("oneParam[%s]", value));
+    }
+
+    @Test
+    public void twoParams(@TestParameter boolean p1, @TestParameter({"1", "2"}) int p2) {
+      ourInvokedTests.add(String.format("twoParams[%s,%d]", p1, p2));
+    }
+
+    @Test
+    public void overloaded(@TestParameter({"value"}) String value) {
+      ourInvokedTests.add(String.format("overloaded[%s]", value));
+    }
+
+    @Test
+    public void overloaded() {
+      ourInvokedTests.add("overloaded");
+    }
+  }
+
+  public void testRunsTestMethodWithSpecificParameterValue() throws Exception {
+    Request request = buildRequestForTestClass("oneParam", "[false]");
+    request.getRunner().run(new RunNotifier());
+    assertEquals(ImmutableList.of("oneParam[false]"), ourInvokedTests);
+  }
+
+  public void testRunsTestMethodWithAllParameterValues() throws Exception {
+    Request request = buildRequestForTestClass("oneParam", null);
+    request.getRunner().run(new RunNotifier());
+    assertEquals(ImmutableList.of("oneParam[false]", "oneParam[true]"), ourInvokedTests);
+  }
+
+  public void testRunsTestMethodWithMultipleParametersWithSpecifiedValues() throws Exception {
+    Request request = buildRequestForTestClass("twoParams", "[true,2]");
+    request.getRunner().run(new RunNotifier());
+    assertEquals(ImmutableList.of("twoParams[true,2]"), ourInvokedTests);
+  }
+
+  public void testRunsTestMethodWithMultipleParametersWithAllParameterCombinations() throws Exception {
+    Request request = buildRequestForTestClass("twoParams", null);
+    request.getRunner().run(new RunNotifier());
+    assertEquals(ImmutableList.of("twoParams[false,1]", "twoParams[false,2]", "twoParams[true,1]", "twoParams[true,2]"), ourInvokedTests);
+  }
+
+  public void testRunsNoTestForNonExistentParametersCombination() throws Exception {
+    Request request = buildRequestForTestClass("twoParams", "[true,9]");
+    request.getRunner().run(new RunNotifier());
+    assertEquals(ImmutableList.of(), ourInvokedTests);
+  }
+
+  public void testRunsAllVariantsOfOverloadedTest() throws Exception {
+    Request request = buildRequestForTestClass("overloaded", null);
+    request.getRunner().run(new RunNotifier());
+    assertEquals(ImmutableList.of("overloaded", "overloaded[value]"), ourInvokedTests);
+  }
+
+  public void testRunsOnlyParameterizedVersionOfOverloadedTestWhenParameterIsSpecified() throws Exception {
+    Request request = buildRequestForTestClass("overloaded", "[value]");
+    request.getRunner().run(new RunNotifier());
+    assertEquals(ImmutableList.of("overloaded[value]"), ourInvokedTests);
+  }
+
+  private static Request buildRequestForTestClass(String methodName, @Nullable String name)
+    throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    String className = JUnit4TestRunnerUtilTest.class.getCanonicalName() + "$" + ExampleTest.class.getSimpleName();
+    return (Request)RUNNER_CLASS.getMethod("buildRequest", String[].class, String.class, boolean.class).invoke(
+      null, new String[]{className + "," + methodName}, name, /* notForked= */ true);
+  }
+
+  /**
+   * Creates a {@link JUnit4TestRunnerUtil} class loaded with a custom loader pointed to local build outputs.
+   */
+  private static Class<?> customLoadedRunner() {
+    URL testLocation = JUnit4TestRunnerUtilTest.class.getProtectionDomain().getCodeSource().getLocation();
+    URL runnerLocation;
+    try {
+      runnerLocation = new URL(testLocation.getProtocol() + ":// " + testLocation.getPath().replace("/test/", "/production/"));
+    }
+    catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+
+    //noinspection IOResourceOpenedButNotSafelyClosed
+    ClassLoader customLoader = new URLClassLoader(new URL[]{runnerLocation}) {
+      @Override
+      public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (name.startsWith(JUnit4TestRunnerUtil.class.getPackage().getName())) {
+          Class<?> clazz = findLoadedClass(name);
+          if (clazz != null) {
+            return clazz;
+          }
+          try {
+            return findClass(name);
+          }
+          catch (ClassNotFoundException e) {
+            // Ignored
+          }
+        }
+        return super.loadClass(name, resolve);
+      }
+    };
+
+    try {
+      return customLoader.loadClass(JUnit4TestRunnerUtil.class.getCanonicalName());
+    }
+    catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}


### PR DESCRIPTION
Intellij junit plugin allows filtering tests by the method name. In case of parameterized tests, the name includes parameters as well (e.g. `test[parameter]`). By default, attempt to run a test with a parameter in the name would fail since a method like that cannot be found. We already special case `junit.Parameterized` to work around the problem.

Extend logic handling parameterized runners to support [`TestParameterInjector`](https://github.com/google/TestParameterInjector). Do not fail on tests with arguments (allowed by `TestParameterInjector`).

Please note that similar problem exists for other parameterization libraries. There are workarounds in some libraries (e.g. [Burst](https://github.com/square/burst/commit/fac095a8eaa4402f37f14692f123d1acb81b962d)), however one cannot properly filter on parameter values without change on the IDE side.

For reference: [`TestParameterInjector` issue](https://github.com/google/TestParameterInjector/issues/6).