### PR TITLE
KTIJ-19721 False positive redundant nullable type warning on @Transient properties

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8688,6 +8688,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                 runTest("testData/inspectionsLocal/redundantNullableReturnType/property/getterWithBody.kt");
             }
 
+            @TestMetadata("hasTransientAnnotation.kt")
+            public void testHasTransientAnnotation() throws Exception {
+                runTest("testData/inspectionsLocal/redundantNullableReturnType/property/hasTransientAnnotation.kt");
+            }
+
             @TestMetadata("initializer.kt")
             public void testInitializer() throws Exception {
                 runTest("testData/inspectionsLocal/redundantNullableReturnType/property/initializer.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantNullableReturnType/property/hasTransientAnnotation.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantNullableReturnType/property/hasTransientAnnotation.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+// WITH_RUNTIME
+class FooClass {
+    @Transient
+    val test: Int?<caret> = 5
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19721