### PR TITLE
Skip searching for symbols when starting up gdb and instead load just the required ones…

### DIFF
--- a/python/helpers/pydev/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/python/helpers/pydev/pydevd_attach_to_process/add_code_to_python_process.py
@@ -462,6 +462,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
     target_dll = os.path.abspath(os.path.normpath(target_dll))
     if not os.path.exists(target_dll):
         raise RuntimeError('Could not find dll file to inject: %s' % target_dll)
+    target_dll_name = os.path.splitext(os.path.basename(target_dll))[0]
 
     # Note: we currently don't support debug builds
     is_debug = 0
@@ -478,12 +479,17 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
 #         '--batch-silent',
     ]
 
+    cmd.extend(["--init-eval-command='set auto-solib-add off'"])  # Faster loading.
+
     cmd.extend(["--eval-command='set scheduler-locking off'"])  # If on we'll deadlock.
 
     cmd.extend(["--eval-command='set architecture %s'" % arch])
 
+    cmd.extend(["--eval-command='sharedlibrary libdl'"])  # For dlopen.
+
     cmd.extend([
         "--eval-command='call dlopen(\"%s\", 2)'" % target_dll,
+        "--eval-command='sharedlibrary %s'" % target_dll_name,
         "--eval-command='call (int)DoAttach(%s, \"%s\", %s)'" % (
             is_debug, python_code, show_debug_info)
     ])


### PR DESCRIPTION
It's possible in a large enough project that searching for debug symbols throughout all the included libs will take longer than PyCharm is willing to wait for the attach code to execute. Since gdb is only being used to connect to and run a Python script in the target Python process, then we can skip this step and have the injected code execute much faster.

I observed the gdb process take over 23 seconds to execute the attach script in the target process while PyCharm shut down the debugging server after 20 seconds.