### PR TITLE
IDEA-254311 Use Windows File Explorer for displaying directory content on WSL when xdg-open is unavailable

### DIFF
--- a/platform/util/src/com/intellij/openapi/util/SystemInfo.java
+++ b/platform/util/src/com/intellij/openapi/util/SystemInfo.java
@@ -10,7 +10,12 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Provides information about operating system, system-wide settings, and Java Runtime.
@@ -80,6 +85,21 @@ public final class SystemInfo {
   private static final NotNullLazyValue<Boolean> ourHasXdgOpen = PathExecLazyValue.create("xdg-open");
   public static boolean hasXdgOpen() {
     return isXWindow && ourHasXdgOpen.getValue();
+  }
+
+  public static boolean isWsl() {
+    Path path = Paths.get("/proc/version");
+    if (Files.exists(path)) {
+      try {
+        return isXWindow && Files.readAllLines(path).stream().anyMatch(line -> line.toLowerCase(Locale.ROOT).contains("microsoft"));
+      }
+      catch (IOException e) {
+        return false;
+      }
+    }
+    else {
+      return false;
+    }
   }
 
   private static final NotNullLazyValue<Boolean> ourHasXdgMime = PathExecLazyValue.create("xdg-mime");


### PR DESCRIPTION
Currently IDEA-Intellij reports the error message *This action isn't supported on the current platform* when it is installed and running inside of WSL that has no installed file explorer (like Nemo or Dolphin) and user attempts to view directory content in the default file manager (e.g. using *Show in File Explorer* action).

With this fix the directory content should be displayed in Windows File Explorer since it allows to browse file-system of WSL. This applies for both major versions of WSL.
In case that user already has set-up file explorer on WSL, *xdg-open* will still be used for displaying directory content.

https://youtrack.jetbrains.com/issue/IDEA-254311