### PR TITLE
Enhance PsiAugmentProvider: support for PsiMethod

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/MethodInnerStuffCache.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/MethodInnerStuffCache.java
@@ -1,0 +1,124 @@
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.psi.impl.source;
+
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.Ref;
+import com.intellij.psi.*;
+import com.intellij.psi.augment.PsiAugmentProvider;
+import com.intellij.psi.impl.light.LightParameterListBuilder;
+import com.intellij.psi.impl.light.LightReferenceListBuilder;
+import com.intellij.psi.impl.light.LightTypeParameterListBuilder;
+import com.intellij.psi.util.CachedValuesManager;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.containers.Interner;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class MethodInnerStuffCache {
+  private final PsiExtensibleMethod myMethod;
+  private final Ref<Pair<Long, Interner<PsiElement>>> myInterner = Ref.create();
+
+  public MethodInnerStuffCache(@NotNull PsiExtensibleMethod myMethod) {
+    this.myMethod = myMethod;
+  }
+
+  @NotNull
+  public PsiParameterList getParametersList(){
+    return CachedValuesManager.getProjectPsiDependentCache(myMethod, __ -> calcParameters());
+  }
+
+  @NotNull
+  public PsiTypeParameterList getTypeParametersList(){
+    return CachedValuesManager.getProjectPsiDependentCache(myMethod, __ -> calcTypeParameters());
+  }
+
+  @NotNull
+  public PsiReferenceList getThrowsList(){
+    return CachedValuesManager.getProjectPsiDependentCache(myMethod, __ -> calcThrows());
+  }
+
+  @Nullable
+  public PsiCodeBlock getBody(){
+    return CachedValuesManager.getProjectPsiDependentCache(myMethod, __ -> calcBody());
+  }
+
+  private @NotNull PsiParameterList calcParameters() {
+    LightParameterListBuilder builder = new LightParameterListBuilder(myMethod.getManager(), JavaLanguage.INSTANCE);
+    Arrays.stream(myMethod.getOwnParametersList().getParameters())
+      .forEach(builder::addParameter);
+    internMembers(PsiAugmentProvider.collectAugments(myMethod, PsiParameterList.class, null))
+      .stream()
+      .map(PsiParameterList::getParameters)
+      .flatMap(Arrays::stream)
+      .forEach(builder::addParameter);
+    return builder;
+  }
+
+  private @NotNull PsiTypeParameterList calcTypeParameters() {
+    LightTypeParameterListBuilder builder = new LightTypeParameterListBuilder(myMethod.getManager(), JavaLanguage.INSTANCE);
+    Arrays.stream(myMethod.getOwnTypeParametersList().getTypeParameters())
+      .forEach(builder::addParameter);
+    internMembers(PsiAugmentProvider.collectAugments(myMethod, PsiTypeParameterList.class, null))
+      .stream()
+      .map(PsiTypeParameterList::getTypeParameters)
+      .flatMap(Arrays::stream)
+      .forEach(builder::addParameter);
+    return builder;
+  }
+
+  private @NotNull PsiReferenceList calcThrows() {
+    LightReferenceListBuilder builder = new LightReferenceListBuilder(myMethod.getManager(), JavaLanguage.INSTANCE, PsiReferenceList.Role.THROWS_LIST);
+    Arrays.stream(myMethod.getOwnThrowsList().getReferencedTypes())
+      .forEach(builder::addReference);
+    internMembers(PsiAugmentProvider.collectAugments(myMethod, PsiReferenceList.class, null))
+      .stream()
+      .peek(this::checkReferenceList)
+      .map(PsiReferenceList::getReferencedTypes)
+      .flatMap(Arrays::stream)
+      .forEach(builder::addReference);
+    return builder;
+  }
+
+  private @Nullable PsiCodeBlock calcBody() {
+    PsiCodeBlock body = myMethod.getOwnBody();
+    if(body == null){
+      return null;
+    }
+
+    PsiCodeBlock result = (PsiCodeBlock) body.copy();
+    internMembers(PsiAugmentProvider.collectAugments(myMethod, PsiStatement.class, null))
+      .forEach(statement -> result.addBefore(statement, result.getFirstBodyElement()));
+    return result;
+  }
+
+  private void checkReferenceList(PsiReferenceList list){
+    if (list.getRole() == PsiReferenceList.Role.THROWS_LIST) {
+      return;
+    }
+
+    throw new IllegalArgumentException("Invalid augment for PsiExtensibleMethod: expected PsiReferenceList with role THROWS_LIST, got " + list.getRole().name());
+  }
+
+
+  @NotNull
+  private <T extends PsiElement> List<T> internMembers(List<T> members) {
+    return ContainerUtil.map(members, this::internMember);
+  }
+
+  private <T extends PsiElement> T internMember(T m) {
+    if (m == null) return null;
+    long modCount = myMethod.getManager().getModificationTracker().getModificationCount();
+    synchronized (myInterner) {
+      Pair<Long, Interner<PsiElement>> pair = myInterner.get();
+      if (pair == null || pair.first.longValue() != modCount) {
+        myInterner.set(pair = Pair.create(modCount, Interner.createWeakInterner()));
+      }
+      //noinspection unchecked
+      return (T)pair.second.intern(m);
+    }
+  }
+}

--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/PsiExtensibleMethod.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/PsiExtensibleMethod.java
@@ -1,0 +1,22 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.psi.impl.source;
+
+import com.intellij.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public interface PsiExtensibleMethod extends PsiMethod {
+  @NotNull
+  PsiParameterList getOwnParametersList();
+
+  @NotNull
+  PsiTypeParameterList getOwnTypeParametersList();
+
+  @NotNull
+  PsiReferenceList getOwnThrowsList();
+
+  @Nullable
+  PsiCodeBlock getOwnBody();
+}

--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/PsiMethodImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/PsiMethodImpl.java
@@ -30,6 +30,7 @@ import com.intellij.ui.icons.RowIcon;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.PlatformIcons;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.List;
@@ -37,7 +38,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class PsiMethodImpl extends JavaStubPsiElement<PsiMethodStub> implements PsiMethod, Queryable {
+public class PsiMethodImpl extends JavaStubPsiElement<PsiMethodStub> implements PsiExtensibleMethod, Queryable {
+  private final MethodInnerStuffCache myInnersCache;
   private SoftReference<PsiType> myCachedType;
 
   public PsiMethodImpl(final PsiMethodStub stub) {
@@ -46,10 +48,12 @@ public class PsiMethodImpl extends JavaStubPsiElement<PsiMethodStub> implements 
 
   protected PsiMethodImpl(final PsiMethodStub stub, final IStubElementType type) {
     super(stub, type);
+    this.myInnersCache = new MethodInnerStuffCache(this);
   }
 
   public PsiMethodImpl(final ASTNode node) {
     super(node);
+    this.myInnersCache = new MethodInnerStuffCache(this);
   }
 
   @Override
@@ -154,13 +158,34 @@ public class PsiMethodImpl extends JavaStubPsiElement<PsiMethodStub> implements 
   }
 
   @Override
-  public PsiTypeParameterList getTypeParameterList() {
+  public @NotNull PsiParameterList getParameterList() {
+    return myInnersCache.getParametersList();
+  }
+
+  @Override
+  public @NotNull PsiReferenceList getThrowsList() {
+    return myInnersCache.getThrowsList();
+  }
+
+  @Override
+  public @Nullable PsiCodeBlock getBody() {
+    return myInnersCache.getBody();
+  }
+
+  @Override
+  @NotNull
+  public PsiTypeParameterList getOwnTypeParametersList() {
     return getRequiredStubOrPsiChild(JavaStubElementTypes.TYPE_PARAMETER_LIST);
   }
 
   @Override
   public boolean hasTypeParameters() {
     return PsiImplUtil.hasTypeParameters(this);
+  }
+
+  @Override
+  public PsiTypeParameterList getTypeParameterList() {
+    return myInnersCache.getTypeParametersList();
   }
 
   @Override
@@ -200,7 +225,7 @@ public class PsiMethodImpl extends JavaStubPsiElement<PsiMethodStub> implements 
 
   @Override
   @NotNull
-  public PsiParameterList getParameterList() {
+  public PsiParameterList getOwnParametersList() {
     PsiParameterList list = getStubOrPsiChild(JavaStubElementTypes.PARAMETER_LIST);
     if (list == null) {
       return CachedValuesManager.getCachedValue(this, () -> {
@@ -228,7 +253,7 @@ public class PsiMethodImpl extends JavaStubPsiElement<PsiMethodStub> implements 
 
   @Override
   @NotNull
-  public PsiReferenceList getThrowsList() {
+  public PsiReferenceList getOwnThrowsList() {
     PsiReferenceList child = getStubOrPsiChild(JavaStubElementTypes.THROWS_LIST);
     if (child != null) return child;
 
@@ -240,7 +265,8 @@ public class PsiMethodImpl extends JavaStubPsiElement<PsiMethodStub> implements 
   }
 
   @Override
-  public PsiCodeBlock getBody() {
+  @Nullable
+  public PsiCodeBlock getOwnBody() {
     return (PsiCodeBlock)getNode().findChildByRoleAsPsiElement(ChildRole.METHOD_BODY);
   }
 


### PR DESCRIPTION
I was recently writing a plugin for IntelliJ and I noticed that PsiAugmentProvider only supports PsiClass. I've added support also for PsiMethod maintaining the same design choices and code style. I was also debating whether adding for PsiFIeld would be appropriate but I don't think that it makes any sense considering that PsiAugmentProvider already provides a way to change the modifiers or infer the type of a PsiElement which are the only use cases that I could think of for said element. On the other hand, adding support for augmenting the extend/implement/permit clause of a class seems to make sense also considering that it has been requested in the past on the IntelliJ forums. Before implementing that I was looking for some feedback on what has arleady been done though.