### PR TITLE
[Minor] Migrate to EvaluatorFragmentParameterInfo

### DIFF
--- a/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/compilation/CodeFragmentCompiler.kt
+++ b/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/compilation/CodeFragmentCompiler.kt
@@ -144,7 +144,7 @@ class CodeFragmentCompiler(private val executionContext: ExecutionContext, priva
         ).apply {
             if (fragmentCompilerBackend == FragmentCompilerBackend.JVM_IR) {
                 val mangler = JvmDescriptorMangler(MainFunctionDetector(bindingContext, compilerConfiguration.languageVersionSettings))
-                val evaluatorFragmentInfo = EvaluatorFragmentInfo.createWithFragmentParameterInfo(
+                val evaluatorFragmentInfo = EvaluatorFragmentInfo(
                     codegenInfo.classDescriptor,
                     codegenInfo.methodDescriptor,
                     codegenInfo.parameters.map { EvaluatorFragmentParameterInfo(it.targetDescriptor, it.isLValue) }


### PR DESCRIPTION
Tiny PR to progress a migration of CodeFragmentCompiler across changes to the combined build.
