### PR TITLE
Remove any backslash in nonNlsCommentPattern in order for the comment to be displayed properly

### DIFF
--- a/plugins/java-i18n/src/com/intellij/codeInspection/i18n/SuppressByCommentOutAction.java
+++ b/plugins/java-i18n/src/com/intellij/codeInspection/i18n/SuppressByCommentOutAction.java
@@ -57,7 +57,7 @@ class SuppressByCommentOutAction extends SuppressIntentionAction {
         prefixFound = true;
       }
     }
-    String commentText = "//" + prefix + nonNlsCommentPattern;
+    String commentText = "//" + prefix + nonNlsCommentPattern.replace("\\", "");
     if (prefixFound) {
       PsiComment newcom = JavaPsiFacade.getElementFactory(project).createCommentFromText(commentText, element);
       comment.replace(newcom);


### PR DESCRIPTION
If the nonNlsCommentPattern contained any escaped special characters (which is needed for e.g the '$' character so that the matching is correct) then the comment would be displayed as is (with the backslash).