### PR TITLE
KTIJ-19016 "Convert to lazy property" and "Convert property initializer to getter" intentions produce uncompilable code for `const val`

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertOrdinaryPropertyToLazyIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertOrdinaryPropertyToLazyIntention.kt
@@ -5,6 +5,7 @@ package org.jetbrains.kotlin.idea.intentions
 import com.intellij.openapi.editor.Editor
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.inspections.collections.isCalling
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtProperty
@@ -15,7 +16,8 @@ class ConvertOrdinaryPropertyToLazyIntention : SelfTargetingIntention<KtProperty
     KtProperty::class.java, KotlinBundle.lazyMessage("convert.to.lazy.property")
 ) {
     override fun isApplicableTo(element: KtProperty, caretOffset: Int): Boolean =
-        !element.isVar && element.initializer != null && element.getter == null && !element.isLocal
+        !element.isVar && element.initializer != null && element.getter == null && !element.isLocal &&
+                !element.hasModifier(KtTokens.CONST_KEYWORD)
 
     override fun applyTo(element: KtProperty, editor: Editor?) {
         val initializer = element.initializer ?: return

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyInitializerToGetterIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyInitializerToGetterIntention.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.quickfix.KotlinSingleIntentionActionFactory
 import org.jetbrains.kotlin.idea.util.hasJvmFieldAnnotation
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPsiFactory
@@ -24,10 +25,13 @@ class ConvertPropertyInitializerToGetterIntention : SelfTargetingRangeIntention<
     override fun applicabilityRange(element: KtProperty): TextRange? {
         val initializer = element.initializer ?: return null
         val nameIdentifier = element.nameIdentifier ?: return null
-        return if (element.getter == null && !element.isExtensionDeclaration() && !element.isLocal && !element.hasJvmFieldAnnotation())
-            TextRange(nameIdentifier.startOffset, initializer.endOffset)
-        else
-            null
+        if (element.getter != null ||
+            element.isExtensionDeclaration() ||
+            element.isLocal ||
+            element.hasJvmFieldAnnotation() ||
+            element.hasModifier(KtTokens.CONST_KEYWORD)
+        ) return null
+        return TextRange(nameIdentifier.startOffset, initializer.endOffset)
     }
 
     override fun allowCaretInsideElement(element: PsiElement): Boolean {

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyToFunctionIntention.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.idea.util.application.executeWriteCommand
 import org.jetbrains.kotlin.idea.util.application.runReadAction
 import org.jetbrains.kotlin.idea.util.hasJvmFieldAnnotation
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
@@ -203,6 +204,7 @@ class ConvertPropertyToFunctionIntention : SelfTargetingIntention<KtProperty>(
                 && !element.isLocal
                 && (element.initializer == null || element.getter == null)
                 && !element.hasJvmFieldAnnotation()
+                && !element.hasModifier(KtTokens.CONST_KEYWORD)
     }
 
     override fun applyTo(element: KtProperty, editor: Editor?) {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6053,6 +6053,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertOrdinaryPropertyToLazy/basic.kt");
         }
 
+        @TestMetadata("const.kt")
+        public void testConst() throws Exception {
+            runTest("testData/intentions/convertOrdinaryPropertyToLazy/const.kt");
+        }
+
         @TestMetadata("noInitializer.kt")
         public void testNoInitializer() throws Exception {
             runTest("testData/intentions/convertOrdinaryPropertyToLazy/noInitializer.kt");
@@ -6440,6 +6445,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
         }
 
+        @TestMetadata("const.kt")
+        public void testConst() throws Exception {
+            runTest("testData/intentions/convertPropertyInitializerToGetter/const.kt");
+        }
+
         @TestMetadata("errorType.kt")
         public void testErrorType() throws Exception {
             runTest("testData/intentions/convertPropertyInitializerToGetter/errorType.kt");
@@ -6526,6 +6536,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
         @TestMetadata("blockBody.kt")
         public void testBlockBody() throws Exception {
             runTest("testData/intentions/convertPropertyToFunction/blockBody.kt");
+        }
+
+        @TestMetadata("const.kt")
+        public void testConst() throws Exception {
+            runTest("testData/intentions/convertPropertyToFunction/const.kt");
         }
 
         @TestMetadata("delegatingProperty.kt")

--- a/plugins/kotlin/idea/tests/testData/intentions/convertOrdinaryPropertyToLazy/const.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertOrdinaryPropertyToLazy/const.kt
@@ -1,0 +1,2 @@
+// IS_APPLICABLE: false
+const val <caret>MY_VALUE = "FOO"

--- a/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/const.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/const.kt
@@ -1,0 +1,2 @@
+// IS_APPLICABLE: false
+const val <caret>MY_VALUE = "FOO"

--- a/plugins/kotlin/idea/tests/testData/intentions/convertPropertyToFunction/const.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertPropertyToFunction/const.kt
@@ -1,0 +1,2 @@
+// IS_APPLICABLE: false
+const val <caret>MY_VALUE = "FOO"


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19016