### PR TITLE
Speed up DependencyGraphModelBuilder

### DIFF
--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/AbstractDependencyNode.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/AbstractDependencyNode.java
@@ -1,21 +1,18 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.openapi.externalSystem.model.project.dependencies;
 
-import com.intellij.openapi.externalSystem.util.BooleanBiFunction;
-import com.intellij.openapi.externalSystem.util.IteratorUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public abstract class AbstractDependencyNode implements DependencyNode, Serializable {
   private final long id;
   @NotNull
   private final List<DependencyNode> dependencies;
-  private String resolutionState;
+  private ResolutionState resolutionState;
   private String selectionReason;
 
   protected AbstractDependencyNode(long id) {
@@ -36,11 +33,11 @@ public abstract class AbstractDependencyNode implements DependencyNode, Serializ
 
   @Nullable
   @Override
-  public String getResolutionState() {
+  public ResolutionState getResolutionState() {
     return resolutionState;
   }
 
-  public void setResolutionState(@Nullable String resolutionState) {
+  public void setResolutionState(@Nullable ResolutionState resolutionState) {
     this.resolutionState = resolutionState;
   }
 
@@ -60,56 +57,12 @@ public abstract class AbstractDependencyNode implements DependencyNode, Serializ
     if (o == null || getClass() != o.getClass()) return false;
 
     AbstractDependencyNode node = (AbstractDependencyNode)o;
-    if (id != node.id) return false;
-    if (resolutionState != null ? !resolutionState.equals(node.resolutionState) : node.resolutionState != null) return false;
-    if (selectionReason != null ? !selectionReason.equals(node.selectionReason) : node.selectionReason != null) return false;
-    if (!match(node)) return false;
-    if (!match(dependencies, node.dependencies)) return false;
-    return true;
+    return id == node.id;
   }
 
   @Override
   public int hashCode() {
     int result = (int)(id ^ (id >>> 32));
-    result = 31 * result + dependencies.size();
-    result = 31 * result + (resolutionState != null ? resolutionState.hashCode() : 0);
-    result = 31 * result + (selectionReason != null ? selectionReason.hashCode() : 0);
     return result;
-  }
-
-  protected abstract boolean match(AbstractDependencyNode o);
-
-  private static boolean match(@NotNull Collection<DependencyNode> dependencies1,
-                               @NotNull Collection<DependencyNode> dependencies2) {
-    return IteratorUtils.match(
-      new DependenciesIterator(dependencies1), new DependenciesIterator(dependencies2),
-      new BooleanBiFunction<DependencyNode, DependencyNode>() {
-        @Override
-        public Boolean fun(DependencyNode o1, DependencyNode o2) {
-          if (o1 instanceof AbstractDependencyNode && o2 instanceof AbstractDependencyNode) {
-            AbstractDependencyNode o11 = (AbstractDependencyNode)o1;
-            AbstractDependencyNode o21 = (AbstractDependencyNode)o2;
-            if (o11.id != o21.id) return false;
-            if (o11.resolutionState != null ? !o11.resolutionState.equals(o21.resolutionState) : o21.resolutionState != null) {
-              return false;
-            }
-            return o11.match(o21);
-          }
-          else {
-            return o1 == null ? o2 == null : o1.equals(o2);
-          }
-        }
-      });
-  }
-
-  private static final class DependenciesIterator extends IteratorUtils.AbstractObjectGraphIterator<DependencyNode> {
-    private DependenciesIterator(Collection<DependencyNode> dependencies) {
-      super(dependencies);
-    }
-
-    @Override
-    public Collection<? extends DependencyNode> getChildren(DependencyNode node) {
-      return node.getDependencies();
-    }
   }
 }

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ArtifactDependencyNodeImpl.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ArtifactDependencyNodeImpl.java
@@ -41,23 +41,4 @@ public class ArtifactDependencyNodeImpl extends AbstractDependencyNode implement
   public String getDisplayName() {
     return group + ':' + module + ':' + version; //NON-NLS
   }
-
-  @Override
-  public boolean match(AbstractDependencyNode dependencyNode) {
-    if (dependencyNode == null || getClass() != dependencyNode.getClass()) return false;
-    ArtifactDependencyNodeImpl node = (ArtifactDependencyNodeImpl)dependencyNode;
-    if (!group.equals(node.group)) return false;
-    if (!module.equals(node.module)) return false;
-    if (!version.equals(node.version)) return false;
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + group.hashCode();
-    result = 31 * result + module.hashCode();
-    result = 31 * result + version.hashCode();
-    return result;
-  }
 }

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/DependencyNode.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/DependencyNode.java
@@ -15,7 +15,7 @@ public interface DependencyNode {
   String getDisplayName();
 
   @Nullable
-  String getResolutionState();
+  ResolutionState getResolutionState();
 
   @Nullable
   String getSelectionReason();

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/DependencyScopeNode.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/DependencyScopeNode.java
@@ -34,23 +34,4 @@ public class DependencyScopeNode extends AbstractDependencyNode {
   public @Nls String getDescription() {
     return description;
   }
-
-  @Override
-  public boolean match(AbstractDependencyNode dependencyNode) {
-    if (dependencyNode == null || getClass() != dependencyNode.getClass()) return false;
-    DependencyScopeNode node = (DependencyScopeNode)dependencyNode;
-    if (!scope.equals(node.scope)) return false;
-    if (!displayName.equals(node.displayName)) return false;
-    if (description != null ? !description.equals(node.description) : node.description != null) return false;
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + scope.hashCode();
-    result = 31 * result + displayName.hashCode();
-    result = 31 * result + (description != null ? description.hashCode() : 0);
-    return result;
-  }
 }

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/FileCollectionDependencyNodeImpl.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/FileCollectionDependencyNodeImpl.java
@@ -28,21 +28,4 @@ public class FileCollectionDependencyNodeImpl extends AbstractDependencyNode imp
   public String getDisplayName() {
     return displayName;
   }
-
-  @Override
-  public boolean match(AbstractDependencyNode dependencyNode) {
-    if (dependencyNode == null || getClass() != dependencyNode.getClass()) return false;
-    FileCollectionDependencyNodeImpl node = (FileCollectionDependencyNodeImpl)dependencyNode;
-    if (!displayName.equals(node.displayName)) return false;
-    if (!path.equals(node.path)) return false;
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + displayName.hashCode();
-    result = 31 * result + path.hashCode();
-    return result;
-  }
 }

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ProjectDependencyNodeImpl.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ProjectDependencyNodeImpl.java
@@ -27,19 +27,4 @@ public class ProjectDependencyNodeImpl extends AbstractDependencyNode implements
   public String getDisplayName() {
     return "project " + projectName;
   }
-
-  @Override
-  public boolean match(AbstractDependencyNode dependencyNode) {
-    if (dependencyNode == null || getClass() != dependencyNode.getClass()) return false;
-    ProjectDependencyNodeImpl node = (ProjectDependencyNodeImpl)dependencyNode;
-    if (!projectName.equals(node.projectName)) return false;
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + projectName.hashCode();
-    return result;
-  }
 }

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ReferenceNode.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ReferenceNode.java
@@ -28,7 +28,7 @@ public class ReferenceNode implements DependencyNode, Serializable {
 
   @Nullable
   @Override
-  public String getResolutionState() {
+  public ResolutionState getResolutionState() {
     return null;
   }
 

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ResolutionState.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/ResolutionState.java
@@ -1,0 +1,7 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.openapi.externalSystem.model.project.dependencies;
+
+public enum ResolutionState {
+  RESOLVED,
+  UNRESOLVED
+}

--- a/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/UnknownDependencyNode.java
+++ b/platform/external-system-rt/src/com/intellij/openapi/externalSystem/model/project/dependencies/UnknownDependencyNode.java
@@ -19,19 +19,4 @@ public class UnknownDependencyNode extends AbstractDependencyNode {
   public String getDisplayName() {
     return name == null ? "unknown" : name; //NON-NLS
   }
-
-  @Override
-  public boolean match(AbstractDependencyNode dependencyNode) {
-    if (dependencyNode == null || getClass() != dependencyNode.getClass()) return false;
-    UnknownDependencyNode node = (UnknownDependencyNode)dependencyNode;
-    if (name != null ? !name.equals(node.name) : node.name != null) return false;
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + (name != null ? name.hashCode() : 0);
-    return result;
-  }
 }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/dependency/analyzer/GradleDependencyAnalyzerContributor.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/dependency/analyzer/GradleDependencyAnalyzerContributor.kt
@@ -124,9 +124,7 @@ class GradleDependencyAnalyzerContributor(private val project: Project) : Depend
 
   private fun DependencyNode.getStatus(data: Dependency.Data): List<DependencyAnalyzerContributor.Status> {
     val status = mutableListOf<DependencyAnalyzerContributor.Status>()
-    // see, org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency.ResolutionState
-    val resolutionState = resolutionState
-    if (resolutionState == "FAILED" || resolutionState == "UNRESOLVED") {
+    if (resolutionState == ResolutionState.UNRESOLVED) {
       val message = ExternalSystemBundle.message("external.system.dependency.analyzer.warning.unresolved")
       status.add(DependencyAnalyzerContributor.Status.Warning(message))
     }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/task/GradleTaskManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/task/GradleTaskManager.java
@@ -27,6 +27,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.Consumer;
 import com.intellij.util.execution.ParametersListUtil;
+import gnu.trove.THash;
 import org.gradle.api.Task;
 import org.gradle.tooling.*;
 import org.gradle.tooling.model.build.BuildEnvironment;
@@ -362,7 +363,7 @@ public class GradleTaskManager implements ExternalSystemTaskManager<GradleExecut
                                    @Nullable TaskCallback callback) {
 
     String taskName = taskClass.getSimpleName();
-    String paths = GradleExecutionHelper.getToolingExtensionsJarPaths(set(taskClass, GsonBuilder.class, ExternalSystemException.class));
+    String paths = GradleExecutionHelper.getToolingExtensionsJarPaths(set(taskClass, GsonBuilder.class, THash.class, ExternalSystemException.class));
     String initScript = "initscript {\n" +
                         "  dependencies {\n" +
                         "    classpath files(" + paths + ")\n" +

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/DependencyGraphModelBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/DependencyGraphModelBuilderImpl.groovy
@@ -17,6 +17,9 @@ import static org.jetbrains.plugins.gradle.tooling.util.resolve.DependencyResolv
 
 @CompileStatic
 class DependencyGraphModelBuilderImpl implements ModelBuilderService {
+
+  DependenciesReport.ReportGenerator reportGenerator = new DependenciesReport.ReportGenerator()
+
   @Override
   boolean canBuild(String modelName) {
     return ProjectDependencies.name == modelName
@@ -40,8 +43,8 @@ class DependencyGraphModelBuilderImpl implements ModelBuilderService {
       def runtimeConfiguration = project.configurations.findByName(runtimeConfigurationName)
       if (runtimeConfiguration == null) continue
 
-      DependencyScopeNode compileScopeNode = DependenciesReport.buildDependenciesGraph(compileConfiguration, project)
-      DependencyScopeNode runtimeScopeNode = DependenciesReport.buildDependenciesGraph(runtimeConfiguration, project)
+      DependencyScopeNode compileScopeNode = reportGenerator.buildDependenciesGraph(compileConfiguration, project)
+      DependencyScopeNode runtimeScopeNode = reportGenerator.buildDependenciesGraph(runtimeConfiguration, project)
 
       if (!compileScopeNode.dependencies.isEmpty() || !runtimeScopeNode.dependencies.isEmpty()) {
         dependencies.add(new ComponentDependenciesImpl(sourceSet.name, compileScopeNode, runtimeScopeNode))

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/serialization/ProjectDependenciesSerializationService.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/serialization/ProjectDependenciesSerializationService.java
@@ -22,6 +22,7 @@ import static org.jetbrains.plugins.gradle.tooling.serialization.ToolingStreamAp
  * @author Vladislav.Soroka
  */
 public final class ProjectDependenciesSerializationService implements SerializationService<ProjectDependencies> {
+  private static final ResolutionState[] RESOLUTION_STATES = ResolutionState.values();
   private final WriteContext myWriteContext = new WriteContext();
   private final ReadContext myReadContext = new ReadContext();
 
@@ -262,7 +263,9 @@ public final class ProjectDependenciesSerializationService implements Serializat
   private static void writeDependencyCommonFields(IonWriter writer, DependencyNode node)
     throws IOException {
     writeLong(writer, "id", node.getId());
-    writeString(writer, "resolutionState", node.getResolutionState());
+    ResolutionState state = node.getResolutionState();
+    int ordinal = state == null ? -1 : state.ordinal();
+    writeLong(writer, "resolutionState", ordinal);
     writeString(writer, "selectionReason", node.getSelectionReason());
   }
 
@@ -343,7 +346,8 @@ public final class ProjectDependenciesSerializationService implements Serializat
           public DependencyNode newInstance() {
             String type = readString(reader, "_type");
             long id = readLong(reader, "id");
-            String resolutionState = readString(reader, "resolutionState");
+            int resolutionStateOrdinal = readInt(reader, "resolutionState");
+            ResolutionState resolutionState = resolutionStateOrdinal == -1 ? null : RESOLUTION_STATES[resolutionStateOrdinal];
             String selectionReason = readString(reader, "selectionReason");
             DependencyNode node;
             if (ProjectDependencyNode.class.getSimpleName().equals(type)) {


### PR DESCRIPTION
Use only Node#id as the criterion for equals/hashCode, greatly speeding up the
redundancy checks during serialization. The ID was not unique in the whole build
before. I fixed that by reusing the graph generator for the whole build and having
an ever-increasing ID counter. The end-result is still the same. ReferenceNodes are
only created when a dependency is found multiple times in the same Configuration.

I've also removed the usage of Gradle's internal dependency report classes, which
were an unnecessary indirection. Instead, the graph generator now uses Gradle's
ResolutionResult API directly. 

Fixes IDEA-283622

For the project mentioned in that issue, sync times are 2 times faster after this change.