### PR TITLE
KTIJ-3020 "Redundant 'inner' modifier" inspection should remove a receiver on the call site

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8791,6 +8791,36 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantInnerClassModifier/inLocalClass.kt");
         }
 
+        @TestMetadata("innerClassConstructorCall.kt")
+        public void testInnerClassConstructorCall() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall.kt");
+        }
+
+        @TestMetadata("innerClassConstructorCall2.kt")
+        public void testInnerClassConstructorCall2() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall2.kt");
+        }
+
+        @TestMetadata("innerClassConstructorCall3.kt")
+        public void testInnerClassConstructorCall3() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall3.kt");
+        }
+
+        @TestMetadata("innerClassConstructorCall4.kt")
+        public void testInnerClassConstructorCall4() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall4.kt");
+        }
+
+        @TestMetadata("innerClassConstructorCall5.kt")
+        public void testInnerClassConstructorCall5() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall5.kt");
+        }
+
+        @TestMetadata("innerClassConstructorCall6.kt")
+        public void testInnerClassConstructorCall6() throws Exception {
+            runTest("testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall6.kt");
+        }
+
         @TestMetadata("noOuterClassMemberReference.kt")
         public void testNoOuterClassMemberReference() throws Exception {
             runTest("testData/inspectionsLocal/redundantInnerClassModifier/noOuterClassMemberReference.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall.kt
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    <caret>inner class Inner
+
+    fun foo() {
+        Inner()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall.kt.after
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    class Inner
+
+    fun foo() {
+        Inner()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall2.kt
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    <caret>inner class Inner
+
+    fun foo() {
+        this.Inner()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall2.kt.after
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    class Inner
+
+    fun foo() {
+        Inner()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall3.kt
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    <caret>inner class Inner
+
+    fun foo(t: Test) {
+        t.Inner()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall3.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall3.kt.after
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    class Inner
+
+    fun foo(t: Test) {
+        Inner()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall4.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall4.kt
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    <caret>inner class Inner
+}
+
+fun foo(t: Test) {
+    t.Inner()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall4.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall4.kt.after
@@ -1,0 +1,9 @@
+package test
+
+class Test {
+    class Inner
+}
+
+fun foo(t: Test) {
+    Test.Inner()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall5.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall5.kt
@@ -1,0 +1,11 @@
+package test
+
+class Test {
+    <caret>inner class Foo {
+        inner class Bar
+    }
+}
+
+fun Test.foo(t: Test) {
+    Foo().Bar()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall5.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall5.kt.after
@@ -1,0 +1,11 @@
+package test
+
+class Test {
+    class Foo {
+        inner class Bar
+    }
+}
+
+fun Test.foo(t: Test) {
+    Test.Foo().Bar()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall6.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall6.kt
@@ -1,0 +1,11 @@
+package test
+
+class Test {
+    class Foo {
+        <caret>inner class Bar
+    }
+}
+
+fun Test.foo(t: Test) {
+    Test.Foo().Bar()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall6.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantInnerClassModifier/innerClassConstructorCall6.kt.after
@@ -1,0 +1,11 @@
+package test
+
+class Test {
+    class Foo {
+        class Bar
+    }
+}
+
+fun Test.foo(t: Test) {
+    Test.Foo.Bar()
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-3020