### PR TITLE
KTIJ-19915 False positive "Redundant with call" with use destructuring declaration and extension component functions in receiver object

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantWithInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantWithInspection.kt
@@ -53,7 +53,11 @@ class RedundantWithInspection : AbstractKotlinInspection() {
                         return
                     }
 
-                    val resolvedCall = element.getResolvedCall(context) ?: return
+                    val resolvedCall = if (element is KtDestructuringDeclarationEntry) {
+                        context[BindingContext.COMPONENT_RESOLVED_CALL, element]
+                    } else {
+                        element.getResolvedCall(context)
+                    } ?: return
 
                     if (isUsageOfDescriptor(lambdaDescriptor, resolvedCall, context)) {
                         used = true

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -9652,6 +9652,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantWith/nested.kt");
         }
 
+        @TestMetadata("notApplicable_destructuringDeclarationEntry.kt")
+        public void testNotApplicable_destructuringDeclarationEntry() throws Exception {
+            runTest("testData/inspectionsLocal/redundantWith/notApplicable_destructuringDeclarationEntry.kt");
+        }
+
         @TestMetadata("notApplicable_explicitThis.kt")
         public void testNotApplicable_explicitThis() throws Exception {
             runTest("testData/inspectionsLocal/redundantWith/notApplicable_explicitThis.kt");

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -9652,6 +9652,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantWith/nested.kt");
         }
 
+        @TestMetadata("notApplicable_delegatedProperty.kt")
+        public void testNotApplicable_delegatedProperty() throws Exception {
+            runTest("testData/inspectionsLocal/redundantWith/notApplicable_delegatedProperty.kt");
+        }
+
+        @TestMetadata("notApplicable_delegatedPropertyByProvideDelegate.kt")
+        public void testNotApplicable_delegatedPropertyByProvideDelegate() throws Exception {
+            runTest("testData/inspectionsLocal/redundantWith/notApplicable_delegatedPropertyByProvideDelegate.kt");
+        }
+
         @TestMetadata("notApplicable_destructuringDeclarationEntry.kt")
         public void testNotApplicable_destructuringDeclarationEntry() throws Exception {
             runTest("testData/inspectionsLocal/redundantWith/notApplicable_destructuringDeclarationEntry.kt");
@@ -9705,6 +9715,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         @TestMetadata("notApplicable_inValueArgument.kt")
         public void testNotApplicable_inValueArgument() throws Exception {
             runTest("testData/inspectionsLocal/redundantWith/notApplicable_inValueArgument.kt");
+        }
+
+        @TestMetadata("notApplicable_iterator.kt")
+        public void testNotApplicable_iterator() throws Exception {
+            runTest("testData/inspectionsLocal/redundantWith/notApplicable_iterator.kt");
+        }
+
+        @TestMetadata("notApplicable_iteratorWithNextOperator.kt")
+        public void testNotApplicable_iteratorWithNextOperator() throws Exception {
+            runTest("testData/inspectionsLocal/redundantWith/notApplicable_iteratorWithNextOperator.kt");
         }
 
         @TestMetadata("notApplicable_labeledReturn.kt")

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_delegatedProperty.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_delegatedProperty.kt
@@ -1,0 +1,17 @@
+// PROBLEM: none
+// WITH_STDLIB
+import kotlin.reflect.KProperty
+
+class A
+
+object B {
+    operator fun A.getValue(nothing: Nothing?, property: KProperty<*>): Any {
+        TODO()
+    }
+}
+
+fun main() {
+    <caret>with(B) {
+        val x by A()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_delegatedPropertyByProvideDelegate.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_delegatedPropertyByProvideDelegate.kt
@@ -1,0 +1,19 @@
+// PROBLEM: none
+// WITH_STDLIB
+import kotlin.reflect.KProperty
+
+class A
+
+object B {
+    operator fun A.provideDelegate(nothing: Nothing?, property: KProperty<*>) = Any()
+}
+
+private operator fun Any.getValue(nothing: Nothing?, property: KProperty<*>): Any {
+    TODO("Not yet implemented")
+}
+
+fun main() {
+    <caret>with(B) {
+        val x by A()
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_destructuringDeclarationEntry.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_destructuringDeclarationEntry.kt
@@ -1,0 +1,15 @@
+// PROBLEM: none
+// WITH_STDLIB
+class A
+
+object B {
+    operator fun A.component1() : String = "1"
+    operator fun A.component2() : String = "2"
+}
+
+fun dd() {
+    <caret>with(B) {
+        val (a, b) = A()
+        println(a + b)
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_iterator.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_iterator.kt
@@ -1,0 +1,15 @@
+// PROBLEM: none
+// WITH_STDLIB
+class A
+
+object B {
+    operator fun A.iterator(): Iterator<A> = TODO()
+}
+
+fun main() {
+    <caret>with(B) {
+        for (a in A()) {
+
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_iteratorWithNextOperator.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/notApplicable_iteratorWithNextOperator.kt
@@ -1,0 +1,17 @@
+// PROBLEM: none
+// WITH_STDLIB
+class A
+
+object B {
+    operator fun A.hasNext(): Boolean = true
+    operator fun A.next() = A()
+}
+
+operator fun A.iterator() = A()
+
+fun main() {
+    <caret>with(B) {
+        for (a in A()) {
+        }
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19915