### PR TITLE
Make runtime dependency filtering faster

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
@@ -598,7 +598,7 @@ public final class DependencyResolverImpl implements DependencyResolver {
   }
 
   private Collection<ExternalDependency> getDependencies(@NotNull Iterable<?> fileCollections, @NotNull String scope) {
-    Collection<ExternalDependency> result = new ArrayList<ExternalDependency>();
+    Set<ExternalDependency> result = new LinkedHashSet<ExternalDependency>();
     for (Object fileCollection : fileCollections) {
       if (fileCollection instanceof FileCollection) {
         result.addAll(getDependencies((FileCollection)fileCollection, scope));


### PR DESCRIPTION
Since getDependencies returned an ArrayList, the filterRuntime method would use
the inefficient List.removeAll rather than the much faster Set#removeAll. This
is now fixed by using a LinkedHashSet, like in the other resolve methods.