### PR TITLE
[python] Add python 3.11 to list of python versions

### DIFF
--- a/python/python-psi-api/src/com/jetbrains/python/psi/FutureFeature.java
+++ b/python/python-psi-api/src/com/jetbrains/python/psi/FutureFeature.java
@@ -28,7 +28,7 @@ public enum FutureFeature {
   ABSOLUTE_IMPORT("absolute_import", LanguageLevel.PYTHON25, LanguageLevel.PYTHON30),
   PRINT_FUNCTION("print_function", LanguageLevel.PYTHON26, LanguageLevel.PYTHON30),
   UNICODE_LITERALS("unicode_literals", LanguageLevel.PYTHON26, LanguageLevel.PYTHON30),
-  ANNOTATIONS("annotations", LanguageLevel.PYTHON37, LanguageLevel.PYTHON310)
+  ANNOTATIONS("annotations", LanguageLevel.PYTHON37, LanguageLevel.PYTHON311)
   // NOTE: only add new features to the end unless you want to break existing stubs that rely on ordinal
   ;
 

--- a/python/python-psi-api/src/com/jetbrains/python/psi/LanguageLevel.java
+++ b/python/python-psi-api/src/com/jetbrains/python/psi/LanguageLevel.java
@@ -60,7 +60,8 @@ public enum LanguageLevel {
   PYTHON37(307),
   PYTHON38(308),
   PYTHON39(309),
-  PYTHON310(310);
+  PYTHON310(310),
+  PYTHON311(311);
 
   /**
    * This value is mostly bound to the compatibility of our debugger and helpers.
@@ -172,6 +173,9 @@ public enum LanguageLevel {
       }
       if (pythonVersion.startsWith("3.10")) {
         return PYTHON310;
+      }
+      if (pythonVersion.startsWith("3.11")) {
+        return PYTHON311;
       }
       return DEFAULT3;
     }


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0664/

Also fixed a small issue where `__future__.annotations` was marked as included in 3.10, when it's now marked as 3.11.