### PR TITLE
Ambiguous method reference is not highlighted when static and non-static methods in match

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/MethodReferenceResolver.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/MethodReferenceResolver.java
@@ -340,6 +340,9 @@ public class MethodReferenceResolver implements ResolveCache.PolyVariantContextR
               return null;
             }
           }
+        } else if (hasReceiver && varargs &&
+                   isCorrectAssignment(parameterTypes, functionalInterfaceParamTypes, interfaceMethod, true, conflict, 1)) {
+          return false;
         }
         return true;
       }

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticNonStaticWithVarargsReferenceTypeAmbiguity.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticNonStaticWithVarargsReferenceTypeAmbiguity.java
@@ -1,0 +1,15 @@
+class Test {
+
+  static class A {
+    void foo(A... as) {}
+    static void foo(A a) {}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A)' and 'foo(A...)' match">foo</error>;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticWithVarargsNonStaticReferenceTypeAmbiguity.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticWithVarargsNonStaticReferenceTypeAmbiguity.java
@@ -1,0 +1,15 @@
+class Test {
+
+  static class A {
+    void foo() {}
+    static void foo(A a, A... as) {}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A, A...)' and 'foo()' match">foo</error>;
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/NewMethodRefHighlightingTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/NewMethodRefHighlightingTest.java
@@ -86,6 +86,7 @@ public class NewMethodRefHighlightingTest extends LightDaemonAnalyzerTestCase {
       .forEach(info -> Assert.assertEquals("<html>Reference to 'm' is ambiguous, both 'm(Test, String)' and 'm(String)' match</html>",
                                            info.getToolTip()));
   }
+  public void testStaticWithVarargsNonStaticReferenceTypeAmbiguity() { doTest(); }
   public void testSuperClassPotentiallyApplicableMembers() { doTest(); }
   public void testExactMethodReferencePertinentToApplicabilityCheck() { doTest(); }
   public void testAmbiguityVarargs() { doTest(); }

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/NewMethodRefHighlightingTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/NewMethodRefHighlightingTest.java
@@ -87,6 +87,7 @@ public class NewMethodRefHighlightingTest extends LightDaemonAnalyzerTestCase {
                                            info.getToolTip()));
   }
   public void testStaticWithVarargsNonStaticReferenceTypeAmbiguity() { doTest(); }
+  public void testStaticNonStaticWithVarargsReferenceTypeAmbiguity() { doTest(); }
   public void testSuperClassPotentiallyApplicableMembers() { doTest(); }
   public void testExactMethodReferencePertinentToApplicabilityCheck() { doTest(); }
   public void testAmbiguityVarargs() { doTest(); }


### PR DESCRIPTION
This PR contains fixes of two problems. I combined them into one PR, as they look very similar and the second fix does not work without the first one.

### 1. IDEA-276613 Static varargs method and non-static method in match

#### How to reproduce the problem
There is ambiguous method reference `A::foo` in the following code snippet
```java
public class Main {

    static class A {
        void foo() {}
        static void foo(A a, A... as) {}
    }

    interface I {
        void bar(A a);
    }

    public static void main(String[] args) {
        I i = A::foo;
    }
}
```
Try to compile using javac 8, 11, 16
```
Main.java:13: error: incompatible types: invalid method reference
        I i = A::foo;
              ^
    reference to foo is ambiguous
      both method foo(A,A...) in A and method foo() in A match
1 error
```

#### Expected IDEA behavior
Red highlight `foo` with message
```
Reference to 'foo' is ambiguous, both 'foo(A, A...)' and 'foo()' match
```

#### Actual IDEA behavior
There is no highlight
<img width="919" alt="actual" src="https://user-images.githubusercontent.com/42293632/130364082-fb5e5c90-0cf3-480f-ba25-2cdce4f2270e.png">

Moreover, IDEA suggests to replace correct lambda with incorrect reference
<img width="717" alt="actuak1" src="https://user-images.githubusercontent.com/42293632/130364422-d8a65fd5-c9bb-4d6c-99cd-a681c8979fd0.png">

#### Why the reference is ambiguous
The method reference is ambiguous because 15.13.1 says
- If the first search produces a static method, and no non-static method is applicable during the second search, then the compile-time declaration is the result of the first search.
- Otherwise, if no static method is applicable during the first search, and the second search produces a non-static method, then the compile-time declaration is the result of the second search. 
- Otherwise, there is no compile-time declaration. 

The first search: `static foo(A, A...)`. The second search: `foo()`. Both conditions are failed so the reference is ambiguous.

#### Proposed solution
The patch adds check that one of the two conditions is true before `MethodReferenceConflictResolver#guardedOverloadResolution` returns the result.

### 2. IDEA-276614 Static method and non-static varargs  method in match

#### How to reproduce the problem
There is ambiguous method reference `A::foo` in the following code snippet
```java
public class Main {

    static class A {
        void foo(A... as) {}
        static void foo(A a) {}
    }

    interface I {
        void bar(A a);
    }

    public static void main(String[] args) {
        I i = A::foo;
    }
}
```
Try to compile using javac 8, 11, 16
```
Main.java:13: error: incompatible types: invalid method reference
        I i = A::foo;
              ^
    reference to foo is ambiguous
      both method foo(A) in A and method foo(A...) in A match
1 error
```

#### Expected IDEA behavior
Red highlight `foo` with message
```
Reference to 'foo' is ambiguous, both 'foo(A...)' and 'foo(A)' match
```

#### Actual IDEA behavior
There is no highlight
<img width="909" alt="actual2" src="https://user-images.githubusercontent.com/42293632/130367370-33e07b34-7d6b-4780-a19d-a8eebc48278c.png">

Moreover, IDEA suggests to replace correct lambda with incorrect reference
<img width="739" alt="actual3" src="https://user-images.githubusercontent.com/42293632/130367401-04fc0dfe-6776-472f-b6fa-81c8c3cf971e.png">

#### Why the reference is ambiguous
The method reference is ambiguous because 15.13.1 says
- If the first search produces a static method, and no non-static method is applicable during the second search, then the compile-time declaration is the result of the first search.
- Otherwise, if no static method is applicable during the first search, and the second search produces a non-static method, then the compile-time declaration is the result of the second search. 
- Otherwise, there is no compile-time declaration. 

The first search: `static foo(A)`. The second search: `foo(A...)`. Both conditions are failed so the reference is ambiguous.

#### Proposed solution 
Before the patch
The first search: `foo(A...)`, `static foo(A)`. The second search: `none`. It is wrong. `foo(A...)` should be in the second search because 15.3.1 says
"In the second search, if P1, ..., Pn is not empty and P1 is a subtype of ReferenceType, then the method reference expression is treated as if it were a method invocation expression with argument expressions of types P2, ..., Pn."
We can verify this by running
```
javac --debug dumpMethodReferenceSearchResults Main.java
```
<img width="615" alt="javac" src="https://user-images.githubusercontent.com/42293632/130368721-0005c8d6-19a6-4e9e-8a7a-37f44ef504ac.png">

The patch moves non-static varargs method from the first search to the second one.
