### PR TITLE
PY-48747 allow all valid Python identifers in target name; fix message

### DIFF
--- a/python/pluginResources/messages/PyBundle.properties
+++ b/python/pluginResources/messages/PyBundle.properties
@@ -209,7 +209,7 @@ python.run.python=Python
 
 testing.form.inspect.only.subclasses.of.unittest.testcase=Inspect only subclasses of unittest.TestCase
 python.testing.target.not.provided=The target is not provided
-python.testing.provide.qualified.name=Provide a qualified name of a function, class or module"
+python.testing.provide.qualified.name=Provide a qualified name of a function, class or module
 python.testing.pattern.can.only.be.used=Pattern can only be used to match files in a folder. Can't use pattern for a file.
 python.testing.cant.resolve=Can't resolve {0}. Try to remove the configuration and generate it again
 python.testing.cant.find.where.declared=Can't find file where {0} declared. Make sure it is in the project root

--- a/python/src/com/jetbrains/extensions/TargetWithVariantExt.kt
+++ b/python/src/com/jetbrains/extensions/TargetWithVariantExt.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
+import com.jetbrains.python.PyNames
 import com.jetbrains.python.run.AbstractPythonRunConfiguration
 import com.jetbrains.python.run.targetBasedConfiguration.PyRunTargetVariant
 import com.jetbrains.python.run.targetBasedConfiguration.TargetWithVariant
@@ -33,7 +34,7 @@ fun TargetWithVariant.asVirtualFile(): VirtualFile? = target?.let { targetAsVirt
  * CUSTOM type is not checked.
  */
 fun TargetWithVariant.isWellFormed(): Boolean = when (targetType) {
-  PyRunTargetVariant.PYTHON -> Regex("^[a-zA-Z0-9._]+[a-zA-Z0-9_]$").matches(target ?: "")
+  PyRunTargetVariant.PYTHON -> PyNames.isIdentifier((target ?: "").replace(".", "_"))
   PyRunTargetVariant.PATH -> !VfsUtil.isBadName(target)
   else -> true
 }

--- a/python/src/com/jetbrains/extensions/TargetWithVariantExt.kt
+++ b/python/src/com/jetbrains/extensions/TargetWithVariantExt.kt
@@ -34,7 +34,7 @@ fun TargetWithVariant.asVirtualFile(): VirtualFile? = target?.let { targetAsVirt
  * CUSTOM type is not checked.
  */
 fun TargetWithVariant.isWellFormed(): Boolean = when (targetType) {
-  PyRunTargetVariant.PYTHON -> PyNames.isIdentifier((target ?: "").replace(".", "_"))
+  PyRunTargetVariant.PYTHON -> target?.let { it.split(".").all { PyNames.isIdentifier(it) } } ?: true
   PyRunTargetVariant.PATH -> !VfsUtil.isBadName(target)
   else -> true
 }


### PR DESCRIPTION
Target with a name containing non-ASCII characters now runs without error prompts.