### PR TITLE
[EE-IR] Inline Function Support

### DIFF
--- a/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/util/inlineAnalysisUtils.kt
+++ b/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/util/inlineAnalysisUtils.kt
@@ -26,7 +26,6 @@ fun analyzeInlinedFunctions(
     val context = analyzeElementWithInline(
         resolutionFacadeForFile,
         file,
-        1,
         analyzedElements,
         !analyzeOnlyReifiedInlineFunctions, bindingContext
     )
@@ -47,7 +46,6 @@ fun analyzeInlinedFunctions(
 private fun analyzeElementWithInline(
     resolutionFacade: ResolutionFacade,
     element: KtElement,
-    deep: Int,
     analyzedElements: MutableSet<KtElement>,
     analyzeInlineFunctions: Boolean,
     fullResolveContext: BindingContext? = null
@@ -124,7 +122,7 @@ private fun analyzeElementWithInline(
 
     analyzedElements.add(element)
 
-    if (declarationsWithBody.isNotEmpty() && deep < 10) {
+    if (declarationsWithBody.isNotEmpty()) {
         for (inlineFunction in declarationsWithBody) {
             val body = inlineFunction.bodyExpression
             if (body != null) {
@@ -132,7 +130,6 @@ private fun analyzeElementWithInline(
                     analyzeElementWithInline(
                         resolutionFacade,
                         inlineFunction,
-                        deep + 1,
                         analyzedElements,
                         analyzeInlineFunctions
                     )

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
@@ -236,6 +236,16 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
             runTest("testData/evaluation/singleBreakpoint/inlineFunctionBreakpointVariants.kt");
         }
 
+        @TestMetadata("inlineFunctionDeepInlining.kt")
+        public void testInlineFunctionDeepInlining() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.kt");
+        }
+
+        @TestMetadata("inlineFunctionDeepInliningSameFile.kt")
+        public void testInlineFunctionDeepInliningSameFile() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.kt");
+        }
+
         @TestMetadata("inlineMethodsInSignature.kt")
         public void testInlineMethodsInSignature() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/inlineMethodsInSignature.kt");
@@ -504,6 +514,11 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
         @TestMetadata("unsafeCall.kt")
         public void testUnsafeCall() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/unsafeCall.kt");
+        }
+
+        @TestMetadata("unusedTransitiveDependencies.kt")
+        public void testUnusedTransitiveDependencies() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.kt");
         }
 
         @TestMetadata("valueParameterName.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -236,6 +236,16 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
             runTest("testData/evaluation/singleBreakpoint/inlineFunctionBreakpointVariants.kt");
         }
 
+        @TestMetadata("inlineFunctionDeepInlining.kt")
+        public void testInlineFunctionDeepInlining() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.kt");
+        }
+
+        @TestMetadata("inlineFunctionDeepInliningSameFile.kt")
+        public void testInlineFunctionDeepInliningSameFile() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.kt");
+        }
+
         @TestMetadata("inlineMethodsInSignature.kt")
         public void testInlineMethodsInSignature() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/inlineMethodsInSignature.kt");
@@ -504,6 +514,11 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
         @TestMetadata("unsafeCall.kt")
         public void testUnsafeCall() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/unsafeCall.kt");
+        }
+
+        @TestMetadata("unusedTransitiveDependencies.kt")
+        public void testUnusedTransitiveDependencies() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.kt");
         }
 
         @TestMetadata("valueParameterName.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
@@ -236,6 +236,16 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
             runTest("testData/evaluation/singleBreakpoint/inlineFunctionBreakpointVariants.kt");
         }
 
+        @TestMetadata("inlineFunctionDeepInlining.kt")
+        public void testInlineFunctionDeepInlining() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.kt");
+        }
+
+        @TestMetadata("inlineFunctionDeepInliningSameFile.kt")
+        public void testInlineFunctionDeepInliningSameFile() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.kt");
+        }
+
         @TestMetadata("inlineMethodsInSignature.kt")
         public void testInlineMethodsInSignature() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/inlineMethodsInSignature.kt");
@@ -504,6 +514,11 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
         @TestMetadata("unsafeCall.kt")
         public void testUnsafeCall() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/unsafeCall.kt");
+        }
+
+        @TestMetadata("unusedTransitiveDependencies.kt")
+        public void testUnusedTransitiveDependencies() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.kt");
         }
 
         @TestMetadata("valueParameterName.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -236,6 +236,16 @@ public abstract class KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerate
             runTest("testData/evaluation/singleBreakpoint/inlineFunctionBreakpointVariants.kt");
         }
 
+        @TestMetadata("inlineFunctionDeepInlining.kt")
+        public void testInlineFunctionDeepInlining() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.kt");
+        }
+
+        @TestMetadata("inlineFunctionDeepInliningSameFile.kt")
+        public void testInlineFunctionDeepInliningSameFile() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.kt");
+        }
+
         @TestMetadata("inlineMethodsInSignature.kt")
         public void testInlineMethodsInSignature() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/inlineMethodsInSignature.kt");
@@ -504,6 +514,11 @@ public abstract class KotlinEvaluateExpressionWithIRFragmentCompilerTestGenerate
         @TestMetadata("unsafeCall.kt")
         public void testUnsafeCall() throws Exception {
             runTest("testData/evaluation/singleBreakpoint/unsafeCall.kt");
+        }
+
+        @TestMetadata("unusedTransitiveDependencies.kt")
+        public void testUnusedTransitiveDependencies() throws Exception {
+            runTest("testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.kt");
         }
 
         @TestMetadata("valueParameterName.kt")

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunction.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunction.kt
@@ -23,5 +23,10 @@ inline fun myFun(f: () -> Int): Int = f()
 
 val String.prop: String
     get() {
-        return "a"
+        return secondUnrelatedLib.x
     }
+
+// FILE: secondUnrelatedLib.kt
+package secondUnrelatedLib
+
+val x: String = "a"

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.kt
@@ -1,0 +1,63 @@
+// FILE: inlineFunction.kt
+package inlineFunctionDeepInlining
+import libOne.*
+
+fun main(args: Array<String>) {
+    //Breakpoint!
+    val a = 1
+}
+
+// EXPRESSION: myFun { 1 }
+// RESULT: 1: I
+
+// FILE: libOne.kt
+package libOne
+import libTwo.*
+inline fun myFun(f: () -> Int): Int = myFun2(f)
+
+// FILE: libTwo.kt
+package libTwo
+import libThree.*
+inline fun myFun2(f: () -> Int): Int = myFun3(f)
+
+// FILE: libThree.kt
+package libThree
+import libFour.*
+inline fun myFun3(f: () -> Int): Int = myFun4(f)
+
+// FILE: libFour.kt
+package libFour
+import libFive.*
+inline fun myFun4(f: () -> Int): Int = myFun5(f)
+
+// FILE: libFive.kt
+package libFive
+import libSix.*
+inline fun myFun5(f: () -> Int): Int = myFun6(f)
+
+// FILE: libSix.kt
+package libSix
+import libSeven.*
+inline fun myFun6(f: () -> Int): Int = myFun7(f)
+
+// FILE: libSeven.kt
+package libSeven
+import libEight.*
+inline fun myFun7(f: () -> Int): Int = myFun8(f)
+
+// FILE: libEight.kt
+package libEight
+import libNine.*
+inline fun myFun8(f: () -> Int): Int = myFun9(f)
+
+// FILE: libNine.kt
+package libNine
+import libTen.*
+inline fun myFun9(f: () -> Int): Int = myFun10(f)
+
+// FILE: libTen.kt
+package libTen
+//import libEleven.*
+inline fun myFun10(f: () -> Int): Int = f()
+
+

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInlining.out
@@ -1,9 +1,8 @@
-LineBreakpoint created at inlineFunction.kt:8
+LineBreakpoint created at inlineFunction.kt:7
 Run Java
 Connected to the target VM
-inlineFunction.kt:8
+inlineFunction.kt:7
 Compile bytecode for myFun { 1 }
-Compile bytecode for foo()
 Disconnected from the target VM
 
 Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.kt
@@ -1,0 +1,50 @@
+// FILE: inlineFunctionDeepInliningSameFile.kt
+package inlineFunctionDeepInliningSameFile
+
+fun main() {
+    //Breakpoint!
+    val a = 1
+}
+
+// EXPRESSION: myFun1 { 50 }
+// RESULT: 50: I
+
+inline fun myFun1(function: () -> Int): Int {
+    return myFun2(function)
+}
+
+inline fun myFun2(function: () -> Int): Int {
+    return myFun3(function)
+}
+
+inline fun myFun3(function: () -> Int): Int {
+    return myFun4(function)
+}
+
+inline fun myFun4(function: () -> Int): Int {
+    return myFun5(function)
+}
+
+inline fun myFun5(function: () -> Int): Int {
+    return myFun6(function)
+}
+
+inline fun myFun6(function: () -> Int): Int {
+    return myFun7(function)
+}
+
+inline fun myFun7(function: () -> Int): Int {
+    return myFun8(function)
+}
+
+inline fun myFun8(function: () -> Int): Int {
+    return myFun9(function)
+}
+
+inline fun myFun9(function: () -> Int): Int {
+    return myFun10(function)
+}
+
+inline fun myFun10(function: () -> Int): Int {
+    return function()
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineFunctionDeepInliningSameFile.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at inlineFunctionDeepInliningSameFile.kt:6
+Run Java
+Connected to the target VM
+inlineFunctionDeepInliningSameFile.kt:6
+Compile bytecode for myFun1 { 50 }
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineMethodsInSignature.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/inlineMethodsInSignature.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at inlineMethodsInSignature.kt:8
 Run Java
 Connected to the target VM

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.kt
@@ -1,0 +1,139 @@
+// FILE: unusedTransitiveDependencies.kt
+package unusedTransitiveDependencies
+import libOne.*
+
+fun main(args: Array<String>) {
+    //Breakpoint!
+    val a = 1
+}
+
+// EXPRESSION: noninlineFunction { 1 }
+// RESULT: 1: I
+
+// FILE: libOne.kt
+package libOne
+
+import libTwo.*
+
+fun noninlineFunction(f: () -> Int): Int = f()
+
+
+fun unusedFunction(): Int {
+    return inlineFunction()
+}
+
+inline fun inlineFunction(): Int {
+    return unusedFunction2()
+}
+
+// FILE: libTwo.kt
+package libTwo
+import libThree.*
+
+fun unusedFunction2(): Int {
+    return inlineFunction2()
+}
+
+inline fun inlineFunction2(): Int {
+    return unusedFunction3()
+}
+
+
+// FILE: libThree.kt
+package libThree
+import libFour.*
+fun unusedFunction3(): Int {
+    return inlineFunction3()
+}
+inline fun inlineFunction3(): Int {
+    return unusedFunction4()
+}
+
+// FILE: libFour.kt
+package libFour
+import libFive.*
+fun unusedFunction4(): Int {
+    return inlineFunction4()
+}
+inline fun inlineFunction4(): Int {
+    return unusedFunction5()
+}
+
+// FILE: libFive.kt
+package libFive
+import libSix.*
+fun unusedFunction5(): Int {
+    return inlineFunction5()
+}
+inline fun inlineFunction5(): Int {
+    return unusedFunction6()
+}
+
+// FILE: libSix.kt
+package libSix
+import libSeven.*
+fun unusedFunction6(): Int {
+    return inlineFunction6()
+}
+inline fun inlineFunction6(): Int {
+    return unusedFunction7()
+}
+
+// FILE: libSeven.kt
+package libSeven
+import libEight.*
+fun unusedFunction7(): Int {
+    return inlineFunction7()
+}
+inline fun inlineFunction7(): Int {
+    return unusedFunction8()
+}
+
+// FILE: libEight.kt
+package libEight
+import libNine.*
+fun unusedFunction8(): Int {
+    return inlineFunction8()
+}
+inline fun inlineFunction8(): Int {
+    return unusedFunction9()
+}
+
+// FILE: libNine.kt
+package libNine
+import libTen.*
+fun unusedFunction9(): Int {
+    return inlineFunction9()
+}
+inline fun inlineFunction9(): Int {
+    return unusedFunction10()
+}
+
+// FILE: libTen.kt
+package libTen
+import libEleven.*
+fun unusedFunction10(): Int {
+    return inlineFunction10()
+}
+inline fun inlineFunction10(): Int {
+    return unusedFunction11()
+}
+
+// FILE: libEleven.kt
+package libEleven
+import libTwelve.*
+fun unusedFunction11(): Int {
+    return inlineFunction11()
+}
+inline fun inlineFunction11(): Int {
+    return unusedFunction12()
+}
+
+// FILE: libTwelve.kt
+package libTwelve
+fun unusedFunction12(): Int {
+    return inlineFunction12()
+}
+inline fun inlineFunction12(): Int {
+    return 1
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/unusedTransitiveDependencies.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at unusedTransitiveDependencies.kt:7
+Run Java
+Connected to the target VM
+unusedTransitiveDependencies.kt:7
+Compile bytecode for noninlineFunction { 1 }
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
~~Dependent on ~~#1802~~, #1839 and JetBrains/kotlin#4657~~

~~Two~~One item~~s~~ for which I would like review comments (marked in the code, as well)

~~1) There is a "inline call depth limit" of 10. I have improved the error reporting to the user, but I am curious to the origin of this limit.~~

2) PSI2IR needs resolution for all supplied `KtFile`s, so I have the fragment frontend additionally analyze all "transitive dependencies" from inline functions. I believe there is a way to reuse the editors running analyses of these files, and would like help to ensure I have hit that.

---

- Pass all transitively dependended-on files through the frontend to facilitate
  making IR out of all it. Needed when generating the modules containing inline
  functions (and their transitive dependencies) through the IR fragment
  compiler.

- Handle inline class mangling of `GENERATED_FOR_DEBUGGER_FUN` function name.

- Improve error messages around inline functions analyzed by the IDE.
