### PR TITLE
feat(vscode-macos-keymap): add actions of HOME, END and control A keys to keymap

### DIFF
--- a/platform/platform-resources/src/keymaps/VSCode OSX.xml
+++ b/platform/platform-resources/src/keymaps/VSCode OSX.xml
@@ -203,10 +203,13 @@
         <keyboard-shortcut first-keystroke="ctrl j" />
     </action>
     <action id="EditorLineEnd">
+        <keyboard-shortcut first-keystroke="END"/>
         <keyboard-shortcut first-keystroke="meta right" />
     </action>
     <action id="EditorLineStart">
+        <keyboard-shortcut first-keystroke="HOME"/>
         <keyboard-shortcut first-keystroke="meta left" />
+        <keyboard-shortcut first-keystroke="control A"/>
     </action>
     <action id="EditorMatchBrace">
         <keyboard-shortcut first-keystroke="shift meta back_slash" />


### PR DESCRIPTION
This pull request is created to solve the issue below.

### Issue

HOME key and control A combination won't move the cursor to the start of the line, 
END key won't move the cursor to the end of the line.

### Expect Behavior

Home key and control A combination move the cursor to the end of the line,
END key moves the cursor to the end of the line.