### PR TITLE
Test: Use canonicalFile for KotlinRoot.REPO for repos in paths with symlinks

### DIFF
--- a/plugins/kotlin/tests-common/test/org/jetbrains/kotlin/test/KotlinRoot.kt
+++ b/plugins/kotlin/tests-common/test/org/jetbrains/kotlin/test/KotlinRoot.kt
@@ -10,11 +10,11 @@ import java.nio.file.Path
 
 object KotlinRoot {
     @JvmField
-    val REPO: File = File(PathManager.getHomePath())
+    val REPO: File = File(PathManager.getHomePath()).canonicalFile
 
     @JvmField
     val DIR: File = REPO.resolve("community/plugins/kotlin").takeIf { it.exists() }
-        ?: File(PathManager.getCommunityHomePath()).resolve("plugins/kotlin")
+        ?: File(PathManager.getCommunityHomePath()).resolve("plugins/kotlin").canonicalFile
 
     @JvmField
     val DIR_PATH: Path = DIR.toPath()


### PR DESCRIPTION
I have my repo in a path with symlinks and some tests fail due to this (e.g., `ParameterInfoTestGenerated`). However I'm not sure how to run all the tests for the plugin locally.