### PR TITLE
Do not use ExternalTestsModelBuilderImpl when android plugin is applied

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalTestsModelBuilderImpl.groovy
@@ -25,6 +25,10 @@ class ExternalTestsModelBuilderImpl implements ModelBuilderService {
   @Override
   Object buildAll(String modelName, Project project) {
     def defaultTestsModel = new DefaultExternalTestsModel()
+    // Projects using android plugins are not supported by this model builder.
+    if (project.plugins.hasPlugin("com.android.base")) {
+      return defaultTestsModel
+    }
     if (javaPluginIsApplied(project)) {
       defaultTestsModel.sourceTestMappings = getMapping(project)
     }


### PR DESCRIPTION
Projects using Android plugins have a different mechanism for
 determining the test sources.