### PR TITLE
Use `F2` for renaming instead of `shift-F6`

### DIFF
--- a/platform/platform-resources/src/keymaps/VSCode.xml
+++ b/platform/platform-resources/src/keymaps/VSCode.xml
@@ -33,7 +33,7 @@
   </action>
   <action id="ChangesView.GroupBy.Directory" />
   <action id="ChangesView.Rename">
-    <keyboard-shortcut first-keystroke="shift f6" />
+    <keyboard-shortcut first-keystroke="f2" />
   </action>
   <action id="ChangesView.SetDefault" />
   <action id="CheckinProject" />
@@ -467,7 +467,7 @@
   <action id="SendEOF" />
   <action id="ShelveChanges.UnshelveWithDialog" />
   <action id="ShelvedChanges.Rename">
-    <keyboard-shortcut first-keystroke="shift f6" />
+    <keyboard-shortcut first-keystroke="f2" />
   </action>
   <action id="ShowBookmarks" />
   <action id="ShowContent" />


### PR DESCRIPTION
In vscode f2 is used for renaming but in the keymap it does not work for git rename commit so this changes it