### PR TITLE
Provide the option to disable adding the VCS root to watched roots

### DIFF
--- a/platform/vcs-api/src/com/intellij/openapi/vcs/AbstractVcs.java
+++ b/platform/vcs-api/src/com/intellij/openapi/vcs/AbstractVcs.java
@@ -648,5 +648,15 @@ public abstract class AbstractVcs extends StartedActivated {
   public boolean needsCaseSensitiveDirtyScope() {
     return false;
   }
+
+  /**
+   * Returns true if VCS root needs to be added to watched roots by 
+   * {@link com.intellij.openapi.vcs.impl.projectlevelman.FileWatchRequestModifier} when updating VCS mappings.
+   *
+   * @return true if VCS root needs to be added to watched roots, false otherwise.
+   */
+  public boolean needsLFSWatchesForRoots() {
+    return true;
+  }
 }
 

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/impl/projectlevelman/FileWatchRequestModifier.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/impl/projectlevelman/FileWatchRequestModifier.java
@@ -48,8 +48,9 @@ public final class FileWatchRequestModifier implements Runnable, Disposable {
 
       Set<String> newWatchedRoots = CollectionFactory.createFilePathSet();
       for (VcsDirectoryMapping mapping : myNewMappings.getDirectoryMappings()) {
+        AbstractVcs vcs = ProjectLevelVcsManager.getInstance(myProject).findVcsByName(mapping.getVcs());
         // <Project> mappings are ignored because they should already be watched by the Project
-        if (!mapping.isDefaultMapping()) {
+        if (!mapping.isDefaultMapping() && vcs.needsLFSWatchesForRoots()) {
           newWatchedRoots.add(FileUtil.toCanonicalPath(mapping.getDirectory()));
         }
       }


### PR DESCRIPTION
Add a `needsLFSWatchesForRoots` flag for `AbstractVcs` to control if we want to add VCS root to watched roots in `FileWatchRequestModifier`. Adding VCS root to watched roots subsumes all sub-directories, which can be problematic in some use-cases (see https://youtrack.jetbrains.com/issue/IDEA-284522 for the discussion).