### PR TITLE
KT-16228: Support markdown tables in KDoc quickdoc renderer

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/kdoc/KDocRenderer.kt
@@ -9,7 +9,9 @@ import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
-import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMElementTypes
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 import org.intellij.markdown.parser.MarkdownParser
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.references.mainReference
@@ -182,7 +184,7 @@ object KDocRenderer {
     }
 
     private fun markdownToHtml(markdown: String, allowSingleParagraph: Boolean = false): String {
-        val markdownTree = MarkdownParser(CommonMarkFlavourDescriptor()).buildMarkdownTreeFromString(markdown)
+        val markdownTree = MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(markdown)
         val markdownNode = MarkdownNode(markdownTree, null, markdown)
 
         // Avoid wrapping the entire converted contents in a <p> tag if it's just a single paragraph
@@ -235,6 +237,7 @@ object KDocRenderer {
                 MarkdownElementTypes.LIST_ITEM -> wrapChildren("li")
                 MarkdownElementTypes.EMPH -> wrapChildren("em")
                 MarkdownElementTypes.STRONG -> wrapChildren("strong")
+                GFMElementTypes.STRIKETHROUGH -> wrapChildren("del")
                 MarkdownElementTypes.ATX_1 -> wrapChildren("h1")
                 MarkdownElementTypes.ATX_2 -> wrapChildren("h2")
                 MarkdownElementTypes.ATX_3 -> wrapChildren("h3")
@@ -292,7 +295,8 @@ object KDocRenderer {
                 MarkdownTokenTypes.RPAREN,
                 MarkdownTokenTypes.LBRACKET,
                 MarkdownTokenTypes.RBRACKET,
-                MarkdownTokenTypes.EXCLAMATION_MARK -> {
+                MarkdownTokenTypes.EXCLAMATION_MARK,
+                GFMTokenTypes.CHECK_BOX -> {
                     sb.append(nodeText)
                 }
                 MarkdownTokenTypes.CODE_LINE -> {
@@ -326,6 +330,38 @@ object KDocRenderer {
                     }
                 }
 
+                GFMTokenTypes.TILDE -> {
+                    if (node.parent?.type != GFMElementTypes.STRIKETHROUGH) {
+                        sb.append(node.text)
+                    }
+                }
+
+                GFMElementTypes.TABLE -> {
+                    val alignment: List<String> = getTableAlignment(node)
+                    var addedBody = false
+                    sb.append("<table>")
+
+                    for (child in node.children) {
+                        if (child.type == GFMElementTypes.HEADER) {
+                            sb.append("<thead>")
+                            processTableRow(sb, child, "th", alignment)
+                            sb.append("</thead>")
+                        } else if (child.type == GFMElementTypes.ROW) {
+                            if (!addedBody) {
+                                sb.append("<tbody>")
+                                addedBody = true
+                            }
+
+                            processTableRow(sb, child, "td", alignment)
+                        }
+                    }
+
+                    if (addedBody) {
+                        sb.append("</tbody>")
+                    }
+                    sb.append("</table>")
+                }
+
                 else -> {
                     processChildren()
                 }
@@ -341,4 +377,31 @@ object KDocRenderer {
     }
 
     private fun String.htmlEscape(): String = replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    private fun processTableRow(sb: StringBuilder, node: MarkdownNode, cellTag: String, alignment: List<String>) {
+        sb.append("<tr>")
+        for ((i, child) in node.children.filter { it.type == GFMTokenTypes.CELL }.withIndex()) {
+            val alignValue = alignment.getOrElse(i) { "" }
+            val alignTag = if (alignValue.isEmpty()) "" else " align=\"$alignValue\""
+            sb.append("<$cellTag$alignTag>")
+            sb.append(child.toHtml())
+            sb.append("</$cellTag>")
+        }
+        sb.append("</tr>")
+    }
+
+    private fun getTableAlignment(node: MarkdownNode): List<String> {
+        val separatorRow = node.child(GFMTokenTypes.TABLE_SEPARATOR)
+            ?: return emptyList()
+
+        return separatorRow.text.split('|').filterNot { it.isBlank() }.map {
+            val trimmed = it.trim()
+            val left = trimmed.startsWith(':')
+            val right = trimmed.endsWith(':')
+            if (left && right) "center"
+            else if (right) "right"
+            else if (left) "left"
+            else ""
+        }
+    }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/quickDoc/QuickDocProviderTestGenerated.java
@@ -193,6 +193,11 @@ public class QuickDocProviderTestGenerated extends AbstractQuickDocProviderTest 
         runTest("testData/editor/quickDoc/OnEnumValuesFunction.kt");
     }
 
+    @TestMetadata("OnFunctionDeclarationWithGFMTable.kt")
+    public void testOnFunctionDeclarationWithGFMTable() throws Exception {
+        runTest("idea/testData/editor/quickDoc/OnFunctionDeclarationWithGFMTable.kt");
+    }
+
     @TestMetadata("OnFunctionDeclarationWithPackage.kt")
     public void testOnFunctionDeclarationWithPackage() throws Exception {
         runTest("testData/editor/quickDoc/OnFunctionDeclarationWithPackage.kt");

--- a/plugins/kotlin/idea/tests/testData/editor/quickDoc/OnFunctionDeclarationWithGFMTable.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/quickDoc/OnFunctionDeclarationWithGFMTable.kt
@@ -1,0 +1,17 @@
+/**
+ * | left  | center | right | default |
+ * | :---- | :----: | ----: | ------- |
+ * | 1     | 2      | 3     | 4       |
+ *
+ *
+ * | foo | bar | baz |
+ * | --- | --- | --- |
+ * | 1   | 2   |
+ * | 3   | 4   | 5   | 6 |
+ *
+ * | header | only |
+ * | ------ | ---- |
+ */
+fun <caret>testFun() = 12
+
+//INFO: <div class='definition'><pre><font color="808080"><i>OnFunctionDeclarationWithGFMTable.kt</i></font><br>public fun <b>testFun</b>(): Int</pre></div><div class='content'><table><thead><tr><th align="left">left</th><th align="center"> center</th><th align="right"> right</th><th> default</th></tr></thead><tbody><tr><td align="left"> 1</td><td align="center"> 2</td><td align="right"> 3</td><td> 4</td></tr></tbody></table>   <table><thead><tr><th> foo</th><th> bar</th><th> baz</th></tr></thead><tbody><tr><td> 1</td><td> 2</td></tr><tr><td> 3</td><td> 4</td><td> 5</td></tr></tbody></table>  <table><thead><tr><th> header</th><th> only</th></tr></thead></table></div><table class='sections'></table>


### PR DESCRIPTION
This commit changes the markdown flavor used parsing for KDocs from CommonMark to GFM. Dokka itself uses GFM, so this change aligns dokka and quickdocs. The KDoc renderer is updated to render the new GFM node types.