### PR TITLE
PY-29257 PY-29564 Fix partially parameterized generic types, parameterized union types

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/psi/types/PyTypeChecker.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/psi/types/PyTypeChecker.java
@@ -688,7 +688,7 @@ public final class PyTypeChecker {
     return !collected.isEmpty();
   }
 
-  private static void collectGenerics(@Nullable PyType type,
+  public static void collectGenerics(@Nullable PyType type,
                                       @NotNull TypeEvalContext context,
                                       @NotNull Set<? super PyGenericType> collected,
                                       @NotNull Set<? super PyType> visited) {

--- a/python/testSrc/com/jetbrains/python/PyTypingTest.java
+++ b/python/testSrc/com/jetbrains/python/PyTypingTest.java
@@ -1523,6 +1523,32 @@ public class PyTypingTest extends PyTestCase {
            "expr: TypeAlias = int\n");
   }
 
+  // PY-29257
+  public void testParameterizedTypeAliasForPartiallyGenericType() {
+    doTest("dict[str, int]",
+           "from typing import TypeVar\n" +
+           "T = TypeVar('T')\n" +
+           "dict_t1 = dict[str, T]\n" +
+           "expr: dict_t1[int]");
+
+    doTest("dict[str, int]",
+           "from typing import TypeVar\n" +
+           "T = TypeVar('T')\n" +
+           "dict_t1 = dict[T, int]\n" +
+           "expr: dict_t1[str]");
+  }
+
+  // PY-49582
+  public void testParameterizedTypeAliasForGenericUnion() {
+    doTest("str | Awaitable[str] | None",
+           "from typing import Awaitable, Optional, TypeVar, Union\n" +
+           "T = TypeVar('T')\n" +
+           "Input = Union[T, Awaitable[T]]\n" +
+           "\n" +
+           "def f(expr: Optional[Input[str]]):\n" +
+           "    pass\n");
+  }
+
   // PY-44974
   public void testBitwiseOrUnionIsInstance() {
     doTest("str | dict | int",


### PR DESCRIPTION
This PR fixes Parameterized Types

Previously a type alias parameter was naïvely applied to the referenced type:
```
dict_t1 = dict[str, T]
dict_t2 = dict_t1[int]
expr: dict_t2
```
 the type  would be `dict[int]` , the first generic `str` would be lost.

Now the referenced type is properly scanned for generics, and substituted with the given parameter. This results in the proper type `dict[str, int]`

Additionally, parameterized aliases to union types were not properly recognized, usually resulting in `Any`

This was the cause for bad type hinting in for example Pulumi and Pytorch.


This fixes the following issues (mostly duplicates):
[PY-29257](https://youtrack.jetbrains.com/issue/PY-29257) Support partially specialized and generic type aliases 
[PY-29564](https://youtrack.jetbrains.com/issue/PY-29564) PyCharm doesn't understand TypeVar parametrisation
[PY-49582](https://youtrack.jetbrains.com/issue/PY-49582) Substituting Literal as TypeVar leads to Any 
[PY-29432](https://youtrack.jetbrains.com/issue/PY-29432) Support parameterizable aliases for generic types 
[PY-31707](https://youtrack.jetbrains.com/issue/PY-31707) Typing: Weird behavious when using Generics 
[PY-33329](https://youtrack.jetbrains.com/issue/PY-33329) Wrong detection of type hint with TypeVar in return type 
[PY-45861](https://youtrack.jetbrains.com/issue/PY-45861) Pulumi Inferred type Any 
[PY-45881](https://youtrack.jetbrains.com/issue/PY-45881) BUG: Duck-typing with complex types & `TypeVar` 
[PY-46320](https://youtrack.jetbrains.com/issue/PY-46320) PyCharm [2020.3.2] fails to infer nested generic type 
[PY-47797](https://youtrack.jetbrains.com/issue/PY-47797) Type Resolving in `torch` 1.8 Nightly for Custom Type Unions 
[PY-48669](https://youtrack.jetbrains.com/issue/PY-48669) Incorrect type inference 
[PY-49158](https://youtrack.jetbrains.com/issue/PY-49158) Support Generic aliases 