### PR TITLE
Support arbitrary parameterized tests by looking for square brackets

### DIFF
--- a/plugins/junit_rt/src/com/intellij/junit4/JUnit4TestRunnerUtil.java
+++ b/plugins/junit_rt/src/com/intellij/junit4/JUnit4TestRunnerUtil.java
@@ -235,6 +235,9 @@ public final class JUnit4TestRunnerUtil {
       }
       catch (NoSuchMethodException ignored) { }
     }
+    if(methodName.contains("[")) {
+      return true;
+    }
     return false;
   }
 


### PR DESCRIPTION
## Context

When filtering individual JUnit4 tests in IntelliJ, the runner will look for a method with the name of the test. For parameterized tests, there is no 1:1 relationship between test name and test method and so this fails.

For `junit.Parameterized` and test methods with parameters, there is an existing workaround for this in `JUnit4TestRunnerUtil`.

This PR supersedes https://github.com/JetBrains/intellij-community/pull/1617, which fixes the same problem in a different way.

## Problem when using TestParameterInjector

[TestParameterInjector](https://github.com/google/TestParameterInjector) is a runner developed at Google, and recently launched as open source project. In the last 2 months, [we had 6 different people asking us to fix this filtering issue in IntelliJ](https://github.com/google/TestParameterInjector/issues/6). The issue arises when fields are used for parameterization:

```java
@RunWith(TestParameterInjector.class)
public class MyTest {

  @TestParameter private boolean isOwner;

  @Test public void test() {...}
}
```

This will result in the following test names:

```
MyTest#test[isOwner=true]
MyTest#test[isOwner=false]
```

which will break the IntelliJ filtering.

## Proposed solution

If the test name contains a square bracket, have `isParameterized()` return `true`.

This makes sense because method names with brackets are illegal in Java. If `isParameterized()` would return `false` for a method with square brackets, its subsequent call to `clazz.getMethod()` would fail and nothing would be run. The logic triggered by `isParameterized()` is treating the test name as `methodName[otherstuff]`, which seems quite reasonable when there is a square bracket.
