### PR TITLE
FIR UAST: handle annotation in annotation

### DIFF
--- a/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/BaseKotlinConverter.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/BaseKotlinConverter.kt
@@ -197,8 +197,10 @@ interface BaseKotlinConverter {
                         el<UAnnotation> { KotlinUNestedAnnotation.create(original, givenParent) }
                     } else null
                 }
-                is KtLightAnnotationForSourceEntry -> {
-                    convertDeclarationOrElement(original.kotlinOrigin, givenParent, requiredTypes)
+                is KtLightElementBase -> {
+                    original.kotlinOrigin?.let {
+                        convertDeclarationOrElement(it, givenParent, requiredTypes)
+                    }
                 }
                 is KtDelegatedSuperTypeEntry -> {
                     el<KotlinSupertypeDelegationUExpression> {

--- a/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/declarations/KotlinUAnnotation.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/declarations/KotlinUAnnotation.kt
@@ -76,7 +76,7 @@ class KotlinUAnnotation(
     givenParent: UElement?
 ) : KotlinUAnnotationBase<KtAnnotationEntry>(annotationEntry, givenParent), UAnnotation {
 
-    override val javaPsi = annotationEntry.toLightAnnotation()
+    override val javaPsi: PsiAnnotation? by lz { annotationEntry.toLightAnnotation() }
 
     override fun annotationUseSiteTarget() = sourcePsi.useSiteTarget?.getAnnotationUseSiteTarget()
 

--- a/plugins/kotlin/uast/uast-kotlin-base/test/org/jetbrains/uast/test/common/kotlin/UastIdentifiersTestBase.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/test/org/jetbrains/uast/test/common/kotlin/UastIdentifiersTestBase.kt
@@ -47,11 +47,14 @@ interface UastIdentifiersTestBase : UastPluginSelection, UastFileComparisonTestB
 
         try {
             file.testIdentifiersParents()
-            if (isExpectedToFail(filePath)) {
-                KtAssert.fail("This test seems not fail anymore. Drop this from the white-list and re-run the test.")
-            }
         } catch (e: AssertionError) {
-            if (!isExpectedToFail(filePath)) throw e
+            if (isExpectedToFail(filePath))
+                return
+            else
+                throw e
+        }
+        if (isExpectedToFail(filePath)) {
+            KtAssert.fail("This test seems not fail anymore. Drop this from the white-list and re-run the test.")
         }
 
         cleanUpIdenticalFile(

--- a/plugins/kotlin/uast/uast-kotlin-base/test/org/jetbrains/uast/test/common/kotlin/UastValuesTestBase.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/test/org/jetbrains/uast/test/common/kotlin/UastValuesTestBase.kt
@@ -29,11 +29,14 @@ interface UastValuesTestBase : UastPluginSelection, UastFileComparisonTestBase {
 
         try {
             KotlinTestUtils.assertEqualsToFile(valuesFile, file.asLogValues())
-            if (isExpectedToFail(filePath)) {
-                KtAssert.fail("This test seems not fail anymore. Drop this from the white-list and re-run the test.")
-            }
         } catch (e: Exception) {
-            if (!isExpectedToFail(filePath)) throw e
+            if (isExpectedToFail(filePath))
+                return
+            else
+                throw e
+        }
+        if (isExpectedToFail(filePath)) {
+            KtAssert.fail("This test seems not fail anymore. Drop this from the white-list and re-run the test.")
         }
 
         cleanUpIdenticalFile(

--- a/plugins/kotlin/uast/uast-kotlin-fir/src/org/jetbrains/uast/kotlin/FirKotlinUastResolveProviderService.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/src/org/jetbrains/uast/kotlin/FirKotlinUastResolveProviderService.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KtConstructorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtSamConstructorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtValueParameterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtNamedSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KtLiteralConstantValue
 import org.jetbrains.kotlin.analysis.api.types.*
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.name.SpecialNames
@@ -396,7 +397,7 @@ interface FirKotlinUastResolveProviderService : BaseKotlinUastResolveProviderSer
     override fun evaluate(uExpression: UExpression): Any? {
         val ktExpression = uExpression.sourcePsi as? KtExpression ?: return null
         analyseForUast(ktExpression) {
-            return ktExpression.evaluate()?.toConst()
+            return (ktExpression.evaluate() as? KtLiteralConstantValue<*>)?.toConst()
         }
     }
 }

--- a/plugins/kotlin/uast/uast-kotlin-fir/src/org/jetbrains/uast/kotlin/FirKotlinUastResolveProviderService.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/src/org/jetbrains/uast/kotlin/FirKotlinUastResolveProviderService.kt
@@ -70,9 +70,8 @@ interface FirKotlinUastResolveProviderService : BaseKotlinUastResolveProviderSer
 
     override fun findDefaultValueForAnnotationAttribute(ktCallElement: KtCallElement, name: String): KtExpression? {
         analyseForUast(ktCallElement) {
-            val resolvedAnnotationCall = ktCallElement.resolveCall() as? KtAnnotationCall ?: return null
             val resolvedAnnotationConstructorSymbol =
-                resolvedAnnotationCall.targetFunction.candidates.singleOrNull() as? KtConstructorSymbol ?: return null
+                ktCallElement.resolveCall()?.targetFunction?.candidates?.singleOrNull() as? KtConstructorSymbol ?: return null
             val parameter = resolvedAnnotationConstructorSymbol.valueParameters.find { it.name.asString() == name } ?: return null
             return (parameter.psi as? KtParameter)?.defaultValue
         }
@@ -194,9 +193,8 @@ interface FirKotlinUastResolveProviderService : BaseKotlinUastResolveProviderSer
 
     override fun qualifiedAnnotationName(ktCallElement: KtCallElement): String? {
         analyseForUast(ktCallElement) {
-            val resolvedAnnotationCall = ktCallElement.resolveCall() as? KtAnnotationCall ?: return null
             val resolvedAnnotationConstructorSymbol =
-                resolvedAnnotationCall.targetFunction.candidates.singleOrNull() as? KtConstructorSymbol ?: return null
+                ktCallElement.resolveCall()?.targetFunction?.candidates?.singleOrNull() as? KtConstructorSymbol ?: return null
             return resolvedAnnotationConstructorSymbol.containingClassIdIfNonLocal
                 ?.asSingleFqName()
                 ?.toString()
@@ -218,9 +216,8 @@ interface FirKotlinUastResolveProviderService : BaseKotlinUastResolveProviderSer
 
     override fun isAnnotationConstructorCall(ktCallElement: KtCallElement): Boolean {
         analyseForUast(ktCallElement) {
-            val resolvedAnnotationCall = ktCallElement.resolveCall() as? KtAnnotationCall ?: return false
             val resolvedAnnotationConstructorSymbol =
-                resolvedAnnotationCall.targetFunction.candidates.singleOrNull() as? KtConstructorSymbol ?: return false
+                ktCallElement.resolveCall()?.targetFunction?.candidates?.singleOrNull() as? KtConstructorSymbol ?: return false
             val ktType = resolvedAnnotationConstructorSymbol.annotatedType.type
             val psiClass = toPsiClass(ktType, ktCallElement, ktCallElement.typeOwnerKind) ?: return false
             return psiClass.isAnnotationType

--- a/plugins/kotlin/uast/uast-kotlin-fir/test/org/jetbrains/kotlin/idea/fir/uast/AbstractFirLegacyUastIdentifiersTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/test/org/jetbrains/kotlin/idea/fir/uast/AbstractFirLegacyUastIdentifiersTest.kt
@@ -15,12 +15,6 @@ abstract class AbstractFirLegacyUastIdentifiersTest : AbstractFirUastIdentifiers
         "uast-kotlin/testData/DestructuringDeclaration.kt",
         "uast-kotlin/testData/LambdaReturn.kt",
         "uast-kotlin/testData/WhenAndDestructing.kt",
-        // TODO: incorrect parent chain for annotations?
-        "uast-kotlin/testData/ParameterPropertyWithAnnotation.kt",
-        "uast-kotlin/testData/PropertyWithAnnotation.kt",
-        "uast-kotlin/testData/SimpleAnnotated.kt",
-        "uast-kotlin/testData/ReifiedParameters.kt",
-        "uast-kotlin/testData/ReceiverFun.kt",
     ).mapTo(mutableSetOf()) { KotlinRoot.DIR_PATH.resolve("uast").resolve(it).absolute().normalize().toString() }
 
     override fun isExpectedToFail(filePath: String): Boolean {

--- a/plugins/kotlin/uast/uast-kotlin-fir/test/org/jetbrains/kotlin/idea/fir/uast/FirUastApiTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/test/org/jetbrains/kotlin/idea/fir/uast/FirUastApiTest.kt
@@ -24,12 +24,8 @@ open class FirUastApiTest : AbstractFirUastTest() {
     }
 
     private val whitelist : Set<String> = setOf(
-        // TODO: psi -> UAST -> psi -> UAST ??
-        "uast-kotlin/testData/AnnotationParameters.kt",
         // TODO: interface method's `hasModifierProperty`
         "uast-kotlin/testData/DefaultImpls.kt",
-        // TODO: vararg, arrayOf call inside annotation
-        "uast-kotlin/testData/AnnotationComplex.kt",
         // TODO: resolve to inline and stdlib
         "uast-kotlin/testData/Resolve.kt",
         // TODO: no lambda call receiver?

--- a/plugins/kotlin/uast/uast-kotlin-fir/test/org/jetbrains/kotlin/idea/fir/uast/env/kotlin/AbstractFirUastTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/test/org/jetbrains/kotlin/idea/fir/uast/env/kotlin/AbstractFirUastTest.kt
@@ -101,13 +101,19 @@ abstract class AbstractFirUastTest : KotlinLightCodeInsightFixtureTestCase(), Ua
         val uFile = UastFacade.convertElementWithParent(psiFile, null) ?: error("Can't get UFile for $testName")
         try {
             checkCallback(normalizedFile.toString(), uFile as UFile)
-            if (isExpectedToFail(filePath, fileContent)) {
-                KtAssert.fail("This test seems not fail anymore. Drop this from the white-list and re-run the test.")
-            }
         } catch (e: AssertionError) {
-            if (!isExpectedToFail(filePath, fileContent)) throw e
+            if (isExpectedToFail(filePath, fileContent))
+                return
+            else
+                throw e
         } catch (e: AssertionFailedError) {
-            if (!isExpectedToFail(filePath, fileContent)) throw e
+            if (isExpectedToFail(filePath, fileContent))
+                return
+            else
+                throw e
+        }
+        if (isExpectedToFail(filePath, fileContent)) {
+            KtAssert.fail("This test seems not fail anymore. Drop this from the white-list and re-run the test.")
         }
     }
 }


### PR DESCRIPTION
The motivation was an API test for `AnnotationComplex.kt` where annotation is used as annotation value in various forms.

First, unlike annotation call:
```kt
@Annotation(...) // annotation call
class C
```
which is parsed as `KtAnnotationEntry`, which is in turn abstracted as `KtAnnotationCall`, annotation as an annotation value:
```kt
annotation class Annotation(val anno: OtherAnnotation)

@Annotation(<expr>OtherAnnotation(...)</expr>) // function call to ctor
class C
```
is a regular function call. 1st commit in [KOTLIN-CR-198](https://kotlin.jetbrains.space/p/kotlin/reviews/198/) showcases those resolved calls. FIR UAST has unnecessarily strong restriction about annotation handling, and 1st commit in this PR addresses that. (2nd commit is a simple improvement while debugging the test.)

FIR IDE and FIR LC don't model not only annotations in annotations, but other kinds of annotation values, such as enum entry or array of allowed types. 3rd and 4th commits in [KOTLIN-CR-198](https://kotlin.jetbrains.space/p/kotlin/reviews/198/) add abstractions and conversions in FIR IDE and LC, respectively. While doing so, constant value returned from constant provider in Analysis API is changed. 3rd commit in this PR changes API usage.

One thing that's noteworthy is, the key of FIR LC change (which affects FIR IDE as well) is `kotlinOrigin`. Without that, a literal could trigger the conversion from UAST Java plugin, not Kotlin one.

2nd commit in [KOTLIN-CR-198](https://kotlin.jetbrains.space/p/kotlin/reviews/198/) and 4th commit in this PR are about weakening conditions to lookup nested annotation. In FE 1.0 LC util and FE 1.0 UAST, a specific class name is used, and aforementioned commits replace it with a common ancestor.

At last, the test passed, but the whitelist logic didn't notify that. And... that's because notification (via assertion error) is caught and then silently ignored. 🤦  With the fix in 5th commit in this PR, we found that one more API test is passing (guess it's also due to various `kotlinOrigin` additions and array annotation value support); and parent conversion in identifier tests is identical to FE 1.0 UAST. 🎉 