### PR TITLE
KTIJ-18325 ReplaceWith quickfix changes receiver variable to `this` for generic function call with `out` type parameter

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInliner/CodeToInlineBuilder.kt
@@ -37,6 +37,7 @@ import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.resolve.scopes.receivers.ImplicitReceiver
 import org.jetbrains.kotlin.resolve.scopes.utils.findClassifier
 import org.jetbrains.kotlin.types.ErrorUtils
+import org.jetbrains.kotlin.types.typeUtil.unCapture
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import org.jetbrains.kotlin.utils.sure
@@ -357,7 +358,7 @@ class CodeToInlineBuilder(
                         val resolutionScope = expression.getResolutionScope(bindingContext, resolutionFacade)
                         val receiverExpressionToInline = receiver.asExpression(resolutionScope, psiFactory)
                         if (receiverExpressionToInline != null) {
-                            val receiverType = receiver.type
+                            val receiverType = receiver.type.unCapture()
                             codeToInline.addPreCommitAction(expressionToResolve) { expr ->
                                 val expressionToReplace = expr.parent as? KtCallExpression ?: expr
                                 val replaced = codeToInline.replaceExpression(

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -5908,6 +5908,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/deprecatedSymbolUsage/extensionForGenericClass.kt");
         }
 
+        @TestMetadata("extensionReceiverWithVarianceType.kt")
+        public void testExtensionReceiverWithVarianceType() throws Exception {
+            runTest("testData/quickfix/deprecatedSymbolUsage/extensionReceiverWithVarianceType.kt");
+        }
+
         @TestMetadata("implicitCompanionObjectThis.kt")
         public void testImplicitCompanionObjectThis() throws Exception {
             runTest("testData/quickfix/deprecatedSymbolUsage/implicitCompanionObjectThis.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/extensionReceiverWithVarianceType.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/extensionReceiverWithVarianceType.kt
@@ -1,0 +1,11 @@
+// "Replace with 'bar(f)'" "true"
+// WITH_RUNTIME
+
+fun test(list: List<Int>) {
+    list.foo<caret> { it }
+}
+
+@Deprecated("", ReplaceWith("bar(f)"))
+fun List<out Int>.foo(f: (Int) -> Unit) {}
+
+fun List<Int>.bar(f: (Int) -> Unit) {}

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/extensionReceiverWithVarianceType.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/extensionReceiverWithVarianceType.kt.after
@@ -1,0 +1,11 @@
+// "Replace with 'bar(f)'" "true"
+// WITH_RUNTIME
+
+fun test(list: List<Int>) {
+    list.bar { it }
+}
+
+@Deprecated("", ReplaceWith("bar(f)"))
+fun List<out Int>.foo(f: (Int) -> Unit) {}
+
+fun List<Int>.bar(f: (Int) -> Unit) {}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-18325