### PR TITLE
IDEA-194699 Use actual parent class when rerunning failed tests with Gradle.

### DIFF
--- a/plugins/gradle/java/src/action/GradleRerunFailedTestsAction.kt
+++ b/plugins/gradle/java/src/action/GradleRerunFailedTestsAction.kt
@@ -79,7 +79,13 @@ class GradleRerunFailedTestsAction(
     val location = testProxy.getLocation(project, projectScope)
     return when (val element = location?.psiElement) {
       is PsiClass -> TestLocationInfo(location, element, element)
-      is PsiMethod -> TestLocationInfo(location, element, element.containingClass, element)
+      is PsiMethod -> {
+        val parentLocation = testProxy.parent.getLocation(project, projectScope)
+        when (val parent = parentLocation?.psiElement) {
+          is PsiClass -> TestLocationInfo(location, element, parent, element)
+          else -> TestLocationInfo(location, element, element.containingClass, element)
+        }
+      }
       else -> TestLocationInfo(location)
     }
   }


### PR DESCRIPTION
Currently, the code-based enclosing class of a method is used to generate a rerun command for Gradle. This does not work well when the test is defined in a superclass though for two reasons

1) IntelliJ will display the parent class in the Tests window, even though it was showing the subclass during the failure
2) While it seems Gradle can still run e.g., `SuperClass.testMethod` when `SuperClass` is concrete, if it's abstract, it doesn't run at all. `SubClass.testMethod` works fine, and also displays the correct test name in the Tests window.