### PR TITLE
KTIJ-19517 Fix false positive warning on move method without param

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/moveConflictUtils.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/move/moveDeclarations/moveConflictUtils.kt
@@ -84,6 +84,7 @@ import org.jetbrains.kotlin.util.isJavaDescriptor
 import org.jetbrains.kotlin.util.supertypesWithAny
 import org.jetbrains.kotlin.utils.SmartSet
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
+import java.util.*
 
 class MoveConflictChecker(
     private val project: Project,
@@ -603,7 +604,9 @@ class MoveConflictChecker(
         fun <T> equivalent(a: T, b: T): Boolean = when (a) {
             is DeclarationDescriptor -> when (a) {
                 is FunctionDescriptor -> b is FunctionDescriptor
-                        && equivalent(a.name, b.name) && a.valueParameters.zip(b.valueParameters).all { equivalent(it.first, it.second) }
+                        && equivalent(a.name, b.name)
+                        && a.valueParameters.size == b.valueParameters.size
+                        && a.valueParameters.zip(b.valueParameters).all { equivalent(it.first, it.second) }
                 is ValueParameterDescriptor -> b is ValueParameterDescriptor
                         && equivalent(a.type, b.type)
                 else -> b is DeclarationDescriptor && equivalent(a.name, b.name)

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/refactoring/move/MoveTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/refactoring/move/MoveTestGenerated.java
@@ -333,6 +333,11 @@ public class MoveTestGenerated extends AbstractMoveTest {
         runTest("testData/refactoring/move/kotlin/moveMethod/moveToClass/propertyAsReference/propertyAsReference.test");
     }
 
+    @TestMetadata("kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/sameMethodNameDifferentParameters.test")
+    public void testKotlin_moveMethod_moveToClass_sameMethodNameDifferentParameters_SameMethodNameDifferentParameters() throws Exception {
+        runTest("testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/sameMethodNameDifferentParameters.test");
+    }
+
     @TestMetadata("kotlin/moveMethod/moveToObject/moveToObject.test")
     public void testKotlin_moveMethod_moveToObject_MoveToObject() throws Exception {
         runTest("testData/refactoring/move/kotlin/moveMethod/moveToObject/moveToObject.test");

--- a/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/after/a/A.kt
+++ b/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/after/a/A.kt
@@ -1,0 +1,6 @@
+package a
+
+import b.B
+
+class A(val b: B) {
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/after/b/B.kt
+++ b/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/after/b/B.kt
@@ -1,0 +1,9 @@
+package b
+
+class B() {
+    fun dummyFun() {}
+    fun toMove(s: String) {}
+    fun toMove() {
+        this.dummyFun()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/before/a/A.kt
+++ b/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/before/a/A.kt
@@ -1,0 +1,9 @@
+package a
+
+import b.B
+
+class A(val b: B) {
+    fun toMove() {
+        b.dummyFun()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/before/b/B.kt
+++ b/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/before/b/B.kt
@@ -1,0 +1,6 @@
+package b
+
+class B() {
+    fun dummyFun() {}
+    fun toMove(s: String) {}
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/sameMethodNameDifferentParameters.test
+++ b/plugins/kotlin/idea/tests/testData/refactoring/move/kotlin/moveMethod/moveToClass/sameMethodNameDifferentParameters/sameMethodNameDifferentParameters.test
@@ -1,0 +1,7 @@
+{
+  "mainFile": "a/A.kt",
+  "type": "MOVE_KOTLIN_METHOD",
+  "methodToMove": "toMove",
+  "methodToMoveParameters": [],
+  "sourceProperty": "b"
+}


### PR DESCRIPTION
When comparing methods it zips the parameters of both methods and checks if the zipped combinations are equal.
In the case where one method has no parameters, the zip returns an empty list. On that empty list the "all" check automatically returns true which is wrong.

https://youtrack.jetbrains.com/issue/KTIJ-19517

I needed to expand the testing setup for move method, because in this case there are 2 methods with the same name, which could not be differenciatet between, resulting in the wrong method being selected for moving.