### PR TITLE
Never step to fake line numbers generated by the Kotlin compiler.

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepAction.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/stepping/KotlinStepAction.kt
@@ -35,5 +35,11 @@ sealed class KotlinStepAction {
         }
     }
 
+    class KotlinStepInto(private val smartStepFilter: MethodFilter?) : KotlinStepAction() {
+        override fun apply(debugProcess: DebugProcessImpl, suspendContext: SuspendContextImpl, ignoreBreakpoints: Boolean) {
+            KotlinStepActionFactory(debugProcess).createKotlinStepIntoAction(smartStepFilter).contextAction(suspendContext)
+        }
+    }
+
     abstract fun apply(debugProcess: DebugProcessImpl, suspendContext: SuspendContextImpl, ignoreBreakpoints: Boolean)
 }

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/stepping/filter/KotlinStepOverFilter.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/stepping/filter/KotlinStepOverFilter.kt
@@ -4,12 +4,14 @@ package org.jetbrains.kotlin.idea.debugger.stepping.filter
 
 import com.intellij.debugger.engine.DebugProcess.JAVA_STRATUM
 import com.intellij.debugger.engine.DebugProcessImpl
+import com.intellij.debugger.engine.MethodFilter
 import com.intellij.debugger.engine.SuspendContextImpl
 import com.intellij.openapi.project.Project
 import com.intellij.util.Range
 import com.sun.jdi.Location
 import com.sun.jdi.StackFrame
 import org.jetbrains.kotlin.codegen.inline.isFakeLocalVariableForInline
+import org.jetbrains.kotlin.idea.debugger.DebuggerUtils.isKotlinFakeLineNumber
 import org.jetbrains.kotlin.idea.debugger.safeLineNumber
 import org.jetbrains.kotlin.idea.debugger.safeMethod
 import org.jetbrains.kotlin.idea.debugger.safeVariables
@@ -53,6 +55,9 @@ class KotlinStepOverFilter(
     private val callerInfo: StepOverCallerInfo
 ) : KotlinMethodFilter {
     override fun locationMatches(context: SuspendContextImpl, location: Location): Boolean {
+        // Never stop on compiler generated fake line numbers.
+        if (isKotlinFakeLineNumber(location)) return false
+
         val stackFrame = context.frameProxy?.stackFrame ?: return true
         val token = LocationToken.from(stackFrame)
         val callerInfo = StepOverCallerInfo.from(location)

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -231,6 +231,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/stepInto/inlineClass.kt");
         }
 
+        @TestMetadata("inlineFunctionLambdaOneLine.kt")
+        public void testInlineFunctionLambdaOneLine() throws Exception {
+            runTest("testData/stepping/stepInto/inlineFunctionLambdaOneLine.kt");
+        }
+
         @TestMetadata("inlineOnly.kt")
         public void testInlineOnly() throws Exception {
             runTest("testData/stepping/stepInto/inlineOnly.kt");
@@ -415,6 +420,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
         @TestMetadata("inlineFunInPropertyGetter.kt")
         public void testInlineFunInPropertyGetter() throws Exception {
             runTest("testData/stepping/stepOver/inlineFunInPropertyGetter.kt");
+        }
+
+        @TestMetadata("inlineFunctionLambdaOneLine.kt")
+        public void testInlineFunctionLambdaOneLine() throws Exception {
+            runTest("testData/stepping/stepOver/inlineFunctionLambdaOneLine.kt");
         }
 
         @TestMetadata("inlineFunctionSameLines.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinDescriptorTestCaseWithStepping.kt
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinDescriptorTestCaseWithStepping.kt
@@ -119,7 +119,7 @@ abstract class KotlinDescriptorTestCaseWithStepping : KotlinDescriptorTestCase()
 
     private fun SuspendContextImpl.doStepInto(ignoreFilters: Boolean, smartStepFilter: MethodFilter?) {
         val stepIntoCommand =
-            runReadAction { commandProvider.getStepIntoCommand(this, ignoreFilters, smartStepFilter, StepRequest.STEP_LINE) }
+            runReadAction { commandProvider.getStepIntoCommand(this, ignoreFilters, smartStepFilter) }
                 ?: dp.createStepIntoCommand(this, ignoreFilters, smartStepFilter)
 
         dp.managerThread.schedule(stepIntoCommand)

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -231,6 +231,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/stepInto/inlineClass.kt");
         }
 
+        @TestMetadata("inlineFunctionLambdaOneLine.kt")
+        public void testInlineFunctionLambdaOneLine() throws Exception {
+            runTest("testData/stepping/stepInto/inlineFunctionLambdaOneLine.kt");
+        }
+
         @TestMetadata("inlineOnly.kt")
         public void testInlineOnly() throws Exception {
             runTest("testData/stepping/stepInto/inlineOnly.kt");
@@ -415,6 +420,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
         @TestMetadata("inlineFunInPropertyGetter.kt")
         public void testInlineFunInPropertyGetter() throws Exception {
             runTest("testData/stepping/stepOver/inlineFunInPropertyGetter.kt");
+        }
+
+        @TestMetadata("inlineFunctionLambdaOneLine.kt")
+        public void testInlineFunctionLambdaOneLine() throws Exception {
+            runTest("testData/stepping/stepOver/inlineFunctionLambdaOneLine.kt");
         }
 
         @TestMetadata("inlineFunctionSameLines.kt")

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineFunctionLambdaOneLine.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineFunctionLambdaOneLine.kt
@@ -1,0 +1,9 @@
+// FILE: inlineFunctionLambdaOneLine.kt
+package inlineFunctionLambdaOneLine
+
+fun main(args: Array<String>) {
+    //Breakpoint! (lambdaOrdinal = -1)
+    42.let { 1 + it }
+}
+
+// STEP_INTO: 2

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineFunctionLambdaOneLine.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineFunctionLambdaOneLine.out
@@ -1,0 +1,9 @@
+LineBreakpoint created at inlineFunctionLambdaOneLine.kt:6 lambdaOrdinal = -1
+Run Java
+Connected to the target VM
+inlineFunctionLambdaOneLine.kt:6
+inlineFunctionLambdaOneLine.kt:6
+inlineFunctionLambdaOneLine.kt:7
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineOnly.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineOnly.kt
@@ -4,7 +4,7 @@ fun main(args: Array<String>) {
     //Breakpoint!
     myPrint("OK")
 
-    forEach { print2("123")}
+    forEach { print2("123") }
 
     println("OK")  //stdlib test
 }

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineOnly.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/stepInto/inlineOnly.out
@@ -3,12 +3,10 @@ Run Java
 Connected to the target VM
 inlineOnly.kt:5
 inlineOnly.kt:7
-inlineOnly.kt:1
 inlineOnly.kt:7
 inlineOnly.kt:13
 inlineOnly.kt:14
 inlineOnly.kt:7
-inlineOnly.kt:1
 inlineOnly.kt:7
 inlineOnly.kt:13
 inlineOnly.kt:14

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/stepOver/inlineFunctionLambdaOneLine.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/stepOver/inlineFunctionLambdaOneLine.kt
@@ -1,0 +1,7 @@
+// FILE: inlineFunctionLambdaOneLine.kt
+package inlineFunctionLambdaOneLine
+
+fun main(args: Array<String>) {
+    //Breakpoint! (lambdaOrdinal = -1)
+    42.let { 1 + it }
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/stepOver/inlineFunctionLambdaOneLine.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/stepOver/inlineFunctionLambdaOneLine.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at inlineFunctionLambdaOneLine.kt:6 lambdaOrdinal = -1
+Run Java
+Connected to the target VM
+inlineFunctionLambdaOneLine.kt:6
+inlineFunctionLambdaOneLine.kt:7
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/util/src/org/jetbrains/kotlin/idea/debugger/DebuggerUtils.kt
+++ b/plugins/kotlin/jvm-debugger/util/src/org/jetbrains/kotlin/idea/debugger/DebuggerUtils.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtilRt
 import com.intellij.psi.search.GlobalSearchScope
+import com.sun.jdi.AbsentInformationException
 import com.sun.jdi.Location
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.kotlin.asJava.finder.JavaElementFinder
@@ -85,5 +86,27 @@ object DebuggerUtils {
     fun isKotlinSourceFile(fileName: String): Boolean {
         val extension = FileUtilRt.getExtension(fileName).toLowerCase()
         return extension in KotlinFileTypeFactoryUtils.KOTLIN_EXTENSIONS
+    }
+
+    fun isKotlinFakeLineNumber(location: Location): Boolean {
+        // The compiler inserts a fake line number for single-line inline function calls with a
+        // lambda parameter such as:
+        //
+        //   42.let { it + 1 }
+        //
+        // This is done so that a breakpoint can be set on the lambda and on the line even though
+        // the lambda is on the same line. When stepping, we do not want to stop at such fake line
+        // numbers. They cause us to step to line 1 of the current file.
+        try {
+            if (location.lineNumber("Kotlin") == 1 &&
+                location.sourcePath("Kotlin") == "kotlin/jvm/internal/FakeKt" &&
+                location.sourceName("Kotlin") == "fake.kt"
+            ) {
+                return true
+            }
+        } catch (e: AbsentInformationException) {
+            // Ignore.
+        }
+        return false
     }
 }


### PR DESCRIPTION
The compiler inserts a fake line number for single-line inline
function calls with a lambda parameter such as:

   `42.let { it + 1 }`

This is done so that a breakpoint can be set on the lambda and
on the line even though the lambda is on the same line. When
stepping, we do not want to stop at such fake line numbers.
They cause us to step to line 1 of the current file.

For StepOver this is simple as we just need to filter them out
in the existing Kotlin specific debugger code.

For StepInto we need to add special Kotlin handling.

^KTIJ-18645 Fixed.