### PR TITLE
FIR IDE: enable CommaInWhenConditionWithoutArgumentFix for FIR

### DIFF
--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/quickfix/MainKtQuickFixRegistrar.kt
@@ -136,6 +136,7 @@ class MainKtQuickFixRegistrar : KtQuickFixRegistrar() {
         // TODO: NON_EXHAUSTIVE_WHEN[_ON_SEALED_CLASS] will be replaced in future. We need to register the fix for those diagnostics as well
         registerPsiQuickFixes(KtFirDiagnostic.NoElseInWhen::class, AddWhenElseBranchFix)
         registerApplicator(AddWhenRemainingBranchFixFactories.noElseInWhen)
+        registerPsiQuickFixes(KtFirDiagnostic.CommaInWhenConditionWithoutArgument::class, CommaInWhenConditionWithoutArgumentFix)
     }
 
     private val typeMismatch = KtQuickFixesListBuilder.registerPsiQuickFix {

--- a/plugins/kotlin/frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/CommaInWhenConditionWithoutArgumentFix.kt
+++ b/plugins/kotlin/frontend-independent/src/org/jetbrains/kotlin/idea/quickfix/CommaInWhenConditionWithoutArgumentFix.kt
@@ -1,4 +1,7 @@
-// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
 
 package org.jetbrains.kotlin.idea.quickfix
 
@@ -6,28 +9,28 @@ import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.diagnostics.Diagnostic
+import com.intellij.util.containers.addIfNotNull
 import org.jetbrains.kotlin.idea.KotlinBundle
-import org.jetbrains.kotlin.idea.intentions.branchedTransformations.combineWhenConditions
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 
-
-class CommaInWhenConditionWithoutArgumentFix(element: PsiElement) : KotlinQuickFixAction<PsiElement>(element), CleanupFix {
+class CommaInWhenConditionWithoutArgumentFix(element: KtWhenExpression) : KotlinPsiOnlyQuickFixAction<KtWhenExpression>(element),
+                                                                          CleanupFix {
     override fun getFamilyName(): String = text
     override fun getText(): String = KotlinBundle.message("replace.with.in.when")
 
     override fun invoke(project: Project, editor: Editor?, file: KtFile) {
-        val whenExpression = element as? KtWhenExpression ?: return
+        val whenExpression = element ?: return
         replaceCommasWithOrsInWhenExpression(whenExpression)
     }
 
-    companion object : KotlinSingleIntentionActionFactory() {
-        override fun createAction(diagnostic: Diagnostic): IntentionAction? =
-            diagnostic.psiElement.parent?.parent?.let(::CommaInWhenConditionWithoutArgumentFix)
+    companion object : QuickFixesPsiBasedFactory<PsiElement>(PsiElement::class, PsiElementSuitabilityCheckers.ALWAYS_SUITABLE) {
+        override fun doCreateQuickFix(psiElement: PsiElement): List<IntentionAction> {
+            return listOfNotNull((psiElement.parent?.parent as? KtWhenExpression)?.let(::CommaInWhenConditionWithoutArgumentFix))
+        }
 
         private class WhenEntryConditionsData(
-            val conditions: Array<KtWhenCondition>,
+            val conditions: List<KtExpression>,
             val first: PsiElement,
             val last: PsiElement,
             val arrow: PsiElement
@@ -37,7 +40,11 @@ class CommaInWhenConditionWithoutArgumentFix(element: PsiElement) : KotlinQuickF
             for (whenEntry in whenExpression.entries) {
                 if (whenEntry.conditions.size > 1) {
                     val conditionsData = getConditionsDataOrNull(whenEntry) ?: return
-                    val replacement = KtPsiFactory(whenEntry).combineWhenConditions(conditionsData.conditions, null) ?: return
+                    // Leave branch untouched if there are no valid conditions
+                    if (conditionsData.conditions.isEmpty()) continue
+                    val replacement = KtPsiFactory(whenEntry).buildExpression {
+                        appendExpressions(conditionsData.conditions, separator = "||")
+                    }
                     whenEntry.deleteChildRange(conditionsData.first, conditionsData.last)
                     whenEntry.addBefore(replacement, conditionsData.arrow)
                 }
@@ -45,7 +52,7 @@ class CommaInWhenConditionWithoutArgumentFix(element: PsiElement) : KotlinQuickF
         }
 
         private fun getConditionsDataOrNull(whenEntry: KtWhenEntry): WhenEntryConditionsData? {
-            val conditions = ArrayList<KtWhenCondition>()
+            val conditions = mutableListOf<KtExpression>()
 
             var arrow: PsiElement? = null
 
@@ -53,7 +60,7 @@ class CommaInWhenConditionWithoutArgumentFix(element: PsiElement) : KotlinQuickF
             whenEntryChildren@ while (child != null) {
                 when {
                     child is KtWhenConditionWithExpression -> {
-                        conditions.add(child)
+                        conditions.addIfNotNull(child.expression)
                     }
                     child.node.elementType == KtTokens.ARROW -> {
                         arrow = child
@@ -66,11 +73,9 @@ class CommaInWhenConditionWithoutArgumentFix(element: PsiElement) : KotlinQuickF
             val last = child?.prevSibling
 
             return if (arrow != null && last != null)
-                WhenEntryConditionsData(conditions.toTypedArray(), whenEntry.firstChild, last, arrow)
+                WhenEntryConditionsData(conditions, whenEntry.firstChild, last, arrow)
             else
                 null
         }
-
     }
-
 }

--- a/plugins/kotlin/idea/tests/testData/quickfix/when/commasInConditionWithNoArguments.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/when/commasInConditionWithNoArguments.kt
@@ -1,4 +1,6 @@
 // "Replace ',' with '||' in when" "true"
+// ERROR: Expected condition of type Boolean
+// ERROR: Expected condition of type Boolean
 fun test(i: Int, j: Int) {
     var b = false
     when {
@@ -6,6 +8,8 @@ fun test(i: Int, j: Int) {
         i > 0<caret>, j > 0 -> { /* code 2 */ }
         j == 0 -> { /* code 3 */ }
         i < 0, j < 0, j > i -> { /* code 4 */ }
+        in 1..2 -> { /* code 5 */ }
+        is Int -> { /* code 6 */ }
         else -> { /* other code */ }
     }
 }

--- a/plugins/kotlin/idea/tests/testData/quickfix/when/commasInConditionWithNoArguments.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/when/commasInConditionWithNoArguments.kt.after
@@ -1,4 +1,6 @@
 // "Replace ',' with '||' in when" "true"
+// ERROR: Expected condition of type Boolean
+// ERROR: Expected condition of type Boolean
 fun test(i: Int, j: Int) {
     var b = false
     when {
@@ -6,6 +8,8 @@ fun test(i: Int, j: Int) {
         i > 0 || j > 0 -> { /* code 2 */ }
         j == 0 -> { /* code 3 */ }
         i < 0 || j < 0 || j > i -> { /* code 4 */ }
+        in 1..2 -> { /* code 5 */ }
+        is Int -> { /* code 6 */ }
         else -> { /* other code */ }
     }
 }


### PR DESCRIPTION
This PR requires https://kotlin.jetbrains.space/p/kotlin/reviews/230/timeline

Also do some minor clean up and change the fix to not to touch a
condition if it doesn't contain any condition with expression.