### PR TITLE
fsNotifier/linux: Fix includes for musl libc

### DIFF
--- a/native/fsNotifier/linux/inotify.c
+++ b/native/fsNotifier/linux/inotify.c
@@ -4,6 +4,7 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/native/fsNotifier/linux/main.c
+++ b/native/fsNotifier/linux/main.c
@@ -3,13 +3,14 @@
 #include "fsnotifier.h"
 
 #include <errno.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <mntent.h>
 #include <paths.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/inotify.h>
+#include <sys/select.h>
 #include <sys/stat.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Add missing sys/select.h include in main.c for timeval struct.

`main.c:148:31: error: invalid use of undefined type 'struct timeval'
  148 |     timeout = (struct timeval){MISSING_ROOT_TIMEOUT, 0};`

On some platforms the missing header is included implicitly, but on musl we'll have to be a little more explicit.