### PR TITLE
KTIJ-15996 Move to class body for primary constructor property in inline class (value class) should be prohibited

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/MovePropertyToClassBodyIntention.kt
@@ -23,7 +23,7 @@ class MovePropertyToClassBodyIntention : SelfTargetingIntention<KtParameter>(
     override fun isApplicableTo(element: KtParameter, caretOffset: Int): Boolean {
         if (!element.isPropertyParameter()) return false
         val containingClass = element.containingClass() ?: return false
-        return !containingClass.isAnnotation() && !containingClass.isData()
+        return !containingClass.isAnnotation() && !containingClass.isData() && !containingClass.isInline() && !containingClass.isValue()
     }
 
     override fun applyTo(element: KtParameter, editor: Editor?) {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -12968,6 +12968,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/movePropertyToClassBody/dataClass.kt");
         }
 
+        @TestMetadata("inlineClass.kt")
+        public void testInlineClass() throws Exception {
+            runTest("testData/intentions/movePropertyToClassBody/inlineClass.kt");
+        }
+
         @TestMetadata("location1.kt")
         public void testLocation1() throws Exception {
             runTest("testData/intentions/movePropertyToClassBody/location1.kt");
@@ -12991,6 +12996,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("testData/intentions/movePropertyToClassBody/simple.kt");
+        }
+
+        @TestMetadata("valueClass.kt")
+        public void testValueClass() throws Exception {
+            runTest("testData/intentions/movePropertyToClassBody/valueClass.kt");
         }
 
         @TestMetadata("vararg.kt")

--- a/plugins/kotlin/idea/tests/testData/intentions/movePropertyToClassBody/inlineClass.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/movePropertyToClassBody/inlineClass.kt
@@ -1,0 +1,2 @@
+// IS_APPLICABLE: false
+inline class C(val <caret>x: Int)

--- a/plugins/kotlin/idea/tests/testData/intentions/movePropertyToClassBody/valueClass.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/movePropertyToClassBody/valueClass.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: false
+// DISABLE-ERRORS
+@JvmInline
+value class C(val <caret>x: Int)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-15996