### PR TITLE
[kotlin] Fix visible variables in the debugger on dex VMs

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinVariablePrintingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinVariablePrintingTestGenerated.java
@@ -23,6 +23,11 @@ public class KotlinVariablePrintingTestGenerated extends AbstractKotlinVariableP
         KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
     }
 
+    @TestMetadata("nestedInlineFunctions.kt")
+    public void testNestedInlineFunctions() throws Exception {
+        runTest("testData/variables/nestedInlineFunctions.kt");
+    }
+
     @TestMetadata("optimisedVariablesInNestedFunctions.kt")
     public void testOptimisedVariablesInNestedFunctions() throws Exception {
         runTest("testData/variables/optimisedVariablesInNestedFunctions.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/nestedInlineFunctions.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/nestedInlineFunctions.kt
@@ -1,0 +1,23 @@
+package nestedInlineFunctions
+
+// SHOW_KOTLIN_VARIABLES
+
+fun main() {
+    val x = 0
+    f {
+        //Breakpoint!
+        g(2)
+    }
+}
+
+inline fun f(block: () -> Unit) {
+    var y = 1
+    //Breakpoint!
+    block()
+}
+
+inline fun g(a: Int) {
+    var z = 3
+    //Breakpoint!
+    println()
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/nestedInlineFunctions.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/nestedInlineFunctions.out
@@ -1,0 +1,18 @@
+LineBreakpoint created at nestedInlineFunctions.kt:9
+LineBreakpoint created at nestedInlineFunctions.kt:16
+LineBreakpoint created at nestedInlineFunctions.kt:22
+Run Java
+Connected to the target VM
+nestedInlineFunctions.kt:16
+KotlinStackFrame (nestedInlineFunctions.kt:16)
+    JavaValue[local] y: int = 1 (nestedInlineFunctions.kt:14)
+nestedInlineFunctions.kt:9
+KotlinStackFrame (nestedInlineFunctions.kt:9)
+    JavaValue[local] x: int = 0 (nestedInlineFunctions.kt:6)
+nestedInlineFunctions.kt:22
+KotlinStackFrame (nestedInlineFunctions.kt:22)
+    JavaValue[local] a: int = 2 (nestedInlineFunctions.kt:19)
+    JavaValue[local] z: int = 3 (nestedInlineFunctions.kt:20)
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
For inline functions, the Kotlin JVM debugger needs to reconstruct the currently visible variables out of metadata which the Kotlin compiler encodes in both the order and names of local variables.

On a dex VM, the order of local variables is not reliable, since locals are kept in registers which may have to be spilled. Spilling resets the start offsets of locals and changes their sorting order. This commit introduces a workaround to recover the actual variable introduction order when running on a dex VM and also makes the code for reconstructing inline call stacks more robust.

---

In particular, the previous code used only the inline depth to determine which variables are visible in the current scope. This is insufficient when there are multiple active stack frames at the same depth:
```kotlin
fun f() {
    val x = 0
    g {
        h(2)
    }
}

inline fun g(block: () -> Unit) {
    var y = 1
    block()
}

inline fun h(a: Int) {
    var z = 3
    /* breakpoint */
}
```
in `h`, both `y` and `z` are at depth `1`, but only `z` is supposed to be visible. The new code handles such examples correctly, but is not yet used consistently throughout the debugger.