### PR TITLE
Small performance improvement for nested loop in Lombok plugin

### DIFF
--- a/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokLoggerHandler.java
+++ b/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokLoggerHandler.java
@@ -33,10 +33,12 @@ public class LombokLoggerHandler extends BaseLombokHandler {
     final boolean lombokLoggerIsStatic = AbstractLogProcessor.isLoggerStatic(psiClass);
 
     for (AbstractLogProcessor logProcessor : logProcessors) {
+      String loggerType = logProcessor.getLoggerType(psiClass); // null when the custom log's declaration is invalid
+      if (loggerType == null) {
+        continue;
+      }
       for (PsiField psiField : psiClass.getFields()) {
-        String loggerType = logProcessor.getLoggerType(psiClass); // null when the custom log's declaration is invalid
-        if (loggerType != null && psiField.getType().equalsToText(loggerType)
-          && checkLoggerField(psiField, lombokLoggerName, lombokLoggerIsStatic)) {
+        if (psiField.getType().equalsToText(loggerType) && checkLoggerField(psiField, lombokLoggerName, lombokLoggerIsStatic)) {
           processLoggerField(psiField, psiClass, logProcessor, lombokLoggerName);
         }
       }


### PR DESCRIPTION
The loggerType doesn't need to be reassigned on each nested loop and you can skip iterating the fields in general when loggerType is null.

Moved here from https://github.com/mplushnikov/lombok-intellij-plugin/pull/1053