### PR TITLE
KTIJ-20381 False positive "Redundant Companion reference" with transitive (not direct) override of Java getter-like method

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantCompanionReferenceInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantCompanionReferenceInspection.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.FakeCallableDescriptorForObject
 import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassNotAny
 import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
+import org.jetbrains.kotlin.resolve.descriptorUtil.overriddenTreeAsSequence
 import org.jetbrains.kotlin.resolve.scopes.utils.findFunction
 import org.jetbrains.kotlin.resolve.scopes.utils.findVariable
 import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
@@ -105,7 +106,7 @@ class RedundantCompanionReferenceInspection : AbstractKotlinInspection() {
 
                 val type = descriptor.type
                 val javaGetter = findMemberFunction(Name.identifier(JvmAbi.getterName(name.asString())))
-                    ?.takeIf { f -> f is JavaMethodDescriptor || f.overriddenDescriptors.any { it is JavaMethodDescriptor } }
+                    ?.takeIf { f -> f is JavaMethodDescriptor || f.overriddenTreeAsSequence(true).any { it is JavaMethodDescriptor } }
                 if (javaGetter?.valueParameters?.isEmpty() == true && javaGetter.returnType?.makeNotNullable() == type) return true
 
                 val variable = expression.getResolutionScope().findVariable(name, NoLookupLocation.FROM_IDE)

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7898,6 +7898,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantCompanionReference/javaGetter2.kt");
         }
 
+        @TestMetadata("javaGetter3.kt")
+        public void testJavaGetter3() throws Exception {
+            runTest("testData/inspectionsLocal/redundantCompanionReference/javaGetter3.kt");
+        }
+
         @TestMetadata("javaSetter.kt")
         public void testJavaSetter() throws Exception {
             runTest("testData/inspectionsLocal/redundantCompanionReference/javaSetter.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantCompanionReference/javaGetter3.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantCompanionReference/javaGetter3.1.java
@@ -1,0 +1,5 @@
+public abstract class J {
+    String getDescription() {
+        return "";
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantCompanionReference/javaGetter3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantCompanionReference/javaGetter3.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+
+abstract class KK : J() {
+    abstract override fun getDescription(): String
+}
+
+class K : KK() {
+    override fun getDescription() = <caret>Companion.description
+
+    companion object {
+        val description = ""
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-20381