### PR TITLE
Update module_redeclarator.py for static funtions

### DIFF
--- a/python/helpers/generator3/module_redeclarator.py
+++ b/python/helpers/generator3/module_redeclarator.py
@@ -529,7 +529,7 @@ class ModuleRedeclarator(object):
             if p_name != "__new__" and type(descriptor).__name__.startswith('classmethod'):
                 # 'classmethod_descriptor' in Python 2.x and 3.x, 'classmethod' in Jython
                 deco = "classmethod"
-            elif type(p_func).__name__.startswith('staticmethod'):
+            elif type(descriptor).__name__.startswith('staticmethod'):
                 deco = "staticmethod"
         if p_name == "__new__":
             deco = "staticmethod"


### PR DESCRIPTION
Update python/helpers/generator3/module_redeclarator.py for static funtions. Change line 532 for staticmethod detection. The detailed information of the bug can be found in https://youtrack.jetbrains.com/issue/PY-49650 and https://youtrack.jetbrains.com/issue/PY-42380.