### PR TITLE
KTIJ-19982 INAPPLICABLE_JVM_FIELD: add quickfix to remove `@JvmField` annotation

### DIFF
--- a/plugins/kotlin/idea/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/idea/resources-en/messages/KotlinBundle.properties
@@ -1551,6 +1551,7 @@ reformat.quick.fix.family.name=Reformat file
 apply.only.to.modified.files.for.projects.under.a.version.control=Apply only to modified files (for projects under a version control)
 file.is.not.properly.formatted=File is not properly formatted
 remove.jvmoverloads.annotation=Remove @JvmOverloads annotation
+remove.jvmfield.annotation=Remove @JvmField annotation
 report.also.for.a.variables.without.a.whitespace.around=Report also for a variables without a whitespace around
 remove.curly.braces=Remove curly braces
 redundant.curly.braces.in.string.template=Redundant curly braces in string template

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveAnnotationFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RemoveAnnotationFix.kt
@@ -30,6 +30,13 @@ class RemoveAnnotationFix(@Nls private val text: String, annotationEntry: KtAnno
         }
     }
 
+    object JvmField : KotlinSingleIntentionActionFactory() {
+        override fun createAction(diagnostic: Diagnostic): RemoveAnnotationFix? {
+            val annotationEntry = diagnostic.psiElement as? KtAnnotationEntry ?: return null
+            return RemoveAnnotationFix(KotlinBundle.message("remove.jvmfield.annotation"), annotationEntry)
+        }
+    }
+
     companion object : KotlinSingleIntentionActionFactory() {
         override fun createAction(diagnostic: Diagnostic): RemoveAnnotationFix? {
             val annotationEntry = diagnostic.psiElement as? KtAnnotationEntry ?: return null

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -557,7 +557,7 @@ class QuickFixRegistrar : QuickFixContributor {
 
         ILLEGAL_INLINE_PARAMETER_MODIFIER.registerFactory(AddInlineToFunctionFix)
 
-        INAPPLICABLE_JVM_FIELD.registerFactory(ReplaceJvmFieldWithConstFix)
+        INAPPLICABLE_JVM_FIELD.registerFactory(ReplaceJvmFieldWithConstFix, RemoveAnnotationFix.JvmField)
 
         CONFLICTING_OVERLOADS.registerFactory(ChangeSuspendInHierarchyFix)
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -10395,6 +10395,16 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
         }
 
+        @TestMetadata("jvmField.kt")
+        public void testJvmField() throws Exception {
+            runTest("testData/quickfix/removeAnnotation/jvmField.kt");
+        }
+
+        @TestMetadata("jvmFieldOnOverridingProperty.kt")
+        public void testJvmFieldOnOverridingProperty() throws Exception {
+            runTest("testData/quickfix/removeAnnotation/jvmFieldOnOverridingProperty.kt");
+        }
+
         @TestMetadata("jvmOverloads.kt")
         public void testJvmOverloads() throws Exception {
             runTest("testData/quickfix/removeAnnotation/jvmOverloads.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmField.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmField.kt
@@ -1,0 +1,5 @@
+// "Remove @JvmField annotation" "true"
+// WITH_RUNTIME
+class Foo {
+    <caret>@JvmField private val bar = 0
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmField.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmField.kt.after
@@ -1,0 +1,5 @@
+// "Remove @JvmField annotation" "true"
+// WITH_RUNTIME
+class Foo {
+    private val bar = 0
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmFieldOnOverridingProperty.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmFieldOnOverridingProperty.kt
@@ -1,0 +1,7 @@
+// "Remove @JvmField annotation" "true"
+// WITH_RUNTIME
+interface I {
+    val x: Int
+}
+
+class C1 : I { <caret>@JvmField override val x: Int = 1 }

--- a/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmFieldOnOverridingProperty.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/removeAnnotation/jvmFieldOnOverridingProperty.kt.after
@@ -1,0 +1,7 @@
+// "Remove @JvmField annotation" "true"
+// WITH_RUNTIME
+interface I {
+    val x: Int
+}
+
+class C1 : I { override val x: Int = 1 }

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/class.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/class.kt
@@ -8,6 +8,7 @@
 // ACTION: Move to constructor
 // ACTION: Specify type explicitly
 // ACTION: Add use-site target 'field'
+// ACTION: Remove @JvmField annotation
 class Foo {
     <caret>@JvmField private val a = "Lorem ipsum"
 }

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/nonConstantInitializer.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/nonConstantInitializer.kt
@@ -6,5 +6,6 @@
 // ACTION: Make public
 // ACTION: Remove explicit type specification
 // ACTION: Add use-site target 'field'
+// ACTION: Remove @JvmField annotation
 fun getText() = ""
 <caret>@JvmField private val text: String = getText()

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/nullable.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/nullable.kt
@@ -6,4 +6,5 @@
 // ACTION: Make public
 // ACTION: Remove explicit type specification
 // ACTION: Add use-site target 'field'
+// ACTION: Remove @JvmField annotation
 <caret>@JvmField private val number: Int? = 42

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/stringTemplateWithVal.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceJvmFieldWithConst/stringTemplateWithVal.kt
@@ -7,5 +7,6 @@
 // ACTION: Make public
 // ACTION: Specify type explicitly
 // ACTION: Add use-site target 'field'
+// ACTION: Remove @JvmField annotation
 val three = 3
 <caret>@JvmField private val text = "${2 + three}"


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19982