### PR TITLE
KTIJ-19394: Ignore backticks when comparing imports

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ImportPathComparator.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ImportPathComparator.kt
@@ -17,7 +17,10 @@ internal class ImportPathComparator(private val packageTable: KotlinPackageEntry
             import1,
             import2,
             { import -> bestEntryMatchIndex(import, ignoreAlias) },
-            { import -> import.toString() }
+            { import ->
+                // Ignore backticks when comparing lexicographically
+                import.toString().replace("`", "")
+            }
         )
     }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/imports/JsOptimizeImportsTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/imports/JsOptimizeImportsTestGenerated.java
@@ -82,6 +82,11 @@ public abstract class JsOptimizeImportsTestGenerated extends AbstractJsOptimizeI
                     runTest("testData/editor/optimizeImports/common/ArrayAccessExpression.kt");
                 }
 
+                @TestMetadata("BacktickSort.kt")
+                public void testBacktickSort() throws Exception {
+                    runTest("testData/editor/optimizeImports/common/BacktickSort.kt");
+                }
+
                 @TestMetadata("ClassMemberImported.kt")
                 public void testClassMemberImported() throws Exception {
                     runTest("testData/editor/optimizeImports/common/ClassMemberImported.kt");

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/imports/JvmOptimizeImportsTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/imports/JvmOptimizeImportsTestGenerated.java
@@ -331,6 +331,11 @@ public abstract class JvmOptimizeImportsTestGenerated extends AbstractJvmOptimiz
                     runTest("testData/editor/optimizeImports/common/ArrayAccessExpression.kt");
                 }
 
+                @TestMetadata("BacktickSort.kt")
+                public void testBacktickSort() throws Exception {
+                    runTest("testData/editor/optimizeImports/common/BacktickSort.kt");
+                }
+
                 @TestMetadata("ClassMemberImported.kt")
                 public void testClassMemberImported() throws Exception {
                     runTest("testData/editor/optimizeImports/common/ClassMemberImported.kt");

--- a/plugins/kotlin/idea/tests/testData/editor/optimizeImports/common/BacktickSort.dependency.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/optimizeImports/common/BacktickSort.dependency.kt
@@ -1,0 +1,5 @@
+package b
+
+fun `fun`() {}
+fun g() {}
+fun `val`() {}

--- a/plugins/kotlin/idea/tests/testData/editor/optimizeImports/common/BacktickSort.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/optimizeImports/common/BacktickSort.kt
@@ -1,0 +1,14 @@
+package a
+
+// Should be sorted, ignoring backticks
+import b.g
+import b.`fun`
+import b.`val`
+
+class Foo(
+    fun bar() {
+        g()
+        `fun`()
+        `val`()
+    }
+)

--- a/plugins/kotlin/idea/tests/testData/editor/optimizeImports/common/BacktickSort.kt.after
+++ b/plugins/kotlin/idea/tests/testData/editor/optimizeImports/common/BacktickSort.kt.after
@@ -1,0 +1,14 @@
+package a
+
+// Should be sorted, ignoring backticks
+import b.`fun`
+import b.g
+import b.`val`
+
+class Foo(
+    fun bar() {
+        g()
+        `fun`()
+        `val`()
+    }
+)


### PR DESCRIPTION
This helps preserve their ordering when sorted lexicologically

This is my first PR – hopefully I didn't miss anything!

https://youtrack.jetbrains.com/issue/KTIJ-19394