### PR TITLE
[kotlin] Fix AddNamesInCommentToJavaCallArgumentsIntention

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddNamesInCommentToJavaCallArgumentsIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/AddNamesInCommentToJavaCallArgumentsIntention.kt
@@ -1,14 +1,18 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package org.jetbrains.kotlin.idea.intentions
 
+import com.intellij.codeInsight.hints.AddToExcludeListCurrentMethodIntention
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.siblings
+import com.intellij.refactoring.suggested.startOffset
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.diagnostics.Severity
 import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassConstructorDescriptor
@@ -17,9 +21,11 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtLambdaArgument
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.components.isVararg
 import org.jetbrains.kotlin.resolve.calls.model.ArgumentMatch
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 class AddNamesInCommentToJavaCallArgumentsIntention: SelfTargetingIntention<KtCallExpression>(
@@ -29,14 +35,30 @@ class AddNamesInCommentToJavaCallArgumentsIntention: SelfTargetingIntention<KtCa
     override fun isApplicableTo(element: KtCallExpression, caretOffset: Int): Boolean {
         val arguments = element.valueArguments.filterNot { it is KtLambdaArgument }
         if (arguments.isEmpty() || arguments.any { it.isNamed() || it.hasBlockComment() }) return false
-        val resolvedCall = element.resolveToCall() ?: return false
+        val context = element.analyze(BodyResolveMode.PARTIAL_WITH_DIAGNOSTICS)
+        val resolvedCall = element.getResolvedCall(context) ?: return false
         val descriptor = resolvedCall.candidateDescriptor
         if (descriptor !is JavaMethodDescriptor && descriptor !is JavaClassConstructorDescriptor) return false
-        return arguments.size == arguments.resolve(resolvedCall).size
+        val resolvedArguments = arguments.resolve(resolvedCall)
+        if (arguments.size != resolvedArguments.size) return false
+        return resolvedArguments.none { (argument, _) ->
+            val argumentExpression = argument.getArgumentExpression()
+            argumentExpression == null || context.diagnostics.forElement(argumentExpression).any { it.severity == Severity.ERROR }
+        }
     }
 
     override fun applyTo(element: KtCallExpression, editor: Editor?) {
         val resolvedCall = element.resolveToCall() ?: return
+        val valueArgumentList = element.valueArgumentList ?: return
+        if (editor != null) {
+            editor.caretModel.moveToOffset(valueArgumentList.startOffset)
+            val addToExcludeListCurrentMethodIntention = AddToExcludeListCurrentMethodIntention()
+            val project = element.project
+            val file = element.containingKtFile
+            if (addToExcludeListCurrentMethodIntention.isAvailable(project, editor, file)) {
+                addToExcludeListCurrentMethodIntention.invoke(project, editor, file)
+            }
+        }
         val psiFactory = KtPsiFactory(element)
         for ((argument, parameter) in element.valueArguments.resolve(resolvedCall)) {
             val isVararg = parameter.isVararg

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -1651,6 +1651,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/addNamesInCommentToJavaCallArguments/methodCallWithNoArguments.kt");
         }
 
+        @TestMetadata("methodCallWithTypeMismatch.kt")
+        public void testMethodCallWithTypeMismatch() throws Exception {
+            runTest("testData/intentions/addNamesInCommentToJavaCallArguments/methodCallWithTypeMismatch.kt");
+        }
+
         @TestMetadata("methodCallWithVararg.kt")
         public void testMethodCallWithVararg() throws Exception {
             runTest("testData/intentions/addNamesInCommentToJavaCallArguments/methodCallWithVararg.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/addNamesInCommentToJavaCallArguments/methodCallWithTypeMismatch.1.java
+++ b/plugins/kotlin/idea/tests/testData/intentions/addNamesInCommentToJavaCallArguments/methodCallWithTypeMismatch.1.java
@@ -1,0 +1,3 @@
+public class Java {
+    public void test(int foo, int bar, long baz) {}
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/addNamesInCommentToJavaCallArguments/methodCallWithTypeMismatch.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/addNamesInCommentToJavaCallArguments/methodCallWithTypeMismatch.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// DISABLE-ERRORS
+fun test(j: Java) {
+    j.test<caret>(1, "", 3)
+}


### PR DESCRIPTION
- Disable inlay hints after adding comments
- Don't suggest when there are type mismatch arguments