### PR TITLE
PY-49452: Do not use distutils package in pytest runner

### DIFF
--- a/python/helpers/pycharm/_jb_pytest_runner.py
+++ b/python/helpers/pycharm/_jb_pytest_runner.py
@@ -3,7 +3,6 @@
 #  Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 
 import pytest
-from distutils import version
 import sys
 from _pytest.config import get_plugin_manager
 from pkg_resources import iter_entry_points
@@ -30,7 +29,7 @@ if __name__ == '__main__':
     args = sys.argv[1:]
     if "--jb-show-summary" in args:
         args.remove("--jb-show-summary")
-    elif version.LooseVersion(pytest.__version__) >= version.LooseVersion("6.0"):
+    elif int(pytest.__version__.split('.')[0]) >= 6:
         args += ["--no-header", "--no-summary", "-q"]
 
     if JB_DISABLE_BUFFERING and "-s" not in args:


### PR DESCRIPTION
As it's slated for removal in 3.12 and 3.10 now shows a red deprecation warning.