### PR TITLE
IDEA-281190: consider `MethodType.methodType` overloads in MethodHandle inspections

### DIFF
--- a/java/java-impl-inspections/src/com/intellij/codeInspection/reflectiveAccess/JavaLangReflectHandleInvocationChecker.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/reflectiveAccess/JavaLangReflectHandleInvocationChecker.java
@@ -5,12 +5,11 @@ import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.java.JavaBundle;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Pair;
-import com.intellij.openapi.util.RecursionGuard;
-import com.intellij.openapi.util.RecursionManager;
 import com.intellij.psi.*;
 import com.intellij.psi.util.InheritanceUtil;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.containers.ContainerUtil;
+import com.siyeh.ig.callMatcher.CallMapper;
 import com.siyeh.ig.psiutils.ExpressionUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,9 +34,14 @@ final class JavaLangReflectHandleInvocationChecker {
   private static final String INVOKE_WITH_ARGUMENTS = "invokeWithArguments";
   private static final String JAVA_LANG_INVOKE_METHOD_HANDLE = "java.lang.invoke.MethodHandle";
 
+  private static final CallMapper<List<Supplier<ReflectiveType>>> LAZY_SIGNATURE_MAPPER = new CallMapper<List<Supplier<ReflectiveType>>>()
+    .register(METHOD_TYPE_WITH_CLASSES_MATCHER, call -> getLazyMethodSignatureForTypes(call))
+    .register(METHOD_TYPE_WITH_LIST_MATCHER, call -> getLazyMethodSignatureForReturnTypeAndList(call))
+    .register(METHOD_TYPE_WITH_ARRAY_MATCHER, call -> getLazyMethodSignatureForReturnTypeAndArray(call))
+    .register(METHOD_TYPE_WITH_METHOD_TYPE_MATCHER, call -> getLazyMethodSignatureForReturnTypeAndMethodType(call))
+    .register(GENERIC_METHOD_TYPE_MATCHER, call -> getLazyMethodSignatureForGenericMethodType(call));
+
   private static final Set<String> METHOD_HANDLE_INVOKE_NAMES = ContainerUtil.set(INVOKE, INVOKE_EXACT, INVOKE_WITH_ARGUMENTS);
-  private static final RecursionGuard<PsiExpression> ourGuard =
-    RecursionManager.createGuard(JavaLangReflectHandleInvocationChecker.class.getName());
 
   static boolean checkMethodHandleInvocation(@NotNull PsiMethodCallExpression methodCall, @NotNull ProblemsHolder holder) {
     final String referenceName = methodCall.getMethodExpression().getReferenceName();
@@ -251,63 +255,96 @@ final class JavaLangReflectHandleInvocationChecker {
   private static List<Supplier<ReflectiveType>> getLazyMethodSignature(@Nullable PsiExpression methodTypeExpression) {
     final PsiExpression typeDefinition = findDefinition(methodTypeExpression);
     if (typeDefinition instanceof PsiMethodCallExpression) {
-      final PsiMethodCallExpression typeDefinitionCall = (PsiMethodCallExpression)typeDefinition;
+      return LAZY_SIGNATURE_MAPPER.mapFirst(((PsiMethodCallExpression)typeDefinition));
+    }
+    return null;
+  }
 
-      if (isCallToMethod(typeDefinitionCall, JAVA_LANG_INVOKE_METHOD_TYPE, METHOD_TYPE)) {
-        final PsiExpression[] arguments = typeDefinitionCall.getArgumentList().getExpressions();
-        if (arguments.length == 2) {
-          final PsiExpression returnType = findDefinition(arguments[0]);
-          final PsiExpression secondArgument = findDefinition(arguments[1]);
-          final List<PsiExpression> components = getArrayOrListComponents(secondArgument);
-          if (components != null) {
-            // Call to MethodType.methodType(Class<?>, List<Class<?>>) or MethodType.methodType(Class<?>, Class<?>[])
-            final List<PsiExpression> signature = ContainerUtil.prepend(components, returnType);
-            return ContainerUtil.map(signature, parameter -> (() -> getReflectiveType(parameter)));
-          }
-          if (secondArgument instanceof PsiMethodCallExpression) {
-            final PsiMethodCallExpression maybeNestedMethodTypeCall = (PsiMethodCallExpression)secondArgument;
-            if (isCallToMethod(maybeNestedMethodTypeCall, JAVA_LANG_INVOKE_METHOD_TYPE, METHOD_TYPE)) {
-              // Call to MethodType.methodType(Class<?>, MethodType)
-              final List<Supplier<ReflectiveType>> nestedSignature =
-                ourGuard.doPreventingRecursion(methodTypeExpression, false, () -> getLazyMethodSignature(maybeNestedMethodTypeCall));
-              if (nestedSignature != null) {
-                final List<Supplier<ReflectiveType>> signature = new ArrayList<>(nestedSignature);
-                if (!signature.isEmpty()) {
-                  signature.set(0, () -> getReflectiveType(returnType));
-                }
-                return signature;
-              }
-            }
-          }
-        }
+  @Nullable
+  private static List<Supplier<ReflectiveType>> getLazyMethodSignatureForGenericMethodType(
+    @NotNull PsiMethodCallExpression methodTypeExpression
+  ) {
+    final PsiExpression[] arguments = methodTypeExpression.getArgumentList().getExpressions();
+    final Pair.NonNull<Integer, Boolean> signature = getGenericSignature(arguments);
+    if (signature != null) {
+      final int objectArgCount = signature.getFirst();
+      final boolean finalArray = signature.getSecond();
+      if (objectArgCount == 0 && !finalArray) {
+        return Collections.emptyList();
+      }
+      final PsiClassType javaLangObject =
+        PsiType.getJavaLangObject(methodTypeExpression.getManager(), methodTypeExpression.getResolveScope());
+      final ReflectiveType objectType = ReflectiveType.create(javaLangObject, false);
+      final List<ReflectiveType> argumentTypes = new ArrayList<>();
+      argumentTypes.add(objectType); // return type
+      for (int i = 0; i < objectArgCount; i++) {
+        argumentTypes.add(objectType);
+      }
+      if (finalArray) {
+        argumentTypes.add(ReflectiveType.arrayOf(objectType));
+      }
+      return ContainerUtil.map(argumentTypes, type -> (() -> type));
+    }
+    return null;
+  }
 
-        if (arguments.length != 0) {
-          return ContainerUtil.map(arguments, argument -> (() -> getReflectiveType(argument)));
+  @Nullable
+  private static List<Supplier<ReflectiveType>> getLazyMethodSignatureForReturnTypeAndMethodType(
+    @NotNull PsiMethodCallExpression callExpression
+  ) {
+    final PsiExpression[] arguments = callExpression.getArgumentList().getExpressions();
+    if (arguments.length == 2) {
+      final PsiExpression methodType = findInnermostMethodType(arguments[1]);
+      if (methodType != null) {
+        final List<Supplier<ReflectiveType>> nestedSignature = getLazyMethodSignature(methodType);
+        if (nestedSignature != null) {
+          final List<Supplier<ReflectiveType>> signature = new ArrayList<>(nestedSignature);
+          if (!signature.isEmpty()) {
+            final PsiExpression returnType = arguments[0];
+            signature.set(0, () -> getReflectiveType(returnType));
+          }
+          return signature;
         }
       }
-      else if (isCallToMethod(typeDefinitionCall, JAVA_LANG_INVOKE_METHOD_TYPE, GENERIC_METHOD_TYPE)) {
-        final PsiExpression[] arguments = typeDefinitionCall.getArgumentList().getExpressions();
-        final Pair.NonNull<Integer, Boolean> signature = getGenericSignature(arguments);
-        if (signature != null) {
-          final int objectArgCount = signature.getFirst();
-          final boolean finalArray = signature.getSecond();
-          if (objectArgCount == 0 && !finalArray) {
-            return Collections.emptyList();
-          }
-          final PsiClassType javaLangObject =
-            PsiType.getJavaLangObject(methodTypeExpression.getManager(), methodTypeExpression.getResolveScope());
-          final ReflectiveType objectType = ReflectiveType.create(javaLangObject, false);
-          final List<ReflectiveType> argumentTypes = new ArrayList<>();
-          argumentTypes.add(objectType); // return type
-          for (int i = 0; i < objectArgCount; i++) {
-            argumentTypes.add(objectType);
-          }
-          if (finalArray) {
-            argumentTypes.add(ReflectiveType.arrayOf(objectType));
-          }
-          return ContainerUtil.map(argumentTypes, type -> (() -> type));
-        }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static List<Supplier<ReflectiveType>> getLazyMethodSignatureForReturnTypeAndArray(@NotNull PsiMethodCallExpression call) {
+    final PsiExpression[] arguments = call.getArgumentList().getExpressions();
+    if (arguments.length == 2) {
+      final PsiExpression returnType = findDefinition(arguments[0]);
+      final PsiExpression secondArgument = arguments[1];
+      final List<PsiExpression> components = getVarargs(secondArgument);
+      if (components != null) {
+        final List<PsiExpression> signature = ContainerUtil.prepend(components, returnType);
+        return ContainerUtil.map(signature, parameter -> (() -> getReflectiveType(parameter)));
       }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static List<Supplier<ReflectiveType>> getLazyMethodSignatureForReturnTypeAndList(@NotNull PsiMethodCallExpression call) {
+    final PsiExpression[] arguments = call.getArgumentList().getExpressions();
+    if (arguments.length == 2) {
+      final PsiExpression list = arguments[1];
+      final List<PsiExpression> components = getListComponents(list);
+      if (components != null) {
+        final PsiExpression returnType = findDefinition(arguments[0]);
+        final List<PsiExpression> signature = ContainerUtil.prepend(components, returnType);
+        return ContainerUtil.map(signature, argument -> (() -> getReflectiveType(argument)));
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static List<Supplier<ReflectiveType>> getLazyMethodSignatureForTypes(@NotNull PsiMethodCallExpression call) {
+    final PsiExpression[] expressions = call.getArgumentList().getExpressions();
+    if (expressions.length != 0) {
+      return ContainerUtil.map(expressions, argument -> (() -> getReflectiveType(argument)));
     }
     return null;
   }

--- a/java/java-tests/testData/inspection/invokeHandleSignature/Constructor.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/Constructor.java
@@ -1,4 +1,6 @@
 import java.lang.invoke.*;
+import java.util.Arrays;
+import java.util.List;
 
 class Main {
   void foo() throws Exception {
@@ -24,6 +26,16 @@ class Main {
     l.findConstructor(NoDefault.class, <warning descr="Cannot resolve constructor 'NoDefault()'">MethodType.methodType(void.class)</warning>);
     l.findConstructor(Class.forName("NoDefault"), <warning descr="Cannot resolve constructor 'NoDefault()'">MethodType.methodType(void.class)</warning>);
 
+  }
+
+  void differentMethodTypeOverloads() throws Exception {
+    MethodHandles.Lookup l = MethodHandles.lookup();
+
+    l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class)</warning>);
+    l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, List.of())</warning>);
+    l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, List.of(new Class<?>[0]))</warning>);
+    l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, Arrays.asList())</warning>);
+    l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, Arrays.asList(new Class<?>[0]))</warning>);
   }
 }
 

--- a/java/java-tests/testData/inspection/invokeHandleSignature/Constructor.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/Constructor.java
@@ -33,9 +33,7 @@ class Main {
 
     l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class)</warning>);
     l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, List.of())</warning>);
-    l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, List.of(new Class<?>[0]))</warning>);
     l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, Arrays.asList())</warning>);
-    l.findConstructor(Test.class, <warning descr="Cannot resolve constructor 'int Test()'">MethodType.methodType(int.class, Arrays.asList(new Class<?>[0]))</warning>);
   }
 }
 

--- a/java/java-tests/testData/inspection/invokeHandleSignature/OverloadedMethod.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/OverloadedMethod.java
@@ -1,4 +1,6 @@
 import java.lang.invoke.*;
+import java.util.Arrays;
+import java.util.List;
 
 class Main {
   void foo() throws Exception {
@@ -25,6 +27,17 @@ class Main {
 
     l.<warning descr="Method 'method' is not static">findStatic</warning>(Test.class, "method", MethodType.methodType(void.class));
     l.findVirtual(Test.class, <warning descr="Cannot resolve method 'doesntExist'">"doesntExist"</warning>, MethodType.methodType(void.class));
+  }
+
+  void differentMethodTypeOverloads() throws Exception {
+    MethodHandles.Lookup l = MethodHandles.lookup();
+
+    l.findVirtual(Test.class, "method", <warning descr="Cannot resolve method 'void method(void)'">MethodType.methodType(void.class, List.of(void.class))</warning>);
+    l.findVirtual(Test.class, "method", <warning descr="Cannot resolve method 'void method(void)'">MethodType.methodType(void.class, new Class<?>[]{void.class})</warning>);
+    l.findVirtual(Test.class, "method", <warning descr="Cannot resolve method 'void method(void)'">MethodType.methodType(void.class, Arrays.asList(void.class))</warning>);
+    l.findVirtual(Test.class, "method", <warning descr="Cannot resolve method 'void method(void)'">MethodType.methodType(void.class, MethodType.methodType(String.class, void.class))</warning>);
+    MethodType methodType = MethodType.methodType(String.class, MethodType.methodType(void.class, void.class));
+    l.findVirtual(Test.class, "method", <warning descr="Cannot resolve method 'void method(void)'">MethodType.methodType(void.class, methodType)</warning>);
   }
 }
 

--- a/java/java-tests/testData/inspection/invokeHandleSignature/Special.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/Special.java
@@ -1,4 +1,6 @@
 import java.lang.invoke.*;
+import java.util.Arrays;
+import java.util.List;
 
 class Main {
   void foo() throws Exception {
@@ -46,6 +48,18 @@ class Main {
 
     l.findSpecial(A.class, <warning descr="Cannot resolve method 'baz'">"baz"</warning>, MethodType.methodType(String.class, double.class), A.class);
     l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, double.class)</warning>, <warning descr="Caller class 'A' must be a subclass of 'B'">A.class</warning>);
+  }
+
+  void differentMethodTypeOverloads() throws Exception {
+    MethodHandles.Lookup l = MethodHandles.lookup();
+
+    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, double.class)</warning>, C.class);
+    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, List.of(double.class))</warning>, C.class);
+    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, List.of(new Class<?>[]{double.class}))</warning>, C.class);
+    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, Arrays.asList(double.class))</warning>, C.class);
+    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, Arrays.asList(new Class<?>[]{double.class}))</warning>, C.class);
+    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, new Class<?>[]{double.class})</warning>, C.class);
+    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, MethodType.methodType(void.class, new Class<?>[]{double.class}))</warning>, C.class);
   }
 }
 

--- a/java/java-tests/testData/inspection/invokeHandleSignature/Special.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/Special.java
@@ -55,9 +55,7 @@ class Main {
 
     l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, double.class)</warning>, C.class);
     l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, List.of(double.class))</warning>, C.class);
-    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, List.of(new Class<?>[]{double.class}))</warning>, C.class);
     l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, Arrays.asList(double.class))</warning>, C.class);
-    l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, Arrays.asList(new Class<?>[]{double.class}))</warning>, C.class);
     l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, new Class<?>[]{double.class})</warning>, C.class);
     l.findSpecial(B.class, "baz", <warning descr="Cannot resolve method 'String baz(double)'">MethodType.methodType(String.class, MethodType.methodType(void.class, new Class<?>[]{double.class}))</warning>, C.class);
   }

--- a/java/java-tests/testData/inspection/invokeHandleSignature/StaticMethod.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/StaticMethod.java
@@ -24,9 +24,7 @@ class Main {
 
     l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, String.class)</warning>);
     l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, List.of(String.class))</warning>);
-    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, List.of(new Class<?>[]{String.class}))</warning>);
     l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, Arrays.asList(String.class))</warning>);
-    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, Arrays.asList(new Class<?>[]{String.class}))</warning>);
     l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, new Class<?>[]{String.class})</warning>);
     l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, MethodType.methodType(void.class, List.of(String.class)))</warning>);
   }

--- a/java/java-tests/testData/inspection/invokeHandleSignature/StaticMethod.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/StaticMethod.java
@@ -1,4 +1,6 @@
 import java.lang.invoke.*;
+import java.util.Arrays;
+import java.util.List;
 
 class Main {
   void foo() throws Exception {
@@ -15,6 +17,18 @@ class Main {
 
     l.<warning descr="Method 'method1' is static">findVirtual</warning>(Test.class, "method1", MethodType.methodType(void.class));
     l.findStatic(Test.class, <warning descr="Cannot resolve method 'doesntExist'">"doesntExist"</warning>, MethodType.methodType(String.class));
+  }
+
+  void differentMethodTypeOverloads() throws Exception {
+    MethodHandles.Lookup l = MethodHandles.lookup();
+
+    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, String.class)</warning>);
+    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, List.of(String.class))</warning>);
+    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, List.of(new Class<?>[]{String.class}))</warning>);
+    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, Arrays.asList(String.class))</warning>);
+    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, Arrays.asList(new Class<?>[]{String.class}))</warning>);
+    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, new Class<?>[]{String.class})</warning>);
+    l.findStatic(Test.class, "method2", <warning descr="Cannot resolve method 'int method2(String)'">MethodType.methodType(int.class, MethodType.methodType(void.class, List.of(String.class)))</warning>);
   }
 }
 

--- a/java/java-tests/testData/inspection/javaLangReflectHandleInvocation/Virtual.java
+++ b/java/java-tests/testData/inspection/javaLangReflectHandleInvocation/Virtual.java
@@ -135,30 +135,31 @@ class Main {
     MethodHandle methodHandle0 = lookup.findVirtual(Test.class, "foo", methodTypeFromArraysAsList);
     methodHandle0.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
 
-    MethodType methodTypeFromArraysAsListWithClassArray = MethodType.methodType(long.class, Arrays.asList(new Class<?>[]{int.class, long.class}));
-    MethodHandle methodHandle1 = lookup.findVirtual(Test.class, "foo", methodTypeFromArraysAsListWithClassArray);
+    MethodType methodTypeFromListOf = MethodType.methodType(long.class, (List.of(int.class, long.class)));
+    MethodHandle methodHandle1 = lookup.findVirtual(Test.class, "foo", methodTypeFromListOf);
     methodHandle1.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
 
-    MethodType methodTypeFromListOf = MethodType.methodType(long.class, List.of(int.class, long.class));
-    MethodHandle methodHandle2 = lookup.findVirtual(Test.class, "foo", methodTypeFromListOf);
+    MethodHandle methodHandle2 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, MethodType.methodType(Object.class, int.class, long.class)));
     methodHandle2.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
 
-    MethodType methodTypeFromListOfWithClassArray = MethodType.methodType(long.class, List.of(new Class[]{int.class, long.class}));
-    MethodHandle methodHandle3 = lookup.findVirtual(Test.class, "foo", methodTypeFromListOfWithClassArray);
+    MethodHandle methodHandle3 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, new Class<?>[]{int.class, long.class}));
     methodHandle3.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
 
-    MethodHandle methodHandle4 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, MethodType.methodType(Object.class, int.class, long.class)));
+    MethodHandle methodHandle4 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, new Class[]{int.class, long.class}));
     methodHandle4.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
 
-    MethodHandle methodHandle5 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, new Class<?>[]{int.class, long.class}));
+    MethodType nestedMethodType5 = MethodType.methodType(long.class, new Class[]{int.class, long.class});
+    MethodHandle methodHandle5 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, nestedMethodType5));
     methodHandle5.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
 
-    MethodHandle methodHandle6 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, new Class[]{int.class, long.class}));
-    methodHandle6.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+    List<Class<?>> noWarningsForMutableLists = Arrays.asList(int.class, String.class);
+    noWarningsForMutableLists.set(1, long.class);
+    MethodHandle methodHandle6 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, noWarningsForMutableLists));
+    methodHandle6.invoke(instance, 1, 2L);
 
-    MethodType nestedMethodType7 = MethodType.methodType(long.class, new Class[]{int.class, long.class});
-    MethodHandle methodHandle7 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, nestedMethodType7));
-    methodHandle7.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+    MethodType noStackOverflowError = MethodType.methodType(long.class, <error descr="Variable 'noStackOverflowError' might not have been initialized">noStackOverflowError</error>);
+    MethodHandle methodHandle7 = lookup.findVirtual(Test.class, "foo", noStackOverflowError);
+    methodHandle7.invoke(instance, 1, 2L);
   }
 
   private static CharSequence charSequence() { return "abc"; }

--- a/java/java-tests/testData/inspection/javaLangReflectHandleInvocation/Virtual.java
+++ b/java/java-tests/testData/inspection/javaLangReflectHandleInvocation/Virtual.java
@@ -1,6 +1,11 @@
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 class Main {
   void fooInt() throws Throwable {
@@ -122,10 +127,47 @@ class Main {
     CharSequence superclassResult3 = (<warning descr="Should be cast to 'java.lang.String'">CharSequence</warning>) handle.invokeExact(instance, "c");
   }
 
+  void fooVariousTypesVariousMethodTypes() throws Throwable {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    Test instance = new Test();
+
+    MethodType methodTypeFromArraysAsList = MethodType.methodType(long.class, Arrays.asList(int.class, long.class));
+    MethodHandle methodHandle0 = lookup.findVirtual(Test.class, "foo", methodTypeFromArraysAsList);
+    methodHandle0.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+
+    MethodType methodTypeFromArraysAsListWithClassArray = MethodType.methodType(long.class, Arrays.asList(new Class<?>[]{int.class, long.class}));
+    MethodHandle methodHandle1 = lookup.findVirtual(Test.class, "foo", methodTypeFromArraysAsListWithClassArray);
+    methodHandle1.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+
+    MethodType methodTypeFromListOf = MethodType.methodType(long.class, List.of(int.class, long.class));
+    MethodHandle methodHandle2 = lookup.findVirtual(Test.class, "foo", methodTypeFromListOf);
+    methodHandle2.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+
+    MethodType methodTypeFromListOfWithClassArray = MethodType.methodType(long.class, List.of(new Class[]{int.class, long.class}));
+    MethodHandle methodHandle3 = lookup.findVirtual(Test.class, "foo", methodTypeFromListOfWithClassArray);
+    methodHandle3.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+
+    MethodHandle methodHandle4 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, MethodType.methodType(Object.class, int.class, long.class)));
+    methodHandle4.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+
+    MethodHandle methodHandle5 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, new Class<?>[]{int.class, long.class}));
+    methodHandle5.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+
+    MethodHandle methodHandle6 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, new Class[]{int.class, long.class}));
+    methodHandle6.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+
+    MethodType nestedMethodType7 = MethodType.methodType(long.class, new Class[]{int.class, long.class});
+    MethodHandle methodHandle7 = lookup.findVirtual(Test.class, "foo", MethodType.methodType(long.class, nestedMethodType7));
+    methodHandle7.invoke<warning descr="3 arguments are expected">(instance, 1, 2, 3)</warning>;
+  }
+
   private static CharSequence charSequence() { return "abc"; }
 }
 
 class Test {
   public int foo(int n) {return n;}
   public String foo(String s) {return s;}
+  public long foo(int i, long l) {
+    return l + i;
+  }
 }

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/JavaLangReflectHandleInvocationTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/JavaLangReflectHandleInvocationTest.kt
@@ -25,9 +25,8 @@ import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 /**
  * @author Pavel.Dolgov
  */
-
-class JavaLangReflectHandleInvocationTest : JavaLangReflectHandleInvocationTestBase(LanguageLevel.JDK_1_7,
-                                                                                    LightJavaCodeInsightFixtureTestCase.JAVA_8) {
+class JavaLangReflectHandleInvocationTest : JavaLangReflectHandleInvocationTestBase(LanguageLevel.JDK_1_9,
+                                                                                     LightJavaCodeInsightFixtureTestCase.JAVA_9) {
   fun testVirtual() = doTest()
   fun testStatic() = doTest()
   fun testConstructor() = doTest()
@@ -37,10 +36,7 @@ class JavaLangReflectHandleInvocationTest : JavaLangReflectHandleInvocationTestB
 
   fun testStaticGetter() = doTest()
   fun testStaticSetter() = doTest()
-}
 
-class Java9LangReflectHandleInvocationTest : JavaLangReflectHandleInvocationTestBase(LanguageLevel.JDK_1_9,
-                                                                                     LightJavaCodeInsightFixtureTestCase.JAVA_9) {
   fun testVarHandle() = doTest()
   fun testStaticVarHandle() = doTest()
   fun testArrayVarHandle() = doTest()

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/JavaLangReflectHandleInvocationTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/JavaLangReflectHandleInvocationTest.kt
@@ -25,8 +25,7 @@ import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 /**
  * @author Pavel.Dolgov
  */
-class JavaLangReflectHandleInvocationTest : JavaLangReflectHandleInvocationTestBase(LanguageLevel.JDK_1_9,
-                                                                                     LightJavaCodeInsightFixtureTestCase.JAVA_9) {
+class JavaLangReflectHandleInvocationTest : LightJavaCodeInsightFixtureTestCase() {
   fun testVirtual() = doTest()
   fun testStatic() = doTest()
   fun testConstructor() = doTest()
@@ -40,21 +39,18 @@ class JavaLangReflectHandleInvocationTest : JavaLangReflectHandleInvocationTestB
   fun testVarHandle() = doTest()
   fun testStaticVarHandle() = doTest()
   fun testArrayVarHandle() = doTest()
-}
 
-abstract class JavaLangReflectHandleInvocationTestBase(val languageLevel: LanguageLevel,
-                                                       val descriptor: LightProjectDescriptor) : LightJavaCodeInsightFixtureTestCase() {
   override fun setUp() {
     super.setUp()
-    LanguageLevelProjectExtension.getInstance(project).languageLevel = languageLevel
+    LanguageLevelProjectExtension.getInstance(project).languageLevel = LanguageLevel.JDK_1_9
     myFixture.enableInspections(JavaLangInvokeHandleSignatureInspection())
   }
 
-  override fun getProjectDescriptor(): LightProjectDescriptor = descriptor
+  override fun getProjectDescriptor(): LightProjectDescriptor = JAVA_9
 
   override fun getBasePath() = JavaTestUtil.getRelativeJavaTestDataPath() + "/inspection/javaLangReflectHandleInvocation"
 
-  protected fun doTest() {
+  private fun doTest() {
     myFixture.testHighlighting("${getTestName(false)}.java")
   }
 }


### PR DESCRIPTION
Hello,

I've described a problem in [IDEA-281190](https://youtrack.jetbrains.com/issue/IDEA-281190) and I propose these changes as a fix

Please, let me know if I should something differently in this PR or maybe consider another approach, and I'll fix the code in PR

Thanks!