### PR TITLE
FIR IDE: fix IgnoreTests.handleTestWithWrongDirective

### DIFF
--- a/plugins/kotlin/completion/tests/testData/basic/common/FunctionVariableCallArgument.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/FunctionVariableCallArgument.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun f(p: (String) -> Unit, s: String) {
     p(<caret>)
 }

--- a/plugins/kotlin/completion/tests/testData/basic/common/InFunctionArguments.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/InFunctionArguments.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class Foo {
     fun add(a: Any) {}
 }

--- a/plugins/kotlin/completion/tests/testData/basic/common/TopLevelClassCompletionInQualifiedCall.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/TopLevelClassCompletionInQualifiedCall.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class Test {
     fun foo(a: Collection<String>) {
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/AnnotationTarget.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/AnnotationTarget.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 @<caret> annotation class Annotated
 
 // EXIST: Target

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/FunctionAnnotation1.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/FunctionAnnotation1.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/FunctionAnnotation2.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/FunctionAnnotation2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation1.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation1.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation2.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class SHello
 
 fun foo(@S<caret>) { }

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation3.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation3.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation4.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation4.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation5.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation5.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation6.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation6.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 val v = 1
 
 enum class InlineOption {

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation7.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation7.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun foo(@kotlin.<caret>) { }
 
 // INVOCATION_COUNT: 1

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation8.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation8.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation9.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotation9.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class SHello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotationArgs.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotationArgs.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 val v = 1
 
 enum class InlineOption {

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotationAutoPopup1.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotationAutoPopup1.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 val v = 1
 
 fun foo(@[S<caret>) { }

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotationAutoPopup2.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/ParameterAnnotationAutoPopup2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 val v = 1
 
 fun foo(@[volatile S<caret>) { }

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation1.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation1.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 package java
 
 annotation class Hello

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation2.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation3.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation3.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation4.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/annotations/TopLevelAnnotation4.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 annotation class Hello
 val v = 1
 

--- a/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/NonPredictableSmartCast1.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/NonPredictableSmartCast1.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.io.File
 
 class C : File("") {

--- a/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/NonPredictableSmartCast2.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/NonPredictableSmartCast2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.io.File
 
 class C : File("") {

--- a/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/SyntheticJavaProperties1.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/SyntheticJavaProperties1.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.io.File
 
 class C : File("") {

--- a/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/SyntheticJavaProperties2.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/java/boldOrGrayed/SyntheticJavaProperties2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.io.File
 
 fun foo(file: File) {

--- a/plugins/kotlin/completion/tests/testData/basic/multifile/GroovyClassNameCompletionFromDefaultPackage/GroovyClassNameCompletionFromDefaultPackage.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/multifile/GroovyClassNameCompletionFromDefaultPackage/GroovyClassNameCompletionFromDefaultPackage.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class TestKotlin
 
 val test = Test<caret>

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/annotation/AnnotationInBrackets.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/annotation/AnnotationInBrackets.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 package some
 
 annotation class AnnComplete

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/annotation/AnnotationInBrackets.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/annotation/AnnotationInBrackets.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 package some
 
 annotation class AnnComplete

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/override/KeepComments.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/override/KeepComments.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 abstract class Foo {
     abstract fun foo()
 }

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/override/KeepComments.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/override/KeepComments.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 abstract class Foo {
     abstract fun foo()
 }

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/Extension_receiverSufficient.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/Extension_receiverSufficient.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class JustClass<T>(val p: T)
 
 fun <T, U> JustClass<T>.chainExt(p: U): JustClass<U> = TODO()

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/Extension_receiverSufficient.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/Extension_receiverSufficient.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class JustClass<T>(val p: T)
 
 fun <T, U> JustClass<T>.chainExt(p: U): JustClass<U> = TODO()

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NoDuplicate.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NoDuplicate.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T> create(): List<T> = listOf()
 fun test() {
     val create: List<Int> = create<Int>().<caret>

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NoDuplicate.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NoDuplicate.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T> create(): List<T> = listOf()
 fun test() {
     val create: List<Int> = create<Int>().subList(<caret>)

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NotGeneric.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NotGeneric.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun Int.chain(): Int = this
 fun test() {
     val chain = 3001.chain().<caret>

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NotGeneric.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/NotGeneric.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun Int.chain(): Int = this
 fun test() {
     val chain = 3001.chain().minus(<caret>)

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_FunRef.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_FunRef.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 
 class S(val a: Int)

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_FunRef.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_FunRef.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 
 class S(val a: Int)

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 
 fun <U, V> createComparator(unused: U, keyExtractor: (V) -> String = { it.toString() }): Comparator<V> = TODO()

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 
 fun <U, V> createComparator(unused: U, keyExtractor: (V) -> String = { it.toString() }): Comparator<V> = TODO()

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument2.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 
 fun <U, V> createComparator(unused: U, keyExtractor: (V) -> String = { it.toString() }): Comparator<V> = TODO()

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument2.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaDefaultOverriddenArgument2.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 
 fun <U, V> createComparator(unused: U, keyExtractor: (V) -> String = { it.toString() }): Comparator<V> = TODO()

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaExplicitInferrable.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaExplicitInferrable.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T, R, C : MutableCollection<in R>> Iterable<T>.mapTo(destination: C, transform: (T) -> R): C = TODO()
 
 // T - from receiver type Iterable<T> => (T)

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaExplicitInferrable.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_LambdaExplicitInferrable.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T, R, C : MutableCollection<in R>> Iterable<T>.mapTo(destination: C, transform: (T) -> R): C = TODO()
 
 // T - from receiver type Iterable<T> => (T)

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_Variable.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_Variable.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 import java.util.function.ToIntFunction
 

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_Variable.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamFunc_Variable.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 import java.util.Comparator
 import java.util.function.ToIntFunction
 

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T> create(param: List<T>): List<T> = param
 
 // T - inferrable from 'param'

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T> create(param: List<T>): List<T> = param
 
 // T - inferrable from 'param'

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple_DefaultOverriddenArgument.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple_DefaultOverriddenArgument.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T: Number> create(param: List<T> = listOf(1 as T)): List<T> = TODO()
 
 // T - inferrable from 'param' argument

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple_DefaultOverriddenArgument.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/typeArgsForGenericFun/WithParamSimple_DefaultOverriddenArgument.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 fun <T: Number> create(param: List<T> = listOf(1 as T)): List<T> = TODO()
 
 // T - inferrable from 'param' argument

--- a/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget1.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget1.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class C(@<caret> val p: String)
 
 // ELEMENT: get

--- a/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget1.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget1.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class C(@get:<caret> val p: String)
 
 // ELEMENT: get

--- a/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget2.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget2.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class C(@<caret>Ann var p: String)
 
 // ELEMENT: set

--- a/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget2.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget2.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class C(@set:<caret>Ann var p: String)
 
 // ELEMENT: set

--- a/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget3.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget3.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class C(@<caret>get:Ann var p: String)
 
 // ELEMENT: set

--- a/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget3.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/keywords/UseSiteAnnotationTarget3.kt.after
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class C(@set:<caret>Ann var p: String)
 
 // ELEMENT: set

--- a/plugins/kotlin/completion/tests/testData/keywords/NoConstructorInCompanion.kt
+++ b/plugins/kotlin/completion/tests/testData/keywords/NoConstructorInCompanion.kt
@@ -1,3 +1,5 @@
+// FIR_IDENTICAL
+// FIR_COMPARISON
 class C {
     companion object {
         constr<caret>

--- a/plugins/kotlin/completion/tests/testData/keywords/NoConstructorInObject.kt
+++ b/plugins/kotlin/completion/tests/testData/keywords/NoConstructorInObject.kt
@@ -1,3 +1,5 @@
+// FIR_IDENTICAL
+// FIR_COMPARISON
 object O {
     constr<caret>
 }

--- a/plugins/kotlin/completion/tests/testData/keywords/NoConstructorInObjectLiteral.kt
+++ b/plugins/kotlin/completion/tests/testData/keywords/NoConstructorInObjectLiteral.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 class C {
     val o = object {
         con<caret>

--- a/plugins/kotlin/completion/tests/testData/keywords/NoValVarInFunctionParameters.kt
+++ b/plugins/kotlin/completion/tests/testData/keywords/NoValVarInFunctionParameters.kt
@@ -1,3 +1,5 @@
+// FIR_IDENTICAL
+// FIR_COMPARISON
 fun foo(v<caret>) {
 }
 

--- a/plugins/kotlin/completion/tests/testData/keywords/NoValVarInSecondaryConstructorParameters.kt
+++ b/plugins/kotlin/completion/tests/testData/keywords/NoValVarInSecondaryConstructorParameters.kt
@@ -1,3 +1,5 @@
+// FIR_IDENTICAL
+// FIR_COMPARISON
 class C {
     constructor(v<caret>)
 }

--- a/plugins/kotlin/frontend-independent/tests/test/org/jetbrains/kotlin/test/utils/IgnoreTests.kt
+++ b/plugins/kotlin/frontend-independent/tests/test/org/jetbrains/kotlin/test/utils/IgnoreTests.kt
@@ -126,15 +126,10 @@ object IgnoreTests {
             true -> "passes"
         }
 
-        val directiveIsOutdated = when {
-            !testPasses && directive is EnableOrDisableTestDirective.Enable -> true
-            testPasses && directive is EnableOrDisableTestDirective.Disable -> true
-            else -> false
-        }
-
-        val directiveIsMissing = !directiveIsOutdated
-
-        if (directiveIsMissing && INSERT_DIRECTIVE_AUTOMATICALLY) {
+        if (INSERT_DIRECTIVE_AUTOMATICALLY &&
+            (directive is EnableOrDisableTestDirective.Enable && testPasses ||
+                    directive is EnableOrDisableTestDirective.Disable && !testPasses)
+        ) {
             testFile.insertDirectivesToFileAndAdditionalFile(directive, additionalFiles, directivePosition)
             val filesWithDirectiveAdded = buildList {
                 add(testFile.fileName.toString())
@@ -145,11 +140,9 @@ object IgnoreTests {
             )
         }
 
-        if (directiveIsOutdated) {
-            throw AssertionError(
-                "Looks like the test $verb, please ${directive.fixDirectiveMessage} the ${testFile.fileName}"
-            )
-        }
+        throw AssertionError(
+            "Looks like the test $verb, please ${directive.fixDirectiveMessage} the ${testFile.fileName}"
+        )
     }
 
     private fun computeAdditionalFilesByExtensions(mainTestFile: Path, additionalFilesExtensions: List<String>): List<Path> {

--- a/plugins/kotlin/idea/tests/testData/findUsages/java/findJavaMethodUsages/OverridenArrayType.0.java
+++ b/plugins/kotlin/idea/tests/testData/findUsages/java/findJavaMethodUsages/OverridenArrayType.0.java
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: com.intellij.psi.PsiMethod
 // OPTIONS: overrides
 abstract public class MyJavaCLass {

--- a/plugins/kotlin/idea/tests/testData/findUsages/java/findJavaMethodUsages/OverridenRawGenericSignatureBase.0.java
+++ b/plugins/kotlin/idea/tests/testData/findUsages/java/findJavaMethodUsages/OverridenRawGenericSignatureBase.0.java
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: com.intellij.psi.PsiMethod
 // OPTIONS: overrides
 public interface Foo {

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/SAM.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/SAM.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/callableReferences.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/callableReferences.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/dataClass.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/dataClass.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/dataClassComponentByRef.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/dataClassComponentByRef.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 // FIND_BY_REF

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/dataClassInsideDataClass.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/dataClassInsideDataClass.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/for.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/for.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/isAndAs.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/isAndAs.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/lambdas.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/lambdas.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/mayTypeAffectAncestors.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/mayTypeAffectAncestors.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/when.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/conventions/components/when.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtParameter
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findFunctionUsages/enumFunctionUsages.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findFunctionUsages/enumFunctionUsages.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtNamedFunction
 // OPTIONS: usages
 enum class E {

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findFunctionUsages/javaAndKotlinOverrides.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findFunctionUsages/javaAndKotlinOverrides.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtNamedFunction
 // OPTIONS: overrides
 open class A<T> {

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findJavaPropertyUsages/javaPropertyUsagesKJK.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findJavaPropertyUsages/javaPropertyUsagesKJK.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtProperty
 // CHECK_SUPER_METHODS_YES_NO_DIALOG: no
 // OPTIONS: usages

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findJavaPropertyUsages/javaPropertyUsagesKK.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findJavaPropertyUsages/javaPropertyUsagesKK.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtProperty
 // CHECK_SUPER_METHODS_YES_NO_DIALOG: no
 // OPTIONS: usages

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findPrimaryConstructorUsages/missingName.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/findPrimaryConstructorUsages/missingName.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtPrimaryConstructor
 // OPTIONS: usages
 

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/internal/findFunctionUsages/enumFunctionUsages.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/internal/findFunctionUsages/enumFunctionUsages.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: org.jetbrains.kotlin.psi.KtNamedFunction
 // OPTIONS: usages
 enum class E {

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/propertyFiles/propertyFileUsagesByRef.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/propertyFiles/propertyFileUsagesByRef.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: com.intellij.lang.properties.psi.PropertiesFile
 // FIND_BY_REF
 import org.jetbrains.annotations.PropertyKey

--- a/plugins/kotlin/idea/tests/testData/findUsages/kotlin/propertyFiles/propertyUsagesByRef.0.kt
+++ b/plugins/kotlin/idea/tests/testData/findUsages/kotlin/propertyFiles/propertyUsagesByRef.0.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 // PSI_ELEMENT: com.intellij.lang.properties.psi.Property
 // FIND_BY_REF
 import org.jetbrains.annotations.PropertyKey

--- a/plugins/kotlin/idea/tests/testData/intentions/convertToBlockBody/valueIsAnonymousObject3.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertToBlockBody/valueIsAnonymousObject3.kt
@@ -1,3 +1,4 @@
+// IGNORE_FIR
 interface I1
 interface I2
 

--- a/plugins/kotlin/idea/tests/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt
@@ -3,3 +3,4 @@ fun test() {
     class A()
     ({ "" } as<caret> () -> String)
 }
+/* IGNORE_FIR */

--- a/plugins/kotlin/idea/tests/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/expressions/removeUselessCastForLambdaInParens4.kt.after
@@ -3,3 +3,4 @@ fun test() {
     class A()
     ({ "" })
 }
+/* IGNORE_FIR */

--- a/plugins/kotlin/idea/tests/testData/quickfix/expressions/uselessElvisForLambdaInNestedParens.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/expressions/uselessElvisForLambdaInNestedParens.kt
@@ -2,3 +2,5 @@
 fun test() {
     ((({ "" } <caret>?: null)))
 }
+
+/* IGNORE_FIR */

--- a/plugins/kotlin/idea/tests/testData/quickfix/expressions/uselessElvisForLambdaInNestedParens.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/expressions/uselessElvisForLambdaInNestedParens.kt.after
@@ -2,3 +2,5 @@
 fun test() {
     { "" }
 }
+
+/* IGNORE_FIR */

--- a/plugins/kotlin/idea/tests/testData/quickfix/wrapWithSafeLetCall/chainedCallTypeMismatch2.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/wrapWithSafeLetCall/chainedCallTypeMismatch2.kt
@@ -7,3 +7,5 @@ fun Int.foo(x: Int) = this + x
 val arg: Int? = 42
 
 val res: Int = 24.hashCode().foo(<caret>arg) + 1
+
+/* IGNORE_FIR */

--- a/plugins/kotlin/idea/tests/testData/quickfix/wrapWithSafeLetCall/chainedCallTypeMismatch2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/wrapWithSafeLetCall/chainedCallTypeMismatch2.kt.after
@@ -7,3 +7,5 @@ fun Int.foo(x: Int) = this + x
 val arg: Int? = 42
 
 val res: Int = arg?.let { 24.hashCode().foo(it) } + 1
+
+/* IGNORE_FIR */


### PR DESCRIPTION
Whenever this function is called, it means the directive is wrong. The current
check actually prevents the test from failing if it's missing a positive
directive