### PR TITLE
Missing bracket in "Duplicate conditions" inspection preview

### DIFF
--- a/plugins/InspectionGadgets/src/inspectionDescriptions/DuplicateCondition.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/DuplicateCondition.html
@@ -14,7 +14,7 @@ Disabling this option may lead to false-positives, for example, when the same me
 </p>
 <p>Example:</p>
 <pre><code>
-  if (iterator.next() != null || iterator.next() != null)
+  if (iterator.next() != null || iterator.next() != null) {
     System.out.println("Got it");
   }
 </code></pre>


### PR DESCRIPTION
Hi @aleksandrazolushkina,

I've noticed a closing bracket without an opening bracket in the _Duplicate conditions_ inspection preview:

```Java8
  if (iterator.next() != null || iterator.next() != null)
    System.out.println("Got it");
  }
```