### PR TITLE
FIR Completion: correctly complete super member

### DIFF
--- a/plugins/kotlin/completion/tests/test/org/jetbrains/kotlin/idea/completion/test/JSBasicCompletionTestGenerated.java
+++ b/plugins/kotlin/completion/tests/test/org/jetbrains/kotlin/idea/completion/test/JSBasicCompletionTestGenerated.java
@@ -35,6 +35,31 @@ public abstract class JSBasicCompletionTestGenerated extends AbstractJSBasicComp
             runTest("testData/basic/common/AfterIntSeparatedWithComments.kt");
         }
 
+        @TestMetadata("ambiguousSuperMethod.kt")
+        public void testAmbiguousSuperMethod() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethod.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodDiamond.kt")
+        public void testAmbiguousSuperMethodDiamond() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodDiamond.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodDiamondAny.kt")
+        public void testAmbiguousSuperMethodDiamondAny() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodDiamondAny.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodHigherUp.kt")
+        public void testAmbiguousSuperMethodHigherUp() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodHigherUp.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodSingleImpl.kt")
+        public void testAmbiguousSuperMethodSingleImpl() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodSingleImpl.kt");
+        }
+
         @TestMetadata("BasicAny.kt")
         public void testBasicAny() throws Exception {
             runTest("testData/basic/common/BasicAny.kt");

--- a/plugins/kotlin/completion/tests/test/org/jetbrains/kotlin/idea/completion/test/JvmBasicCompletionTestGenerated.java
+++ b/plugins/kotlin/completion/tests/test/org/jetbrains/kotlin/idea/completion/test/JvmBasicCompletionTestGenerated.java
@@ -35,6 +35,31 @@ public abstract class JvmBasicCompletionTestGenerated extends AbstractJvmBasicCo
             runTest("testData/basic/common/AfterIntSeparatedWithComments.kt");
         }
 
+        @TestMetadata("ambiguousSuperMethod.kt")
+        public void testAmbiguousSuperMethod() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethod.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodDiamond.kt")
+        public void testAmbiguousSuperMethodDiamond() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodDiamond.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodDiamondAny.kt")
+        public void testAmbiguousSuperMethodDiamondAny() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodDiamondAny.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodHigherUp.kt")
+        public void testAmbiguousSuperMethodHigherUp() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodHigherUp.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodSingleImpl.kt")
+        public void testAmbiguousSuperMethodSingleImpl() throws Exception {
+            runTest("testData/basic/common/ambiguousSuperMethodSingleImpl.kt");
+        }
+
         @TestMetadata("BasicAny.kt")
         public void testBasicAny() throws Exception {
             runTest("testData/basic/common/BasicAny.kt");

--- a/plugins/kotlin/completion/tests/test/org/jetbrains/kotlin/idea/completion/test/handlers/BasicCompletionHandlerTestGenerated.java
+++ b/plugins/kotlin/completion/tests/test/org/jetbrains/kotlin/idea/completion/test/handlers/BasicCompletionHandlerTestGenerated.java
@@ -28,6 +28,16 @@ public class BasicCompletionHandlerTestGenerated extends AbstractBasicCompletion
         runTest("testData/handlers/basic/AddLabelToReturn.kt");
     }
 
+    @TestMetadata("AmbiguousSuperMethod.kt")
+    public void testAmbiguousSuperMethod() throws Exception {
+        runTest("testData/handlers/basic/AmbiguousSuperMethod.kt");
+    }
+
+    @TestMetadata("AmbiguousSuperMethodWithArgument.kt")
+    public void testAmbiguousSuperMethodWithArgument() throws Exception {
+        runTest("testData/handlers/basic/AmbiguousSuperMethodWithArgument.kt");
+    }
+
     @TestMetadata("ClassKeywordBeforeName.kt")
     public void testClassKeywordBeforeName() throws Exception {
         runTest("testData/handlers/basic/ClassKeywordBeforeName.kt");

--- a/plugins/kotlin/completion/tests/testData/basic/common/SuperMembers4.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/SuperMembers4.kt
@@ -1,3 +1,4 @@
+// FIR_COMPARISON
 open class B {
     open fun foo() {}
     open fun bar() {}

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethod.fir.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethod.fir.kt
@@ -1,0 +1,23 @@
+// FIR_COMPARISON
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i: Int) {}
+}
+
+fun A.bar() {}
+fun B.bar() {}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.fo<caret>
+    }
+}
+
+// EXIST: { lookupString:"foo", tailText:"(i: Int) for A" }
+// EXIST: { lookupString:"foo", tailText:"(i: Int) for B" }
+// EXIST: { lookupString:"foo", tailText:"(j) for A" }
+// EXIST: { lookupString:"foo", tailText:"(j) for B" }
+// ABSENT: bar

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethod.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethod.kt
@@ -1,0 +1,23 @@
+// FIR_COMPARISON
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i: Int) {}
+}
+
+fun A.bar() {}
+fun B.bar() {}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.fo<caret>
+    }
+}
+
+// EXIST: { lookupString:"foo", tailText:"(i: Int)" }
+// EXIST: { lookupString:"foo", tailText:"(i: Int)" }
+// EXIST: { lookupString:"foo", tailText:"(i)" }
+// EXIST: { lookupString:"foo", tailText:"(i)" }
+// ABSENT: bar

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamond.fir.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamond.fir.kt
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+interface A {
+    fun foo() {}
+}
+
+interface B1 : A
+interface B2 : A
+
+class C : B1, B2 {
+    fun test() {
+        super.fo<caret>
+    }
+}
+
+//
+// EXIST: { lookupString:"foo", tailText:"() for B1" }
+// EXIST: { lookupString:"foo", tailText:"() for B2" }
+// NOTHING_ELSE

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamond.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamond.kt
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+interface A {
+    fun foo() {}
+}
+
+interface B1 : A
+interface B2 : A
+
+class C : B1, B2 {
+    fun test() {
+        super.fo<caret>
+    }
+}
+
+//
+// EXIST: { lookupString:"foo", tailText:"()" }
+// EXIST: { lookupString:"foo", tailText:"()" }
+// NOTHING_ELSE

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamondAny.fir.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamondAny.fir.kt
@@ -1,0 +1,16 @@
+// FIR_COMPARISON
+interface A {
+    fun foo() {}
+}
+
+interface B1 : A
+interface B2 : A
+
+class C : B1, B2 {
+    fun test() {
+        super.hash<caret>
+    }
+}
+
+// EXIST: { lookupString:"hashCode", tailText:"()" }
+// NOTHING_ELSE

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamondAny.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodDiamondAny.kt
@@ -1,0 +1,17 @@
+// FIR_COMPARISON
+interface A {
+    fun foo() {}
+}
+
+interface B1 : A
+interface B2 : A
+
+class C : B1, B2 {
+    fun test() {
+        super.hash<caret>
+    }
+}
+
+// EXIST: { lookupString:"hashCode", tailText:"()" }
+// EXIST: { lookupString:"hashCode", tailText:"()" }
+// NOTHING_ELSE

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodHigherUp.fir.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodHigherUp.fir.kt
@@ -1,0 +1,20 @@
+// FIR_COMPARISON
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface A2 : A
+
+interface B {
+    fun foo(j: Int) {}
+}
+
+class C : A2, B {
+    fun test() {
+        super.fo<caret>
+    }
+}
+
+// EXIST: { lookupString:"foo", tailText:"(i: Int) for A2" }
+// EXIST: { lookupString:"foo", tailText:"(j: Int) for B" }
+// NOTHING_ELSE

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodHigherUp.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodHigherUp.kt
@@ -1,0 +1,20 @@
+// FIR_COMPARISON
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface A2 : A
+
+interface B {
+    fun foo(j: Int) {}
+}
+
+class C : A2, B {
+    fun test() {
+        super.fo<caret>
+    }
+}
+
+// EXIST: { lookupString:"foo", tailText:"(i: Int)" }
+// EXIST: { lookupString:"foo", tailText:"(j: Int)" }
+// NOTHING_ELSE

--- a/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodSingleImpl.kt
+++ b/plugins/kotlin/completion/tests/testData/basic/common/ambiguousSuperMethodSingleImpl.kt
@@ -1,0 +1,18 @@
+// FIR_IDENTICAL
+// FIR_COMPARISON
+interface A {
+    fun foo(i: Int)
+}
+
+interface B {
+    fun foo(i: Int) {}
+}
+
+class C : A, B {
+    fun test() {
+        super.fo<caret>
+    }
+}
+
+// EXIST: { lookupString:"foo", tailText:"(i: Int)" }
+// NOTHING_ELSE

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.fir.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.fir.kt
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.fo<caret>
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(i: Int) for A"

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.fir.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.fir.kt.after
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super<A>.foo(<caret>)
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(i: Int) for A"

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.kt
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.fo<caret>
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(i: Int)"

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethod.kt.after
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.foo(<caret>)
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(i: Int)"

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.fir.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.fir.kt
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.fo<caret>
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(j) for A"

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.fir.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.fir.kt.after
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super<A>.foo(j)<caret>
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(j) for A"

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.kt
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.kt
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.fo<caret>
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(i)"

--- a/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.kt.after
+++ b/plugins/kotlin/completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.kt.after
@@ -1,0 +1,18 @@
+// FIR_COMPARISON
+package foo.bar
+interface A {
+    fun foo(i: Int) {}
+}
+
+interface B {
+    fun foo(i2: Int) {}
+}
+
+class C : A, B {
+    override fun foo(j: Int) {
+        super.foo(i)<caret>
+    }
+}
+
+// ELEMENT: "foo"
+// TAIL_TEXT: "(i)"

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/Completions.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/Completions.kt
@@ -2,10 +2,10 @@
 
 package org.jetbrains.kotlin.idea.completion
 
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
 import org.jetbrains.kotlin.idea.completion.context.*
 import org.jetbrains.kotlin.idea.completion.contributors.FirCompletionContributorFactory
 import org.jetbrains.kotlin.idea.completion.contributors.complete
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
 
 internal object Completions {
     fun KtAnalysisSession.complete(
@@ -16,9 +16,12 @@ internal object Completions {
             is FirExpressionNameReferencePositionContext -> {
                 complete(factory.keywordContributor(0), positionContext)
                 complete(factory.callableContributor(0), positionContext)
-                complete(factory.superMemberContributor(0), positionContext)
                 complete(factory.classifierContributor(0), positionContext)
                 complete(factory.packageCompletionContributor(1), positionContext)
+            }
+
+            is FirSuperReceiverNameReferencePositionContext -> {
+                complete(factory.superMemberContributor(0), positionContext)
             }
 
             is FirTypeNameReferencePositionContext -> {

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/context/FirPositionCompletionContext.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/context/FirPositionCompletionContext.kt
@@ -72,6 +72,16 @@ internal class FirAnnotationTypeNameReferencePositionContext(
     val annotationEntry: KtAnnotationEntry,
 ) : FirNameReferencePositionContext()
 
+/**
+ * Example
+ * ```
+ * class A {
+ *   fun test() {
+ *     super<<caret>>
+ *   }
+ * }
+ * ```
+ */
 internal class FirSuperTypeCallNameReferencePositionContext(
     override val position: PsiElement,
     override val reference: KtSimpleNameReference,
@@ -80,6 +90,23 @@ internal class FirSuperTypeCallNameReferencePositionContext(
     val superExpression: KtSuperExpression,
 ) : FirNameReferencePositionContext()
 
+/**
+ * Example
+ * ```
+ * class A {
+ *   fun test() {
+ *     super.<caret>
+ *   }
+ * }
+ * ```
+ */
+internal class FirSuperReceiverNameReferencePositionContext(
+    override val position: PsiElement,
+    override val reference: KtSimpleNameReference,
+    override val nameExpression: KtSimpleNameExpression,
+    override val explicitReceiver: KtExpression?,
+    val superExpression: KtSuperExpression,
+) : FirNameReferencePositionContext()
 
 internal class FirExpressionNameReferencePositionContext(
     override val position: PsiElement,
@@ -187,6 +214,13 @@ internal object FirPositionCompletionContextDetector {
                     position, reference, nameExpression, explicitReceiver
                 )
             }
+            explicitReceiver is KtSuperExpression -> FirSuperReceiverNameReferencePositionContext(
+                position,
+                reference,
+                nameExpression,
+                explicitReceiver,
+                explicitReceiver
+            )
             else -> {
                 FirExpressionNameReferencePositionContext(position, reference, nameExpression, explicitReceiver)
             }

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/contributors/FirSuperMemberCompletionContributor.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/contributors/FirSuperMemberCompletionContributor.kt
@@ -3,45 +3,146 @@
 package org.jetbrains.kotlin.idea.completion.contributors
 
 import com.intellij.psi.util.parentsOfType
+import com.intellij.refactoring.suggested.createSmartPointer
 import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
 import org.jetbrains.kotlin.analysis.api.symbols.KtCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionLikeSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtSyntheticJavaPropertySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolWithModality
+import org.jetbrains.kotlin.analysis.api.types.KtIntersectionType
+import org.jetbrains.kotlin.analysis.api.types.KtType
+import org.jetbrains.kotlin.analysis.api.types.KtUsualClassType
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.idea.completion.ItemPriority
 import org.jetbrains.kotlin.idea.completion.checkers.CompletionVisibilityChecker
 import org.jetbrains.kotlin.idea.completion.context.FirBasicCompletionContext
-import org.jetbrains.kotlin.idea.completion.context.FirNameReferencePositionContext
+import org.jetbrains.kotlin.idea.completion.context.FirSuperReceiverNameReferencePositionContext
 import org.jetbrains.kotlin.idea.completion.contributors.helpers.collectNonExtensions
 import org.jetbrains.kotlin.idea.completion.lookups.CallableInsertionOptions
 import org.jetbrains.kotlin.idea.completion.lookups.CallableInsertionStrategy
 import org.jetbrains.kotlin.idea.completion.lookups.detectImportStrategy
 import org.jetbrains.kotlin.idea.completion.weighers.WeighingContext
 import org.jetbrains.kotlin.idea.completion.weighers.WeighingContext.Companion.createWeighingContext
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtSuperExpression
+import org.jetbrains.kotlin.utils.addIfNotNull
 
 internal class FirSuperMemberCompletionContributor(
     basicContext: FirBasicCompletionContext,
     priority: Int
-) : FirCompletionContributorBase<FirNameReferencePositionContext>(basicContext, priority) {
-    override fun KtAnalysisSession.complete(positionContext: FirNameReferencePositionContext) = with(positionContext) {
-        val superReceiver = explicitReceiver as? KtSuperExpression ?: return
+) : FirCompletionContributorBase<FirSuperReceiverNameReferencePositionContext>(basicContext, priority) {
+    override fun KtAnalysisSession.complete(positionContext: FirSuperReceiverNameReferencePositionContext) = with(positionContext) {
+        val superReceiver = positionContext.superExpression
         val expectedType = nameExpression.getExpectedType()
         val visibilityChecker = CompletionVisibilityChecker.create(basicContext, positionContext)
-        val possibleReceiverScope = superReceiver.getKtType()?.getTypeScope() ?: return
-        val nonExtensionMembers = collectNonExtensions(possibleReceiverScope, visibilityChecker, scopeNameFilter)
+        val superType = superReceiver.getKtType() ?: return
         val weighingContext = createWeighingContext(
             superReceiver,
             expectedType,
             emptyList(), // Implicit receivers do not match for this completion contributor.
             fakeKtFile
         )
-        collectDelegateCallToSuperMember(weighingContext, superReceiver, nonExtensionMembers)
+
+        val (nonExtensionMembers: Iterable<Pair<KtType, KtCallableSymbol>>, namesNeedDisambiguation: Set<Name>) = if (superType !is KtIntersectionType) {
+            val scope = superType.getTypeScope() ?: return
+            collectNonExtensions(scope, visibilityChecker, scopeNameFilter).map { superType to it }.asIterable() to emptySet()
+        } else {
+            getSymbolsAndNamesNeedDisambiguation(superType.conjuncts, visibilityChecker)
+        }
+        collectCallToSuperMember(superReceiver, nonExtensionMembers, weighingContext, namesNeedDisambiguation)
+        collectDelegateCallToSuperMember(weighingContext, superReceiver, nonExtensionMembers, namesNeedDisambiguation)
+
+    }
+
+    private fun KtAnalysisSession.getSymbolsAndNamesNeedDisambiguation(
+        superTypes: List<KtType>,
+        visibilityChecker: CompletionVisibilityChecker
+    ): Pair<List<Pair<KtType, KtCallableSymbol>>, Set<Name>> {
+        val allSymbols = mutableListOf<Pair<KtType, KtCallableSymbol>>()
+        val symbolsInAny = mutableSetOf<KtCallableSymbol>()
+        val symbolCountsByName = mutableMapOf<Name, Int>()
+        for (superType in superTypes) {
+            for (symbol in getNonExtensionsMemberSymbols(superType, visibilityChecker)) {
+                // Abstract symbol does not participate completion.
+                if (symbol !is KtSymbolWithModality || symbol.modality == Modality.ABSTRACT) continue
+
+                // Unlike typical diamond cases, calls to method of `Any` always do not need extra qualification.
+                if (symbol.callableIdIfNonLocal?.classId == StandardClassIds.Any) {
+                    if (symbol in symbolsInAny) continue
+                    symbolsInAny.add(symbol)
+                }
+
+                allSymbols.add(superType to symbol)
+                val name = symbol.callableIdIfNonLocal?.callableName ?: continue
+                symbolCountsByName[name] = (symbolCountsByName[name] ?: 0) + 1
+            }
+        }
+
+        val nameNeedDisambiguation = mutableSetOf<Name>()
+        for ((name, count) in symbolCountsByName) {
+            if (count > 1) {
+                nameNeedDisambiguation.add(name)
+            }
+        }
+        return Pair(allSymbols, nameNeedDisambiguation)
+    }
+
+    private fun KtAnalysisSession.getNonExtensionsMemberSymbols(
+        receiverType: KtType,
+        visibilityChecker: CompletionVisibilityChecker
+    ): Sequence<KtCallableSymbol> {
+        val possibleReceiverScope = receiverType.getTypeScope() ?: return emptySequence()
+        return collectNonExtensions(possibleReceiverScope, visibilityChecker, scopeNameFilter)
+    }
+
+    private fun KtAnalysisSession.collectCallToSuperMember(
+        superReceiver: KtSuperExpression,
+        nonExtensionMembers: Iterable<Pair<KtType, KtCallableSymbol>>,
+        context: WeighingContext,
+        namesNeedDisambiguation: Set<Name>
+    ) {
+        val syntheticPropertyOrigins = mutableSetOf<KtFunctionSymbol>()
+        nonExtensionMembers
+            .onEach {
+                if (it is KtSyntheticJavaPropertySymbol) {
+                    syntheticPropertyOrigins.add(it.javaGetterSymbol)
+                    syntheticPropertyOrigins.addIfNotNull(it.javaSetterSymbol)
+                }
+            }
+            .forEach { (superType, callableSymbol) ->
+                if (callableSymbol !in syntheticPropertyOrigins) {
+                    // For basic completion, FE1.0 skips Java functions that are mapped to Kotlin properties.
+                    addCallableSymbolToCompletion(
+                        context,
+                        callableSymbol,
+                        CallableInsertionOptions(
+                            detectImportStrategy(callableSymbol),
+                            wrapWithDisambiguationIfNeeded(
+                                getInsertionStrategy(callableSymbol),
+                                superType,
+                                callableSymbol,
+                                namesNeedDisambiguation,
+                                superReceiver
+                            )
+                        )
+                    )
+                }
+            }
+    }
+
+    private fun getInsertionStrategy(symbol: KtCallableSymbol): CallableInsertionStrategy = when (symbol) {
+        is KtFunctionLikeSymbol -> CallableInsertionStrategy.AsCall
+        else -> CallableInsertionStrategy.AsIdentifier
     }
 
     private fun KtAnalysisSession.collectDelegateCallToSuperMember(
         context: WeighingContext,
         superReceiver: KtSuperExpression,
-        nonExtensionMembers: Sequence<KtCallableSymbol>,
+        nonExtensionMembers: Iterable<Pair<KtType, KtCallableSymbol>>,
+        namesNeedDisambiguation: Set<Name>
     ) {
         // A map that contains all containing functions as values, each of which is indexed by symbols it overrides. For example, consider
         // the following code
@@ -73,7 +174,7 @@ internal class FirSuperMemberCompletionContributor(
 
         if (superFunctionToContainingFunction.isEmpty()) return
 
-        for (callableSymbol in nonExtensionMembers) {
+        for ((superType, callableSymbol) in nonExtensionMembers) {
             val matchedContainingFunction = superFunctionToContainingFunction[callableSymbol] ?: continue
             if (callableSymbol !is KtFunctionSymbol) continue
             if (callableSymbol.valueParameters.isEmpty()) continue
@@ -91,10 +192,32 @@ internal class FirSuperMemberCompletionContributor(
                 callableSymbol,
                 CallableInsertionOptions(
                     detectImportStrategy(callableSymbol),
-                    CallableInsertionStrategy.WithCallArgs(args)
+                    wrapWithDisambiguationIfNeeded(
+                        CallableInsertionStrategy.WithCallArgs(args),
+                        superType,
+                        callableSymbol,
+                        namesNeedDisambiguation,
+                        superReceiver
+                    )
                 ),
                 priority = ItemPriority.SUPER_METHOD_WITH_ARGUMENTS
             )
+        }
+    }
+
+    private fun wrapWithDisambiguationIfNeeded(
+        insertionStrategy: CallableInsertionStrategy,
+        superType: KtType,
+        callableSymbol: KtCallableSymbol,
+        namesNeedDisambiguation: Set<Name>,
+        superReceiver: KtSuperExpression
+    ): CallableInsertionStrategy {
+        val superClassId = (superType as? KtUsualClassType)?.classId
+        val needDisambiguation = callableSymbol.callableIdIfNonLocal?.callableName in namesNeedDisambiguation
+        return if (needDisambiguation && superClassId != null) {
+            CallableInsertionStrategy.WithSuperDisambiguation(superReceiver.createSmartPointer(), superClassId, insertionStrategy)
+        } else {
+            insertionStrategy
         }
     }
 }

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/contributors/helpers/completionHelpers.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/contributors/helpers/completionHelpers.kt
@@ -22,11 +22,11 @@ private fun scheduleCompletion(context: InsertionContext) {
     }
 }
 
-internal fun InsertionContext.insertSymbol(symbol: String) {
+internal fun InsertionContext.insertSymbol(symbol: String, position: Int = tailOffset, moveCaretToEnd: Boolean = true) {
     PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(document)
-    document.insertString(tailOffset, symbol)
+    document.insertString(position, symbol)
     commitDocument()
-    editor.caretModel.moveToOffset(tailOffset)
+    if (moveCaretToEnd) editor.caretModel.moveToOffset(tailOffset)
 }
 
 internal fun InsertionContext.addTypeArguments(typeArgumentsCount: Int) {

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/lookups/CallableInsertionStrategy.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/lookups/CallableInsertionStrategy.kt
@@ -3,10 +3,18 @@
 package org.jetbrains.kotlin.idea.completion.lookups
 
 import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.psi.SmartPsiElementPointer
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtSuperExpression
 
 internal sealed class CallableInsertionStrategy {
     object AsCall : CallableInsertionStrategy()
     object AsIdentifier : CallableInsertionStrategy()
     class AsIdentifierCustom(val insertionHandlerAction: InsertionContext.() -> Unit) : CallableInsertionStrategy()
-    class WithCallArgs(val args: List<String>): CallableInsertionStrategy()
+    class WithCallArgs(val args: List<String>) : CallableInsertionStrategy()
+    class WithSuperDisambiguation(
+        val superExpressionPointer: SmartPsiElementPointer<KtSuperExpression>,
+        val superClassId: ClassId,
+        val subStrategy: CallableInsertionStrategy
+    ) : CallableInsertionStrategy()
 }

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/lookups/factories/VariableLookupElementFactory.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/lookups/factories/VariableLookupElementFactory.kt
@@ -7,11 +7,6 @@ import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.util.TextRange
-import org.jetbrains.kotlin.idea.completion.lookups.*
-import org.jetbrains.kotlin.idea.completion.lookups.CompletionShortNamesRenderer.renderVariable
-import org.jetbrains.kotlin.idea.completion.lookups.TailTextProvider.getTailText
-import org.jetbrains.kotlin.idea.completion.lookups.TailTextProvider.insertLambdaBraces
-import org.jetbrains.kotlin.idea.core.withRootPrefixIfNeeded
 import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
 import org.jetbrains.kotlin.analysis.api.components.KtTypeRendererOptions
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
@@ -19,6 +14,11 @@ import org.jetbrains.kotlin.analysis.api.symbols.KtSyntheticJavaPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtVariableLikeSymbol
 import org.jetbrains.kotlin.analysis.api.types.KtFunctionalType
 import org.jetbrains.kotlin.analysis.api.types.KtSubstitutor
+import org.jetbrains.kotlin.idea.completion.lookups.*
+import org.jetbrains.kotlin.idea.completion.lookups.CompletionShortNamesRenderer.renderVariable
+import org.jetbrains.kotlin.idea.completion.lookups.TailTextProvider.getTailText
+import org.jetbrains.kotlin.idea.completion.lookups.TailTextProvider.insertLambdaBraces
+import org.jetbrains.kotlin.idea.core.withRootPrefixIfNeeded
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.renderer.render
@@ -30,8 +30,25 @@ internal class VariableLookupElementFactory {
         substitutor: KtSubstitutor = KtSubstitutor.Empty(token),
     ): LookupElementBuilder {
         val rendered = renderVariable(symbol, substitutor)
+        var builder = createLookupElementBuilder(options, symbol, rendered, substitutor)
+
+        if (symbol is KtPropertySymbol) {
+            builder = builder.withLookupString(symbol.javaGetterName.asString())
+            symbol.javaSetterName?.let { builder = builder.withLookupString(it.asString()) }
+        }
+
+        return withSymbolInfo(symbol, builder)
+    }
+
+    private fun KtAnalysisSession.createLookupElementBuilder(
+        options: CallableInsertionOptions,
+        symbol: KtVariableLikeSymbol,
+        rendered: String,
+        substitutor: KtSubstitutor,
+        insertionStrategy: CallableInsertionStrategy = options.insertionStrategy
+    ): LookupElementBuilder {
         val symbolType = substitutor.substituteOrSelf(symbol.annotatedType.type)
-        var builder = when (options.insertionStrategy) {
+        return when (insertionStrategy) {
             CallableInsertionStrategy.AsCall -> {
                 val functionalType = symbolType as KtFunctionalType
                 val lookupObject = FunctionCallLookupObject(
@@ -46,14 +63,17 @@ internal class VariableLookupElementFactory {
                     substitutor.substituteOrSelf(it).render(CompletionShortNamesRenderer.TYPE_RENDERING_OPTIONS)
                 }
 
-                val typeText = substitutor
-                    .substituteOrSelf(functionalType.returnType)
-                    .render(CompletionShortNamesRenderer.TYPE_RENDERING_OPTIONS)
+                val typeText =
+                    substitutor.substituteOrSelf(functionalType.returnType).render(CompletionShortNamesRenderer.TYPE_RENDERING_OPTIONS)
 
                 LookupElementBuilder.create(lookupObject, symbol.name.asString())
                     .withTailText(tailText, true)
                     .withTypeText(typeText)
                     .withInsertHandler(FunctionInsertionHandler)
+            }
+            is CallableInsertionStrategy.WithSuperDisambiguation -> {
+                val builder = createLookupElementBuilder(options, symbol, rendered, substitutor, insertionStrategy.subStrategy)
+                updateLookupElementBuilderToInsertTypeQualifierOnSuper(builder, insertionStrategy)
             }
             else -> {
                 val lookupObject = VariableLookupObject(symbol.name, options, rendered)
@@ -65,13 +85,6 @@ internal class VariableLookupElementFactory {
                     .withInsertHandler(VariableInsertionHandler)
             }
         }
-
-        if (symbol is KtPropertySymbol) {
-            builder = builder.withLookupString(symbol.javaGetterName.asString())
-            symbol.javaSetterName?.let { builder = builder.withLookupString(it.asString()) }
-        }
-
-        return withSymbolInfo(symbol, builder)
     }
 
     private fun KtAnalysisSession.markIfSyntheticJavaProperty(

--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/lookups/utils.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/completion/lookups/utils.kt
@@ -2,15 +2,21 @@
 
 package org.jetbrains.kotlin.idea.completion.lookups
 
+import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.util.TextRange
-import org.jetbrains.kotlin.idea.completion.KotlinFirIconProvider
+import com.intellij.refactoring.suggested.endOffset
 import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
 import org.jetbrains.kotlin.analysis.api.analyse
 import org.jetbrains.kotlin.analysis.api.symbols.KtSymbol
 import org.jetbrains.kotlin.analysis.api.tokens.HackToForceAllowRunningAnalyzeOnEDT
 import org.jetbrains.kotlin.analysis.api.tokens.hackyAllowRunningOnEdt
+import org.jetbrains.kotlin.idea.completion.KotlinFirIconProvider
+import org.jetbrains.kotlin.idea.completion.contributors.helpers.insertSymbol
+import org.jetbrains.kotlin.idea.util.shortenReferencesInRange
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtSuperExpression
 
 internal fun KtAnalysisSession.withSymbolInfo(
     symbol: KtSymbol,
@@ -45,5 +51,28 @@ internal fun shortenReferencesForFirCompletion(targetFile: KtFile, textRange: Te
         }
     }
     shortenings.invokeShortening()
+}
+
+
+internal fun updateLookupElementBuilderToInsertTypeQualifierOnSuper(
+    builder: LookupElementBuilder,
+    insertionStrategy: CallableInsertionStrategy.WithSuperDisambiguation
+) =
+    builder.withInsertHandler { context, item ->
+        builder.insertHandler?.handleInsert(context, item)
+        val superExpression = insertionStrategy.superExpressionPointer.element ?: return@withInsertHandler
+        superExpression.setSuperTypeQualifier(context, insertionStrategy.superClassId)
+    }.appendTailText(" for ${insertionStrategy.superClassId.relativeClassName}", true)
+
+
+private fun KtSuperExpression.setSuperTypeQualifier(
+    context: InsertionContext,
+    superClassId: ClassId
+) {
+    superTypeQualifier?.delete()
+    val typeQualifier = "<${superClassId.asFqNameString()}>"
+    context.insertSymbol(typeQualifier, instanceReference.endOffset, moveCaretToEnd = false)
+    context.commitDocument()
+    shortenReferencesInRange(context.file as KtFile, TextRange(this.endOffset, this.endOffset + typeQualifier.length))
 }
 

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/completion/HighLevelJvmBasicCompletionTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/completion/HighLevelJvmBasicCompletionTestGenerated.java
@@ -35,6 +35,31 @@ public abstract class HighLevelJvmBasicCompletionTestGenerated extends AbstractH
             runTest("../completion/tests/testData/basic/common/AfterIntSeparatedWithComments.kt");
         }
 
+        @TestMetadata("ambiguousSuperMethod.kt")
+        public void testAmbiguousSuperMethod() throws Exception {
+            runTest("../completion/tests/testData/basic/common/ambiguousSuperMethod.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodDiamond.kt")
+        public void testAmbiguousSuperMethodDiamond() throws Exception {
+            runTest("../completion/tests/testData/basic/common/ambiguousSuperMethodDiamond.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodDiamondAny.kt")
+        public void testAmbiguousSuperMethodDiamondAny() throws Exception {
+            runTest("../completion/tests/testData/basic/common/ambiguousSuperMethodDiamondAny.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodHigherUp.kt")
+        public void testAmbiguousSuperMethodHigherUp() throws Exception {
+            runTest("../completion/tests/testData/basic/common/ambiguousSuperMethodHigherUp.kt");
+        }
+
+        @TestMetadata("ambiguousSuperMethodSingleImpl.kt")
+        public void testAmbiguousSuperMethodSingleImpl() throws Exception {
+            runTest("../completion/tests/testData/basic/common/ambiguousSuperMethodSingleImpl.kt");
+        }
+
         @TestMetadata("BasicAny.kt")
         public void testBasicAny() throws Exception {
             runTest("../completion/tests/testData/basic/common/BasicAny.kt");

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/completion/test/handlers/HighLevelBasicCompletionHandlerTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/completion/test/handlers/HighLevelBasicCompletionHandlerTestGenerated.java
@@ -28,6 +28,16 @@ public class HighLevelBasicCompletionHandlerTestGenerated extends AbstractHighLe
         runTest("../completion/tests/testData/handlers/basic/AddLabelToReturn.kt");
     }
 
+    @TestMetadata("AmbiguousSuperMethod.kt")
+    public void testAmbiguousSuperMethod() throws Exception {
+        runTest("../completion/tests/testData/handlers/basic/AmbiguousSuperMethod.kt");
+    }
+
+    @TestMetadata("AmbiguousSuperMethodWithArgument.kt")
+    public void testAmbiguousSuperMethodWithArgument() throws Exception {
+        runTest("../completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.kt");
+    }
+
     @TestMetadata("ClassKeywordBeforeName.kt")
     public void testClassKeywordBeforeName() throws Exception {
         runTest("../completion/tests/testData/handlers/basic/ClassKeywordBeforeName.kt");

--- a/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceBasicCompletionHandlerTestGenerated.java
+++ b/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceBasicCompletionHandlerTestGenerated.java
@@ -28,6 +28,16 @@ public class PerformanceBasicCompletionHandlerTestGenerated extends AbstractPerf
         runTest("../completion/tests/testData/handlers/basic/AddLabelToReturn.kt");
     }
 
+    @TestMetadata("AmbiguousSuperMethod.kt")
+    public void testAmbiguousSuperMethod() throws Exception {
+        runTest("../completion/tests/testData/handlers/basic/AmbiguousSuperMethod.kt");
+    }
+
+    @TestMetadata("AmbiguousSuperMethodWithArgument.kt")
+    public void testAmbiguousSuperMethodWithArgument() throws Exception {
+        runTest("../completion/tests/testData/handlers/basic/AmbiguousSuperMethodWithArgument.kt");
+    }
+
     @TestMetadata("ClassKeywordBeforeName.kt")
     public void testClassKeywordBeforeName() throws Exception {
         runTest("../completion/tests/testData/handlers/basic/ClassKeywordBeforeName.kt");


### PR DESCRIPTION
Consider the following:

```
public interface A {
    public fun foo(i: Int) {}
}

public interface B {
    public fun foo(i: Int) {}
}

fun A.bar() {}

fun B.bar() {}

class C : A, B {
    override fun foo(j: Int) {
        super.<caret>
    }
}
```

Currently both FIR offers one `foo` entry. After completion, the code
becomes `super.foo()` which is ambiguous and cause a compiler error.
FE1.0 suffers from the same problem.

In addition, it offers `bar`, which is not valid for `super`

This fix does the following
1. offer two `foo` entries with tail text to differentiate them.
2. insert `<A>` or `<B>` at the end of `super` after completion so the
   completed code is correct
3. No longer offer extension functions on super (`bar`) in the example.