### PR TITLE
KTIJ-19745 False positive "Redundant 'suspend' modifier" with suspend lambda in constructor whish is used inside suspend method

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10078,6 +10078,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantSuspend/invokingByQualified.kt");
         }
 
+        @TestMetadata("nullableFunctionType.kt")
+        public void testNullableFunctionType() throws Exception {
+            runTest("testData/inspectionsLocal/redundantSuspend/nullableFunctionType.kt");
+        }
+
         @TestMetadata("override.kt")
         public void testOverride() throws Exception {
             runTest("testData/inspectionsLocal/redundantSuspend/override.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/nullableFunctionType.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/nullableFunctionType.kt
@@ -1,0 +1,5 @@
+// IGNORE_FE10_BINDING_BY_FIR
+// PROBLEM: none
+class Test(private val fn: (suspend (Int) -> String)?) {
+    <caret>suspend fun invokeFunction(x: Int): String = fn!!(x)
+}

--- a/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
+++ b/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
@@ -1538,6 +1538,11 @@ public abstract class Fe10BindingLocalInspectionTestGenerated extends AbstractFe
             runTest("../idea/tests/testData/inspectionsLocal/redundantSuspend/invokingByQualified.kt");
         }
 
+        @TestMetadata("nullableFunctionType.kt")
+        public void testNullableFunctionType() throws Exception {
+            runTest("../idea/tests/testData/inspectionsLocal/redundantSuspend/nullableFunctionType.kt");
+        }
+
         @TestMetadata("override.kt")
         public void testOverride() throws Exception {
             runTest("../idea/tests/testData/inspectionsLocal/redundantSuspend/override.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19745