### PR TITLE
Fix spell check warnings in hexadecimal colour strings

### DIFF
--- a/spellchecker/src/com/intellij/spellchecker/inspections/TextSplitter.java
+++ b/spellchecker/src/com/intellij/spellchecker/inspections/TextSplitter.java
@@ -33,7 +33,7 @@ public class TextSplitter extends BaseSplitter {
     return INSTANCE;
   }
 
-  private static final Pattern EXTENDED_WORD_AND_SPECIAL = Pattern.compile("(&[^;]+;)|(([#]|0x[0-9]*)?\\p{L}+'?\\p{L}[_\\p{L}]*)");
+  private static final Pattern EXTENDED_WORD_AND_SPECIAL = Pattern.compile("(&[^;]+;)|((([#]|0x)[0-9]*)?\\p{L}+'?\\p{L}[_\\p{L}]*)");
 
   @Override
   public void split(@Nullable String text, @NotNull TextRange range, Consumer<TextRange> consumer) {

--- a/spellchecker/src/com/intellij/spellchecker/inspections/WordSplitter.java
+++ b/spellchecker/src/com/intellij/spellchecker/inspections/WordSplitter.java
@@ -34,7 +34,7 @@ public class WordSplitter extends BaseSplitter {
   }
 
   @NonNls
-  private static final Pattern SPECIAL = Pattern.compile("&\\p{Alnum}{2};?|#\\p{Alnum}{3,6}|0x\\p{Alnum}?");
+  private static final Pattern SPECIAL = Pattern.compile("&\\p{Alnum}{2};?|#\\p{Alnum}{3,8}|0x\\p{Alnum}?");
 
   @Override
   public void split(@Nullable String text, @NotNull TextRange range, Consumer<TextRange> consumer) {

--- a/spellchecker/testData/inspection/xmlWithMistakes/test.xml
+++ b/spellchecker/testData/inspection/xmlWithMistakes/test.xml
@@ -5,6 +5,8 @@
 <mail>fooo.baaaar@gmail.com</mail>
 <file email="fooo.baaaar@gmail.com"></file>
 <url>https://fooobaaar.com</url>
+<color>#33FFFFFF</color>
+<color>#3FFFF3</color>
 <URL><![CDATA[http://www.fooobaaar.com/page?id=1]]></URL>
 <file url="https://fooobaaar.com"></file>
 <description><![CDATA[ <TYPO descr="Typo: In word 'foozz'">foozz</TYPO> ]]></description>


### PR DESCRIPTION
Previously, strings such as "#33FFFF" would trigger typo warnings, since the regular expression used to split the word would detect "FFFF" as a word; more generally, unless the "#" were to be followed by a letter, the hex string would be split between the last number and the first letter, triggering a spell check on the letters. This pull request corrects the regular expressions used to split words.

I've updated one of the test files to demonstrate this.