### PR TITLE
Rebase underscore names

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/underscoreNames.ir.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/underscoreNames.ir.out
@@ -1,0 +1,20 @@
+LineBreakpoint created at underscoreNames.kt:18 lambdaOrdinal = 1
+Run Java
+Connected to the target VM
+underscoreNames.kt:18
+Compile bytecode for x
+Compile bytecode for y
+KotlinStackFrame (underscoreNames.kt:18)
+    JavaValue[this] this: UnderscoreNamesKt$main$1@uniqueID = Function3<underscoreNames.A, java.lang.String, java.lang.Integer, java.lang.String>
+        JavaValue[field] arity: int = 3 (Lambda.!EXT!)
+    JavaValue[local] w: int = 1 (underscoreNames.kt:11)
+    JavaValue[local] x: double = 1.0 (underscoreNames.kt:11)
+    JavaValue[local] y: char = '0' 48 (underscoreNames.kt:11)
+    JavaValue[local] a: double = 1.0 (underscoreNames.kt:13)
+    JavaValue[local] c: char = '0' 48 (underscoreNames.kt:13)
+    JavaValue[local] _: java.lang.String (underscoreNames.kt:14)
+    JavaValue[local] d: char = '0' 48 (underscoreNames.kt:14)
+    JavaValue[local] q: java.lang.String (underscoreNames.kt:16)
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
The special variables for objects to be destructured and variables
for ignored arguments have been removed from the local variable
table with the IR backend.