### PR TITLE
Try at an fix for the issue that (at least on macOS) external diff co…

### DIFF
--- a/platform/diff-impl/src/com/intellij/diff/tools/external/ExternalDiffToolUtil.java
+++ b/platform/diff-impl/src/com/intellij/diff/tools/external/ExternalDiffToolUtil.java
@@ -259,6 +259,9 @@ public final class ExternalDiffToolUtil {
       patterns.put("%4", outputFile.getPath());
 
       final Process process = execute(settings.getMergeExePath(), settings.getMergeParameters(), patterns);
+      
+      InputStream is = process.getInputStream();
+      try { is.close(); } catch (Exception ignore) {}
 
       if (settings.isMergeTrustExitCode()) {
         final Ref<Boolean> resultRef = new Ref<>();
@@ -340,7 +343,11 @@ public final class ExternalDiffToolUtil {
     GeneralCommandLine commandLine = new GeneralCommandLine();
     commandLine.setExePath(exePath);
     commandLine.addParameters(args);
-    return commandLine.createProcess();
+    
+    Process result = commandLine.createProcess();
+    InputStream is = result.getInputStream();
+    try { is.close(); } catch (Exception ignore) {}
+    return result;
   }
 
   //


### PR DESCRIPTION
…mmand line and merge utilities that also accept a pipe in as file need to have their stdin closed. Otherwise the process hangs until the host app quits. As a reproduction example you can use e.g. SubEthaEdit's see tool ( https:://subethaedit.net ) or if you are quick ksdiff from kaleidoscope (although we fixed that on our end too by recognizing your caller process and not waiting as special consideration)

This is just identifiyng the places and doing what should be done in general terms, I do have a lack of build environment to verify this works correctly and or reliably or even compiles.