### PR TITLE
Cast return of the dlopen call in case debug symbols are missing.

### DIFF
--- a/python/helpers/pydev/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/python/helpers/pydev/pydevd_attach_to_process/add_code_to_python_process.py
@@ -483,7 +483,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
     cmd.extend(["--eval-command='set architecture %s'" % arch])
 
     cmd.extend([
-        "--eval-command='call dlopen(\"%s\", 2)'" % target_dll,
+        "--eval-command='call (void*)dlopen(\"%s\", 2)'" % target_dll,
         "--eval-command='call (int)DoAttach(%s, \"%s\", %s)'" % (
             is_debug, python_code, show_debug_info)
     ])


### PR DESCRIPTION
To fix the following error with gdb 8.3.1 when trying to attach to a Python process.

> 'dlopen@GLIBC_2.2.5' has unknown return type; cast the call to its declared return type
> No symbol "DoAttach" in current context.


`void *dlopen(const char *filename, int flags);` [Source](https://man7.org/linux/man-pages/man3/dlopen.3.html )

[See also for more details.](https://github.com/fabioz/PyDev.Debugger/pull/151)