### PR TITLE
KTIJ-17485 False positive 'Explicitly given type is redundant here' with companion object

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt
@@ -7,11 +7,16 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.idea.intentions.RemoveExplicitTypeIntention
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.AbbreviatedType
+import org.jetbrains.kotlin.types.KotlinType
 
 class RedundantExplicitTypeInspection : AbstractKotlinInspection() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
@@ -66,6 +71,8 @@ class RedundantExplicitTypeInspection : AbstractKotlinInspection() {
                 }
                 is KtNameReferenceExpression -> {
                     if (typeReference.text != initializer.getReferencedName()) return false
+                    val initializerType = initializer.getType(property.analyze(BodyResolveMode.PARTIAL))
+                    if (initializerType != type && initializerType.isCompanionObject()) return false
                 }
                 is KtCallExpression -> {
                     if (typeReference.text != initializer.calleeExpression?.text) return false
@@ -74,5 +81,8 @@ class RedundantExplicitTypeInspection : AbstractKotlinInspection() {
             }
             return true
         }
+
+        private fun KotlinType?.isCompanionObject() =
+            (this?.constructor?.declarationDescriptor as? ClassDescriptor)?.isCompanionObject == true
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7769,6 +7769,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantExplicitType/interface.kt");
         }
 
+        @TestMetadata("interfaceWithCompanionObject.kt")
+        public void testInterfaceWithCompanionObject() throws Exception {
+            runTest("testData/inspectionsLocal/redundantExplicitType/interfaceWithCompanionObject.kt");
+        }
+
         @TestMetadata("long.kt")
         public void testLong() throws Exception {
             runTest("testData/inspectionsLocal/redundantExplicitType/long.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantExplicitType/interfaceWithCompanionObject.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantExplicitType/interfaceWithCompanionObject.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+interface Foo {
+    companion object : Foo
+}
+
+fun bar() {
+    var value: Foo<caret> = Foo
+    value = object : Foo {}
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-17485