### PR TITLE
Allow customizing ActionMenu UI

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionMenu.java
+++ b/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionMenu.java
@@ -1,4 +1,4 @@
-// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.openapi.actionSystem.impl;
 
 import com.intellij.ide.DataManager;
@@ -46,7 +46,12 @@ import java.awt.event.MouseEvent;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * @author Gabriel Pizarro
+ */
 public final class ActionMenu extends JBMenu {
+  private static final String uiClassID = "ActionMenuUI";
+
   private final String myPlace;
   private final DataContext myContext;
   private final ActionRef<ActionGroup> myGroup;
@@ -131,8 +136,18 @@ public final class ActionMenu extends JBMenu {
   }
 
   @Override
+  public String getUIClassID() {
+    return uiClassID;
+  }
+
+  @Override
   public void updateUI() {
-    setUI(IdeaMenuUI.createUI(this));
+    if (UIManager.get(getUIClassID()) != null) {
+      setUI(UIManager.getUI(this));
+    } else {
+      setUI(IdeaMenuUI.createUI(this));
+    }
+
     setFont(UIUtil.getMenuFont());
 
     JPopupMenu popupMenu = getPopupMenu();

--- a/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionMenuItem.java
+++ b/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/ActionMenuItem.java
@@ -1,4 +1,4 @@
-// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.openapi.actionSystem.impl;
 
 import com.intellij.featureStatistics.FeatureUsageTracker;
@@ -33,7 +33,11 @@ import java.awt.event.KeyEvent;
 
 import static com.intellij.openapi.keymap.KeymapUtil.getActiveKeymapShortcuts;
 
+/**
+ * @author Gabriel Pizarro
+ */
 public class ActionMenuItem extends JBCheckBoxMenuItem {
+  private static final String uiClassID = "ActionMenuItemUI";
   static final Icon EMPTY_ICON = EmptyIcon.create(16, 1);
 
   private final ActionRef<AnAction> myAction;
@@ -190,8 +194,17 @@ public class ActionMenuItem extends JBCheckBoxMenuItem {
   }
 
   @Override
+  public String getUIClassID() {
+    return uiClassID;
+  }
+
+  @Override
   public void updateUI() {
-    setUI(BegMenuItemUI.createUI(this));
+    if (UIManager.get(getUIClassID()) != null) {
+      setUI(UIManager.getUI(this));
+    } else {
+      setUI(BegMenuItemUI.createUI(this));
+    }
   }
 
   /**

--- a/platform/platform-impl/src/com/intellij/ui/plaf/beg/BegMenuItemUI.java
+++ b/platform/platform-impl/src/com/intellij/ui/plaf/beg/BegMenuItemUI.java
@@ -1,5 +1,4 @@
-
-// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.ui.plaf.beg;
 
 import com.intellij.ide.ui.UISettings;
@@ -42,8 +41,9 @@ import java.lang.reflect.Method;
 /**
  * @author Eugene Belyaev
  * @author Vladimir Kondratyev
+ * @author Gabriel Pizarro
  */
-public final class BegMenuItemUI extends BasicMenuItemUI {
+public class BegMenuItemUI extends BasicMenuItemUI {
   private static final Rectangle b = new Rectangle(0, 0, 0, 0);
   private static final Rectangle j = new Rectangle();
   private static final Rectangle d = new Rectangle();


### PR DESCRIPTION
Currently, the UIs for `ActionMenu` and `ActionMenuItem` are hardcoded, unlike most other Swing components in IntelliJ. This change allows plugin developers to provide their own components for action menus (File, Edit, View, etc.).

I was building my own plugin that provides custom components and noticed this issue, so I thought I would help fix it. This is my first time contributing to IntelliJ, so please let me know if I did something wrong. I made sure to read the guidelines and will sign the contributor license right after creating this PR.

I wasn't sure if tests should be included -- based on OpenJDK's Swing tests, it's not necessary. Please also let me know if I should merge to a different branch.