### PR TITLE
KTIJ-19619 Incorrect adding brace after `when` before infix keyword on Enter autocomplete

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinEnterAfterUnmatchedBraceHandler.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KotlinEnterAfterUnmatchedBraceHandler.kt
@@ -43,6 +43,8 @@ class KotlinEnterAfterUnmatchedBraceHandler : EnterAfterUnmatchedBraceHandler() 
 
     override fun getRBraceOffset(file: PsiFile, editor: Editor, caretOffset: Int): Int {
         val element = file.findElementAt(caretOffset - 1)
+        val nextSibling = element?.nextSibling
+        if (nextSibling is PsiWhiteSpace && nextSibling.textContains('\n')) return super.getRBraceOffset(file, editor, caretOffset)
         val endOffset = when (val parent = element?.parent) {
             is KtFunctionLiteral -> {
                 val call = parent.getStrictParentOfType<KtCallExpression>()

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/TypingIndentationTestBaseGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/TypingIndentationTestBaseGenerated.java
@@ -307,6 +307,11 @@ public abstract class TypingIndentationTestBaseGenerated extends AbstractTypingI
                 runTest("testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer.after.kt");
             }
 
+            @TestMetadata("NotApplicableOnInitializer2.after.kt")
+            public void testNotApplicableOnInitializer2() throws Exception {
+                runTest("testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer2.after.kt");
+            }
+
             @TestMetadata("WhenBeforeLocalPropertyInitializer.after.kt")
             public void testWhenBeforeLocalPropertyInitializer() throws Exception {
                 runTest("testData/indentationOnNewline/afterUnmatchedBrace/WhenBeforeLocalPropertyInitializer.after.kt");

--- a/plugins/kotlin/idea/tests/testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer2.after.kt
+++ b/plugins/kotlin/idea/tests/testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer2.after.kt
@@ -1,0 +1,5 @@
+val test = when {
+    <caret>
+}
+
+infix fun Int.foo(x: Int) = 42

--- a/plugins/kotlin/idea/tests/testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer2.kt
+++ b/plugins/kotlin/idea/tests/testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer2.kt
@@ -1,0 +1,3 @@
+val test = when {<caret>
+
+infix fun Int.foo(x: Int) = 42

--- a/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceTypingIndentationTestGenerated.java
+++ b/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceTypingIndentationTestGenerated.java
@@ -307,6 +307,11 @@ public abstract class PerformanceTypingIndentationTestGenerated extends Abstract
                 runTest("../idea/tests/testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer.after.kt");
             }
 
+            @TestMetadata("NotApplicableOnInitializer2.after.kt")
+            public void testNotApplicableOnInitializer2() throws Exception {
+                runTest("../idea/tests/testData/indentationOnNewline/afterUnmatchedBrace/NotApplicableOnInitializer2.after.kt");
+            }
+
             @TestMetadata("WhenBeforeLocalPropertyInitializer.after.kt")
             public void testWhenBeforeLocalPropertyInitializer() throws Exception {
                 runTest("../idea/tests/testData/indentationOnNewline/afterUnmatchedBrace/WhenBeforeLocalPropertyInitializer.after.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19619