### PR TITLE
FIR IDE: fix completion test generation

### DIFF
--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/asJava/classes/FirLightClassTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/asJava/classes/FirLightClassTestGenerated.java
@@ -50,6 +50,26 @@ public class FirLightClassTestGenerated extends AbstractFirLightClassTest {
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationClass.kt"));
     }
 
+    @TestMetadata("AnnotationJvmRepeatable.kt")
+    public void testAnnotationJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJavaRepeatable.kt")
+    public void testAnnotationKotlinAndJavaRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJavaRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJvmRepeatable.kt")
+    public void testAnnotationKotlinAndJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationRepeatable.kt")
+    public void testAnnotationRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationRepeatable.kt"));
+    }
+
     @TestMetadata("Constructors.kt")
     public void testConstructors() throws Exception {
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/Constructors.kt"));

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
@@ -1816,6 +1816,11 @@ public abstract class HighLevelQuickFixTestGenerated extends AbstractHighLevelQu
             runTest("../idea/tests/testData/quickfix/when/addElseBranchEnumStatement.kt");
         }
 
+        @TestMetadata("addElseBranchSealed.kt")
+        public void testAddElseBranchSealed() throws Exception {
+            runTest("../idea/tests/testData/quickfix/when/addElseBranchSealed.kt");
+        }
+
         @TestMetadata("addRemainingBranchesBlankLine.kt")
         public void testAddRemainingBranchesBlankLine() throws Exception {
             runTest("../idea/tests/testData/quickfix/when/addRemainingBranchesBlankLine.kt");

--- a/plugins/kotlin/generators/test/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
+++ b/plugins/kotlin/generators/test/org/jetbrains/kotlin/generators/tests/GenerateTests.kt
@@ -183,6 +183,7 @@ import org.jetbrains.kotlin.tools.projectWizard.wizard.AbstractYamlNewWizardProj
 import org.jetbrains.kotlin.idea.compilerPlugin.kotlinxSerialization.AbstractSerializationPluginIdeDiagnosticTest
 import org.jetbrains.kotlin.idea.compilerPlugin.kotlinxSerialization.AbstractSerializationQuickFixTest
 import org.jetbrains.kotlin.idea.fir.imports.AbstractFirJvmOptimizeImportsTest
+import org.jetbrains.kotlin.testGenerator.model.Patterns.KT_WITHOUT_DOT_AND_FIR_PREFIX
 import org.jetbrains.uast.test.comparasion.*
 
 fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
@@ -1111,17 +1112,17 @@ private fun assembleWorkspace(): TWorkspace = workspace {
 
     testGroup("fir", testDataPath = "../completion/tests/testData") {
         testClass<AbstractHighLevelJvmBasicCompletionTest> {
-            model("basic/common")
-            model("basic/java")
-            model("../../idea-fir/testData/completion/basic/common", testClassName = "CommonFir")
+            model("basic/common", pattern = KT_WITHOUT_FIR_PREFIX)
+            model("basic/java", pattern = KT_WITHOUT_FIR_PREFIX)
+            model("../../idea-fir/testData/completion/basic/common", testClassName = "CommonFir", pattern = KT_WITHOUT_FIR_PREFIX)
         }
 
         testClass<AbstractHighLevelBasicCompletionHandlerTest> {
-            model("handlers/basic", pattern = KT_WITHOUT_DOTS)
+            model("handlers/basic", pattern = KT_WITHOUT_DOT_AND_FIR_PREFIX)
         }
 
         testClass<AbstractFirKeywordCompletionHandlerTest> {
-            model("handlers/keywords", pattern = KT_WITHOUT_DOTS)
+            model("handlers/keywords", pattern = KT_WITHOUT_DOT_AND_FIR_PREFIX)
         }
 
         testClass<AbstractHighLevelWeigherTest> {
@@ -1286,13 +1287,13 @@ private fun assembleWorkspace(): TWorkspace = workspace {
         }
 
         testClass<AbstractJSBasicCompletionTest> {
-            model("basic/common")
-            model("basic/js")
+            model("basic/common", pattern = KT_WITHOUT_FIR_PREFIX)
+            model("basic/js", pattern = KT_WITHOUT_FIR_PREFIX)
         }
 
         testClass<AbstractJvmBasicCompletionTest> {
-            model("basic/common")
-            model("basic/java")
+            model("basic/common", pattern = KT_WITHOUT_FIR_PREFIX)
+            model("basic/java", pattern = KT_WITHOUT_FIR_PREFIX)
         }
 
         testClass<AbstractJvmSmartCompletionTest> {
@@ -1308,19 +1309,19 @@ private fun assembleWorkspace(): TWorkspace = workspace {
         }
 
         testClass<AbstractBasicCompletionHandlerTest> {
-            model("handlers/basic", pattern = KT_WITHOUT_DOTS)
+            model("handlers/basic", pattern = KT_WITHOUT_DOT_AND_FIR_PREFIX)
         }
 
         testClass<AbstractSmartCompletionHandlerTest> {
-            model("handlers/smart")
+            model("handlers/smart", pattern = KT_WITHOUT_FIR_PREFIX)
         }
 
         testClass<AbstractKeywordCompletionHandlerTest> {
-            model("handlers/keywords")
+            model("handlers/keywords", pattern = KT_WITHOUT_FIR_PREFIX)
         }
 
         testClass<AbstractCompletionCharFilterTest> {
-            model("handlers/charFilter", pattern = KT_WITHOUT_DOTS)
+            model("handlers/charFilter", pattern = KT_WITHOUT_DOT_AND_FIR_PREFIX)
         }
 
         testClass<AbstractMultiFileJvmBasicCompletionTest> {

--- a/plugins/kotlin/generators/test/org/jetbrains/kotlin/testGenerator/model/TModel.kt
+++ b/plugins/kotlin/generators/test/org/jetbrains/kotlin/testGenerator/model/TModel.kt
@@ -48,6 +48,7 @@ object Patterns {
     val KT_WITHOUT_DOTS: ModelMatcher = forRegex("^([^.]+)\\.kt$")
     val KT_OR_KTS_WITHOUT_DOTS: ModelMatcher = forRegex("^([^.]+)\\.(kt|kts)$")
     val KT_WITHOUT_FIR_PREFIX: ModelMatcher = forRegex("""^(.+)(?<!\.fir)\.kt$""")
+    val KT_WITHOUT_DOT_AND_FIR_PREFIX: ModelMatcher = forRegex("""^([^.]+)(?<!\.fir)\.kt$""")
 }
 
 fun MutableTSuite.model(

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/asJava/classes/UltraLightClassSanityTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/asJava/classes/UltraLightClassSanityTestGenerated.java
@@ -50,6 +50,26 @@ public class UltraLightClassSanityTestGenerated extends AbstractUltraLightClassS
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationClass.kt"));
     }
 
+    @TestMetadata("AnnotationJvmRepeatable.kt")
+    public void testAnnotationJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJavaRepeatable.kt")
+    public void testAnnotationKotlinAndJavaRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJavaRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJvmRepeatable.kt")
+    public void testAnnotationKotlinAndJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationRepeatable.kt")
+    public void testAnnotationRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationRepeatable.kt"));
+    }
+
     @TestMetadata("Constructors.kt")
     public void testConstructors() throws Exception {
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/Constructors.kt"));

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/IdeCompiledLightClassTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/IdeCompiledLightClassTestGenerated.java
@@ -50,6 +50,26 @@ public class IdeCompiledLightClassTestGenerated extends AbstractIdeCompiledLight
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationClass.kt"));
     }
 
+    @TestMetadata("AnnotationJvmRepeatable.kt")
+    public void testAnnotationJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJavaRepeatable.kt")
+    public void testAnnotationKotlinAndJavaRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJavaRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJvmRepeatable.kt")
+    public void testAnnotationKotlinAndJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationRepeatable.kt")
+    public void testAnnotationRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationRepeatable.kt"));
+    }
+
     @TestMetadata("Constructors.kt")
     public void testConstructors() throws Exception {
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/Constructors.kt"));

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/IdeLightClassTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/caches/resolve/IdeLightClassTestGenerated.java
@@ -50,6 +50,26 @@ public class IdeLightClassTestGenerated extends AbstractIdeLightClassTest {
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationClass.kt"));
     }
 
+    @TestMetadata("AnnotationJvmRepeatable.kt")
+    public void testAnnotationJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJavaRepeatable.kt")
+    public void testAnnotationKotlinAndJavaRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJavaRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationKotlinAndJvmRepeatable.kt")
+    public void testAnnotationKotlinAndJvmRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationKotlinAndJvmRepeatable.kt"));
+    }
+
+    @TestMetadata("AnnotationRepeatable.kt")
+    public void testAnnotationRepeatable() throws Exception {
+        runTest(compilerTestData("compiler/testData/asJava/lightClasses/AnnotationRepeatable.kt"));
+    }
+
     @TestMetadata("Constructors.kt")
     public void testConstructors() throws Exception {
         runTest(compilerTestData("compiler/testData/asJava/lightClasses/Constructors.kt"));

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/decompiler/stubBuilder/LoadJavaClsStubTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/decompiler/stubBuilder/LoadJavaClsStubTestGenerated.java
@@ -2562,11 +2562,6 @@ public abstract class LoadJavaClsStubTestGenerated extends AbstractLoadJavaClsSt
             runTest(compilerTestData("compiler/testData/loadJava/compiledKotlin/prop/ExtVarl.kt"));
         }
 
-        @TestMetadata("nonConstValWithConstantValueAttribute.kt")
-        public void testNonConstValWithConstantValueAttribute() throws Exception {
-            runTest(compilerTestData("compiler/testData/loadJava/compiledKotlin/prop/nonConstValWithConstantValueAttribute.kt"));
-        }
-
         @TestMetadata("NsVal.kt")
         public void testNsVal() throws Exception {
             runTest(compilerTestData("compiler/testData/loadJava/compiledKotlin/prop/NsVal.kt"));

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/stubs/ResolveByStubTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/stubs/ResolveByStubTestGenerated.java
@@ -2562,11 +2562,6 @@ public abstract class ResolveByStubTestGenerated extends AbstractResolveByStubTe
             runTest(compilerTestData("compiler/testData/loadJava/compiledKotlin/prop/ExtVarl.kt"));
         }
 
-        @TestMetadata("nonConstValWithConstantValueAttribute.kt")
-        public void testNonConstValWithConstantValueAttribute() throws Exception {
-            runTest(compilerTestData("compiler/testData/loadJava/compiledKotlin/prop/nonConstValWithConstantValueAttribute.kt"));
-        }
-
         @TestMetadata("NsVal.kt")
         public void testNsVal() throws Exception {
             runTest(compilerTestData("compiler/testData/loadJava/compiledKotlin/prop/NsVal.kt"));


### PR DESCRIPTION
Commit#1 contains the fix to ignore FIR files for completion tests.

Commit#2 contains other changes by running the test generation. Note that some
of the tests are not passing. But I am not sure how the tests related to light
classes are set up. It looks like the test files are in the Kotlin repo. But
maintaining tests across repos seem to be very counter-productive. Is this
intended?