### PR TITLE
KTIJ-19591 'Property could be private' causes compile error when property is used in annotation

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -6760,6 +6760,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         public void testSubObjectFunctionCall() throws Exception {
             runTest("testData/inspectionsLocal/memberVisibilityCanBePrivate/subObjectFunctionCall.kt");
         }
+
+        @TestMetadata("usedInAnnotationOnContainingObject.kt")
+        public void testUsedInAnnotationOnContainingObject() throws Exception {
+            runTest("testData/inspectionsLocal/memberVisibilityCanBePrivate/usedInAnnotationOnContainingObject.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/usedInAnnotationOnContainingObject.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/usedInAnnotationOnContainingObject.kt
@@ -1,0 +1,9 @@
+// WITH_RUNTIME
+// PROBLEM: none
+
+annotation class Annotation(val value: String)
+
+@Annotation(Test.ID)
+object Test {
+    const val <caret>ID = "test"
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19591