### PR TITLE
Calling to Enum.values() inspection

### DIFF
--- a/java/java-impl/src/META-INF/JavaPlugin.xml
+++ b/java/java-impl/src/META-INF/JavaPlugin.xml
@@ -1445,6 +1445,11 @@
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
                      implementationClass="com.intellij.codeInspection.ReplaceInefficientStreamCountInspection"
                      key="inspection.replace.inefficient.stream.count.display.name" bundle="messages.JavaBundle"/>
+    <localInspection groupPath="Java" language="JAVA" shortName="EnumValues"
+                     groupBundle="messages.InspectionsBundle"
+                     groupKey="group.names.performance.issues" enabledByDefault="false" level="WARNING"
+                     implementationClass="com.intellij.codeInspection.EnumValuesInspection"
+                     key="inspection.message.enum.values.call" bundle="messages.JavaBundle"/>
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="ComparatorCombinators"
                      groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.language.level.specific.issues.and.migration.aids8" enabledByDefault="true" level="WARNING"

--- a/java/java-impl/src/com/intellij/codeInspection/EnumValuesInspection.java
+++ b/java/java-impl/src/com/intellij/codeInspection/EnumValuesInspection.java
@@ -1,0 +1,25 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.codeInspection;
+
+import com.intellij.java.JavaBundle;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiMethodCallExpression;
+import com.siyeh.ig.callMatcher.CallMatcher;
+import org.jetbrains.annotations.NotNull;
+
+public class EnumValuesInspection extends AbstractBaseJavaLocalInspectionTool {
+
+  @Override
+  public @NotNull PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problems, boolean isOnTheFly) {
+    return new JavaElementVisitor() {
+      @Override
+      public void visitMethodCallExpression(PsiMethodCallExpression expression) {
+        super.visitMethodCallExpression(expression);
+        if (CallMatcher.enumValues().test(expression)) {
+          problems.registerProblem(expression, JavaBundle.message("inspection.message.enum.values.call"));
+        }
+      }
+    };
+  }
+}

--- a/java/java-impl/src/inspectionDescriptions/EnumValues.html
+++ b/java/java-impl/src/inspectionDescriptions/EnumValues.html
@@ -1,0 +1,7 @@
+<!-- Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<html>
+<body>
+<p>Reports <b>EnumType.values()</b> method calls which lead to clone of the array of the enum constants every time.</p>
+<!-- tooltip end -->
+</body>
+</html>

--- a/java/java-tests/testData/inspection/enumValuesCall/EnumValuesCall.java
+++ b/java/java-tests/testData/inspection/enumValuesCall/EnumValuesCall.java
@@ -1,0 +1,8 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+class SomeClass {
+  enum SomeEnum {Constant, AnotherConstant}
+
+  public static void main(String[] args) {
+    <warning descr="Call to Enum.values()">SomeEnum.values()</warning>;
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/EnumValuesInspectionTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/EnumValuesInspectionTest.java
@@ -1,0 +1,26 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.java.codeInspection;
+
+import com.intellij.JavaTestUtil;
+import com.intellij.codeInspection.EnumValuesInspection;
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
+import com.siyeh.ig.LightJavaInspectionTestCase;
+
+public class EnumValuesInspectionTest extends LightJavaInspectionTestCase {
+  public static final String TEST_DATA_DIR = "/inspection/enumValuesCall/";
+
+  public void testEnumValuesCall() {
+    doTest();
+  }
+
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new EnumValuesInspection();
+  }
+
+  @Override
+  protected String getBasePath() {
+    return JavaTestUtil.getRelativeJavaTestDataPath() + TEST_DATA_DIR;
+  }
+}

--- a/java/openapi/resources/messages/JavaBundle.properties
+++ b/java/openapi/resources/messages/JavaBundle.properties
@@ -1626,6 +1626,7 @@ label.jvm.method.name=JVM method name
 link.configure.classes.excluded.from.completion=Configure classes excluded from completion
 exception.navigation.fetching.target.position=Fetching target position
 inspection.preview.feature.0.is.preview.api.message={0} is a preview API and may be removed in a future release
+inspection.message.enum.values.call=Call to Enum.values()
 progress.title.detect.overridden.methods=Check overriding methods
 intention.name.iterate.over=Iterate over {0}
 advanced.settings.group.compiler=Compiler


### PR DESCRIPTION
The inspection reports EnumType.values() method calls which leads to clone of the array of the enum constants every time.