### PR TITLE
Read java.class.path unconditionally

### DIFF
--- a/platform/bootstrap/src/com/intellij/ide/BootstrapClassLoaderUtil.java
+++ b/platform/bootstrap/src/com/intellij/ide/BootstrapClassLoaderUtil.java
@@ -183,6 +183,7 @@ public final class BootstrapClassLoaderUtil {
 
   private static @NotNull Collection<Path> computeClassPath(@NotNull Path libDir) throws IOException {
     Collection<Path> classpath = new LinkedHashSet<>();
+    parseClassPathString(System.getProperty("java.class.path"), classpath);
 
     Path classPathFile = libDir.resolve("classpath.txt");
     try (Stream<String> stream = Files.lines(classPathFile)) {
@@ -200,8 +201,6 @@ public final class BootstrapClassLoaderUtil {
     }
 
     // no classpath file - compute classpath
-    parseClassPathString(System.getProperty("java.class.path"), classpath);
-
     Class<BootstrapClassLoaderUtil> aClass = BootstrapClassLoaderUtil.class;
     String selfRootPath = PathManager.getResourceRoot(aClass, "/" + aClass.getName().replace('.', '/') + ".class");
     assert selfRootPath != null;


### PR DESCRIPTION
There are some development environments in which (1) the
lib/classpath.txt file exists *and* (2) certain plugins need to be
loaded from the Java classpath rather than from the plugins directory.

Thus java.class.path should always be added in the bootstrap
classloader, even if lib/classpath.txt exists. Any duplicates
between the two are already filtered out.

Issue link: https://youtrack.jetbrains.com/issue/IDEA-278177

cc @develar 