### PR TITLE
[kotlin] KTIJ-19714 Remove duplicated extract constant action for kotlin

### DIFF
--- a/plugins/kotlin/plugin/resources/META-INF/refactorings.xml
+++ b/plugins/kotlin/plugin/resources/META-INF/refactorings.xml
@@ -201,11 +201,6 @@
       <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="IntroduceField"/>
     </action>
 
-    <action id="IntroduceConstantKt" class="org.jetbrains.kotlin.idea.refactoring.introduce.introduceConstant.IntroduceConstantAction"
-            use-shortcut-of="IntroduceConstant">
-      <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="IntroduceProperty"/>
-    </action>
-
     <action id="ExtractFunctionToScope" class="org.jetbrains.kotlin.idea.refactoring.introduce.extractFunction.ExtractFunctionToScopeAction">
       <keyboard-shortcut keymap="$default" first-keystroke="control alt shift M"/>
       <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="ExtractFunction"/>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19714

Seems like I misunderstood what that thing does and thus duplicated it. The java equivalent of refactorings.xml already has the action defined.

With it removed it looks like this now
![image](https://user-images.githubusercontent.com/41164160/134230142-d1cded35-eef8-4a12-b73d-fe4e573bddde.png)
