### PR TITLE
KTIJ-18387 "Redundant 'inner' modifier" inspection should warn when access containing class members of not this object

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8321,6 +8321,31 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReference5.kt");
         }
 
+        @TestMetadata("hasOuterClassMemberReferenceFromNotThis.kt")
+        public void testHasOuterClassMemberReferenceFromNotThis() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis.kt");
+        }
+
+        @TestMetadata("hasOuterClassMemberReferenceFromNotThis2.kt")
+        public void testHasOuterClassMemberReferenceFromNotThis2() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis2.kt");
+        }
+
+        @TestMetadata("hasOuterClassMemberReferenceFromNotThis3.kt")
+        public void testHasOuterClassMemberReferenceFromNotThis3() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis3.kt");
+        }
+
+        @TestMetadata("hasOuterClassMemberReferenceFromNotThis4.kt")
+        public void testHasOuterClassMemberReferenceFromNotThis4() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis4.kt");
+        }
+
+        @TestMetadata("hasOuterClassMemberReferenceFromNotThis5.kt")
+        public void testHasOuterClassMemberReferenceFromNotThis5() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis5.kt");
+        }
+
         @TestMetadata("hasOuterClassMemberReferenceInSuperTypeConstructorCall.kt")
         public void testHasOuterClassMemberReferenceInSuperTypeConstructorCall() throws Exception {
             runTest("testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceInSuperTypeConstructorCall.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis.kt
@@ -1,0 +1,18 @@
+class Test {
+    <caret>inner class Inner {
+        fun test() {
+            Test().innerVal
+            Test().innerFun()
+            Test().Inner2()
+            Test().Inner2().inner2Fun()
+        }
+    }
+
+    val innerVal = 1
+
+    fun innerFun() {}
+
+    inner class Inner2 {
+        fun inner2Fun() {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis.kt.after
@@ -1,0 +1,18 @@
+class Test {
+    class Inner {
+        fun test() {
+            Test().innerVal
+            Test().innerFun()
+            Test().Inner2()
+            Test().Inner2().inner2Fun()
+        }
+    }
+
+    val innerVal = 1
+
+    fun innerFun() {}
+
+    inner class Inner2 {
+        fun inner2Fun() {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis2.kt
@@ -1,0 +1,18 @@
+class Test {
+    <caret>inner class Inner {
+        fun test(t: Test) {
+            t.innerVal
+            t.innerFun()
+            t.Inner2()
+            t.Inner2().inner2Fun()
+        }
+    }
+
+    val innerVal = 1
+
+    fun innerFun() {}
+
+    inner class Inner2 {
+        fun inner2Fun() {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis2.kt.after
@@ -1,0 +1,18 @@
+class Test {
+    class Inner {
+        fun test(t: Test) {
+            t.innerVal
+            t.innerFun()
+            t.Inner2()
+            t.Inner2().inner2Fun()
+        }
+    }
+
+    val innerVal = 1
+
+    fun innerFun() {}
+
+    inner class Inner2 {
+        fun inner2Fun() {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis3.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+class Foo {
+    fun Foo.foo() {}
+
+    <caret>inner class Bar {
+        fun bar(f: Foo) {
+            f.foo()
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis4.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis4.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+class Foo {
+    val Foo.foo
+        get() = 1
+
+    <caret>inner class Bar {
+        fun bar(f: Foo) {
+            f.foo
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis5.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis5.kt
@@ -1,0 +1,12 @@
+// WITH_RUNTIME
+class Foo {
+    fun Foo.foo() {}
+
+    <caret>inner class Bar {
+        fun bar(f: Foo) {
+            with (f) {
+                f.foo()
+            }
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis5.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/hasOuterClassMemberReferenceFromNotThis5.kt.after
@@ -1,0 +1,12 @@
+// WITH_RUNTIME
+class Foo {
+    fun Foo.foo() {}
+
+    class Bar {
+        fun bar(f: Foo) {
+            with (f) {
+                f.foo()
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-18387
https://youtrack.jetbrains.com/issue/KTIJ-18385