### PR TITLE
KTIJ-19319 Fix NPE in Gradle sync due wrong assignment of null to NotNull annotated setter

### DIFF
--- a/plugins/kotlin/gradle/gradle-idea/src/org/jetbrains/kotlin/idea/gradle/configuration/KotlinGradleSourceSetDataService.kt
+++ b/plugins/kotlin/gradle/gradle-idea/src/org/jetbrains/kotlin/idea/gradle/configuration/KotlinGradleSourceSetDataService.kt
@@ -178,7 +178,7 @@ class KotlinGradleLibraryDataService : AbstractProjectDataService<LibraryData, V
                 ideLibrary is LibraryEx &&
                 (ideLibrary.kind === JSLibraryKind || ideLibrary.kind === NativeLibraryKind || ideLibrary.kind === CommonLibraryKind)
             ) {
-                modifiableModel.kind = null
+                modifiableModel.forgetKind()
             }
         }
     }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19319

## Description

Theoretically the old code should **not compile**, because `var kind: PersistentLibraryKind<*>` is not null, but `null` is assigned.
Wrong caller:
https://github.com/JetBrains/intellij-community/blob/7e5833b36d485c6fc5a0886ea57ba46e8134f923/plugins/kotlin/gradle/gradle-idea/src/org/jetbrains/kotlin/idea/gradle/configuration/KotlinGradleSourceSetDataService.kt#L181

Definition:
https://github.com/JetBrains/intellij-community/blob/7e5833b36d485c6fc5a0886ea57ba46e8134f923/platform/projectModel-api/src/com/intellij/openapi/roots/impl/libraries/LibraryEx.java#L78
 
Implementation:
https://github.com/JetBrains/intellij-community/blob/5ad188a484f8825670523cd57bb5a4ed6c2a2087/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/LibraryModifiableModelBridgeImpl.kt#L276

Because the code compiles (how?), under some rare circumstances, this NPE is fired and a Gradle sync is not possible anymore. A reproducer is not possible.

## Solution

Because ModifiableModelEx offers a `forgetKind` method, I GUESSED, this could be the fix, as forgetKind resets the kind to UnknownLibraryKind: https://github.com/JetBrains/intellij-community/blob/bb655361dfbee9e969cff7086eac5894d97beafe/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/libraries/LibraryImpl.java#L455

Because it is not possible to reproduce the NPE, please check it!