### PR TITLE
IDEA-258738: Double click doesn't select a word if it includes a sear…

### DIFF
--- a/platform/lang-impl/src/com/intellij/find/impl/livePreview/SearchResults.java
+++ b/platform/lang-impl/src/com/intellij/find/impl/livePreview/SearchResults.java
@@ -58,8 +58,6 @@ public class SearchResults implements DocumentListener, CaretListener {
       if (occurrenceAtCaret != null && occurrenceAtCaret != myCursor) {
         moveCursorTo(occurrenceAtCaret, false, false);
         myEditor.getCaretModel().moveToOffset(offset);
-        myEditor.getSelectionModel().removeSelection();
-        notifyCursorMoved();
       }
     }
   }


### PR DESCRIPTION
`SearchResults#caretPositionChanged()` called after `SelectionModelImpl#fireSelectionChanged()` which repaint selection result properly, call `myEditor.getSelectionModel().removeSelection()` in `SearchResults#caretPositionChanged()` is inappropriate.

`notifyCursorMoved();` is redundant too, introduce the indicator problem reported in [IDEA-272238](https://youtrack.jetbrains.com/issue/IDEA-272238)