### PR TITLE
[kotlin] Test for printing variables when debugging reentrant inline functions

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinVariablePrintingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinVariablePrintingTestGenerated.java
@@ -52,4 +52,9 @@ public class KotlinVariablePrintingTestGenerated extends AbstractKotlinVariableP
     public void testOptimisedVariablesWithWhen() throws Exception {
         runTest("testData/variables/optimisedVariablesWithWhen.kt");
     }
+
+    @TestMetadata("reentrantInlineFunctions.kt")
+    public void testReentrantInlineFunctions() throws Exception {
+        runTest("testData/variables/reentrantInlineFunctions.kt");
+    }
 }

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/reentrantInlineFunctions.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/reentrantInlineFunctions.kt
@@ -1,0 +1,26 @@
+package reentrantInlineFunctions
+
+// SHOW_KOTLIN_VARIABLES
+
+fun main() {
+    val x = 0
+    //Breakpoint!
+    f(true) { x ->
+        //Breakpoint!
+        f(false) { x ->
+            //Breakpoint!
+            println()
+        }
+    }
+}
+
+inline fun f(b: Boolean, block: (Int) -> Unit) {
+    if (b) {
+        val x = 1
+        //Breakpoint!
+        block(x)
+    } else {
+        //Breakpoint!
+        block(2)
+    }
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/reentrantInlineFunctions.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/reentrantInlineFunctions.out
@@ -1,0 +1,26 @@
+LineBreakpoint created at reentrantInlineFunctions.kt:8
+LineBreakpoint created at reentrantInlineFunctions.kt:10
+LineBreakpoint created at reentrantInlineFunctions.kt:12
+LineBreakpoint created at reentrantInlineFunctions.kt:21
+LineBreakpoint created at reentrantInlineFunctions.kt:24
+Run Java
+Connected to the target VM
+reentrantInlineFunctions.kt:8
+KotlinStackFrame (reentrantInlineFunctions.kt:8)
+    JavaValue[local] x: int = 0 (reentrantInlineFunctions.kt:6)
+reentrantInlineFunctions.kt:21
+KotlinStackFrame (reentrantInlineFunctions.kt:21)
+    JavaValue[local] b: boolean = true (reentrantInlineFunctions.kt:17)
+    JavaValue[local] x: int = 1 (reentrantInlineFunctions.kt:19)
+reentrantInlineFunctions.kt:10
+KotlinStackFrame (reentrantInlineFunctions.kt:10)
+    JavaValue[local] x: int = 1 (reentrantInlineFunctions.kt:8)
+reentrantInlineFunctions.kt:24
+KotlinStackFrame (reentrantInlineFunctions.kt:24)
+    JavaValue[local] b: boolean = false (reentrantInlineFunctions.kt:17)
+reentrantInlineFunctions.kt:12
+KotlinStackFrame (reentrantInlineFunctions.kt:12)
+    JavaValue[local] x: int = 2 (reentrantInlineFunctions.kt:10)
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
This PR adds a test for the problem fixed in #1640 and adds some more comments to the code.

The underlying cause of the problem fixed in #1640 are reentrant inline functions with different variables. In this case, we don't see the scope introduction variables since they are hidden by later variables with the same name and the debug information appears to be inconsistent. Since we are only displaying the currently active inline call frame this is unlikely to be a problem in practice and we can simply hide inconsistent inlining locals.