### PR TITLE
Parsing Java String literals: avoid allocations and pre-size StringBuilders

### DIFF
--- a/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightUtil.java
+++ b/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightUtil.java
@@ -1210,9 +1210,8 @@ public final class HighlightUtil {
         }
         text = text.substring(1, text.length() - 1);
 
-        StringBuilder chars = new StringBuilder();
-        boolean success = PsiLiteralExpressionImpl.parseStringCharacters(text, chars, null);
-        if (!success) {
+        CharSequence chars = CodeInsightUtilCore.parseStringCharacters(text, null);
+        if (chars == null) {
           String message = JavaErrorBundle.message("illegal.escape.character.in.character.literal");
           return HighlightInfo.newHighlightInfo(HighlightInfoType.ERROR).range(expression).descriptionAndTooltip(message).create();
         }
@@ -1252,9 +1251,7 @@ public final class HighlightUtil {
             return HighlightInfo.newHighlightInfo(HighlightInfoType.ERROR).range(expression).descriptionAndTooltip(message).create();
           }
 
-          StringBuilder chars = new StringBuilder();
-          boolean success = PsiLiteralExpressionImpl.parseStringCharacters(text, chars, null);
-          if (!success) {
+          if (CodeInsightUtilCore.parseStringCharacters(text, null) == null) {
             String message = JavaErrorBundle.message("illegal.escape.character.in.string.literal");
             return HighlightInfo.newHighlightInfo(HighlightInfoType.ERROR).range(expression).descriptionAndTooltip(message).create();
           }
@@ -1268,7 +1265,7 @@ public final class HighlightUtil {
             return HighlightInfo.newHighlightInfo(HighlightInfoType.ERROR).range(p, p).endOfLine().descriptionAndTooltip(message).create();
           }
           else {
-            StringBuilder chars = new StringBuilder();
+            StringBuilder chars = new StringBuilder(text.length());
             int[] offsets = new int[text.length() + 1];
             boolean success = CodeInsightUtilCore.parseStringCharacters(text, chars, offsets);
             if (!success) {

--- a/java/java-impl/src/com/intellij/spellchecker/LiteralExpressionTokenizer.java
+++ b/java/java-impl/src/com/intellij/spellchecker/LiteralExpressionTokenizer.java
@@ -72,7 +72,7 @@ public class LiteralExpressionTokenizer extends EscapeSequenceTokenizer<PsiLiter
   }
 
   public static void processTextWithEscapeSequences(PsiLiteralExpression element, String text, TokenConsumer consumer) {
-    StringBuilder unescapedText = new StringBuilder();
+    StringBuilder unescapedText = new StringBuilder(text.length());
     int[] offsets = new int[text.length() + 1];
     CodeInsightUtilCore.parseStringCharacters(text, unescapedText, offsets);
 

--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/PsiLiteralExpressionImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/PsiLiteralExpressionImpl.java
@@ -134,9 +134,8 @@ public class PsiLiteralExpressionImpl
         return null;
       }
       text = text.substring(1, textLength - 1);
-      StringBuilder chars = new StringBuilder();
-      boolean success = parseStringCharacters(text, chars, null);
-      if (!success) return null;
+      CharSequence chars = CodeInsightUtilCore.parseStringCharacters(text, null);
+      if (chars == null) return null;
       if (chars.length() != 1) return null;
       return chars.charAt(0);
     }
@@ -157,9 +156,8 @@ public class PsiLiteralExpressionImpl
   @Nullable
   private static String internedParseStringCharacters(final String chars) {
     if (chars == null) return null;
-    final StringBuilder outChars = new StringBuilder(chars.length());
-    final boolean success = parseStringCharacters(chars, outChars, null);
-    return success ? outChars.toString() : null;
+    final CharSequence outChars = CodeInsightUtilCore.parseStringCharacters(chars, null);
+    return outChars == null ? null : outChars.toString();
   }
 
   public static boolean parseStringCharacters(@NotNull String chars, @NotNull StringBuilder outChars, int @Nullable [] sourceOffsets) {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/portability/HardcodedFileSeparatorsInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/portability/HardcodedFileSeparatorsInspection.java
@@ -231,9 +231,8 @@ public class HardcodedFileSeparatorsInspection extends BaseInspection {
     private void registerErrorInString(@NotNull PsiLiteralExpression expression) {
       final String text = expression.getText();
       final int[] offsets = new int[text.length() + 1];
-      final StringBuilder result = new StringBuilder();
-      final boolean success = CodeInsightUtilCore.parseStringCharacters(text, result, offsets);
-      if (!success) {
+      final CharSequence result = CodeInsightUtilCore.parseStringCharacters(text, offsets);
+      if (result == null) {
         return;
       }
       for (int i = 0, length = result.length(); i < length; i++) {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/portability/HardcodedLineSeparatorsInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/portability/HardcodedLineSeparatorsInspection.java
@@ -54,9 +54,8 @@ public class HardcodedLineSeparatorsInspection extends BaseInspection {
       }
       final String text = expression.getText();
       final int[] offsets = new int[text.length() + 1];
-      final StringBuilder result = new StringBuilder();
-      final boolean success = CodeInsightUtilCore.parseStringCharacters(text, result, offsets);
-      if (success) {
+      final CharSequence result = CodeInsightUtilCore.parseStringCharacters(text, offsets);
+      if (result != null) {
         for (int i = 0, max = result.length(); i < max; i++) {
           final char c = result.charAt(i);
           if (c == '\n' || c == '\r') {


### PR DESCRIPTION
Added an `CodeInsightUtilCore.parseStringCharacters` overload which returns a `CharSequence`, particularly
* original `String`, if it has no escape sequences (this eliminates extra `new StringBuilder()`),
* а pre-sized `StringBuilder`, if there were some escape sequences (originally, not every call-site pre-sized the SB),
* `null`, if the literal is invalid.

`StringParser` is turned into a static utility class, instance creation is eliminated.

No public methods were removed or incompatibly changed.

Additional observations:
* `CodeInsightUtilCore#parseStringCharacters(String, StringBuilder, int[], boolean, boolean, char...)` is never used directly. Thus, `slashMustBeEscaped = true, exitOnEscapingWrongSymbol = true, endChars = [ ', " ]` all the time except for plugins  which could pass anything to this public method. `endChars` is never `[ ' ]` or `[ " ]` which looks suspicious (wasn't it designed for requesting to parse a `"String"` or `'char'` explicitly in some cases?)
* In `HighlightUtil` ([one](https://github.com/Miha-x64/intellij-community/blob/a7ef031f8e11a1fd30da390014c1d8dee68832e4/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightUtil.java#L1213-L1218), [two](https://github.com/Miha-x64/intellij-community/blob/a7ef031f8e11a1fd30da390014c1d8dee68832e4/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightUtil.java#L1254), and [three](https://github.com/Miha-x64/intellij-community/blob/a7ef031f8e11a1fd30da390014c1d8dee68832e4/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightUtil.java#L1268-L1273)) the actual characters are never read. The call-sites mind whether the parsing was successful and/or how many characters long the string is. In this case, `NullAppendable` (there are already two available: package-private in `com.intellij.openapi.util.io` and public `org.apache.commons.io.output`) can be used, or `CharCountingAppendable` can be implemented. (Pros: less allocations. Cons: megamorphic calls. To make it better, `NullAppendable` could be just a singleton instance of `CharCountingAppendable`.) I will do this as another PR if maintainers approve the idea.

Just bought 64GB RAM to contribute memory optimizations :man_facepalming: :tada: 