### PR TITLE
Remove final keyword from TreeExpandableItemsHandler

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/TreeExpandableItemsHandler.java
+++ b/platform/platform-impl/src/com/intellij/ui/TreeExpandableItemsHandler.java
@@ -18,7 +18,7 @@ import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
-public final class TreeExpandableItemsHandler extends AbstractExpandableItemsHandler<Integer, JTree> {
+public class TreeExpandableItemsHandler extends AbstractExpandableItemsHandler<Integer, JTree> {
   protected TreeExpandableItemsHandler(final JTree tree) {
     super(tree);
     final TreeSelectionListener selectionListener = new TreeSelectionListener() {


### PR DESCRIPTION
This was added by commit e9f84643
breaking compilation of existing subclasses.