### PR TITLE
[EE-IR] Use reflection to avoid the need for accessors when compiling fragments

### DIFF
--- a/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/DebuggerFieldSyntheticScopeProvider.kt
+++ b/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/DebuggerFieldSyntheticScopeProvider.kt
@@ -235,4 +235,7 @@ internal class DebuggerFieldPropertyDescriptor(
     /*isActual = */false,
     /*isExternal = */false,
     /*isDelegated = */false
-)
+) {
+    override val getter: PropertyGetterDescriptorImpl?
+        get() = null
+}

--- a/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/compilation/CodeFragmentCompiler.kt
+++ b/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/compilation/CodeFragmentCompiler.kt
@@ -8,8 +8,8 @@ import com.intellij.openapi.util.Key
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.analyzer.moduleInfo
 import org.jetbrains.kotlin.backend.common.output.OutputFile
-import org.jetbrains.kotlin.backend.common.phaser.PhaseConfig
 import org.jetbrains.kotlin.backend.jvm.*
+import org.jetbrains.kotlin.backend.jvm.lower.reflectiveAccessLowering
 import org.jetbrains.kotlin.backend.jvm.serialization.JvmIdSignatureDescriptor
 import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.codegen.CodeFragmentCodegen.Companion.getSharedTypeIfApplicable
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.descriptors.impl.*
 import org.jetbrains.kotlin.idea.FrontendInternals
 import org.jetbrains.kotlin.idea.MainFunctionDetector
 import org.jetbrains.kotlin.idea.caches.project.ModuleSourceInfo
+import org.jetbrains.kotlin.idea.debugger.evaluate.DebuggerFieldPropertyDescriptor
 import org.jetbrains.kotlin.idea.debugger.evaluate.EvaluationStatus
 import org.jetbrains.kotlin.idea.debugger.evaluate.ExecutionContext
 import org.jetbrains.kotlin.idea.debugger.evaluate.classLoading.ClassToLoad
@@ -33,9 +34,12 @@ import org.jetbrains.kotlin.idea.debugger.evaluate.compilation.CompiledDataDescr
 import org.jetbrains.kotlin.idea.debugger.evaluate.getResolutionFacadeForCodeFragment
 import org.jetbrains.kotlin.idea.project.languageVersionSettings
 import org.jetbrains.kotlin.incremental.components.LookupLocation
+import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.backend.jvm.serialization.JvmDescriptorMangler
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.util.NameProvider
+import org.jetbrains.kotlin.load.java.descriptors.JavaPropertyDescriptor
 import org.jetbrains.kotlin.load.kotlin.toSourceElement
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -138,35 +142,70 @@ class CodeFragmentCompiler(private val executionContext: ExecutionContext, priva
             if (fragmentCompilerBackend == FragmentCompilerBackend.JVM_IR) {
                 val mangler = JvmDescriptorMangler(MainFunctionDetector(bindingContext, compilerConfiguration.languageVersionSettings))
                 val evaluatorFragmentInfo = EvaluatorFragmentInfo(
-                        codegenInfo.classDescriptor,
-                        codegenInfo.methodDescriptor,
-                        codegenInfo.parameters.map { it.targetDescriptor }
+                    codegenInfo.classDescriptor,
+                    codegenInfo.methodDescriptor,
+                    codegenInfo.parameters.map { it.targetDescriptor }
                 )
+                codegenFactory(
+                    JvmIrCodegenFactory(
+                        configuration = compilerConfiguration,
+                        phaseConfig = null,
+                        externalMangler = mangler,
+                        externalSymbolTable = FragmentCompilerSymbolTableDecorator(
+                            JvmIdSignatureDescriptor(mangler),
+                            IrFactoryImpl,
+                            evaluatorFragmentInfo,
+                            NameProvider.DEFAULT,
+                        ),
+                        prefixPhases = reflectiveAccessLowering,
+                        jvmGeneratorExtensions = object : JvmGeneratorExtensionsImpl(compilerConfiguration) {
+                            // Top-level declarations in the project being debugged is served to the compiler as
+                            // PSI, not as class files. PSI2IR generate these as "external declarations" and
+                            // here we provide a shim from the PSI structures serving the names of facade classes
+                            // for top level declarations (as the facade classes do not exist in the PSI but are
+                            // created and _named_ during compilation).
+                            override fun getContainerSource(descriptor: DeclarationDescriptor): DeserializedContainerSource? {
+                                val psiSourceFile =
+                                    descriptor.toSourceElement.containingFile as? PsiSourceFile ?: return super.getContainerSource(
+                                        descriptor
+                                    )
+                                return FacadeClassSourceShimForFragmentCompilation(psiSourceFile)
+                            }
 
-                codegenFactory(JvmIrCodegenFactory(
-                    configuration = compilerConfiguration,
-                    phaseConfig = PhaseConfig(jvmPhases),
-                    externalMangler = mangler,
-                    externalSymbolTable = FragmentCompilerSymbolTableDecorator(
-                        JvmIdSignatureDescriptor(mangler),
-                        IrFactoryImpl,
-                        evaluatorFragmentInfo,
-                        NameProvider.DEFAULT,
-                    ),
-                    jvmGeneratorExtensions = object : JvmGeneratorExtensionsImpl(compilerConfiguration) {
-                        // Top-level declarations in the project being debugged is served to the compiler as
-                        // PSI, not as class files. PSI2IR generate these as "external declarations" and
-                        // here we provide a shim from the PSI structures serving the names of facade classes
-                        // for top level declarations (as the facade classes do not exist in the PSI but are
-                        // created and _named_ during compilation).
-                        override fun getContainerSource(descriptor: DeclarationDescriptor): DeserializedContainerSource? {
-                            val psiSourceFile =
-                                descriptor.toSourceElement.containingFile as? PsiSourceFile ?: return super.getContainerSource(descriptor)
-                            return FacadeClassSourceShimForFragmentCompilation(psiSourceFile)
-                        }
-                    },
-                    evaluatorFragmentInfoForPsi2Ir = evaluatorFragmentInfo
-                ))
+                            @OptIn(ObsoleteDescriptorBasedAPI::class)
+                            override fun isAccessorWithExplicitImplementation(accessor: IrSimpleFunction): Boolean {
+                                return (accessor.descriptor as? PropertyAccessorDescriptor)?.hasBody() == true
+                            }
+
+                            override fun remapDebuggerFieldPropertyDescriptor(propertyDescriptor: PropertyDescriptor): PropertyDescriptor {
+                                return when (propertyDescriptor) {
+                                    is DebuggerFieldPropertyDescriptor -> {
+                                        val fieldDescriptor = JavaPropertyDescriptor.create(
+                                            propertyDescriptor.containingDeclaration,
+                                            propertyDescriptor.annotations,
+                                            propertyDescriptor.modality,
+                                            propertyDescriptor.visibility,
+                                            propertyDescriptor.isVar,
+                                            Name.identifier(propertyDescriptor.fieldName.removeSuffix("_field")),
+                                            propertyDescriptor.source,
+                                            /*isStaticFinal= */ false
+                                        )
+                                        fieldDescriptor.setType(
+                                            propertyDescriptor.type,
+                                            propertyDescriptor.typeParameters,
+                                            propertyDescriptor.dispatchReceiverParameter,
+                                            propertyDescriptor.extensionReceiverParameter
+                                        )
+                                        fieldDescriptor
+                                    }
+                                    else ->
+                                        propertyDescriptor
+                                }
+                            }
+                        },
+                        evaluatorFragmentInfoForPsi2Ir = evaluatorFragmentInfo
+                    )
+                )
             }
             generateDeclaredClassFilter(GeneratedClassFilterForCodeFragment(codeFragment))
         }.build()

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
@@ -436,6 +436,11 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
             runTest("testData/evaluation/singleBreakpoint/privatePropertyWithExplicitDefaultGetter.kt");
         }
 
+        @TestMetadata("privatePropertyWithNonDefaultAccessor.kt")
+        public void testPrivatePropertyWithNonDefaultAccessor() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.kt");
+        }
+
         @TestMetadata("protectedMember.kt")
         public void testProtectedMember() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/protectedMember.kt");
@@ -633,6 +638,11 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
                 @TestMetadata("outerMembersNoReflection.kt")
                 public void testOuterMembersNoReflection() throws Exception {
                     runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/outerMembersNoReflection.kt");
+                }
+
+                @TestMetadata("privateAnnotationCompanionValue.kt")
+                public void testPrivateAnnotationCompanionValue() throws Exception {
+                    runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.kt");
                 }
 
                 @TestMetadata("selfMembers.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -436,6 +436,11 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
             runTest("testData/evaluation/singleBreakpoint/privatePropertyWithExplicitDefaultGetter.kt");
         }
 
+        @TestMetadata("privatePropertyWithNonDefaultAccessor.kt")
+        public void testPrivatePropertyWithNonDefaultAccessor() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.kt");
+        }
+
         @TestMetadata("protectedMember.kt")
         public void testProtectedMember() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/protectedMember.kt");
@@ -633,6 +638,11 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
                 @TestMetadata("outerMembersNoReflection.kt")
                 public void testOuterMembersNoReflection() throws Exception {
                     runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/outerMembersNoReflection.kt");
+                }
+
+                @TestMetadata("privateAnnotationCompanionValue.kt")
+                public void testPrivateAnnotationCompanionValue() throws Exception {
+                    runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.kt");
                 }
 
                 @TestMetadata("selfMembers.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
@@ -436,6 +436,11 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
             runTest("testData/evaluation/singleBreakpoint/privatePropertyWithExplicitDefaultGetter.kt");
         }
 
+        @TestMetadata("privatePropertyWithNonDefaultAccessor.kt")
+        public void testPrivatePropertyWithNonDefaultAccessor() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.kt");
+        }
+
         @TestMetadata("protectedMember.kt")
         public void testProtectedMember() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/protectedMember.kt");
@@ -633,6 +638,11 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
                 @TestMetadata("outerMembersNoReflection.kt")
                 public void testOuterMembersNoReflection() throws Exception {
                     runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/outerMembersNoReflection.kt");
+                }
+
+                @TestMetadata("privateAnnotationCompanionValue.kt")
+                public void testPrivateAnnotationCompanionValue() throws Exception {
+                    runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.kt");
                 }
 
                 @TestMetadata("selfMembers.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -436,6 +436,11 @@ public abstract class KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerate
             runTest("testData/evaluation/singleBreakpoint/privatePropertyWithExplicitDefaultGetter.kt");
         }
 
+        @TestMetadata("privatePropertyWithNonDefaultAccessor.kt")
+        public void testPrivatePropertyWithNonDefaultAccessor() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.kt");
+        }
+
         @TestMetadata("protectedMember.kt")
         public void testProtectedMember() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/protectedMember.kt");
@@ -633,6 +638,11 @@ public abstract class KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerate
                 @TestMetadata("outerMembersNoReflection.kt")
                 public void testOuterMembersNoReflection() throws Exception {
                     runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/outerMembersNoReflection.kt");
+                }
+
+                @TestMetadata("privateAnnotationCompanionValue.kt")
+                public void testPrivateAnnotationCompanionValue() throws Exception {
+                    runTest("testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.kt");
                 }
 
                 @TestMetadata("selfMembers.kt")

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/extensionMemberFunction.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/extensionMemberFunction.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at extensionMemberFunction.kt:13
 LineBreakpoint created at extensionMemberFunction.kt:19
 LineBreakpoint created at extensionMemberFunction.kt:25

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/extensionMemberProperty.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/extensionMemberProperty.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at extensionMemberProperty.kt:13
 LineBreakpoint created at extensionMemberProperty.kt:19
 LineBreakpoint created at extensionMemberProperty.kt:25

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/invisibleDeclarations.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/invisibleDeclarations.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at invisibleDeclarations.kt:16
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/privateMembersPriority.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/privateMembersPriority.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at privateMembersPriority.kt:21
 LineBreakpoint created at privateMembersPriority.kt:33
 LineBreakpoint created at privateMembersPriority.kt:40

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/inaccessibleMembers.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/inaccessibleMembers.kt
@@ -22,7 +22,7 @@ fun main() {
 }
 
 // EXPRESSION: block { Foo("foo") }
-// RESULT: Method threw 'java.lang.IllegalAccessError' exception.
+// RESULT: instance of test.Foo(id=ID): Ltest/Foo;
 
 // EXPRESSION: block { Foo.Nested(1, -5, "x") }
 // RESULT: instance of test.Foo$Nested(id=ID): Ltest/Foo$Nested;

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/inaccessibleMembers.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/inaccessibleMembers.out
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
+// IGNORE_BACKEND: JVM_WITH_OLD_EVALUATOR, JVM_IR_WITH_OLD_EVALUATOR
 LineBreakpoint created at inaccessibleMembers.kt:21
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/inaccessibleTypes.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/inaccessibleTypes.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at test.kt:7
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/javaFields.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/javaFields.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at test.kt:9
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/javaMethods.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/javaMethods.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at test.kt:9
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/kotlinFields.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/kotlinFields.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at kotlinFields.kt:31
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/kotlinMethods.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/kotlinMethods.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at test.kt:40
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/membersFromLocalClass.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/membersFromLocalClass.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at membersFromLocalClass.kt:22
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/outerMembers.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/outerMembers.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at outerMembers.kt:23
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.kt
@@ -1,0 +1,19 @@
+package privateAnnotationCompanionValue
+
+annotation class Anno(val value: String) {
+    companion object {
+        private val test: Int = 4
+    }
+}
+
+@Anno("abc")
+class SomeClass
+
+fun main(args: Array<String>) {
+    //Breakpoint!
+    val a = 5
+}
+
+
+// EXPRESSION: Anno.test
+// RESULT: 4: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/privateAnnotationCompanionValue.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at privateAnnotationCompanionValue.kt:14
+Run Java
+Connected to the target VM
+privateAnnotationCompanionValue.kt:14
+Compile bytecode for Anno.test
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/selfMembers.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/selfMembers.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at selfMembers.kt:22
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/superMembers.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/compilingEvaluator/inaccessibleMembers/superMembers.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at superMembers.kt:19
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/fieldGetters.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/fieldGetters.kt
@@ -56,6 +56,9 @@ class K2 {
 // RESULT: Unresolved reference: foo_field
 
 // EXPRESSION: PublicFieldGetter().foo
+// RESULT: "a": Ljava/lang/String;
+
+// EXPRESSION: PublicFieldGetter().getFoo()
 // RESULT: "b": Ljava/lang/String;
 
 // EXPRESSION: PublicFieldGetter().foo_field
@@ -74,6 +77,9 @@ class K2 {
 // RESULT: "e": Ljava/lang/String;
 
 // EXPRESSION: PublicGetter1().foo
+// RESULT: "a": Ljava/lang/String;
+
+// EXPRESSION: PublicGetter1().getFoo()
 // RESULT: "g": Ljava/lang/String;
 
 // EXPRESSION: PublicGetter1().foo_field
@@ -98,6 +104,9 @@ class K2 {
 // RESULT: Unresolved reference: foo_field
 
 // EXPRESSION: PublicFieldAndGetterInParent().foo
+// RESULT: "b": Ljava/lang/String;
+
+// EXPRESSION: PublicFieldAndGetterInParent().getFoo()
 // RESULT: "a": Ljava/lang/String;
 
 // EXPRESSION: PublicFieldAndGetterInParent().foo_field

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/fieldGetters.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/fieldGetters.out
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
+// IGNORE_BACKEND: JVM_WITH_OLD_EVALUATOR, JVM_IR_WITH_OLD_EVALUATOR
 LineBreakpoint created at fieldGetters.kt:9
 Run Java
 Connected to the target VM
@@ -12,18 +12,21 @@ Compile bytecode for PackagePrivateField().foo
 Compile bytecode for ProtectedField().foo
 Compile bytecode for PrivateField().foo
 Compile bytecode for PublicFieldGetter().foo
+Compile bytecode for PublicFieldGetter().getFoo()
 Compile bytecode for PublicFieldGetter().foo_field
 Compile bytecode for PrivateFieldPublicGetter().foo
 Compile bytecode for PrivateFieldPublicGetter().foo_field
 Compile bytecode for PrivateFieldPrivateGetter().foo
 Compile bytecode for PrivateFieldPrivateGetter().foo_field
 Compile bytecode for PublicGetter1().foo
+Compile bytecode for PublicGetter1().getFoo()
 Compile bytecode for PublicGetter1().foo_field
 Compile bytecode for PublicGetter2().foo
 Compile bytecode for PublicGetter2().foo_field
 Compile bytecode for PrivateGetter1().foo
 Compile bytecode for PublicGetterOnly().foo
 Compile bytecode for PublicFieldAndGetterInParent().foo
+Compile bytecode for PublicFieldAndGetterInParent().getFoo()
 Compile bytecode for PublicFieldAndGetterInParent().foo_field
 Disconnected from the target VM
 

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/javaContext/jcProperty.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/javaContext/jcProperty.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at test.kt:7
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privateClass.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privateClass.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at privateClass.kt:6
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privateFieldInCompanion.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privateFieldInCompanion.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at privateFieldInCompanion.kt:18
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privateMember.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privateMember.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at privateMember.kt:9
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.kt
@@ -1,0 +1,16 @@
+package privatePropertyWithExplicitDefaultGetter
+
+fun main(args: Array<String>) {
+    val base = Some()
+
+    //Breakpoint!
+    args.size
+}
+
+class Some {
+    private val a: Int = 1
+        get() = 4 * field
+}
+
+// EXPRESSION: base.a
+// RESULT: 4: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/privatePropertyWithNonDefaultAccessor.out
@@ -1,7 +1,7 @@
-LineBreakpoint created at privatePropertyWithExplicitDefaultGetter.kt:7
+LineBreakpoint created at privatePropertyWithNonDefaultAccessor.kt:7
 Run Java
 Connected to the target VM
-privatePropertyWithExplicitDefaultGetter.kt:7
+privatePropertyWithNonDefaultAccessor.kt:7
 Compile bytecode for base.a
 Disconnected from the target VM
 

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/protectedMember.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/protectedMember.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at protectedMember.kt:5
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/superCallsCaptured.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/superCallsCaptured.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at superCallsCaptured.kt:15
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/superCallsSimple.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/superCallsSimple.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at superCallsSimple.kt:14
 Run Java
 Connected to the target VM


### PR DESCRIPTION
Plug-in side changes to accommodate the new IR-based fragment evaluator. This PR contains:

- the plumbing required to use the new mechanism for reflective accesses.
- unmutes now-succeeding tests.
- mutes 2 "fixes" and improvements on the existing evaluator: access to private constructors and aligning fragment semantics of access to private fields with getters with the _language_ semantics. I.e. running `println(x)` and "Evaluating" `x` display the same value.

Dependent on JetBrains/kotlin#4599