### PR TITLE
KTIJ-20509 False positive "Unused symbol" for unused in source code primary constructor parameter of value (inline) class

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
@@ -617,7 +617,11 @@ class UnusedSymbolInspection : AbstractKotlinInspection() {
         return list
     }
 
-    private fun KtParameter.isInlineClassProperty() = hasValOrVar() && containingClassOrObject?.hasModifier(KtTokens.INLINE_KEYWORD) == true
+    private fun KtParameter.isInlineClassProperty(): Boolean {
+        if (!hasValOrVar()) return false
+        return containingClassOrObject?.hasModifier(KtTokens.INLINE_KEYWORD) == true ||
+                containingClassOrObject?.hasModifier(KtTokens.VALUE_KEYWORD) == true
+    }
 }
 
 class SafeDeleteFix(declaration: KtDeclaration) : LocalQuickFix {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -15526,6 +15526,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction9.kt");
         }
 
+        @TestMetadata("valueClassParameter.kt")
+        public void testValueClassParameter() throws Exception {
+            runTest("testData/inspectionsLocal/unusedSymbol/valueClassParameter.kt");
+        }
+
         @TestMetadata("withJvmNameUsedFromKotlin.kt")
         public void testWithJvmNameUsedFromKotlin() throws Exception {
             runTest("testData/inspectionsLocal/unusedSymbol/withJvmNameUsedFromKotlin.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/valueClassParameter.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/valueClassParameter.kt
@@ -1,0 +1,17 @@
+// PROBLEM: none
+// WITH_STDLIB
+@JvmInline
+value class V internal constructor(private val <caret>value: Int) {
+    companion object {
+        val Foo = V(0)
+        val Bar = V(1)
+        val Baz = V(2)
+    }
+
+    override fun toString() = when (this) {
+        Foo -> "Foo"
+        Bar -> "Bar"
+        Baz -> "Baz"
+        else -> ""
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-20509