### PR TITLE
extend "equals between incompatible type" inspection

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
@@ -2179,7 +2179,7 @@ ignored.class.names=Ignore Classes (Including Subclasses)
 ignored.class.label=Ignored classes (including subclasses):
 meta.annotation.without.runtime.retention=Test annotation without '@Retention(RUNTIME)' annotation
 string.equals.char.sequence.display.name='String.equals()' called with 'CharSequence' argument
-string.equals.char.sequence.problem.descriptor=<code>String.#ref()</code> called with ''{0}'' argument #loc
+string.equals.char.sequence.problem.descriptor=<code>String.equals()</code> called with ''{0}'' argument #loc
 object.equals.can.be.equality.display.name='equals()' call can be replaced with '=='
 object.equals.can.be.equality.problem.descriptor=<code>#ref()</code> can be replaced with '=='
 not.object.equals.can.be.equality.problem.descriptor=<code>!#ref()</code> can be replaced with '!='

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/BaseEqualsVisitor.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/BaseEqualsVisitor.java
@@ -2,11 +2,14 @@
 package com.siyeh.ig.bugs;
 
 import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTypesUtil;
 import com.intellij.psi.util.PsiUtil;
 import com.siyeh.ig.BaseInspectionVisitor;
 import com.siyeh.ig.callMatcher.CallMatcher;
 import com.siyeh.ig.psiutils.ExpressionUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 
 /**
  * @author Bas Leijdekkers
@@ -20,6 +23,17 @@ abstract class BaseEqualsVisitor extends BaseInspectionVisitor {
     CallMatcher.anyOf(
       CallMatcher.staticCall("java.util.Objects", "equals").parameterCount(2),
       CallMatcher.staticCall("com.google.common.base.Objects", "equal").parameterCount(2));
+  private static final CallMatcher PREDICATE_TEST =
+    CallMatcher.instanceCall(CommonClassNames.JAVA_UTIL_FUNCTION_PREDICATE, "test").parameterCount(1);
+  private static final CallMatcher PREDICATE_IS_EQUAL =
+    CallMatcher.staticCall(CommonClassNames.JAVA_UTIL_FUNCTION_PREDICATE, "isEqual").parameterCount(1);
+  private static final CallMatcher PREDICATE_SOURCE_FOR_FIND_IS_EQUAL =
+    CallMatcher.anyOf(
+      CallMatcher.staticCall(CommonClassNames.JAVA_UTIL_FUNCTION_PREDICATE, "not").parameterCount(1),
+      CallMatcher.instanceCall(CommonClassNames.JAVA_UTIL_FUNCTION_PREDICATE, "negate").parameterCount(0),
+      CallMatcher.instanceCall(CommonClassNames.JAVA_UTIL_FUNCTION_PREDICATE, "or").parameterCount(1),
+      CallMatcher.instanceCall(CommonClassNames.JAVA_UTIL_FUNCTION_PREDICATE, "and").parameterCount(1)
+    );
 
   @Override
   public void visitMethodReferenceExpression(PsiMethodReferenceExpression expression) {
@@ -53,19 +67,156 @@ abstract class BaseEqualsVisitor extends BaseInspectionVisitor {
   public void visitMethodCallExpression(@NotNull PsiMethodCallExpression expression) {
     super.visitMethodCallExpression(expression);
     final PsiExpression[] arguments = expression.getArgumentList().getExpressions();
-    final PsiExpression expression1;
-    final PsiExpression expression2;
     if (OBJECT_EQUALS.test(expression)) {
-      expression1 = PsiUtil.skipParenthesizedExprDown(ExpressionUtils.getEffectiveQualifier(expression.getMethodExpression()));
-      expression2 = PsiUtil.skipParenthesizedExprDown(arguments[0]);
+      PsiExpression expression1 =
+        PsiUtil.skipParenthesizedExprDown(ExpressionUtils.getEffectiveQualifier(expression.getMethodExpression()));
+      PsiExpression expression2 = PsiUtil.skipParenthesizedExprDown(arguments[0]);
+      checkTypes(expression, expression1, expression2);
     }
     else if (STATIC_EQUALS.test(expression)) {
-      expression1 = PsiUtil.skipParenthesizedExprDown(arguments[0]);
-      expression2 = PsiUtil.skipParenthesizedExprDown(arguments[1]);
+      PsiExpression expression1 = PsiUtil.skipParenthesizedExprDown(arguments[0]);
+      PsiExpression expression2 = PsiUtil.skipParenthesizedExprDown(arguments[1]);
+      checkTypes(expression, expression1, expression2);
     }
-    else {
-      return;
+    else if (PREDICATE_IS_EQUAL.test(expression)) {
+      PsiExpression expression1 = PsiUtil.skipParenthesizedExprDown(arguments[0]);
+      PsiType psiType1 = getType(expression1);
+      PsiType psiType2 = resolveIsEqualPredicateType(expression);
+      if (psiType1 == null || psiType2 == null) {
+        return;
+      }
+      checkTypes(expression.getMethodExpression(), psiType1, psiType2);
     }
+  }
+
+  @Nullable
+  private static PsiType resolveIsEqualPredicateType(PsiMethodCallExpression expression) {
+    PsiExpression upperPredicate = expression;
+    PsiElement parent = upperPredicate.getParent();
+    int max = 100;
+    int currentLevel = 0;
+    while (currentLevel <= max) {
+      currentLevel++;
+      if (parent instanceof PsiParenthesizedExpression || parent instanceof PsiReferenceExpression) {
+        parent = parent.getParent();
+      }
+      else if (parent instanceof PsiExpressionList && isPredicateSourceForIsEqual(parent.getParent())) {
+        upperPredicate = (PsiExpression)parent.getParent();
+        parent = upperPredicate.getParent();
+      }
+      else if (isPredicateSourceForIsEqual(parent)) {
+        upperPredicate = (PsiExpression)parent;
+        parent = upperPredicate.getParent();
+      }
+      else {
+        break;
+      }
+    }
+
+    return findPsiTypeForPredicate(upperPredicate, parent);
+  }
+
+  @Nullable
+  private static PsiType findPsiTypeForPredicate(PsiExpression upperPredicate, PsiElement parent) {
+    PsiType returnParameter = findPredicateParameter(upperPredicate);
+    if (returnParameter != null) {
+      return returnParameter;
+    }
+
+    if (parent instanceof PsiMethodCallExpression) {
+      final PsiMethodCallExpression callExpresion = (PsiMethodCallExpression)parent;
+      if (PREDICATE_TEST.test(callExpresion)) {
+        final PsiExpression[] argumentExpressions = callExpresion.getArgumentList().getExpressions();
+        if (argumentExpressions.length != 1) {
+          return null;
+        }
+        PsiExpression argument = PsiUtil.skipParenthesizedExprDown(argumentExpressions[0]);
+        return getType(argument);
+      }
+    }
+    else if (parent instanceof PsiExpressionList) {
+      return findPredicateTypeFromExpressionList(upperPredicate, (PsiExpressionList)parent);
+    }
+    return null;
+  }
+
+  @Nullable
+  private static PsiType findPredicateTypeFromExpressionList(PsiExpression upperPredicate, PsiExpressionList expressionList) {
+    Integer index = findParameterIndex(expressionList, upperPredicate);
+    if (index == null || expressionList.getExpressionCount() <= index) {
+      return null;
+    }
+
+    if (!(expressionList.getParent() instanceof PsiMethodCallExpression)) {
+      return null;
+    }
+
+    final PsiMethodCallExpression expectedCall = (PsiMethodCallExpression)expressionList.getParent();
+    PsiMethod method = expectedCall.resolveMethod();
+    if (method == null) {
+      return null;
+    }
+    PsiType[] arguments = method.getSignature(expectedCall.resolveMethodGenerics().getSubstitutor())
+      .getParameterTypes();
+
+    if (arguments.length <= index) {
+      return null;
+    }
+    PsiType type = arguments[index];
+    if (!(type instanceof PsiClassType)) {
+      return null;
+    }
+    PsiClassType classType = (PsiClassType)type;
+    if (classType.getParameterCount() != 1 || !PsiTypesUtil.classNameEquals(classType, CommonClassNames.JAVA_UTIL_FUNCTION_PREDICATE)) {
+      return null;
+    }
+    PsiType parameter = classType.getParameters()[0];
+    //Object can be cast to any
+    if (parameter == null || parameter.equalsToText(CommonClassNames.JAVA_LANG_OBJECT)) {
+      return null;
+    }
+    if (parameter instanceof PsiWildcardType) {
+      PsiWildcardType psiWildcardType = (PsiWildcardType)parameter;
+      parameter = psiWildcardType.isSuper() ? psiWildcardType.getSuperBound() : parameter;
+    }
+    return parameter;
+  }
+
+  @Nullable
+  private static Integer findParameterIndex(PsiExpressionList list, PsiExpression predicate) {
+    for (int i = 0; i < list.getExpressionCount(); i++) {
+      final PsiExpression expression = list.getExpressions()[i];
+      if (predicate.equals(PsiUtil.skipParenthesizedExprDown(expression))) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static PsiType findPredicateParameter(PsiExpression predicate) {
+    final PsiType returnType = predicate.getType();
+    if (!(returnType instanceof PsiClassType)) {
+      return null;
+    }
+
+    PsiClassType classType = (PsiClassType)returnType;
+    if (classType.getParameterCount() != 1) {
+      return null;
+    }
+    PsiType parameter = classType.getParameters()[0];
+    if (!parameter.equalsToText(CommonClassNames.JAVA_LANG_OBJECT)) {
+      return parameter;
+    }
+    return null;
+  }
+
+  private static boolean isPredicateSourceForIsEqual(PsiElement parent) {
+    return parent instanceof PsiMethodCallExpression &&
+           PREDICATE_SOURCE_FOR_FIND_IS_EQUAL.test((PsiMethodCallExpression)parent);
+  }
+
+  private void checkTypes(@NotNull PsiMethodCallExpression expression, PsiExpression expression1, PsiExpression expression2) {
     if (expression1 == null || expression2 == null) {
       return;
     }

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/equals_on_suspicious_object/EqualsOnSuspiciousObject.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/equals_on_suspicious_object/EqualsOnSuspiciousObject.java
@@ -26,5 +26,8 @@ public class EqualsOnSuspiciousObject {
     if(Objects.<warning descr="Suspicious call to 'equals()' on 'StringBuilder' object">equals</warning>(sb1, sb2)) {
       System.out.println("Strange");
     }
+    if(java.util.function.Predicate.<warning descr="Suspicious call to 'equals()' on 'StringBuilder' object">isEqual</warning>(sb1).test(sb2)) {
+      System.out.println("Strange");
+    }
   }
 }

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/EqualsBetweenInconvertibleTypesInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/EqualsBetweenInconvertibleTypesInspectionTest.java
@@ -51,7 +51,7 @@ public class EqualsBetweenInconvertibleTypesInspectionTest extends LightJavaInsp
       "  }" +
       "}");
   }
-  
+
   public void testRaw() {
     doTest(
       "import java.util.Collection;" +
@@ -74,6 +74,73 @@ public class EqualsBetweenInconvertibleTypesInspectionTest extends LightJavaInsp
            "  BiPredicate<Long, Double> bp2 = Object::/*'equals' between objects of inconvertible types 'Long' and 'Double'*/equals/**/;\n" +
            "  BiPredicate<Long, Long> bpOk = Object::equals;\n" +
            "}\n");
+  }
+
+  public void testSimplePredicateIsEqualTest() {
+    doMemberTest("public <T> void foo(T t) {\n" +
+                 "    (java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'int'*/isEqual/**/(\"1\")).test(1);\n" +
+                 "    java.util.function.Predicate.isEqual(\"1\").test(new Object());\n" +
+                 "    java.util.function.Predicate.isEqual(new Object()).test(1);\n" +
+                 "    java.util.function.Predicate.isEqual(\"1\").test(t);\n" +
+                 "    java.util.function.Predicate.not(\n" +
+                 "                        java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'int'*/isEqual/**/(\"1\")\n" +
+                 "                )\n" +
+                 "                        .or(java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'int'*/isEqual/**/(\"1\"))\n" +
+                 "                        .and(java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'int'*/isEqual/**/(\"1\"))\n" +
+                 "                        .negate().test(1);\n" +
+                 "    java.util.function.Predicate.not(\n" +
+                 "                        java.util.function.Predicate.isEqual(new Object())\n" +
+                 "                )\n" +
+                 "                        .or(java.util.function.Predicate.isEqual(new Object()))\n" +
+                 "                        .and(java.util.function.Predicate.isEqual(new Object()))\n" +
+                 "                        .negate().test(1);\n" +
+                 "}\n");
+  }
+
+  public void testStreamPredicateEqualTest() {
+    doMemberTest("    public void foo() {\n" +
+                 "        java.util.List<Integer> collect = java.util.stream.Stream.of(1)\n" +
+                 "                .filter(java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Integer'*/isEqual/**/(\"1\"))\n" +
+                 "                .filter(java.util.function.Predicate.not(\n" +
+                 "                        java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Integer'*/isEqual/**/(\"1\")\n" +
+                 "                )\n" +
+                 "                        .or(java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Integer'*/isEqual/**/(\"1\"))\n" +
+                 "                        .and(java.util.function.Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Integer'*/isEqual/**/(\"1\"))\n" +
+                 "                        .negate())\n" +
+                 "                .filter(java.util.function.Predicate.not(\n" +
+                 "                        java.util.function.Predicate.isEqual(new Object())\n" +
+                 "                )\n" +
+                 "                        .or(t->t.equals(1))\n" +
+                 "                        .and(java.util.function.Predicate.isEqual(new Object()))\n" +
+                 "                        .negate())\n" +
+                 "                .filter(java.util.function.Predicate.isEqual(new Object()))\n" +
+                 "                .collect(java.util.stream.Collectors.toList());\n" +
+                 "    }\n");
+  }
+
+  public void testStreamPredicateEqualWithGenericTest() {
+    doTest(
+      "import java.util.function.Predicate;\n" +
+      "\n" +
+      "public class X {\n" +
+      "    public static void example() {\n" +
+      "        test(Predicate.isEqual(\"1\"), Predicate.isEqual(\"1\"),\n" +
+      "                Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Integer'*/isEqual/**/(\"1\"), " +
+      "                Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Number'*/isEqual/**/(\"1\"));\n" +
+      "        test(Predicate.not(Predicate.isEqual(\"1\")), Predicate.not(Predicate.isEqual(\"1\")),\n" +
+      "                Predicate.not(Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Integer'*/isEqual/**/(\"1\")), " +
+      "                Predicate.not(Predicate./*'isEqual' between objects of inconvertible types 'String' and 'Number'*/isEqual/**/(\"1\")));\n" +
+      "\n" +
+      "        test(Predicate.isEqual(new Object()), Predicate.isEqual(new Object()),\n" +
+      "                Predicate.isEqual(new Object()), Predicate.isEqual(new Object()));\n" +
+      "        test(Predicate.not(Predicate.isEqual(new Object())), Predicate.not(Predicate.isEqual(new Object())),\n" +
+      "                Predicate.not(Predicate.isEqual(new Object())), Predicate.not(Predicate.isEqual(new Object())));\n" +
+      "    }\n" +
+      "\n" +
+      "    static <T> void test(Predicate t1, Predicate<T> t2,\n" +
+      "                         Predicate<? super Integer> t3, Predicate<? extends Number> t4) {}\n" +
+      "}\n" +
+      "\n");
   }
 
   public void testNoCommonSubclass() {
@@ -207,7 +274,7 @@ public class EqualsBetweenInconvertibleTypesInspectionTest extends LightJavaInsp
            "  }\n" +
            "}");
   }
-  
+
   public void testCapture() {
     doTest("class X<A, B> {\n" +
            "  static final X<?, ?> CONST = new X<>();\n" +
@@ -240,6 +307,6 @@ public class EqualsBetweenInconvertibleTypesInspectionTest extends LightJavaInsp
   @NotNull
   @Override
   protected LightProjectDescriptor getProjectDescriptor() {
-    return JAVA_8;
+    return JAVA_11;
   }
 }

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/StringEqualsCharSequenceInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/StringEqualsCharSequenceInspectionTest.java
@@ -43,6 +43,12 @@ public class StringEqualsCharSequenceInspectionTest extends LightJavaInspectionT
                  "}");
   }
 
+  public void testPredicate() {
+    doMemberTest("boolean m(String s, CharSequence cs) {" +
+                 "  return java.util.function.Predicate./*'String.equals()' called with 'CharSequence' argument*/isEqual/**/(s).test(cs);" +
+                 "}");
+  }
+
   @Nullable
   @Override
   protected InspectionProfileEntry getInspection() {


### PR DESCRIPTION
I'd like to suggest one extension for inspection:

**What steps will reproduce the issue?**

`java.util.function.Predicate.isEqual("1").test(1);
`
or

```
java.util.stream.Stream.of(1)
.filter(java.util.function.Predicate.isEqual("1"))

```
It can lead to error. And it is possible because

`static <T> Predicate<T> isEqual(Object targetRef)
`

**What is the expected result?**

Warning about that, like `"1".equals(1) `- EqualsBetweenInconvertibleTypesInspection



I hope, my solution is not very bad, and I am ready to improve it in the way you say.
It is very interesting and important for me to try to improve so awesome product  like IDEA.

This inspection is important for me because we have already had troubles, when we compare two different types.


https://youtrack.jetbrains.com/issue/IDEA-270600