### PR TITLE
Teach launcher.py about ideScript

### DIFF
--- a/platform/platform-resources/src/launcher.py
+++ b/platform/platform-resources/src/launcher.py
@@ -20,7 +20,8 @@ def print_usage(cmd):
            '  {0} [project_dir] [-w|--wait]\n' +
            '  {0} [-l|--line line] [project_dir|--temp-project] [-w|--wait] file[:line]\n' +
            '  {0} diff <left> <right>\n' +
-           '  {0} merge <local> <remote> [base] <merged>').format(cmd))
+           '  {0} merge <local> <remote> [base] <merged>\n' +
+           '  {0} ideScript <script>').format(cmd))
 
 
 def write_to_sock(sock, data):
@@ -57,7 +58,7 @@ def process_args(argv):
         if arg == '-h' or arg == '-?' or arg == '--help':
             print_usage(argv[0])
             exit(0)
-        elif i == 0 and (arg == 'diff' or arg == 'merge' or arg == '--temp-project'):
+        elif i == 0 and (arg == 'diff' or arg == 'merge' or arg == 'ideScript' or arg == '--temp-project'):
             args.append(arg)
         elif arg == '-l' or arg == '--line':
             args.append(arg)


### PR DESCRIPTION
Make `launcher.py` aware of `ideScript` command, so it can be used to trigger running an IDE script in a existing IntelliJ IDEA instance

### Test case
1. In IntelliJ IDEA CE go to Tools > Create Command Line Launcher to save the launcher script, e.g. as `/tmp/idea`
2. Create a file called `test.groovy` with contents `com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater({com.intellij.openapi.ui.Messages.showMessageDialog(null, "Hello World!", "Greeting", null)})`
3. Run `/tmp/idea ideScript ./test.groovy`
4. Switch to running IDEA app, observe "Hello World!" popup window

By comparison, prior to this change, the same steps above would not run `./test.groovy`, instead the IDEA editor would open up it up for editing.

@gregsh I thought you might be interested in this PR since you wrote the `ideScript` component