### PR TITLE
Treat JUnit4 runners with special annotation as parameterized

### DIFF
--- a/plugins/junit_rt/src/com/intellij/junit4/JUnit4TestRunnerUtil.java
+++ b/plugins/junit_rt/src/com/intellij/junit4/JUnit4TestRunnerUtil.java
@@ -224,9 +224,17 @@ public final class JUnit4TestRunnerUtil {
 
   private static boolean isParameterized(final String methodName,
                                          final Class<?> clazz) {
-    final RunWith clazzAnnotation = clazz.getAnnotation(RunWith.class);
-    if (clazzAnnotation != null && Parameterized.class.isAssignableFrom(clazzAnnotation.value())) {
+    final RunWith runWithAnnotation = clazz.getAnnotation(RunWith.class);
+    if (runWithAnnotation != null && Parameterized.class.isAssignableFrom(runWithAnnotation.value())) {
       return true;
+    }
+    if (runWithAnnotation != null) {
+      for (Annotation runnerAnnotation : runWithAnnotation.value().getDeclaredAnnotations()) {
+        if (runnerAnnotation.annotationType().getSimpleName()
+            .equals("ParameterizedRunnerIntroducingTestNamesWithSquareBrackets")) {
+          return true;
+        }
+      }
     }
     if (methodName != null) {
       try {


### PR DESCRIPTION
## Context

When filtering individual JUnit4 tests in IntelliJ, the runner will look for a method with the name of the test. For parameterized tests, there is no 1:1 relationship between test name and test method and so this fails.

For `junit.Parameterized` and test methods with parameters, there is an existing workaround for this in `JUnit4TestRunnerUtil`.

## Problem when using TestParameterInjector

[TestParameterInjector](https://github.com/google/TestParameterInjector) is a runner developed at Google, and recently launched as open source project. In the last 2 months, [we had 3 different people asking us to fix this filtering issue in IntelliJ](https://github.com/google/TestParameterInjector/issues/6). The issue arises when fields are used for parameterization:

```java
@RunWith(TestParameterInjector.class)
public class MyTest {

  @TestParameter private boolean isOwner;

  @Test public void test() {...}
}
```

This will result in the following test names:

```
MyTest#test[isOwner=true]
MyTest#test[isOwner=false]
```

which will break the IntelliJ filtering.

## Proposed solution

With this pull request, the TestParameterInjector class would be changed as follows:

```java
package com.google.testing.junit.testparameterinjector

@ParameterizedRunnerIntroducingTestNamesWithSquareBrackets
static class TestParameterInjector extends Runner { ... }

@Retention(RUNTIME)
@interface ParameterizedRunnerIntroducingTestNamesWithSquareBrackets  {}
```

Other parameterized runners facing the same issue can define their own annotation with the same name and fix the same issue that way.