### PR TITLE
IDEA-279961: Enable double negation cleanup

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/DoubleNegationInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/DoubleNegationInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -30,7 +31,7 @@ import com.siyeh.ig.psiutils.TypeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class DoubleNegationInspection extends BaseInspection {
+public class DoubleNegationInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
+++ b/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
@@ -616,7 +616,7 @@
                      implementationClass="com.siyeh.ig.controlflow.DefaultNotLastCaseInSwitchInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="DoubleNegation" bundle="messages.InspectionGadgetsBundle" key="double.negation.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.control.flow.issues" enabledByDefault="true"
-                     level="WARNING" implementationClass="com.siyeh.ig.controlflow.DoubleNegationInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.controlflow.DoubleNegationInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="DuplicateCondition" bundle="messages.InspectionGadgetsBundle" key="duplicate.condition.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.control.flow.issues" enabledByDefault="true"
                      level="WARNING" implementationClass="com.siyeh.ig.controlflow.DuplicateConditionInspection"/>

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/controlflow/DoubleNegationFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/controlflow/DoubleNegationFixTest.java
@@ -32,6 +32,22 @@ public class DoubleNegationFixTest extends IGQuickFixesTestCase {
     myDefaultHint = InspectionGadgetsBundle.message("double.negation.quickfix");
   }
 
+  public void testDoubleNegation() {
+    doExpressionTest(myDefaultHint,
+                     "!/**/!(System.currentTimeMillis() > 1_000_000)",
+                     "System.currentTimeMillis() > 1_000_000");
+  }
+
   public void testDoubleDoubleNegation() { doTest(); }
+
   public void testPolyadicParentheses() { doTest(); }
+
+  public void testDoNotCleanupWithSingleNegation() {
+    assertQuickfixNotAvailable(myDefaultHint,
+                               "class X {\n" +
+                               "  boolean test(boolean isValid) {\n" +
+                               "    return !/**/isValid;\n" +
+                               "  }\n" +
+                               "}\n");
+  }
 }


### PR DESCRIPTION
Hi @BasLeijdekkers,

I suggest to make the _Double negation_ quickfix a cleanup too. It works correctly and it enhances the features of _IntelliJ_. I also added some tests.
https://youtrack.jetbrains.com/issue/IDEA-279961