### PR TITLE
UAST: deprecate use of KotlinTypeMapper#mapType

### DIFF
--- a/plugins/kotlin/uast/uast-kotlin-idea/src/org/jetbrains/uast/kotlin/internal/IdeaKotlinUastResolveProviderService.kt
+++ b/plugins/kotlin/uast/uast-kotlin-idea/src/org/jetbrains/uast/kotlin/internal/IdeaKotlinUastResolveProviderService.kt
@@ -3,14 +3,11 @@
 package org.jetbrains.uast.kotlin.internal
 
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.codegen.ClassBuilderMode
-import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.core.resolveCandidates
 import org.jetbrains.kotlin.idea.project.languageVersionSettings
-import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.resolve.calls.callUtil.getCall
@@ -20,14 +17,6 @@ import org.jetbrains.uast.kotlin.resolveToDeclarationImpl
 
 class IdeaKotlinUastResolveProviderService : KotlinUastResolveProviderService {
     override fun getBindingContext(element: KtElement) = element.analyze(BodyResolveMode.PARTIAL_WITH_CFA)
-
-    override fun getTypeMapper(element: KtElement): KotlinTypeMapper? {
-        return KotlinTypeMapper(
-            getBindingContext(element), ClassBuilderMode.LIGHT_CLASSES,
-            JvmProtoBufUtil.DEFAULT_MODULE_NAME, element.languageVersionSettings,
-            useOldInlineClassesManglingScheme = false
-        )
-    }
 
     override fun isJvmElement(psiElement: PsiElement): Boolean = psiElement.isJvmElement
 

--- a/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastResolveProviderService.kt
+++ b/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastResolveProviderService.kt
@@ -36,7 +36,6 @@ import org.jetbrains.uast.kotlin.psi.UastKotlinPsiParameterBase
 
 interface KotlinUastResolveProviderService : BaseKotlinUastResolveProviderService {
     fun getBindingContext(element: KtElement): BindingContext
-    fun getTypeMapper(element: KtElement): KotlinTypeMapper?
     fun getLanguageVersionSettings(element: KtElement): LanguageVersionSettings
 
     override val languagePlugin: UastLanguagePlugin

--- a/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/CliKotlinUastResolveProviderService.kt
+++ b/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/CliKotlinUastResolveProviderService.kt
@@ -4,7 +4,6 @@ package org.jetbrains.uast.kotlin.internal
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.analyzer.AnalysisResult
-import org.jetbrains.kotlin.codegen.ClassBuilderMode
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
@@ -12,7 +11,6 @@ import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.container.get
 import org.jetbrains.kotlin.context.ProjectContext
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
@@ -29,10 +27,6 @@ class CliKotlinUastResolveProviderService : KotlinUastResolveProviderService {
 
     override fun getBindingContext(element: KtElement): BindingContext {
         return element.project.analysisCompletedHandler?.getBindingContext() ?: BindingContext.EMPTY
-    }
-
-    override fun getTypeMapper(element: KtElement): KotlinTypeMapper? {
-        return element.project.analysisCompletedHandler?.getTypeMapper()
     }
 
     override fun isJvmElement(psiElement: PsiElement) = true
@@ -53,20 +47,6 @@ class UastAnalysisHandlerExtension : AnalysisHandlerExtension {
     fun getBindingContext() = context
 
     fun getLanguageVersionSettings() = languageVersionSettings
-
-    fun getTypeMapper(): KotlinTypeMapper? {
-        if (typeMapper != null) return typeMapper
-        val bindingContext = context ?: return null
-
-        val typeMapper = KotlinTypeMapper(
-            bindingContext, ClassBuilderMode.LIGHT_CLASSES,
-            JvmProtoBufUtil.DEFAULT_MODULE_NAME,
-            KotlinTypeMapper.LANGUAGE_VERSION_SETTINGS_DEFAULT, // TODO use proper LanguageVersionSettings
-            useOldInlineClassesManglingScheme = false
-        )
-        this.typeMapper = typeMapper
-        return typeMapper
-    }
 
     override fun doAnalysis(
         project: Project,

--- a/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/KotlinUastTypeMapper.kt
+++ b/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/KotlinUastTypeMapper.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.uast.kotlin.internal
+
+import org.jetbrains.kotlin.builtins.functions.FunctionClassDescriptor
+import org.jetbrains.kotlin.builtins.functions.FunctionClassKind
+import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
+import org.jetbrains.kotlin.codegen.signature.AsmTypeFactory
+import org.jetbrains.kotlin.codegen.signature.JvmSignatureWriter
+import org.jetbrains.kotlin.codegen.state.isMostPreciseContravariantArgument
+import org.jetbrains.kotlin.codegen.state.isMostPreciseCovariantArgument
+import org.jetbrains.kotlin.codegen.state.updateArgumentModeFromAnnotations
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.load.kotlin.TypeMappingConfiguration
+import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
+import org.jetbrains.kotlin.load.kotlin.mapType
+import org.jetbrains.kotlin.name.SpecialNames
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.types.*
+import org.jetbrains.kotlin.types.checker.SimpleClassicTypeSystemContext
+import org.jetbrains.kotlin.types.checker.convertVariance
+import org.jetbrains.kotlin.types.model.*
+import org.jetbrains.org.objectweb.asm.Type
+
+object KotlinUastTypeMapper {
+    private val staticTypeMappingConfiguration = object : TypeMappingConfiguration<Type> {
+        override fun commonSupertype(types: Collection<KotlinType>): KotlinType {
+            return CommonSupertypes.commonSupertype(types)
+        }
+
+        override fun getPredefinedTypeForClass(classDescriptor: ClassDescriptor): Type? {
+            return null
+        }
+
+        override fun getPredefinedInternalNameForClass(classDescriptor: ClassDescriptor): String? {
+            return null
+        }
+
+        override fun processErrorType(kotlinType: KotlinType, descriptor: ClassDescriptor) {
+            // Light class mode: not generating body, and thus not report error type.
+        }
+
+        override fun preprocessType(kotlinType: KotlinType): KotlinType? {
+            return null
+        }
+    }
+
+    fun mapType(
+        type: KotlinType,
+        signatureVisitor: JvmSignatureWriter? = null,
+        mode: TypeMappingMode = TypeMappingMode.DEFAULT_UAST,
+    ): Type {
+        return mapType(
+            type, AsmTypeFactory, mode, staticTypeMappingConfiguration, signatureVisitor
+        ) { ktType, asmType, typeMappingMode ->
+            writeGenericType(ktType, asmType, signatureVisitor, typeMappingMode)
+        }
+    }
+
+    private fun mapType(descriptor: ClassifierDescriptor): Type {
+        return mapType(descriptor.defaultType)
+    }
+
+    private fun writeGenericType(
+        type: KotlinType,
+        asmType: Type,
+        signatureVisitor: JvmSignatureWriter?,
+        mode: TypeMappingMode
+    ) {
+        if (signatureVisitor == null) return
+
+        // Nothing mapping rules:
+        //  Map<Nothing, Foo> -> Map
+        //  Map<Foo, List<Nothing>> -> Map<Foo, List>
+        //  In<Nothing, Foo> == In<*, Foo> -> In<?, Foo>
+        //  In<Nothing, Nothing> -> In
+        //  Inv<in Nothing, Foo> -> Inv
+        if (signatureVisitor.skipGenericSignature() || hasNothingInNonContravariantPosition(type) || type.arguments.isEmpty()) {
+            signatureVisitor.writeAsmType(asmType)
+            return
+        }
+
+        val possiblyInnerType = type.buildPossiblyInnerType() ?: error("possiblyInnerType with arguments should not be null")
+
+        val innerTypesAsList = possiblyInnerType.segments()
+
+        val indexOfParameterizedType = innerTypesAsList.indexOfFirst { innerPart -> innerPart.arguments.isNotEmpty() }
+        if (indexOfParameterizedType < 0 || innerTypesAsList.size == 1) {
+            signatureVisitor.writeClassBegin(asmType)
+            writeGenericArguments(signatureVisitor, possiblyInnerType, mode)
+        } else {
+            val outerType = innerTypesAsList[indexOfParameterizedType]
+
+            signatureVisitor.writeOuterClassBegin(asmType, mapType(outerType.classDescriptor).internalName)
+            writeGenericArguments(signatureVisitor, outerType, mode)
+
+            writeInnerParts(innerTypesAsList, signatureVisitor, mode, indexOfParameterizedType + 1) // inner parts separated by `.`
+        }
+
+        signatureVisitor.writeClassEnd()
+    }
+
+    private fun hasNothingInNonContravariantPosition(kotlinType: KotlinType): Boolean =
+        SimpleClassicTypeSystemContext.hasNothingInNonContravariantPosition(kotlinType)
+
+    private fun TypeSystemContext.hasNothingInNonContravariantPosition(type: KotlinTypeMarker): Boolean {
+        val typeConstructor = type.typeConstructor()
+
+        for (i in 0 until type.argumentsCount()) {
+            val projection = type.getArgument(i)
+            if (projection.isStarProjection()) continue
+
+            val argument = projection.getType()
+
+            if (argument.isNullableNothing() ||
+                argument.isNothing() && typeConstructor.getParameter(i).getVariance() != TypeVariance.IN
+            ) return true
+        }
+
+        return false
+    }
+
+    private fun writeInnerParts(
+        innerTypesAsList: List<PossiblyInnerType>,
+        signatureVisitor: JvmSignatureWriter,
+        mode: TypeMappingMode,
+        index: Int
+    ) {
+        for (innerPart in innerTypesAsList.subList(index, innerTypesAsList.size)) {
+            signatureVisitor.writeInnerClass(getJvmShortName(innerPart.classDescriptor))
+            writeGenericArguments(signatureVisitor, innerPart, mode)
+        }
+    }
+
+    private fun writeGenericArguments(
+        signatureVisitor: JvmSignatureWriter,
+        type: PossiblyInnerType,
+        mode: TypeMappingMode
+    ) {
+        val classDescriptor = type.classDescriptor
+        val parameters = classDescriptor.declaredTypeParameters
+        val arguments = type.arguments
+
+        if (classDescriptor is FunctionClassDescriptor) {
+            if (classDescriptor.hasBigArity ||
+                classDescriptor.functionKind == FunctionClassKind.KFunction ||
+                classDescriptor.functionKind == FunctionClassKind.KSuspendFunction
+            ) {
+                // kotlin.reflect.KFunction{n}<P1, ..., Pn, R> is mapped to kotlin.reflect.KFunction<R> (for all n), and
+                // kotlin.Function{n}<P1, ..., Pn, R> is mapped to kotlin.jvm.functions.FunctionN<R> (for n > 22).
+                // So for these classes, we need to skip all type arguments except the very last one
+                writeGenericArguments(signatureVisitor, listOf(arguments.last()), listOf(parameters.last()), mode)
+                return
+            }
+        }
+
+        writeGenericArguments(signatureVisitor, arguments, parameters, mode)
+    }
+
+    private fun writeGenericArguments(
+        signatureVisitor: JvmSignatureWriter,
+        arguments: List<TypeProjection>,
+        parameters: List<TypeParameterDescriptor>,
+        mode: TypeMappingMode
+    ) {
+        with(SimpleClassicTypeSystemContext) {
+            writeGenericArguments(signatureVisitor, arguments, parameters, mode) { type, sw, mode ->
+                mapType(type as KotlinType, sw, mode)
+            }
+        }
+    }
+
+    private fun TypeSystemCommonBackendContext.writeGenericArguments(
+        signatureVisitor: JvmSignatureWriter,
+        arguments: List<TypeArgumentMarker>,
+        parameters: List<TypeParameterMarker>,
+        mode: TypeMappingMode,
+        mapType: (KotlinTypeMarker, JvmSignatureWriter, TypeMappingMode) -> Type
+    ) {
+        for ((parameter, argument) in parameters.zip(arguments)) {
+            if (argument.isStarProjection() ||
+                // In<Nothing, Foo> == In<*, Foo> -> In<?, Foo>
+                argument.getType().isNothing() && parameter.getVariance() == TypeVariance.IN
+            ) {
+                signatureVisitor.writeUnboundedWildcard()
+            } else {
+                val argumentMode = mode.updateArgumentModeFromAnnotations(argument.getType(), this)
+                val projectionKind = getVarianceForWildcard(parameter, argument, argumentMode)
+
+                signatureVisitor.writeTypeArgument(projectionKind)
+
+                mapType(
+                    argument.getType(), signatureVisitor,
+                    argumentMode.toGenericArgumentMode(
+                        getEffectiveVariance(parameter.getVariance().convertVariance(), argument.getVariance().convertVariance())
+                    )
+                )
+
+                signatureVisitor.writeTypeArgumentEnd()
+            }
+        }
+    }
+
+    private fun TypeSystemCommonBackendContext.getVarianceForWildcard(
+        parameter: TypeParameterMarker, projection: TypeArgumentMarker, mode: TypeMappingMode
+    ): Variance {
+        val projectionKind = projection.getVariance().convertVariance()
+        val parameterVariance = parameter.getVariance().convertVariance()
+
+        if (parameterVariance == Variance.INVARIANT) {
+            return projectionKind
+        }
+
+        if (mode.skipDeclarationSiteWildcards) {
+            return Variance.INVARIANT
+        }
+
+        if (projectionKind == Variance.INVARIANT || projectionKind == parameterVariance) {
+            if (mode.skipDeclarationSiteWildcardsIfPossible && !projection.isStarProjection()) {
+                if (parameterVariance == Variance.OUT_VARIANCE && isMostPreciseCovariantArgument(projection.getType())) {
+                    return Variance.INVARIANT
+                }
+
+                if (parameterVariance == Variance.IN_VARIANCE && isMostPreciseContravariantArgument(projection.getType(), parameter)) {
+                    return Variance.INVARIANT
+                }
+            }
+            return parameterVariance
+        }
+
+        // In<out X> = In<*>
+        // Out<in X> = Out<*>
+        return Variance.OUT_VARIANCE
+    }
+
+    private fun getJvmShortName(klass: ClassDescriptor): String {
+        return JavaToKotlinClassMap.mapKotlinToJava(DescriptorUtils.getFqName(klass))?.shortClassName?.asString()
+            ?: SpecialNames.safeIdentifier(klass.name).identifier
+    }
+}

--- a/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/kotlinInternalUastUtils.kt
+++ b/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/internal/kotlinInternalUastUtils.kt
@@ -59,6 +59,7 @@ import org.jetbrains.kotlin.types.typeUtil.isInterface
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import org.jetbrains.uast.*
+import org.jetbrains.uast.kotlin.internal.KotlinUastTypeMapper
 import org.jetbrains.uast.kotlin.psi.UastDescriptorLightMethod
 import org.jetbrains.uast.kotlin.psi.UastFakeLightMethod
 import org.jetbrains.uast.kotlin.psi.UastFakeLightPrimaryConstructor
@@ -138,9 +139,6 @@ internal fun KotlinType.toPsiType(
 
     val project = context.project
 
-    val typeMapper = project.getService(KotlinUastResolveProviderService::class.java)
-        .getTypeMapper(context) ?: return UastErrorType
-
     val languageVersionSettings = project.getService(KotlinUastResolveProviderService::class.java)
         .getLanguageVersionSettings(context)
 
@@ -148,7 +146,7 @@ internal fun KotlinType.toPsiType(
     val typeMappingMode = if (boxed) TypeMappingMode.GENERIC_ARGUMENT_UAST else TypeMappingMode.DEFAULT_UAST
     val approximatedType =
         TypeApproximator(this.builtIns, languageVersionSettings).approximateDeclarationType(this, true)
-    typeMapper.mapType(approximatedType, signatureWriter, typeMappingMode)
+    KotlinUastTypeMapper.mapType(approximatedType, signatureWriter, typeMappingMode)
 
     val signature = StringCharacterIterator(signatureWriter.toString())
 


### PR DESCRIPTION
As per [KT-48532](https://youtrack.jetbrains.com/issue/KT-48532), old BE will be deprecated, and `KotlinTypeMapper` is part of it ([Kt-48773](https://youtrack.jetbrains.com/issue/KT-48773)). FE 1.0 UAST uses it to convert `KotlinType` to `PsiType`.

As part of NI (new inference), `AbstractTypeMapper` is introduced and used across BE IR (`IrTypeMapper`) and FE IR (`FirJvmTypeMapper`). Adding yet another implementation of `AbstractTypeMapper` for `KotlinType` (#1741) is not that trivial as described there.

Instead, this PR is a short-term solution: use `descriptorBasedTypeSignatureMapping.kt` along with utils for generic type writing from `KotlinTypeMapper`.