### PR TITLE
KTIJ-19110 "Enum class is never used / Safe Delete" false positive when using `values()`

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
@@ -469,12 +469,16 @@ class UnusedSymbolInspection : AbstractKotlinInspection() {
 
         if (declaration is KtEnumEntry) {
             val enumClass = declaration.containingClass()?.takeIf { it.isEnum() }
-            if (enumClass != null
-                && ReferencesSearch.search(KotlinReferencesSearchParameters(enumClass, useScope)).any(::hasBuiltInEnumFunctionReference)
-            ) return true
+            if (hasBuiltInEnumFunctionReference(enumClass, useScope)) return true
         }
 
         return referenceUsed || checkPrivateDeclaration(declaration, descriptor)
+    }
+
+    private fun hasBuiltInEnumFunctionReference(enumClass: KtClass?, useScope: SearchScope): Boolean {
+        if (enumClass == null) return false
+        return enumClass.anyDescendantOfType(KtExpression::isReferenceToBuiltInEnumFunction) ||
+                ReferencesSearch.search(KotlinReferencesSearchParameters(enumClass, useScope)).any(::hasBuiltInEnumFunctionReference)
     }
 
     private fun hasBuiltInEnumFunctionReference(reference: PsiReference): Boolean {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -15254,6 +15254,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction.kt");
         }
 
+        @TestMetadata("usedEnumFunction10.kt")
+        public void testUsedEnumFunction10() throws Exception {
+            runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction10.kt");
+        }
+
         @TestMetadata("usedEnumFunction2.kt")
         public void testUsedEnumFunction2() throws Exception {
             runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction2.kt");
@@ -15287,6 +15292,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         @TestMetadata("usedEnumFunction8.kt")
         public void testUsedEnumFunction8() throws Exception {
             runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction8.kt");
+        }
+
+        @TestMetadata("usedEnumFunction9.kt")
+        public void testUsedEnumFunction9() throws Exception {
+            runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction9.kt");
         }
 
         @TestMetadata("withJvmNameUsedFromKotlin.kt")

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunction10.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunction10.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+enum class SomeEnum {
+    <caret>USED;
+
+    fun test() {
+        val f = ::valueOf
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunction9.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunction9.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+enum class SomeEnum {
+    <caret>USED;
+
+    fun test() {
+        values()
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19110