### PR TITLE
KTIJ-19062 SENSELESS_NULL_IN_WHEN quickfix "Remove branch" removes whole `when` entry with multiple conditions

### DIFF
--- a/plugins/kotlin/idea/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/idea/resources-en/messages/KotlinBundle.properties
@@ -1180,6 +1180,7 @@ remove.val.var.from.parameter=Remove 'val/var' from parameter
 remove.0.from.parameter=Remove ''{0}'' from parameter
 remove.else.branch=Remove else branch
 remove.branch=Remove branch
+remove.condition=Remove condition
 rename.identifier.fix.text=Rename
 rename.to.0=Rename to ''{0}''
 rename.parameter.to.match.overridden.method=Rename parameter to match overridden method

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -267,7 +267,7 @@ class QuickFixRegistrar : QuickFixContributor {
         NO_ELSE_IN_WHEN.registerFactory(AddWhenElseBranchFix)
         NO_ELSE_IN_WHEN.registerFactory(AddWhenRemainingBranchesFix)
         REDUNDANT_ELSE_IN_WHEN.registerFactory(RemoveWhenBranchFix)
-        SENSELESS_NULL_IN_WHEN.registerFactory(RemoveWhenBranchFix)
+        SENSELESS_NULL_IN_WHEN.registerFactory(RemoveWhenBranchFix, RemoveWhenConditionFix)
         NON_EXHAUSTIVE_WHEN.registerFactory(AddWhenElseBranchFix)
         NON_EXHAUSTIVE_WHEN.registerFactory(AddWhenRemainingBranchesFix)
         NON_EXHAUSTIVE_WHEN_ON_SEALED_CLASS.registerFactory(AddWhenElseBranchFix)

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWhenBranchFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWhenBranchFix.kt
@@ -30,7 +30,9 @@ class RemoveWhenBranchFix(element: KtWhenEntry) : KotlinQuickFixAction<KtWhenEnt
                 Errors.REDUNDANT_ELSE_IN_WHEN ->
                     (diagnostic.psiElement as? KtWhenEntry)?.let { RemoveWhenBranchFix(it) }
                 Errors.SENSELESS_NULL_IN_WHEN ->
-                    diagnostic.psiElement.getStrictParentOfType<KtWhenEntry>()?.let { RemoveWhenBranchFix(it) }
+                    diagnostic.psiElement.getStrictParentOfType<KtWhenEntry>()
+                        ?.takeIf { it.conditions.size == 1 }
+                        ?.let { RemoveWhenBranchFix(it) }
                 else ->
                     null
             }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWhenConditionFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWhenConditionFix.kt
@@ -1,0 +1,37 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.psi.EditCommaSeparatedListHelper
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtWhenCondition
+import org.jetbrains.kotlin.psi.KtWhenEntry
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+
+class RemoveWhenConditionFix(element: KtWhenCondition) : KotlinQuickFixAction<KtWhenCondition>(element) {
+    override fun getFamilyName() = KotlinBundle.message("remove.condition")
+
+    override fun getText() = familyName
+
+    override fun invoke(project: Project, editor: Editor?, file: KtFile) {
+        element?.let { EditCommaSeparatedListHelper.removeItem(it) }
+    }
+
+    companion object : KotlinSingleIntentionActionFactory() {
+        override fun createAction(diagnostic: Diagnostic): RemoveWhenConditionFix? {
+            return when (diagnostic.factory) {
+                Errors.SENSELESS_NULL_IN_WHEN -> {
+                    val whenCondition = diagnostic.psiElement.getStrictParentOfType<KtWhenCondition>() ?: return null
+                    val whenEntry = whenCondition.parent as? KtWhenEntry ?: return null
+                    if (whenEntry.conditions.size >= 2) RemoveWhenConditionFix(whenCondition) else null
+                }
+                else -> null
+            }
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -14279,9 +14279,19 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/when/noElseInWhenWithoutBranches.kt");
         }
 
+        @TestMetadata("notRedundantBranch.kt")
+        public void testNotRedundantBranch() throws Exception {
+            runTest("testData/quickfix/when/notRedundantBranch.kt");
+        }
+
         @TestMetadata("removeRedundantBranch.kt")
         public void testRemoveRedundantBranch() throws Exception {
             runTest("testData/quickfix/when/removeRedundantBranch.kt");
+        }
+
+        @TestMetadata("removeRedundantCondition.kt")
+        public void testRemoveRedundantCondition() throws Exception {
+            runTest("testData/quickfix/when/removeRedundantCondition.kt");
         }
 
         @TestMetadata("removeRedundantElse.kt")

--- a/plugins/kotlin/idea/tests/testData/quickfix/when/notRedundantBranch.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/when/notRedundantBranch.kt
@@ -1,0 +1,13 @@
+// "Remove branch" "false"
+// ACTION: Add braces to 'when' entry
+// ACTION: Add braces to all 'when' entries
+// ACTION: Enable a trailing comma by default in the formatter
+// ACTION: Remove condition
+fun test(x: Int): String {
+    return when (x) {
+        1 -> "1"
+        2 -> "2"
+        <caret>null, 3 -> "3"
+        else -> ""
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/when/removeRedundantCondition.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/when/removeRedundantCondition.kt
@@ -1,0 +1,11 @@
+// "Remove condition" "true"
+fun foo(): Int = 1
+
+fun println(i: Int) {}
+
+fun main() {
+    when (foo()) {
+        <caret>null, 1 -> println(1)
+        else -> println(0)
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/when/removeRedundantCondition.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/when/removeRedundantCondition.kt.after
@@ -1,0 +1,11 @@
+// "Remove condition" "true"
+fun foo(): Int = 1
+
+fun println(i: Int) {}
+
+fun main() {
+    when (foo()) {
+        1 -> println(1)
+        else -> println(0)
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19062