### PR TITLE
KTIJ-11519 Call chain on collection type may be simplified: mapNotNull{}.first() -> firstNotNullOf{}

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt
@@ -197,6 +197,15 @@ class SimplifiableCallChainInspection : AbstractCallChainChecker() {
                 removeNotNullAssertion = true, replaceableLanguageVersion = LanguageVersion.KOTLIN_1_4
             ),
 
+            Conversion(
+                "kotlin.collections.mapNotNull", "kotlin.collections.first", "firstNotNullOf",
+                replaceableLanguageVersion = LanguageVersion.KOTLIN_1_5
+            ),
+            Conversion(
+                "kotlin.collections.mapNotNull", "kotlin.collections.firstOrNull", "firstNotNullOfOrNull",
+                replaceableLanguageVersion = LanguageVersion.KOTLIN_1_5
+            ),
+
             Conversion("kotlin.collections.listOf", "kotlin.collections.filterNotNull", "listOfNotNull")
         ).map {
             when (val replacement = it.replacement) {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1899,6 +1899,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                 runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNull.kt");
             }
 
+            @TestMetadata("mapNotNullFirst.kt")
+            public void testMapNotNullFirst() throws Exception {
+                runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirst.kt");
+            }
+
+            @TestMetadata("mapNotNullFirstOrNull.kt")
+            public void testMapNotNullFirstOrNull() throws Exception {
+                runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirstOrNull.kt");
+            }
+
             @TestMetadata("mapNotNullWithSuspendFunctionCall.kt")
             public void testMapNotNullWithSuspendFunctionCall() throws Exception {
                 runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullWithSuspendFunctionCall.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirst.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirst.kt
@@ -1,0 +1,7 @@
+// LANGUAGE_VERSION: 1.5
+// WITH_RUNTIME
+data class User(val id: Long, val name: String?)
+
+fun test(users: List<User>) {
+    users.<caret>mapNotNull { it.name }.first()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirst.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirst.kt.after
@@ -1,0 +1,7 @@
+// LANGUAGE_VERSION: 1.5
+// WITH_RUNTIME
+data class User(val id: Long, val name: String?)
+
+fun test(users: List<User>) {
+    users.firstNotNullOf { it.name }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirstOrNull.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirstOrNull.kt
@@ -1,0 +1,7 @@
+// LANGUAGE_VERSION: 1.5
+// WITH_RUNTIME
+data class User(val id: Long, val name: String?)
+
+fun test(users: List<User>) {
+    users.<caret>mapNotNull { it.name }.firstOrNull()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirstOrNull.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapNotNullFirstOrNull.kt.after
@@ -1,0 +1,7 @@
+// LANGUAGE_VERSION: 1.5
+// WITH_RUNTIME
+data class User(val id: Long, val name: String?)
+
+fun test(users: List<User>) {
+    users.firstNotNullOfOrNull { it.name }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-11519