### PR TITLE
IDEA-277826 Do not create test configurations when no test sources found

### DIFF
--- a/plugins/gradle/java/src/execution/test/runner/AllInDirectoryGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/AllInDirectoryGradleConfigurationProducer.java
@@ -115,6 +115,7 @@ public final class AllInDirectoryGradleConfigurationProducer extends GradleTestR
     PsiFileSystemItem directory = (PsiFileSystemItem)contextLocation;
     if (!directory.isDirectory()) return null;
     List<VirtualFile> sources = findTestSourcesUnderDirectory(module, directory.getVirtualFile());
+    if (sources.isEmpty()) return null;
     return new ConfigurationData(module, directory, sources, projectPath);
   }
 


### PR DESCRIPTION
When creating configurations for AllInDirectoryGradleConfigurationProducer, take into consideration the
fact of actual test sources being available within the given context
location.