### PR TITLE
FIR IDE: KotlinHighLevelFunctionParameterInfoHandler follow-ups

### DIFF
--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinHighLevelFunctionParameterInfoHandler.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/parameterInfo/KotlinHighLevelFunctionParameterInfoHandler.kt
@@ -115,7 +115,7 @@ abstract class KotlinHighLevelParameterInfoWithCallHandlerBase<TArgumentList : K
             }
 
             val candidates = resolvedCall?.targetFunction?.candidates ?: return null
-            context.itemsToShow = candidates.map { CandidateInfo(it.createPointer()) }.toTypedArray()
+            context.itemsToShow = candidates.map { CandidateInfo(it.createPointer(), it.deprecationStatus != null) }.toTypedArray()
 
             argumentList
         }
@@ -409,8 +409,7 @@ abstract class KotlinHighLevelParameterInfoWithCallHandlerBase<TArgumentList : K
         }
 
         val backgroundColor = if (isCallResolvedToCandidate) GREEN_BACKGROUND else context.defaultParameterColor
-        // TODO: Strikeout if deprecated. Deprecation status not currently in HL API
-        val strikeout = false
+        val strikeout = itemToShow.isDeprecated
 
         // Disabled when there are too many arguments.
         val allParametersUsed = usedParameterIndices.size == valueParameterCount
@@ -449,6 +448,7 @@ abstract class KotlinHighLevelParameterInfoWithCallHandlerBase<TArgumentList : K
 
     data class CandidateInfo(
         val candidate: KtSymbolPointer<KtFunctionLikeSymbol>,
+        val isDeprecated: Boolean,
         var callInfo: CallInfo? = null  // Populated in updateParameterInfo()
     )
 }

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/parameterInfo/utils.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/parameterInfo/utils.kt
@@ -2,8 +2,7 @@
 package org.jetbrains.kotlin.idea.parameterInfo
 
 import org.jetbrains.kotlin.idea.frontend.api.KtAnalysisSession
-import org.jetbrains.kotlin.idea.frontend.api.symbols.KtFunctionLikeSymbol
-import org.jetbrains.kotlin.idea.frontend.api.symbols.KtValueParameterSymbol
+import org.jetbrains.kotlin.idea.frontend.api.symbols.*
 import org.jetbrains.kotlin.idea.frontend.api.symbols.markers.KtSymbolWithVisibility
 import org.jetbrains.kotlin.psi.*
 
@@ -17,9 +16,7 @@ internal fun KtAnalysisSession.resolveCallCandidates(callElement: KtElement): Co
             val parent = callElement.parent
             val receiver = if (parent is KtDotQualifiedExpression && parent.selectorExpression == callElement) {
                 parent.receiverExpression
-            } else {
-                null
-            }
+            } else null
             Pair(callElement.resolveCall(), receiver)
         }
         is KtArrayAccessExpression -> Pair(callElement.resolveCall(), callElement.arrayExpression)
@@ -29,32 +26,39 @@ internal fun KtAnalysisSession.resolveCallCandidates(callElement: KtElement): Co
 
 
     val fileSymbol = callElement.containingKtFile.getFileSymbol()
-    return resolvedCall.targetFunction.candidates.filter { candidateSymbol ->
-        if (callElement is KtConstructorDelegationCall) {
-            // Exclude caller from candidates for `this(...)` delegated constructor calls.
-            // The parent of KtDelegatedConstructorCall should be the KtConstructor. We don't need to get the symbol for the constructor
-            // to determine if it's a self-call; we can just compare the candidate's PSI.
-            val candidatePsi = candidateSymbol.psi
-            if (candidatePsi != null && candidatePsi == callElement.parent) {
-                return@filter false
-            }
-        }
-
-        if (receiver != null) {
-            // Filter out candidates with wrong receiver
-            val receiverType = receiver.getKtType() ?: error("Receiver should have a KtType")
-            val candidateReceiverType = candidateSymbol.receiverType?.type
-            if (candidateReceiverType != null && receiverType.isNotSubTypeOf(candidateReceiverType)) return@filter false
-        }
-
-        // Filter out candidates not visible from call site
-        if (candidateSymbol is KtSymbolWithVisibility && !isVisible(candidateSymbol, fileSymbol, receiver, callElement)) return@filter false
-
-        true
-    }.map {
+    return resolvedCall.targetFunction.candidates.filter { filterCandidate(it, callElement, fileSymbol, receiver) }.map {
         // TODO: The argument mapping should also be per-candidate once we have all candidates available.
         CandidateWithMapping(it, resolvedCall.argumentMapping)
     }
+}
+
+internal fun KtAnalysisSession.filterCandidate(
+    candidateSymbol: KtSymbol,
+    callElement: KtElement,
+    fileSymbol: KtFileSymbol,
+    receiver: KtExpression?
+): Boolean {
+    if (callElement is KtConstructorDelegationCall) {
+        // Exclude caller from candidates for `this(...)` delegated constructor calls.
+        // The parent of KtDelegatedConstructorCall should be the KtConstructor. We don't need to get the symbol for the constructor
+        // to determine if it's a self-call; we can just compare the candidate's PSI.
+        val candidatePsi = candidateSymbol.psi
+        if (candidatePsi != null && candidatePsi == callElement.parent) {
+            return false
+        }
+    }
+
+    if (receiver != null && candidateSymbol is KtCallableSymbol) {
+        // Filter out candidates with wrong receiver
+        val receiverType = receiver.getKtType() ?: error("Receiver should have a KtType")
+        val candidateReceiverType = candidateSymbol.receiverType?.type
+        if (candidateReceiverType != null && receiverType.isNotSubTypeOf(candidateReceiverType)) return false
+    }
+
+    // Filter out candidates not visible from call site
+    if (candidateSymbol is KtSymbolWithVisibility && !isVisible(candidateSymbol, fileSymbol, receiver, callElement)) return false
+
+    return true
 }
 
 internal data class CandidateWithMapping(

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/parameterInfo/utils.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/parameterInfo/utils.kt
@@ -1,0 +1,48 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.kotlin.idea.parameterInfo
+
+import org.jetbrains.kotlin.idea.frontend.api.KtAnalysisSession
+import org.jetbrains.kotlin.idea.frontend.api.symbols.KtFunctionLikeSymbol
+import org.jetbrains.kotlin.idea.frontend.api.symbols.KtValueParameterSymbol
+import org.jetbrains.kotlin.idea.frontend.api.symbols.markers.KtSymbolWithVisibility
+import org.jetbrains.kotlin.psi.*
+
+// Analogous to Call.resolveCandidates() in plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/Utils.kt
+internal fun KtAnalysisSession.resolveCallCandidates(callElement: KtElement): Collection<CandidateWithMapping> {
+    // TODO: FE 1.0 plugin collects all candidates (i.e., all overloads), even if arguments do not match. Not just resolved call.
+    // See Call.resolveCandidates() in core/src/org/jetbrains/kotlin/idea/core/Utils.kt. Note `replaceCollectAllCandidates(true)`.
+
+    val (resolvedCall, receiver) = when (callElement) {
+        is KtCallElement -> {
+            val parent = callElement.parent
+            val receiver = if (parent is KtDotQualifiedExpression && parent.selectorExpression == callElement) {
+                parent.receiverExpression
+            } else {
+                null
+            }
+            Pair(callElement.resolveCall(), receiver)
+        }
+        is KtArrayAccessExpression -> Pair(callElement.resolveCall(), callElement.arrayExpression)
+        else -> return emptyList()
+    }
+    if (resolvedCall == null) return emptyList()
+
+
+    val fileSymbol = callElement.containingKtFile.getFileSymbol()
+    return resolvedCall.targetFunction.candidates.filter { candidateSymbol ->
+        // TODO: Filter out candidates with wrong receiver
+
+        // Filter out candidates not visible from call site
+        if (candidateSymbol is KtSymbolWithVisibility && !isVisible(candidateSymbol, fileSymbol, receiver, callElement)) return@filter false
+
+        true
+    }.map {
+        // TODO: The argument mapping should also be per-candidate once we have all candidates available.
+        CandidateWithMapping(it, resolvedCall.argumentMapping)
+    }
+}
+
+internal data class CandidateWithMapping(
+    val candidate: KtFunctionLikeSymbol,
+    val argumentMapping: LinkedHashMap<KtExpression, KtValueParameterSymbol>
+)

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
@@ -107,6 +107,11 @@ public abstract class FirParameterInfoTestGenerated extends AbstractFirParameter
             runTest("../idea/tests/testData/parameterInfo/functionCall/Deprecated.kt");
         }
 
+        @TestMetadata("DeprecatedHidden.kt")
+        public void testDeprecatedHidden() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/DeprecatedHidden.kt");
+        }
+
         @TestMetadata("deprecatedSinceKotlinApplicable.kt")
         public void testDeprecatedSinceKotlinApplicable() throws Exception {
             runTest("../idea/tests/testData/parameterInfo/functionCall/deprecatedSinceKotlinApplicable.kt");
@@ -220,6 +225,16 @@ public abstract class FirParameterInfoTestGenerated extends AbstractFirParameter
         @TestMetadata("NoAnnotations.kt")
         public void testNoAnnotations() throws Exception {
             runTest("../idea/tests/testData/parameterInfo/functionCall/NoAnnotations.kt");
+        }
+
+        @TestMetadata("NoCandidatesDeprecatedHidden.kt")
+        public void testNoCandidatesDeprecatedHidden() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/NoCandidatesDeprecatedHidden.kt");
+        }
+
+        @TestMetadata("NoCandidatesNotAccessible.kt")
+        public void testNoCandidatesNotAccessible() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/NoCandidatesNotAccessible.kt");
         }
 
         @TestMetadata("NoShadowedDeclarations.kt")

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
@@ -411,6 +411,36 @@ public abstract class FirParameterInfoTestGenerated extends AbstractFirParameter
         public void testUpdateOnTyping() throws Exception {
             runTest("../idea/tests/testData/parameterInfo/functionCall/UpdateOnTyping.kt");
         }
+
+        @TestMetadata("Vararg.kt")
+        public void testVararg() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/Vararg.kt");
+        }
+
+        @TestMetadata("VarargFirstArgTrailingComma.kt")
+        public void testVarargFirstArgTrailingComma() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/VarargFirstArgTrailingComma.kt");
+        }
+
+        @TestMetadata("VarargMultipleArgsTrailingComma.kt")
+        public void testVarargMultipleArgsTrailingComma() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/VarargMultipleArgsTrailingComma.kt");
+        }
+
+        @TestMetadata("VarargNamedArg.kt")
+        public void testVarargNamedArg() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/VarargNamedArg.kt");
+        }
+
+        @TestMetadata("VarargSpreadArg.kt")
+        public void testVarargSpreadArg() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/VarargSpreadArg.kt");
+        }
+
+        @TestMetadata("VarargUpdateOnTyping.kt")
+        public void testVarargUpdateOnTyping() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/VarargUpdateOnTyping.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
@@ -530,6 +530,21 @@ public abstract class FirParameterInfoTestGenerated extends AbstractFirParameter
             runTest("../idea/tests/testData/parameterInfo/typeArguments/JavaClassNoParens.kt");
         }
 
+        @TestMetadata("NoCandidatesDeprecatedHidden.kt")
+        public void testNoCandidatesDeprecatedHidden() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/typeArguments/NoCandidatesDeprecatedHidden.kt");
+        }
+
+        @TestMetadata("NoCandidatesNotAccessible.kt")
+        public void testNoCandidatesNotAccessible() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/typeArguments/NoCandidatesNotAccessible.kt");
+        }
+
+        @TestMetadata("NoCandidatesWrongReceiver.kt")
+        public void testNoCandidatesWrongReceiver() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/typeArguments/NoCandidatesWrongReceiver.kt");
+        }
+
         @TestMetadata("Overloads.kt")
         public void testOverloads() throws Exception {
             runTest("../idea/tests/testData/parameterInfo/typeArguments/Overloads.kt");

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
@@ -237,6 +237,16 @@ public abstract class FirParameterInfoTestGenerated extends AbstractFirParameter
             runTest("../idea/tests/testData/parameterInfo/functionCall/NoCandidatesNotAccessible.kt");
         }
 
+        @TestMetadata("NoCandidatesSelfDelegatedConstructorCall.kt")
+        public void testNoCandidatesSelfDelegatedConstructorCall() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/NoCandidatesSelfDelegatedConstructorCall.kt");
+        }
+
+        @TestMetadata("NoCandidatesWrongReceiver.kt")
+        public void testNoCandidatesWrongReceiver() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/NoCandidatesWrongReceiver.kt");
+        }
+
         @TestMetadata("NoShadowedDeclarations.kt")
         public void testNoShadowedDeclarations() throws Exception {
             runTest("../idea/tests/testData/parameterInfo/functionCall/NoShadowedDeclarations.kt");

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/parameterInfo/FirParameterInfoTestGenerated.java
@@ -377,6 +377,36 @@ public abstract class FirParameterInfoTestGenerated extends AbstractFirParameter
             runTest("../idea/tests/testData/parameterInfo/functionCall/TypeInference.kt");
         }
 
+        @TestMetadata("UnmappedAfterCurrent.kt")
+        public void testUnmappedAfterCurrent() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/UnmappedAfterCurrent.kt");
+        }
+
+        @TestMetadata("UnmappedBeforeCurrent.kt")
+        public void testUnmappedBeforeCurrent() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/UnmappedBeforeCurrent.kt");
+        }
+
+        @TestMetadata("UnmappedCurrent.kt")
+        public void testUnmappedCurrent() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/UnmappedCurrent.kt");
+        }
+
+        @TestMetadata("UnresolvedAfterCurrent.kt")
+        public void testUnresolvedAfterCurrent() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/UnresolvedAfterCurrent.kt");
+        }
+
+        @TestMetadata("UnresolvedBeforeCurrent.kt")
+        public void testUnresolvedBeforeCurrent() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/UnresolvedBeforeCurrent.kt");
+        }
+
+        @TestMetadata("UnresolvedCurrent.kt")
+        public void testUnresolvedCurrent() throws Exception {
+            runTest("../idea/tests/testData/parameterInfo/functionCall/UnresolvedCurrent.kt");
+        }
+
         @TestMetadata("UpdateOnTyping.kt")
         public void testUpdateOnTyping() throws Exception {
             runTest("../idea/tests/testData/parameterInfo/functionCall/UpdateOnTyping.kt");

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
@@ -710,7 +710,7 @@ public abstract class HighLevelQuickFixTestGenerated extends AbstractHighLevelQu
             runTest("../idea/tests/testData/quickfix/expressions/uselessElvisForLambdaInNecessaryNestedParens.kt");
         }
 
-        @TestMetadata("uselessElvisForHighLevelQuickFixTestGenerated.Expressions.testUselessElvisForLambdaInNestedParensLambdaInNestedParens.kt")
+        @TestMetadata("uselessElvisForLambdaInNestedParens.kt")
         public void testUselessElvisForLambdaInNestedParens() throws Exception {
             runTest("../idea/tests/testData/quickfix/expressions/uselessElvisForLambdaInNestedParens.kt");
         }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/MockParameterInfoUIContext.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/MockParameterInfoUIContext.java
@@ -13,7 +13,7 @@ public class MockParameterInfoUIContext implements ParameterInfoUIContext {
     private final PsiElement myParameterOwner;
     private final int myCurrentParameterIndex;
 
-    private final ArrayList<String> result = new ArrayList<String>();
+    private final ArrayList<String> result = new ArrayList<>();
 
     MockParameterInfoUIContext(PsiElement parameterOwner, int currentParameterIndex) {
         myParameterOwner = parameterOwner;
@@ -100,6 +100,9 @@ public class MockParameterInfoUIContext implements ParameterInfoUIContext {
     }
     
     public String getResultText() {
+        if (result.isEmpty()) {
+            return "NO_CANDIDATES";
+        }
         StringBuilder stringBuilder = new StringBuilder();
         Collections.sort(result);
         for (String s : result) {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -237,6 +237,16 @@ public abstract class ParameterInfoTestGenerated extends AbstractParameterInfoTe
             runTest("testData/parameterInfo/functionCall/NoCandidatesNotAccessible.kt");
         }
 
+        @TestMetadata("NoCandidatesSelfDelegatedConstructorCall.kt")
+        public void testNoCandidatesSelfDelegatedConstructorCall() throws Exception {
+            runTest("testData/parameterInfo/functionCall/NoCandidatesSelfDelegatedConstructorCall.kt");
+        }
+
+        @TestMetadata("NoCandidatesWrongReceiver.kt")
+        public void testNoCandidatesWrongReceiver() throws Exception {
+            runTest("testData/parameterInfo/functionCall/NoCandidatesWrongReceiver.kt");
+        }
+
         @TestMetadata("NoShadowedDeclarations.kt")
         public void testNoShadowedDeclarations() throws Exception {
             runTest("testData/parameterInfo/functionCall/NoShadowedDeclarations.kt");

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -377,6 +377,36 @@ public abstract class ParameterInfoTestGenerated extends AbstractParameterInfoTe
             runTest("testData/parameterInfo/functionCall/TypeInference.kt");
         }
 
+        @TestMetadata("UnmappedAfterCurrent.kt")
+        public void testUnmappedAfterCurrent() throws Exception {
+            runTest("testData/parameterInfo/functionCall/UnmappedAfterCurrent.kt");
+        }
+
+        @TestMetadata("UnmappedBeforeCurrent.kt")
+        public void testUnmappedBeforeCurrent() throws Exception {
+            runTest("testData/parameterInfo/functionCall/UnmappedBeforeCurrent.kt");
+        }
+
+        @TestMetadata("UnmappedCurrent.kt")
+        public void testUnmappedCurrent() throws Exception {
+            runTest("testData/parameterInfo/functionCall/UnmappedCurrent.kt");
+        }
+
+        @TestMetadata("UnresolvedAfterCurrent.kt")
+        public void testUnresolvedAfterCurrent() throws Exception {
+            runTest("testData/parameterInfo/functionCall/UnresolvedAfterCurrent.kt");
+        }
+
+        @TestMetadata("UnresolvedBeforeCurrent.kt")
+        public void testUnresolvedBeforeCurrent() throws Exception {
+            runTest("testData/parameterInfo/functionCall/UnresolvedBeforeCurrent.kt");
+        }
+
+        @TestMetadata("UnresolvedCurrent.kt")
+        public void testUnresolvedCurrent() throws Exception {
+            runTest("testData/parameterInfo/functionCall/UnresolvedCurrent.kt");
+        }
+
         @TestMetadata("UpdateOnTyping.kt")
         public void testUpdateOnTyping() throws Exception {
             runTest("testData/parameterInfo/functionCall/UpdateOnTyping.kt");

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -530,6 +530,21 @@ public abstract class ParameterInfoTestGenerated extends AbstractParameterInfoTe
             runTest("testData/parameterInfo/typeArguments/JavaClassNoParens.kt");
         }
 
+        @TestMetadata("NoCandidatesDeprecatedHidden.kt")
+        public void testNoCandidatesDeprecatedHidden() throws Exception {
+            runTest("testData/parameterInfo/typeArguments/NoCandidatesDeprecatedHidden.kt");
+        }
+
+        @TestMetadata("NoCandidatesNotAccessible.kt")
+        public void testNoCandidatesNotAccessible() throws Exception {
+            runTest("testData/parameterInfo/typeArguments/NoCandidatesNotAccessible.kt");
+        }
+
+        @TestMetadata("NoCandidatesWrongReceiver.kt")
+        public void testNoCandidatesWrongReceiver() throws Exception {
+            runTest("testData/parameterInfo/typeArguments/NoCandidatesWrongReceiver.kt");
+        }
+
         @TestMetadata("Overloads.kt")
         public void testOverloads() throws Exception {
             runTest("testData/parameterInfo/typeArguments/Overloads.kt");

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -107,6 +107,11 @@ public abstract class ParameterInfoTestGenerated extends AbstractParameterInfoTe
             runTest("testData/parameterInfo/functionCall/Deprecated.kt");
         }
 
+        @TestMetadata("DeprecatedHidden.kt")
+        public void testDeprecatedHidden() throws Exception {
+            runTest("testData/parameterInfo/functionCall/DeprecatedHidden.kt");
+        }
+
         @TestMetadata("deprecatedSinceKotlinApplicable.kt")
         public void testDeprecatedSinceKotlinApplicable() throws Exception {
             runTest("testData/parameterInfo/functionCall/deprecatedSinceKotlinApplicable.kt");
@@ -220,6 +225,16 @@ public abstract class ParameterInfoTestGenerated extends AbstractParameterInfoTe
         @TestMetadata("NoAnnotations.kt")
         public void testNoAnnotations() throws Exception {
             runTest("testData/parameterInfo/functionCall/NoAnnotations.kt");
+        }
+
+        @TestMetadata("NoCandidatesDeprecatedHidden.kt")
+        public void testNoCandidatesDeprecatedHidden() throws Exception {
+            runTest("testData/parameterInfo/functionCall/NoCandidatesDeprecatedHidden.kt");
+        }
+
+        @TestMetadata("NoCandidatesNotAccessible.kt")
+        public void testNoCandidatesNotAccessible() throws Exception {
+            runTest("testData/parameterInfo/functionCall/NoCandidatesNotAccessible.kt");
         }
 
         @TestMetadata("NoShadowedDeclarations.kt")

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/parameterInfo/ParameterInfoTestGenerated.java
@@ -411,6 +411,36 @@ public abstract class ParameterInfoTestGenerated extends AbstractParameterInfoTe
         public void testUpdateOnTyping() throws Exception {
             runTest("testData/parameterInfo/functionCall/UpdateOnTyping.kt");
         }
+
+        @TestMetadata("Vararg.kt")
+        public void testVararg() throws Exception {
+            runTest("testData/parameterInfo/functionCall/Vararg.kt");
+        }
+
+        @TestMetadata("VarargFirstArgTrailingComma.kt")
+        public void testVarargFirstArgTrailingComma() throws Exception {
+            runTest("testData/parameterInfo/functionCall/VarargFirstArgTrailingComma.kt");
+        }
+
+        @TestMetadata("VarargMultipleArgsTrailingComma.kt")
+        public void testVarargMultipleArgsTrailingComma() throws Exception {
+            runTest("testData/parameterInfo/functionCall/VarargMultipleArgsTrailingComma.kt");
+        }
+
+        @TestMetadata("VarargNamedArg.kt")
+        public void testVarargNamedArg() throws Exception {
+            runTest("testData/parameterInfo/functionCall/VarargNamedArg.kt");
+        }
+
+        @TestMetadata("VarargSpreadArg.kt")
+        public void testVarargSpreadArg() throws Exception {
+            runTest("testData/parameterInfo/functionCall/VarargSpreadArg.kt");
+        }
+
+        @TestMetadata("VarargUpdateOnTyping.kt")
+        public void testVarargUpdateOnTyping() throws Exception {
+            runTest("testData/parameterInfo/functionCall/VarargUpdateOnTyping.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/arrayAccess/UpdateOnTypingSet.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/arrayAccess/UpdateOnTypingSet.kt
@@ -1,4 +1,3 @@
-// IGNORE_FIR
 class A {
     operator fun get(x: Int) {}
     operator fun set(x: String, y: Int, value: Int) {}

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/DeprecatedHidden.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/DeprecatedHidden.kt
@@ -1,0 +1,9 @@
+@Deprecated("", level = DeprecationLevel.HIDDEN) fun f(x: Int) = 2
+fun f(x: Int, y: Boolean) = 3
+
+fun d(x: Int) {
+    f(<caret>1)
+}
+/*
+Text: (<highlight>x: Int</highlight>, y: Boolean), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/LocalFunctionBug.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/LocalFunctionBug.kt
@@ -1,4 +1,3 @@
-// IGNORE_FIR
 fun foo() {
     fun fff(p: String, c: Char) {}
 

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesDeprecatedHidden.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesDeprecatedHidden.kt
@@ -1,0 +1,8 @@
+// IGNORE_FIR
+// TODO: @Deprecated(HIDDEN) candidates should be as if unresolved
+@Deprecated("", level = DeprecationLevel.HIDDEN) fun f(x: Int) = 2
+
+fun d(x: Int) {
+    f(<caret>1)
+}
+// NO_CANDIDATES

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesNotAccessible.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesNotAccessible.kt
@@ -1,0 +1,8 @@
+class C {
+    protected fun foo(p: Int){}
+}
+
+fun f(c: C) {
+    c.foo(<caret>1)
+}
+// NO_CANDIDATES

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesSelfDelegatedConstructorCall.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesSelfDelegatedConstructorCall.kt
@@ -1,0 +1,5 @@
+class B {
+    constructor() : this(<caret>)
+}
+
+// NO_CANDIDATES

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesWrongReceiver.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NoCandidatesWrongReceiver.kt
@@ -1,0 +1,6 @@
+fun String.foo(p: Int){}
+
+fun f(a: Any) {
+    a.foo(<caret>1)
+}
+// NO_CANDIDATES

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NotGreen.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NotGreen.kt
@@ -1,3 +1,5 @@
+// IGNORE_FIR
+// TODO: Fails because no argument mapping is available when there are multiple ambiguous candidates
 open class A(x: Int) {
     fun m(x: Int, y: Boolean) = 2
     fun m(x: Int) = 1

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NotGreen.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/NotGreen.kt
@@ -1,5 +1,3 @@
-// IGNORE_FIR
-// TODO: Fails because no argument mapping is available when there are multiple ambiguous candidates
 open class A(x: Int) {
     fun m(x: Int, y: Boolean) = 2
     fun m(x: Int) = 1

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnmappedAfterCurrent.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnmappedAfterCurrent.kt
@@ -1,0 +1,8 @@
+fun m(x: Int, y: Boolean) = 2
+
+fun d() {
+    m(<caret>y = false, unmapped = false)
+}
+/*
+Text: (<highlight>[y: Boolean]</highlight>, [x: Int]), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnmappedBeforeCurrent.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnmappedBeforeCurrent.kt
@@ -1,0 +1,8 @@
+fun m(x: Int, y: Boolean) = 2
+
+fun d() {
+    m(unmapped = 1, <caret>y = false)
+}
+/*
+Text: (<highlight>[y: Boolean]</highlight>, [x: Int]), Disabled: true, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnmappedCurrent.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnmappedCurrent.kt
@@ -1,0 +1,8 @@
+fun m(x: Int, y: Boolean) = 2
+
+fun d() {
+    m(y = false, <caret>unmapped = false)
+}
+/*
+Text: (<disabled>[y: Boolean],</disabled><highlight> </highlight>[x: Int]), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnresolvedAfterCurrent.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnresolvedAfterCurrent.kt
@@ -1,0 +1,8 @@
+fun m(x: Int, y: Boolean) = 2
+
+fun d() {
+    m(1, <caret>unresolved)
+}
+/*
+Text: (x: Int, <highlight>y: Boolean</highlight>), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnresolvedBeforeCurrent.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnresolvedBeforeCurrent.kt
@@ -1,0 +1,8 @@
+fun m(x: Int, y: Boolean) = 2
+
+fun d() {
+    m(unresolved, <caret>true)
+}
+/*
+Text: (x: Int, <highlight>y: Boolean</highlight>), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnresolvedCurrent.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UnresolvedCurrent.kt
@@ -1,0 +1,8 @@
+fun m(x: Int, y: Boolean) = 2
+
+fun d() {
+    m(<caret>1, unresolved)
+}
+/*
+Text: (<highlight>x: Int</highlight>, y: Boolean), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UpdateOnTyping.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/UpdateOnTyping.kt
@@ -1,4 +1,3 @@
-// IGNORE_FIR
 fun fff(p: String, c: Char) {}
 
 fun foo() {

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/Vararg.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/Vararg.kt
@@ -1,0 +1,8 @@
+fun m(x: Boolean, vararg y: Int) = 2
+
+fun d() {
+    m(true, 1, <caret>2)
+}
+/*
+Text: (x: Boolean, <highlight>vararg y: Int</highlight>), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargFirstArgTrailingComma.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargFirstArgTrailingComma.kt
@@ -1,0 +1,8 @@
+fun m(x: Boolean, vararg y: Int) = 2
+
+fun d() {
+    m(true,<caret>)
+}
+/*
+Text: (x: Boolean, <highlight>vararg y: Int</highlight>), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargMultipleArgsTrailingComma.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargMultipleArgsTrailingComma.kt
@@ -1,0 +1,8 @@
+fun m(x: Boolean, vararg y: Int) = 2
+
+fun d() {
+    m(true, 1, 2,<caret>)
+}
+/*
+Text: (x: Boolean, <highlight>vararg y: Int</highlight>), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargNamedArg.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargNamedArg.kt
@@ -1,0 +1,9 @@
+fun m(x: Boolean, vararg y: Int) = 2
+
+fun d() {
+    val a = intArrayOf(1, 2, 3)
+    m(y = <caret>a, x = true)
+}
+/*
+Text: (<highlight>[vararg y: Int]</highlight>, [x: Boolean]), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargSpreadArg.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargSpreadArg.kt
@@ -1,0 +1,9 @@
+fun m(x: Boolean, vararg y: Int) = 2
+
+fun d() {
+    val a = intArrayOf(1, 2, 3)
+    m(true, 1, *a<caret>, 4)
+}
+/*
+Text: (x: Boolean, <highlight>vararg y: Int</highlight>), Disabled: false, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargUpdateOnTyping.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/VarargUpdateOnTyping.kt
@@ -1,0 +1,11 @@
+fun m(x: Boolean, vararg y: Int) = 2
+
+fun d() {
+    m(true, <caret>)
+}
+
+// TYPE: "true, "
+
+/*
+Text: (x: Boolean, <highlight>vararg y: Int</highlight>), Disabled: true, Strikeout: false, Green: true
+*/

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/deprecatedSinceKotlinApplicable.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/functionCall/deprecatedSinceKotlinApplicable.kt
@@ -1,4 +1,3 @@
-// IGNORE_FIR
 @Suppress("DEPRECATED_SINCE_KOTLIN_OUTSIDE_KOTLIN_SUBPACKAGE")
 @Deprecated("")
 @DeprecatedSinceKotlin(warningSince = "1.0")

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/typeArguments/NoCandidatesDeprecatedHidden.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/typeArguments/NoCandidatesDeprecatedHidden.kt
@@ -1,0 +1,8 @@
+// IGNORE_FIR
+// TODO: @Deprecated(HIDDEN) candidates should be as if unresolved
+@Deprecated("", level = DeprecationLevel.HIDDEN) fun <T> f(x: Int): T? = null
+
+fun d(x: Int) {
+    f<<caret>>(1)
+}
+// NO_CANDIDATES

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/typeArguments/NoCandidatesNotAccessible.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/typeArguments/NoCandidatesNotAccessible.kt
@@ -1,0 +1,8 @@
+class C {
+    protected fun <T> foo(p: Int): T? = null
+}
+
+fun f(c: C) {
+    c.foo<<caret>>(1)
+}
+// NO_CANDIDATES

--- a/plugins/kotlin/idea/tests/testData/parameterInfo/typeArguments/NoCandidatesWrongReceiver.kt
+++ b/plugins/kotlin/idea/tests/testData/parameterInfo/typeArguments/NoCandidatesWrongReceiver.kt
@@ -1,0 +1,6 @@
+fun <T> String.foo(p: Int): T? = null
+
+fun f(a: Any) {
+    a.foo<<caret>>(1)
+}
+// NO_CANDIDATES


### PR DESCRIPTION
1. Strikeout deprecated candidates.
2. Disabled candidates when there are arguments before the current argument that don't match the corresponding parameter type (i.e., type mismatch). Added more tests.
3. Properly handle `vararg` parameter arguments. The computation for which parameter to highlight did not account for multiple arguments for `vararg` parameters, which was pretty obvious in retrospect. Added more tests. Requires [KOTLIN-MR-188](https://kotlin.jetbrains.space/p/kotlin/reviews/188/files).