### PR TITLE
KTIJ-18901 "Create parameter" quick-fix by default doesn't add `val` keyword for missing parameter of annotation class, producing uncompilable code

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -5119,6 +5119,16 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
                     KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
                 }
 
+                @TestMetadata("annotationClass.kt")
+                public void testAnnotationClass() throws Exception {
+                    runTest("testData/quickfix/createFromUsage/createVariable/parameter/annotationClass.kt");
+                }
+
+                @TestMetadata("annotationClass2.kt")
+                public void testAnnotationClass2() throws Exception {
+                    runTest("testData/quickfix/createFromUsage/createVariable/parameter/annotationClass2.kt");
+                }
+
                 @TestMetadata("assignedInFun.kt")
                 public void testAssignedInFun() throws Exception {
                     runTest("testData/quickfix/createFromUsage/createVariable/parameter/assignedInFun.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass.kt
@@ -1,0 +1,5 @@
+// "Create property 'x' as constructor parameter" "true"
+annotation class Annotation
+
+@Annotation(<caret>x = 1)
+class C

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass.kt.after
@@ -1,0 +1,5 @@
+// "Create property 'x' as constructor parameter" "true"
+annotation class Annotation(val x: Int)
+
+@Annotation(x = 1)
+class C

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass2.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass2.kt
@@ -1,0 +1,5 @@
+// "Create property 'y' as constructor parameter" "true"
+annotation class Annotation(val x: Int)
+
+@Annotation(x = 1, <caret>y = 2)
+class C

--- a/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/createFromUsage/createVariable/parameter/annotationClass2.kt.after
@@ -1,0 +1,5 @@
+// "Create property 'y' as constructor parameter" "true"
+annotation class Annotation(val x: Int, val y: Int)
+
+@Annotation(x = 1, y = 2)
+class C


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-18901