### PR TITLE
KTIJ-19220 Context action "Convert concatenation to template" produces invalid code for "super.toString()" fragments.

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertToStringTemplateIntention.kt
@@ -73,7 +73,8 @@ open class ConvertToStringTemplateIntention : SelfTargetingOffsetIndependentInte
             if (expr == null) return ""
             val expression = KtPsiUtil.safeDeparenthesize(expr).let {
                 when {
-                    (it as? KtDotQualifiedExpression)?.isToString() == true -> it.receiverExpression
+                    (it as? KtDotQualifiedExpression)?.isToString() == true && it.receiverExpression !is KtSuperExpression ->
+                        it.receiverExpression
                     it is KtLambdaExpression && it.parent is KtLabeledExpression -> expr
                     else -> it
                 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -8536,6 +8536,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertToStringTemplate/stringPlusStringLiteral.kt");
         }
 
+        @TestMetadata("superToString.kt")
+        public void testSuperToString() throws Exception {
+            runTest("testData/intentions/convertToStringTemplate/superToString.kt");
+        }
+
         @TestMetadata("templatePlusStringLiteral.kt")
         public void testTemplatePlusStringLiteral() throws Exception {
             runTest("testData/intentions/convertToStringTemplate/templatePlusStringLiteral.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertToStringTemplate/superToString.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertToStringTemplate/superToString.kt
@@ -1,0 +1,4 @@
+class C {
+    override fun toString(): String =
+        <caret>super.toString() + " and more!"
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertToStringTemplate/superToString.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertToStringTemplate/superToString.kt.after
@@ -1,0 +1,4 @@
+class C {
+    override fun toString(): String =
+        "${super.toString()} and more!"
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19220