### PR TITLE
Fix improved gradle hotswap detection

### DIFF
--- a/plugins/gradle/java/src/execution/build/GradleImprovedHotswapDetection.java
+++ b/plugins/gradle/java/src/execution/build/GradleImprovedHotswapDetection.java
@@ -43,6 +43,7 @@ public final class GradleImprovedHotswapDetection {
       .forEach(output -> context.fileGenerated(output.getRoot(), output.getPath()));
 
     Set<String> dirtyRoots = outputs.stream()
+      .filter(output -> StringUtil.isEmpty(output.getPath()))
       .map(GradleImprovedHotswapOutput::getRoot)
       .collect(Collectors.toSet());
 

--- a/plugins/gradle/java/testSources/compiler/GradleImprovedHotswapDetectionTest.java
+++ b/plugins/gradle/java/testSources/compiler/GradleImprovedHotswapDetectionTest.java
@@ -114,9 +114,7 @@ public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTest
   public void testBuildMainProject() {
     compileModules("project.main");
 
-    List<String> expected = newArrayList(mainRoot,
-                                         apiMainRoot, apiJar,
-                                         implMainRoot);
+    List<String> expected = newArrayList(apiJar);
 
     if (isGradleOlderThan("3.5")) {
       expected.add(implJar);
@@ -151,11 +149,7 @@ public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTest
   public void testBuildTestProject() {
     compileModules("project.test");
 
-    List<String> expected = newArrayList(mainRoot,
-                                         testRoot,
-                                         apiMainRoot,
-                                         apiJar,
-                                         implMainRoot);
+    List<String> expected = newArrayList(apiJar);
 
     if (isGradleOlderThan("3.5")) {
       expected.add(implJar);
@@ -197,12 +191,12 @@ public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTest
     clearOutputs();
     compileModules("project.main");
 
-    List<String> expected = newArrayList(mainRoot);
     if (isGradleNewerOrSameAs("7.1")) {
-      expected.add("build/tmp/compileJava/previous-compilation-data.bin");
+      assertThat(dirtyOutputRoots).as("Dirty output roots").containsExactlyInAnyOrder("build/tmp/compileJava/previous-compilation-data.bin");
+    } else {
+      assertThat(dirtyOutputRoots).as("Dirty output roots").isEmpty();
     }
 
-    assertThat(dirtyOutputRoots).as("Dirty output roots").containsExactlyInAnyOrderElementsOf(expected);
     assertThat(generatedFiles)
       .containsOnly(Map.entry(mainRoot, Set.of("my/pack/App.class")));
   }
@@ -255,7 +249,7 @@ public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTest
     clearOutputs();
     compileModules("project.main");
 
-    List<String> expected = newArrayList(implMainRoot);
+    List<String> expected = new ArrayList<>();
 
     if (isGradleOlderThan("3.5")) {
       expected.add(implJar);
@@ -280,11 +274,12 @@ public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTest
     clearOutputs();
     compileModules("project.test");
 
-    List<String> expected = newArrayList(testRoot);
+    List<String> expected = new ArrayList<>();
     if (isGradleNewerOrSameAs("7.1")) {
-      expected.add("build/tmp/compileTestJava/previous-compilation-data.bin");
+      assertThat(dirtyOutputRoots).as("Dirty output roots").containsExactlyInAnyOrder("build/tmp/compileTestJava/previous-compilation-data.bin");
+    } else {
+      assertThat(dirtyOutputRoots).as("Dirty output roots").isEmpty();
     }
-    assertThat(dirtyOutputRoots).as("Dirty output roots").containsExactlyInAnyOrderElementsOf(expected);
     assertThat(generatedFiles).as("Generated files").containsOnly(
       Map.entry(testRoot, Set.of("my/pack/AppTest.class"))
     );
@@ -313,12 +308,11 @@ public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTest
     clearOutputs();
     compileModules("project.main");
 
-    List<String> expected = newArrayList(mainRoot);
     if (isGradleNewerOrSameAs("7.1")) {
-      expected.add("build/tmp/compileJava/previous-compilation-data.bin");
+      assertThat(dirtyOutputRoots).as("Dirty output roots").containsExactlyInAnyOrder("build/tmp/compileJava/previous-compilation-data.bin");
+    } else {
+      assertThat(dirtyOutputRoots).as("Dirty output roots").isEmpty();
     }
-
-    assertThat(dirtyOutputRoots).as("Dirty output roots").containsExactlyInAnyOrderElementsOf(expected);
     assertThat(generatedFiles).containsOnly(Map.entry(mainRoot, Set.of("my/pack/App.class")));
   }
 
@@ -331,7 +325,7 @@ public class GradleImprovedHotswapDetectionTest extends GradleDelegatedBuildTest
     clearOutputs();
     compileModules("project.main");
 
-    assertThat(dirtyOutputRoots).containsExactly("build/resources/main");
+    assertThat(dirtyOutputRoots).as("Dirty output roots").isEmpty();
     assertThat(generatedFiles).containsOnly(Map.entry("build/resources/main", Set.of("runtime.properties")));
   }
 


### PR DESCRIPTION
@vladsoroka I tested improved gradle hotswap detection in EAP build of 2021.2 and realized that there was a bug in the implementation.

The implementation was marking too many directories as dirty roots. Marking all folders as dirty roots resulted in all class files being hot swapped in our test project - the implementation was not working as intended.

The fix is to only mark directories as dirty roots for outputs that don't have a path - i.e. when Gradle task declares output as a file and not as a folder, such as the jar task.

Original implementation of improved Gradle hotswap detection is in #1551