### PR TITLE
language inject with mutation

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt
@@ -485,11 +485,27 @@ abstract class KotlinInjectionTest : AbstractInjectionTest() {
             injectedText = "<html></html>"
         )
 
+        fun testMutationNested() = doInjectionPresentTest(
+            """
+            class A { val b: B = B() }
+            class B {
+                @org.intellij.lang.annotations.Language("HTML")
+                var html = ""
+            }
+            fun test() {
+                val a = A()
+                a.b.html = "<ht<caret>ml></html>"
+            }
+            """,
+            languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false,
+            injectedText = "<html></html>"
+        )
+
         fun testMutationAbstract() = doInjectionPresentTest(
             """
             abstract class A {
                 @org.intellij.lang.annotations.Language("HTML")
-                var html
+                var html: String
             }
             fun A.test() {
               html = "<ht<caret>ml></html>"

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt
@@ -498,6 +498,19 @@ abstract class KotlinInjectionTest : AbstractInjectionTest() {
             languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false,
             injectedText = "<html></html>"
         )
+
+        fun testPlusEqMutation() = doInjectionPresentTest(
+            """
+            @org.intellij.lang.annotations.Language("TEXT")
+            var text = "hello"
+
+            fun test() {
+              text += "wor<caret>ld"
+            }
+            """,
+            languageId = PlainTextLanguage.INSTANCE.id, unInjectShouldBePresent = false,
+            injectedText = "world"
+        )
     }
 
     class TestBucket3 : KotlinInjectionTest() {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/psi/KotlinInjectionTest.kt
@@ -471,6 +471,33 @@ abstract class KotlinInjectionTest : AbstractInjectionTest() {
                 ShredInfo(range(3, 23), hostRange = range(13, 16), prefix = "missingValue", suffix = "check")
             )
         )
+
+        fun testMutation() = doInjectionPresentTest(
+            """
+            @org.intellij.lang.annotations.Language("HTML")
+            var html = ""
+
+            fun test() {
+              html = "<ht<caret>ml></html>"
+            }
+            """,
+            languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false,
+            injectedText = "<html></html>"
+        )
+
+        fun testMutationAbstract() = doInjectionPresentTest(
+            """
+            abstract class A {
+                @org.intellij.lang.annotations.Language("HTML")
+                var html
+            }
+            fun A.test() {
+              html = "<ht<caret>ml></html>"
+            }
+            """,
+            languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false,
+            injectedText = "<html></html>"
+        )
     }
 
     class TestBucket3 : KotlinInjectionTest() {

--- a/plugins/kotlin/injection/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjectionContributor.kt
+++ b/plugins/kotlin/injection/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjectionContributor.kt
@@ -171,8 +171,9 @@ class KotlinLanguageInjectionContributor : LanguageInjectionContributor {
             ?: injectWithMutation(place)
     }
 
+    private val stringOperators = listOf(KtTokens.EQ, KtTokens.PLUSEQ)
     private fun injectWithMutation(host: KtElement): InjectionInfo? {
-        val parent = (host.parent as? KtBinaryExpression)?.takeIf { it.operationToken == KtTokens.EQ } ?: return null
+        val parent = (host.parent as? KtBinaryExpression)?.takeIf { it.operationToken in stringOperators } ?: return null
         if (parent.right != host) return null
         val variable = parent.left ?: return null
 

--- a/plugins/kotlin/injection/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjectionSupport.kt
+++ b/plugins/kotlin/injection/src/org/jetbrains/kotlin/idea/injection/KotlinLanguageInjectionSupport.kt
@@ -108,8 +108,10 @@ class KotlinLanguageInjectionSupport : AbstractLanguageInjectionSupport() {
         return commentRef.get() as? PsiComment
     }
 
-    internal fun findAnnotationInjectionLanguageId(host: KtElement): InjectionInfo? {
-        val annotationEntry = findAnnotationInjection(host) ?: return null
+    internal fun findAnnotationInjectionLanguageId(host: KtElement): InjectionInfo? =
+        findAnnotationInjection(host)?.let(::toInjectionInfo)
+
+    internal fun toInjectionInfo(annotationEntry: KtAnnotationEntry): InjectionInfo? {
         val extractLanguageFromInjectAnnotation = extractLanguageFromInjectAnnotation(annotationEntry) ?: return null
         val prefix = extractStringArgumentByName(annotationEntry, "prefix")
         val suffix = extractStringArgumentByName(annotationEntry, "suffix")


### PR DESCRIPTION
If a variable is annotated with `@Language`, language injections are then also applied to writes to the variable.

Can be useful in a mutation based DSL.