### PR TITLE
IDEA-130373 Still "do highlight during VFS refresh" but fix frequent …

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/DaemonCodeAnalyzerImpl.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/DaemonCodeAnalyzerImpl.java
@@ -895,8 +895,12 @@ public final class DaemonCodeAnalyzerImpl extends DaemonCodeAnalyzerEx implement
           entry.setValue(dumbAwarePasses);
           hasPasses |= dumbAwarePasses.length != 0;
         }
+
+        HeavyProcessLatch.INSTANCE.executeOutOfHeavyProcessButType(
+          HeavyProcessLatch.Type.Syncing,
+          () -> dca.stopProcess(true, "re-scheduled to execute after all heavy processes (except VFS) finished"));
+
         if (!hasPasses) {
-          // will be re-scheduled by HeavyLatch listener in DaemonListeners
           return;
         }
       }

--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/DaemonListeners.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/DaemonListeners.java
@@ -385,8 +385,6 @@ public final class DaemonListeners implements Disposable {
           PsiManager.getInstance(myProject).dropPsiCaches();
         }
       }));
-    HeavyProcessLatch.INSTANCE.addListener(this, __ ->
-      myDaemonCodeAnalyzer.stopProcess(true, "re-scheduled to execute after heavy processing finished"));
   }
 
   private <T, U extends KeyedLazyInstance<T>> void restartOnExtensionChange(@NotNull ExtensionPointName<U> name, @NotNull String message) {


### PR DESCRIPTION
https://github.com/JetBrains/intellij-community/commit/01e0d412641e52bb4185517928bbbd9e7a21c13f#diff-4497b4c4afdd25574053db8b6de01a43669c1b3200a5d4d31d14da002614e400 fixed highlight to no longer blocked by VFS refresh, which is good. 

However, once highlight do start with all passes (heavy process beside vfs refresh finished), highlight keeps getting interrupted (daemon cancel & restart), as it listen to every single HeavyProcess's stopProcess.  
For example, 
- for a small file it restarted 5 times or so when highlighting 
- for a big file that took really long to highlight, it get interrupted for like 600+ times. 
Each Interruption looks like this (I added some local debug log for heavy process start/end and Update Runnable scheduled)
```
2021-05-14 18:20:09,217 [ 294602]  DEBUG - l.io.storage.HeavyProcessLatch -  null Heavy process started.
2021-05-14 18:20:09,217 [ 294602]  DEBUG - l.io.storage.HeavyProcessLatch -  null Heavy process finished. 
2021-05-14 18:20:09,217 [ 294602]  DEBUG - aemon.impl.PassExecutorService -                                                                                                          null Cancel re-scheduled to execute after heavy processing finished true; progress=797829327 V 
2021-05-14 18:20:09,218 [ 294603]  DEBUG - aemon.impl.PassExecutorService -                                                                                                          null Update Runnable scheduled. reason: re-scheduled to execute after heavy processing finished; progress=797829327 X 
```

For fix, i figured we shouldn't listen to every single stopProcess(), but should only restart heavy process ONCE, upon all heavy process beside vfs has finished. There comes this fix

You may find it very similar to before https://github.com/JetBrains/intellij-community/commit/01e0d412641e52bb4185517928bbbd9e7a21c13f#diff-4497b4c4afdd25574053db8b6de01a43669c1b3200a5d4d31d14da002614e40, where we queue a one time runnable to restart daemon after heavy process, but it's different in terms of I 
(1) queue one-time runnable to happen after heavy process EXCEPT VFS
(2) does NOT require `if (!hasPass)` to queue this runnable. This is important, as sometimes MOST pass is filtered due to dumbaware, but some is left, in that case we still need to queue this runnable. 