### PR TITLE
FIR IDE: refactor KotlinFindUsagesSupport...

### DIFF
--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesSupportFirImpl.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesSupportFirImpl.kt
@@ -9,41 +9,51 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiReference
 import com.intellij.psi.search.GlobalSearchScope
-import org.jetbrains.kotlin.idea.KotlinBundle
-import org.jetbrains.kotlin.idea.core.util.showYesNoCancelDialog
+import com.intellij.util.Processor
 import org.jetbrains.kotlin.analysis.api.analyseInModalWindow
 import org.jetbrains.kotlin.analysis.api.symbols.KtCallableSymbol
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtNamedSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolWithKind
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.core.util.showYesNoCancelDialog
 import org.jetbrains.kotlin.idea.refactoring.CHECK_SUPER_METHODS_YES_NO_DIALOG
 import org.jetbrains.kotlin.idea.refactoring.formatPsiClass
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.SpecialNames
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getElementTextWithContext
 
 class KotlinFindUsagesSupportFirImpl : KotlinFindUsagesSupport {
-    override fun isCallReceiverRefersToCompanionObject(element: KtElement, companionObject: KtObjectDeclaration): Boolean {
+    override fun processCompanionObjectInternalReferences(
+        companionObject: KtObjectDeclaration,
+        referenceProcessor: Processor<PsiReference>
+    ): Boolean {
+        // TODO: implement this
         return false
     }
 
     override fun isDataClassComponentFunction(element: KtParameter): Boolean {
+        // TODO: implement this
         return false
     }
 
     override fun getTopMostOverriddenElementsToHighlight(target: PsiElement): List<PsiElement> {
+        // TODO: implement this
         return emptyList()
     }
 
     override fun tryRenderDeclarationCompactStyle(declaration: KtDeclaration): String? {
+        // TODO: implement this
         return (declaration as? KtNamedDeclaration)?.name ?: "SUPPORT FOR FIR"
     }
 
     override fun isConstructorUsage(psiReference: PsiReference, ktClassOrObject: KtClassOrObject): Boolean {
+        // TODO: implement this
         return false
     }
 
     override fun getSuperMethods(declaration: KtDeclaration, ignore: Collection<PsiElement>?): List<PsiElement> {
+        // TODO: implement this
         return emptyList()
     }
 

--- a/plugins/kotlin/frontend-independent/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesSupport.kt
+++ b/plugins/kotlin/frontend-independent/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesSupport.kt
@@ -6,8 +6,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.Processor
 import org.jetbrains.kotlin.idea.util.application.getServiceSafe
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtParameter
 
 interface KotlinFindUsagesSupport {
 
@@ -15,10 +19,13 @@ interface KotlinFindUsagesSupport {
         fun getInstance(project: Project): KotlinFindUsagesSupport = project.getServiceSafe()
 
         val KtParameter.isDataClassComponentFunction: Boolean
-            get() =  getInstance(project).isDataClassComponentFunction(this)
+            get() = getInstance(project).isDataClassComponentFunction(this)
 
-        fun KtElement.isCallReceiverRefersToCompanionObject(companionObject: KtObjectDeclaration): Boolean =
-            getInstance(project).isCallReceiverRefersToCompanionObject(this, companionObject)
+        fun processCompanionObjectInternalReferences(
+            companionObject: KtObjectDeclaration,
+            referenceProcessor: Processor<PsiReference>
+        ): Boolean =
+            getInstance(companionObject.project).processCompanionObjectInternalReferences(companionObject, referenceProcessor)
 
         fun getTopMostOverriddenElementsToHighlight(target: PsiElement): List<PsiElement> =
             getInstance(target.project).getTopMostOverriddenElementsToHighlight(target)
@@ -36,7 +43,7 @@ interface KotlinFindUsagesSupport {
             getInstance(project).sourcesAndLibraries(delegate, project)
     }
 
-    fun isCallReceiverRefersToCompanionObject(element: KtElement, companionObject: KtObjectDeclaration): Boolean
+    fun processCompanionObjectInternalReferences(companionObject: KtObjectDeclaration, referenceProcessor: Processor<PsiReference>): Boolean
 
     fun isDataClassComponentFunction(element: KtParameter): Boolean
 

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesSupportImpl.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/findUsages/KotlinFindUsagesSupportImpl.kt
@@ -6,13 +6,27 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.Processor
 import org.jetbrains.kotlin.idea.search.usagesSearch.dataClassComponentFunction
+import org.jetbrains.kotlin.idea.search.usagesSearch.isCallReceiverRefersToCompanionObject
 import org.jetbrains.kotlin.idea.search.usagesSearch.isConstructorUsage
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 class KotlinFindUsagesSupportImpl : KotlinFindUsagesSupport {
-    override fun isCallReceiverRefersToCompanionObject(element: KtElement, companionObject: KtObjectDeclaration): Boolean =
-        org.jetbrains.kotlin.idea.search.usagesSearch.isCallReceiverRefersToCompanionObject(element, companionObject)
+    override fun processCompanionObjectInternalReferences(
+        companionObject: KtObjectDeclaration,
+        referenceProcessor: Processor<PsiReference>
+    ): Boolean {
+        val klass = companionObject.getStrictParentOfType<KtClass>() ?: return true
+        return !klass.anyDescendantOfType(fun(element: KtElement): Boolean {
+            if (element == companionObject) return false // skip companion object itself
+            return if (isCallReceiverRefersToCompanionObject(element, companionObject)) {
+                element.references.any { !referenceProcessor.process(it) }
+            } else false
+        })
+    }
 
     override fun isDataClassComponentFunction(element: KtParameter): Boolean =
         element.dataClassComponentFunction() != null


### PR DESCRIPTION
so that analyse can be done once for the entire container element rather
than on each element individually.