### PR TITLE
KTIJ-18684 UNSAFE_OPERATOR_CALL with plusAssign on MutableMap: Fix "Add non-null asserted call" and omit "Replace with safe call" quickfixes

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceInfixOrOperatorCallFixFactory.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ReplaceInfixOrOperatorCallFixFactory.kt
@@ -6,16 +6,20 @@ import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
+import org.jetbrains.kotlin.idea.inspections.collections.isMap
 import org.jetbrains.kotlin.idea.intentions.canBeReplacedWithInvokeCall
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtArrayAccessExpression
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.resolve.calls.util.getImplicitReceiverValue
+import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.expressions.OperatorConventions
+import org.jetbrains.kotlin.types.isNullable
+import org.jetbrains.kotlin.types.typeUtil.builtIns
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 object ReplaceInfixOrOperatorCallFixFactory : KotlinSingleIntentionActionFactory() {
@@ -33,18 +37,23 @@ object ReplaceInfixOrOperatorCallFixFactory : KotlinSingleIntentionActionFactory
 
         when (val parent = expression.parent) {
             is KtBinaryExpression -> {
-                return when {
-                    parent.left == null || parent.right == null -> null
-                    parent.operationToken == KtTokens.EQ -> null
-                    parent.operationToken in OperatorConventions.COMPARISON_OPERATIONS -> null
+                val left = parent.left
+                when {
+                    left == null || parent.right == null -> return null
+                    parent.operationToken == KtTokens.EQ -> return null
+                    parent.operationToken in OperatorConventions.COMPARISON_OPERATIONS -> return null
                     else -> {
+                        if (parent.operationToken in KtTokens.AUGMENTED_ASSIGNMENTS && left is KtArrayAccessExpression) {
+                            val type = left.arrayExpression?.getType(left.analyze()) ?: return null
+                            if (type.isMap(type.builtIns) && type.arguments.lastOrNull()?.type?.isNullable() != true) return null
+                        }
                         val binaryOperatorName = if (parent.operationToken == KtTokens.IDENTIFIER) {
                             // Get name of infix function call
                             parent.operationReference.text
                         } else {
                             parent.resolveToCall(BodyResolveMode.FULL)?.candidateDescriptor?.name?.asString()
                         }
-                        binaryOperatorName?.let {
+                        return binaryOperatorName?.let {
                             ReplaceInfixOrOperatorCallFix(parent, parent.shouldHaveNotNullType(), binaryOperatorName)
                         }
                     }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -11858,6 +11858,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/replaceInfixOrOperatorCall/containsBinaryOperator.kt");
         }
 
+        @TestMetadata("divAssignOnMutableMap.kt")
+        public void testDivAssignOnMutableMap() throws Exception {
+            runTest("testData/quickfix/replaceInfixOrOperatorCall/divAssignOnMutableMap.kt");
+        }
+
         @TestMetadata("hasElvis.kt")
         public void testHasElvis() throws Exception {
             runTest("testData/quickfix/replaceInfixOrOperatorCall/hasElvis.kt");
@@ -11868,9 +11873,34 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/replaceInfixOrOperatorCall/list.kt");
         }
 
+        @TestMetadata("minusAssignOnMutableMap.kt")
+        public void testMinusAssignOnMutableMap() throws Exception {
+            runTest("testData/quickfix/replaceInfixOrOperatorCall/minusAssignOnMutableMap.kt");
+        }
+
         @TestMetadata("notContainsBinaryOperator.kt")
         public void testNotContainsBinaryOperator() throws Exception {
             runTest("testData/quickfix/replaceInfixOrOperatorCall/notContainsBinaryOperator.kt");
+        }
+
+        @TestMetadata("plusAssignOnMutableMap.kt")
+        public void testPlusAssignOnMutableMap() throws Exception {
+            runTest("testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMap.kt");
+        }
+
+        @TestMetadata("plusAssignOnMutableMapWithNullableValueType.kt")
+        public void testPlusAssignOnMutableMapWithNullableValueType() throws Exception {
+            runTest("testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMapWithNullableValueType.kt");
+        }
+
+        @TestMetadata("remAssignOnMutableMap.kt")
+        public void testRemAssignOnMutableMap() throws Exception {
+            runTest("testData/quickfix/replaceInfixOrOperatorCall/remAssignOnMutableMap.kt");
+        }
+
+        @TestMetadata("timesAssignOnMutableMap.kt")
+        public void testTimesAssignOnMutableMap() throws Exception {
+            runTest("testData/quickfix/replaceInfixOrOperatorCall/timesAssignOnMutableMap.kt");
         }
     }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -847,9 +847,49 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("testData/quickfix/addExclExclCall/operationBinary.kt");
             }
 
+            @TestMetadata("operationDecrement.kt")
+            public void testOperationDecrement() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationDecrement.kt");
+            }
+
+            @TestMetadata("operationDivAssign.kt")
+            public void testOperationDivAssign() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationDivAssign.kt");
+            }
+
             @TestMetadata("operationIn.kt")
             public void testOperationIn() throws Exception {
                 runTest("testData/quickfix/addExclExclCall/operationIn.kt");
+            }
+
+            @TestMetadata("operationIncrement.kt")
+            public void testOperationIncrement() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationIncrement.kt");
+            }
+
+            @TestMetadata("operationMinusAssign.kt")
+            public void testOperationMinusAssign() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationMinusAssign.kt");
+            }
+
+            @TestMetadata("operationPlusAssign.kt")
+            public void testOperationPlusAssign() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationPlusAssign.kt");
+            }
+
+            @TestMetadata("operationPlusAssignOnMutableMap.kt")
+            public void testOperationPlusAssignOnMutableMap() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationPlusAssignOnMutableMap.kt");
+            }
+
+            @TestMetadata("operationRemAssign.kt")
+            public void testOperationRemAssign() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationRemAssign.kt");
+            }
+
+            @TestMetadata("operationTimesAssign.kt")
+            public void testOperationTimesAssign() throws Exception {
+                runTest("testData/quickfix/addExclExclCall/operationTimesAssign.kt");
             }
 
             @TestMetadata("operationUnary.kt")

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDecrement.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDecrement.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i--<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDecrement.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDecrement.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i = i!! - 1
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDivAssign.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDivAssign.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i /=<caret> 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDivAssign.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationDivAssign.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i = i!! / 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationIncrement.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationIncrement.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i++<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationIncrement.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationIncrement.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i = i!! + 1
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationMinusAssign.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationMinusAssign.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i -=<caret> 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationMinusAssign.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationMinusAssign.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i = i!! - 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssign.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssign.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i +=<caret> 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssign.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssign.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i = i!! + 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssignOnMutableMap.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssignOnMutableMap.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+// WITH_STDLIB
+fun test(map: MutableMap<Int, Int>) {
+    map[3] +=<caret> 5
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssignOnMutableMap.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationPlusAssignOnMutableMap.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+// WITH_STDLIB
+fun test(map: MutableMap<Int, Int>) {
+    map[3] = map[3]!! + 5
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationRemAssign.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationRemAssign.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i %=<caret> 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationRemAssign.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationRemAssign.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i = i!! % 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationTimesAssign.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationTimesAssign.kt
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i *=<caret> 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationTimesAssign.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addExclExclCall/operationTimesAssign.kt.after
@@ -1,0 +1,5 @@
+// "Add non-null asserted (!!) call" "true"
+fun test() {
+    var i: Int? = 0
+    i = i!! * 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/divAssignOnMutableMap.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/divAssignOnMutableMap.kt
@@ -1,0 +1,9 @@
+// "Replace with safe (?.) call" "false"
+// WITH_STDLIB
+// ACTION: Add non-null asserted (!!) call
+// ACTION: Replace overloaded operator with function call
+// ACTION: Replace with ordinary assignment
+// ERROR: Operator call corresponds to a dot-qualified call 'map[3].divAssign(5)' which is not allowed on a nullable receiver 'map[3]'.
+fun test(map: MutableMap<Int, Int>) {
+    map[3] /=<caret> 5
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/minusAssignOnMutableMap.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/minusAssignOnMutableMap.kt
@@ -1,0 +1,9 @@
+// "Replace with safe (?.) call" "false"
+// WITH_STDLIB
+// ACTION: Add non-null asserted (!!) call
+// ACTION: Replace overloaded operator with function call
+// ACTION: Replace with ordinary assignment
+// ERROR: Operator call corresponds to a dot-qualified call 'map[3].minusAssign(5)' which is not allowed on a nullable receiver 'map[3]'.
+fun test(map: MutableMap<Int, Int>) {
+    map[3] -=<caret> 5
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMap.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMap.kt
@@ -1,0 +1,9 @@
+// "Replace with safe (?.) call" "false"
+// WITH_STDLIB
+// ACTION: Add non-null asserted (!!) call
+// ACTION: Replace overloaded operator with function call
+// ACTION: Replace with ordinary assignment
+// ERROR: Operator call corresponds to a dot-qualified call 'map[3].plusAssign(5)' which is not allowed on a nullable receiver 'map[3]'.
+fun test(map: MutableMap<Int, Int>) {
+    map[3] +=<caret> 5
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMapWithNullableValueType.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMapWithNullableValueType.kt
@@ -1,0 +1,5 @@
+// "Replace with safe (?.) call" "true"
+// WITH_STDLIB
+fun test(map: MutableMap<Int, Int?>) {
+    map[3] +=<caret> 5
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMapWithNullableValueType.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/plusAssignOnMutableMapWithNullableValueType.kt.after
@@ -1,0 +1,5 @@
+// "Replace with safe (?.) call" "true"
+// WITH_STDLIB
+fun test(map: MutableMap<Int, Int?>) {
+    map[3] = map[3]?.plus(5)
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/remAssignOnMutableMap.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/remAssignOnMutableMap.kt
@@ -1,0 +1,9 @@
+// "Replace with safe (?.) call" "false"
+// WITH_STDLIB
+// ACTION: Add non-null asserted (!!) call
+// ACTION: Replace overloaded operator with function call
+// ACTION: Replace with ordinary assignment
+// ERROR: Operator call corresponds to a dot-qualified call 'map[3].remAssign(5)' which is not allowed on a nullable receiver 'map[3]'.
+fun test(map: MutableMap<Int, Int>) {
+    map[3] %=<caret> 5
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/timesAssignOnMutableMap.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/replaceInfixOrOperatorCall/timesAssignOnMutableMap.kt
@@ -1,0 +1,9 @@
+// "Replace with safe (?.) call" "false"
+// WITH_STDLIB
+// ACTION: Add non-null asserted (!!) call
+// ACTION: Replace overloaded operator with function call
+// ACTION: Replace with ordinary assignment
+// ERROR: Operator call corresponds to a dot-qualified call 'map[3].timesAssign(5)' which is not allowed on a nullable receiver 'map[3]'.
+fun test(map: MutableMap<Int, Int>) {
+    map[3] *=<caret> 5
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-18684