### PR TITLE
Parcelize: Fix tests and add a test for IgnoredOnParcel annotations in objects

### DIFF
--- a/plugins/kotlin/compiler-plugins/parcelize/tests/test/org/jetbrains/kotlin/pacelize/ide/test/ParcelizeCheckerTestGenerated.java
+++ b/plugins/kotlin/compiler-plugins/parcelize/tests/test/org/jetbrains/kotlin/pacelize/ide/test/ParcelizeCheckerTestGenerated.java
@@ -73,6 +73,11 @@ public class ParcelizeCheckerTestGenerated extends AbstractParcelizeCheckerTest 
         runTest("testData/checker/notMagicParcel.kt");
     }
 
+    @TestMetadata("objectProperties.kt")
+    public void testObjectProperties() throws Exception {
+        runTest("testData/checker/objectProperties.kt");
+    }
+
     @TestMetadata("properties.kt")
     public void testProperties() throws Exception {
         runTest("testData/checker/properties.kt");

--- a/plugins/kotlin/compiler-plugins/parcelize/tests/test/org/jetbrains/kotlin/pacelize/ide/test/parcelizeTestUtil.kt
+++ b/plugins/kotlin/compiler-plugins/parcelize/tests/test/org/jetbrains/kotlin/pacelize/ide/test/parcelizeTestUtil.kt
@@ -12,7 +12,7 @@ import java.io.File
 
 fun addParcelizeLibraries(module: Module) {
     ConfigLibraryUtil.addLibrary(module, "androidJar") {
-        addRoot(File(PathManager.getHomePath(), "community/android/android/testData/android.jar"), OrderRootType.CLASSES)
+        addRoot(File(PathManager.getCommunityHomePath(), "android/android/testData/android.jar"), OrderRootType.CLASSES)
     }
     ConfigLibraryUtil.addLibrary(module, "parcelizeRuntime") {
         addRoot(AdditionalKotlinArtifacts.parcelizeRuntime, OrderRootType.CLASSES)

--- a/plugins/kotlin/compiler-plugins/parcelize/tests/testData/checker/objectProperties.kt
+++ b/plugins/kotlin/compiler-plugins/parcelize/tests/testData/checker/objectProperties.kt
@@ -1,0 +1,27 @@
+// WITH_RUNTIME
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcelable
+
+@Parcelize
+object A : Parcelable {
+    @IgnoredOnParcel
+    var a: String = ""
+
+    @IgnoredOnParcel
+    val b: String = ""
+
+    val <warning descr="[PROPERTY_WONT_BE_SERIALIZED] Property would not be serialized into a 'Parcel'. Add '@IgnoredOnParcel' annotation to remove the warning">secondName</warning>: String = ""
+
+    val <warning descr="[PROPERTY_WONT_BE_SERIALIZED] Property would not be serialized into a 'Parcel'. Add '@IgnoredOnParcel' annotation to remove the warning">delegated</warning> by lazy { "" }
+
+    lateinit var <warning descr="[PROPERTY_WONT_BE_SERIALIZED] Property would not be serialized into a 'Parcel'. Add '@IgnoredOnParcel' annotation to remove the warning">lateinit</warning>: String
+
+    val customGetter: String
+        get() = ""
+
+    var customSetter: String
+        get() = ""
+        set(<warning descr="[UNUSED_PARAMETER] Parameter 'v' is never used">v</warning>) {}
+}


### PR DESCRIPTION
- The path to `android.jar` in the parcelize tests seems to be wrong. It's possible that this is done on purpose for teamcity, in which case `getPlugins.sh` should probably generate a `community/android` symlink.
- Added a test for [PR 4579](https://github.com/JetBrains/kotlin/pull/4579) in the Kotlin repository.