### PR TITLE
KTIJ-11380 Live template for "iter" generates illegal $VAR$ template variable name `object` for `Iterable<Object>`

### DIFF
--- a/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt
+++ b/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/KotlinNameSuggester.kt
@@ -100,7 +100,7 @@ object KotlinNameSuggester {
         val result = LinkedHashSet<String>()
 
         suggestNamesByExpressionOnly(collection, bindingContext, { true })
-            .mapNotNull { StringUtil.unpluralize(it) }
+            .mapNotNull { name -> StringUtil.unpluralize(name).takeUnless { it.isKeyword() } }
             .mapTo(result) { suggestNameByName(it, validator) }
 
         result.addNamesByType(elementType, validator)
@@ -111,6 +111,8 @@ object KotlinNameSuggester {
 
         return result
     }
+
+    private fun String?.isKeyword() = this in KtTokens.KEYWORDS.types.map { it.toString() }
 
     fun suggestNamesByFqName(
         fqName: FqName,

--- a/plugins/kotlin/live-templates/tests/test/org/jetbrains/kotlin/idea/liveTemplates/LiveTemplatesTest.kt
+++ b/plugins/kotlin/live-templates/tests/test/org/jetbrains/kotlin/idea/liveTemplates/LiveTemplatesTest.kt
@@ -192,6 +192,12 @@ class LiveTemplatesTest : KotlinLightCodeInsightFixtureTestCase() {
         checkAfter()
     }
 
+    fun testIter_ForKeywordVariable() {
+        start()
+        nextTab(2)
+        checkAfter()
+    }
+
     fun testAnonymous_1() {
         start()
 

--- a/plugins/kotlin/live-templates/tests/testData/iter_ForKeywordVariable.exp.kt
+++ b/plugins/kotlin/live-templates/tests/testData/iter_ForKeywordVariable.exp.kt
@@ -1,0 +1,5 @@
+fun f(objects: List<String>) {
+    for (s in objects) {
+
+    }
+}

--- a/plugins/kotlin/live-templates/tests/testData/iter_ForKeywordVariable.kt
+++ b/plugins/kotlin/live-templates/tests/testData/iter_ForKeywordVariable.kt
@@ -1,0 +1,3 @@
+fun f(objects: List<String>) {
+    <caret>
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-11380