### PR TITLE
IDEA-279879 Highlight each line with trailing spaces in text block not just the first one

### DIFF
--- a/java/java-impl-inspections/src/com/intellij/codeInspection/TrailingWhitespacesInTextBlockInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/TrailingWhitespacesInTextBlockInspection.java
@@ -46,7 +46,7 @@ public class TrailingWhitespacesInTextBlockInspection extends AbstractBaseJavaLo
                 holder.registerProblem(expression, new TextRange(start + j + 1, start + j + 2),
                                        JavaBundle.message("inspection.trailing.whitespaces.in.text.block.message"),
                                        createFixes());
-                return;
+                break;
               }
             }
           }


### PR DESCRIPTION
This PR fixes IDEA-279879. 

#### Proposed solution
Continue processing lines of text block, instead of returning from the function

#### IDEA behavior after the change
![text_after](https://user-images.githubusercontent.com/42293632/136446981-d684c88e-7981-4545-8bd9-86c4ced7a0a3.png)
