### PR TITLE
KTIJ-18878 Folding: functions with expression body and comment above the function are wrongly folded

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/KotlinFoldingBuilder.kt
@@ -116,9 +116,10 @@ class KotlinFoldingBuilder : CustomFoldingBuilder(), DumbAware {
     private fun getRangeToFold(node: ASTNode, document: Document): TextRange {
         if (node.elementType is KtFunctionElementType) {
             val function = node.psi as? KtNamedFunction
+            val funKeyword = function?.funKeyword
             val bodyExpression = function?.bodyExpression
-            if (bodyExpression != null && bodyExpression !is KtBlockExpression) {
-                if (function.startLine(document) != bodyExpression.startLine(document)) {
+            if (funKeyword != null && bodyExpression != null && bodyExpression !is KtBlockExpression) {
+                if (funKeyword.startLine(document) != bodyExpression.startLine(document)) {
                     val lineBreak = bodyExpression.siblings(forward = false, withItself = false).firstOrNull { "\n" in it.text }
                     if (lineBreak != null) {
                         return TextRange(lineBreak.startOffset, bodyExpression.endOffset)

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/folding/KotlinFoldingTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/folding/KotlinFoldingTestGenerated.java
@@ -30,6 +30,11 @@ public abstract class KotlinFoldingTestGenerated extends AbstractKotlinFoldingTe
             runTest("testData/folding/noCollapse/class.kt");
         }
 
+        @TestMetadata("commentAndSingleLineFunction.kt")
+        public void testCommentAndSingleLineFunction() throws Exception {
+            runTest("testData/folding/noCollapse/commentAndSingleLineFunction.kt");
+        }
+
         @TestMetadata("function.kt")
         public void testFunction() throws Exception {
             runTest("testData/folding/noCollapse/function.kt");

--- a/plugins/kotlin/idea/tests/testData/folding/noCollapse/commentAndSingleLineFunction.kt
+++ b/plugins/kotlin/idea/tests/testData/folding/noCollapse/commentAndSingleLineFunction.kt
@@ -1,0 +1,2 @@
+// comment
+fun test() = 1 + 1


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-18878