### PR TITLE
Not quoting replacement by regexp if not necessary

### DIFF
--- a/plugins/InspectionGadgets/src/com/siyeh/ig/performance/DynamicRegexReplaceableByCompiledPatternInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/performance/DynamicRegexReplaceableByCompiledPatternInspection.java
@@ -33,19 +33,15 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
 
 public class DynamicRegexReplaceableByCompiledPatternInspection extends
                                                                 BaseInspection {
   @NonNls
-  protected static final Collection<String> regexMethodNames = new HashSet<>(4);
-   static {
-    regexMethodNames.add("matches");
-    regexMethodNames.add("replace");
-    regexMethodNames.add("replaceFirst");
-    regexMethodNames.add("replaceAll");
-    regexMethodNames.add("split");
-  }
+  protected static final Collection<String> regexMethodNames = Set.of(
+    "matches", "replace", "replaceFirst", "replaceAll", "split"
+  );
 
   @Override
   protected InspectionGadgetsFix buildFix(Object... infos) {
@@ -132,8 +128,12 @@ public class DynamicRegexReplaceableByCompiledPatternInspection extends
           expressionText.append(methodName);
         }
         expressionText.append('(');
+        boolean quote = false;
         if (literalReplacement) {
-          expressionText.append("java.util.regex.Matcher.quoteReplacement(");
+          quote = (expressionsLength > 1 && needsQuote(expressions[1]));
+          if (quote) {
+            expressionText.append("java.util.regex.Matcher.quoteReplacement(");
+          }
         }
         if (expressionsLength > 1) {
           expressionText.append(commentTracker.text(expressions[1]));
@@ -141,7 +141,7 @@ public class DynamicRegexReplaceableByCompiledPatternInspection extends
             expressionText.append(',').append(commentTracker.text(expressions[i]));
           }
         }
-        if (literalReplacement) {
+        if (literalReplacement && quote) {
           expressionText.append(')');
         }
         expressionText.append(')');
@@ -153,6 +153,12 @@ public class DynamicRegexReplaceableByCompiledPatternInspection extends
       newMethodCallExpression = CodeInsightUtilCore.forcePsiPostprocessAndRestoreElement(newMethodCallExpression);
       final PsiReferenceExpression reference = getReference(newMethodCallExpression);
       HighlightUtils.showRenameTemplate(aClass, (PsiNameIdentifierOwner)field, reference);
+    }
+
+    private static boolean needsQuote(PsiExpression expr) {
+      Object constExprValue = ExpressionUtils.computeConstantExpression(expr);
+      return !(constExprValue instanceof String) ||
+             Matcher.quoteReplacement((String) constExprValue) != constExprValue;
     }
 
     private static PsiReferenceExpression getReference(PsiMethodCallExpression newMethodCallExpression) {


### PR DESCRIPTION
Avoid `Matcher.quoteReplacement` when it is not necessary