### PR TITLE
[IDEA-272825] Enable cleanups

### DIFF
--- a/java/java-impl-inspections/src/com/intellij/codeInspection/PatternVariableCanBeUsedInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/PatternVariableCanBeUsedInspection.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class PatternVariableCanBeUsedInspection extends AbstractBaseJavaLocalInspectionTool {
+public class PatternVariableCanBeUsedInspection extends AbstractBaseJavaLocalInspectionTool implements CleanupLocalInspectionTool {
   @NotNull
   @Override
   public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {

--- a/java/java-impl/src/inspectionDescriptions/RedundantCompareCall.html
+++ b/java/java-impl/src/inspectionDescriptions/RedundantCompareCall.html
@@ -5,7 +5,7 @@ Reports comparisons in which the <code>compare</code> method is superfluous.
 <pre><code>
   boolean result = Integer.compare(a, b) == 0;
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   boolean result = a == b;
 </code></pre>

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/assignment/AssignmentUsedAsConditionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/assignment/AssignmentUsedAsConditionInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.assignment;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -28,7 +29,7 @@ import com.siyeh.ig.PsiReplacementUtil;
 import com.siyeh.ig.psiutils.CommentTracker;
 import org.jetbrains.annotations.NotNull;
 
-public class AssignmentUsedAsConditionInspection extends BaseInspection {
+public class AssignmentUsedAsConditionInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/assignment/IncrementDecrementUsedAsExpressionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/assignment/IncrementDecrementUsedAsExpressionInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.assignment;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -35,7 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class IncrementDecrementUsedAsExpressionInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/assignment/ReplaceAssignmentWithOperatorAssignmentInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/assignment/ReplaceAssignmentWithOperatorAssignmentInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.assignment;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class ReplaceAssignmentWithOperatorAssignmentInspection extends BaseInspection {
+public class ReplaceAssignmentWithOperatorAssignmentInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   /**
    * @noinspection PublicField

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/InnerClassReferencedViaSubclassInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/InnerClassReferencedViaSubclassInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.bugs;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -28,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Bas Leijdekkers
  */
-public class InnerClassReferencedViaSubclassInspection extends BaseInspection {
+public class InnerClassReferencedViaSubclassInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/UseOfPropertiesAsHashtableInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/UseOfPropertiesAsHashtableInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.bugs;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -33,7 +34,7 @@ import com.siyeh.ig.psiutils.TypeUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public class UseOfPropertiesAsHashtableInspection extends BaseInspection {
+public class UseOfPropertiesAsHashtableInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/classlayout/FinalMethodInFinalClassInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/classlayout/FinalMethodInFinalClassInspection.java
@@ -16,6 +16,8 @@
 package com.siyeh.ig.classlayout;
 
 import com.intellij.codeInsight.AnnotationUtil;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
+import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.psi.*;
 import com.siyeh.InspectionGadgetsBundle;
 import com.siyeh.ig.BaseInspection;
@@ -24,7 +26,7 @@ import com.siyeh.ig.InspectionGadgetsFix;
 import com.siyeh.ig.fixes.RemoveModifierFix;
 import org.jetbrains.annotations.NotNull;
 
-public class FinalMethodInFinalClassInspection extends BaseInspection {
+public class FinalMethodInFinalClassInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public BaseInspectionVisitor buildVisitor() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/classlayout/UtilityClassCanBeEnumInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/classlayout/UtilityClassCanBeEnumInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.classlayout;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -22,7 +23,7 @@ import java.util.List;
 /**
  * @author Bas Leijdekkers
  */
-public class UtilityClassCanBeEnumInspection extends BaseInspection {
+public class UtilityClassCanBeEnumInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ConfusingElseInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ConfusingElseInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.project.Project;
@@ -31,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class ConfusingElseInspection extends BaseInspection {
+public class ConfusingElseInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @SuppressWarnings({"PublicField"})
   public boolean reportWhenNoStatementFollow = true;

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ConstantConditionalExpressionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ConstantConditionalExpressionInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.redundantCast.RemoveRedundantCastUtil;
 import com.intellij.openapi.project.Project;
@@ -34,7 +35,7 @@ import com.siyeh.ig.psiutils.CommentTracker;
 import org.jetbrains.annotations.NotNull;
 
 public class ConstantConditionalExpressionInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean isEnabledByDefault() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/DefaultNotLastCaseInSwitchInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/DefaultNotLastCaseInSwitchInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.java.analysis.JavaAnalysisBundle;
 import com.intellij.openapi.project.Project;
@@ -29,7 +30,7 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class DefaultNotLastCaseInSwitchInspection extends BaseInspection {
+public class DefaultNotLastCaseInSwitchInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ExpressionMayBeFactorizedInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ExpressionMayBeFactorizedInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiBinaryExpression;
@@ -24,7 +25,7 @@ import static com.intellij.psi.JavaTokenType.*;
 /**
  * @author Fabrice TIERCELIN
  */
-public class ExpressionMayBeFactorizedInspection extends BaseInspection {
+public class ExpressionMayBeFactorizedInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ForLoopReplaceableByWhileInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/ForLoopReplaceableByWhileInspection.java
@@ -16,6 +16,7 @@
 package com.siyeh.ig.controlflow;
 
 import com.intellij.codeInsight.BlockUtils;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ProblemHighlightType;
@@ -40,7 +41,7 @@ import javax.swing.*;
 import java.util.Collection;
 import java.util.Objects;
 
-public class ForLoopReplaceableByWhileInspection extends BaseInspection {
+public class ForLoopReplaceableByWhileInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   /**
    * @noinspection PublicField

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/NegatedEqualityExpressionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/NegatedEqualityExpressionInspection.java
@@ -3,6 +3,7 @@
  */
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -19,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author Bas Leijdekkers
  */
-public class NegatedEqualityExpressionInspection extends BaseInspection {
+public class NegatedEqualityExpressionInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/PointlessNullCheckInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/PointlessNullCheckInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.dataFlow.*;
 import com.intellij.codeInspection.dataFlow.StandardMethodContract.ValueConstraint;
 import com.intellij.psi.*;
@@ -25,7 +26,7 @@ import java.util.stream.Stream;
 
 import static com.intellij.util.ObjectUtils.tryCast;
 
-public class PointlessNullCheckInspection extends BaseInspection {
+public class PointlessNullCheckInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/UnnecessaryLabelOnBreakStatementInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/UnnecessaryLabelOnBreakStatementInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -26,7 +27,7 @@ import com.siyeh.ig.InspectionGadgetsFix;
 import org.jetbrains.annotations.NotNull;
 
 public class UnnecessaryLabelOnBreakStatementInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/UnnecessaryReturnInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/UnnecessaryReturnInspection.java
@@ -15,6 +15,8 @@
  */
 package com.siyeh.ig.controlflow;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
+import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.util.Ref;
 import com.intellij.psi.*;
@@ -31,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class UnnecessaryReturnInspection extends BaseInspection {
+public class UnnecessaryReturnInspection extends BaseInspection implements CleanupLocalInspectionTool {
   @SuppressWarnings("PublicField")
   public boolean ignoreInThenBranch = false;
 

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/errorhandling/EmptyFinallyBlockInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/errorhandling/EmptyFinallyBlockInspection.java
@@ -16,6 +16,7 @@
 package com.siyeh.ig.errorhandling;
 
 import com.intellij.codeInsight.BlockUtils;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class EmptyFinallyBlockInspection extends BaseInspection {
+public class EmptyFinallyBlockInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean isEnabledByDefault() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/finalization/FinalizeNotProtectedInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/finalization/FinalizeNotProtectedInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.finalization;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class FinalizeNotProtectedInspection extends BaseInspection {
+public class FinalizeNotProtectedInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/inheritance/NonProtectedConstructorInAbstractClassInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/inheritance/NonProtectedConstructorInAbstractClassInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.inheritance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
@@ -29,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 public class NonProtectedConstructorInAbstractClassInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   /**
    * @noinspection PublicField

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/inheritance/TypeParameterExtendsFinalClassInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/inheritance/TypeParameterExtendsFinalClassInspection.java
@@ -16,6 +16,7 @@
 package com.siyeh.ig.inheritance;
 
 import com.intellij.codeInsight.daemon.impl.analysis.JavaGenericsUtil;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -33,7 +34,7 @@ import com.siyeh.ig.psiutils.MethodUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class TypeParameterExtendsFinalClassInspection extends BaseInspection {
+public class TypeParameterExtendsFinalClassInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/initialization/DoubleBraceInitializationInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/initialization/DoubleBraceInitializationInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.initialization;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -32,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Bas Leijdekkers
  */
-public class DoubleBraceInitializationInspection extends BaseInspection {
+public class DoubleBraceInitializationInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/j2me/MultiplyOrDivideByPowerOfTwoInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/j2me/MultiplyOrDivideByPowerOfTwoInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.j2me;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.project.Project;
@@ -35,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 
 public class MultiplyOrDivideByPowerOfTwoInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   /**
    * @noinspection PublicField

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/HtmlTagCanBeJavadocTagInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/HtmlTagCanBeJavadocTagInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.javadoc;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.editor.Document;
@@ -40,7 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class HtmlTagCanBeJavadocTagInspection extends BaseInspection {
+public class HtmlTagCanBeJavadocTagInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/MissingDeprecatedAnnotationInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/MissingDeprecatedAnnotationInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.javadoc;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.project.Project;
@@ -38,7 +39,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
-final class MissingDeprecatedAnnotationInspection extends BaseInspection {
+final class MissingDeprecatedAnnotationInspection extends BaseInspection implements CleanupLocalInspectionTool {
   @SuppressWarnings("PublicField") public boolean warnOnMissingJavadoc = false;
 
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnnecessaryInheritDocInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnnecessaryInheritDocInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.javadoc;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
@@ -31,7 +32,7 @@ import com.siyeh.ig.psiutils.MethodUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public class UnnecessaryInheritDocInspection extends BaseInspection {
+public class UnnecessaryInheritDocInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnnecessaryJavaDocLinkInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/javadoc/UnnecessaryJavaDocLinkInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.javadoc;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.project.Project;
@@ -35,7 +36,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
-public class UnnecessaryJavaDocLinkInspection extends BaseInspection {
+public class UnnecessaryJavaDocLinkInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   private static final int THIS_METHOD = 1;
   private static final int THIS_CLASS = 2;

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/AssertEqualsCalledOnArrayInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/AssertEqualsCalledOnArrayInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.junit;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.PsiArrayType;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiMethodCallExpression;
@@ -14,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class AssertEqualsCalledOnArrayInspection extends BaseInspection {
+public class AssertEqualsCalledOnArrayInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/AssertEqualsMayBeAssertSameInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/AssertEqualsMayBeAssertSameInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.junit;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiUtil;
 import com.siyeh.InspectionGadgetsBundle;
@@ -10,7 +11,7 @@ import com.siyeh.ig.InspectionGadgetsFix;
 import com.siyeh.ig.testFrameworks.AssertHint;
 import org.jetbrains.annotations.NotNull;
 
-public class AssertEqualsMayBeAssertSameInspection extends BaseInspection {
+public class AssertEqualsMayBeAssertSameInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/MultipleExceptionsDeclaredOnTestMethodInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/MultipleExceptionsDeclaredOnTestMethodInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.junit;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -30,7 +31,7 @@ import com.siyeh.ig.psiutils.TestUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class MultipleExceptionsDeclaredOnTestMethodInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/UseOfObsoleteAssertInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/junit/UseOfObsoleteAssertInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.junit;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
@@ -31,7 +32,7 @@ import com.siyeh.ig.InspectionGadgetsFix;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class UseOfObsoleteAssertInspection extends BaseInspection {
+public class UseOfObsoleteAssertInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/memory/UnnecessaryEmptyArrayUsageInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/memory/UnnecessaryEmptyArrayUsageInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.memory;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiTypesUtil;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Konstantin Bulenkov
  */
-public class UnnecessaryEmptyArrayUsageInspection extends BaseInspection {
+public class UnnecessaryEmptyArrayUsageInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/BigDecimalLegacyMethodInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/BigDecimalLegacyMethodInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.migration;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -21,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Bas Leijdekkers
  */
-public class BigDecimalLegacyMethodInspection extends BaseInspection {
+public class BigDecimalLegacyMethodInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/CollectionsFieldAccessReplaceableByMethodCallInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/CollectionsFieldAccessReplaceableByMethodCallInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.migration;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Bas Leijdekkers
  */
-public class CollectionsFieldAccessReplaceableByMethodCallInspection extends BaseInspection {
+public class CollectionsFieldAccessReplaceableByMethodCallInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/EqualsReplaceableByObjectsCallInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/EqualsReplaceableByObjectsCallInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.migration;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ProblemHighlightType;
@@ -28,7 +29,7 @@ import javax.swing.*;
 /**
  * @author Bas Leijdekkers
  */
-public class EqualsReplaceableByObjectsCallInspection extends BaseInspection {
+public class EqualsReplaceableByObjectsCallInspection extends BaseInspection implements CleanupLocalInspectionTool {
   public boolean checkNotNull;
 
   private static final EquivalenceChecker EQUIVALENCE = new NoSideEffectExpressionEquivalenceChecker();

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/TryWithIdenticalCatchesInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/migration/TryWithIdenticalCatchesInspection.java
@@ -2,6 +2,7 @@
 package com.siyeh.ig.migration;
 
 import com.intellij.codeInsight.daemon.impl.analysis.HighlightControlFlowUtil;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ui.InspectionOptionsPanel;
@@ -33,7 +34,7 @@ import javax.swing.*;
 import java.util.*;
 import java.util.function.BiPredicate;
 
-public class TryWithIdenticalCatchesInspection extends BaseInspection {
+public class TryWithIdenticalCatchesInspection extends BaseInspection implements CleanupLocalInspectionTool {
   public boolean ignoreBlocksWithDifferentComments = true;
 
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/BigDecimalEqualsInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/BigDecimalEqualsInspection.java
@@ -16,6 +16,7 @@
 package com.siyeh.ig.numeric;
 
 import com.intellij.codeInsight.Nullability;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.dataFlow.NullabilityUtil;
@@ -35,7 +36,7 @@ import com.siyeh.ig.psiutils.ParenthesesUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public class BigDecimalEqualsInspection extends BaseInspection {
+public class BigDecimalEqualsInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/CachedNumberConstructorCallInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/CachedNumberConstructorCallInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel;
@@ -36,7 +37,7 @@ import javax.swing.*;
 import java.util.HashSet;
 import java.util.Set;
 
-public class CachedNumberConstructorCallInspection extends BaseInspection {
+public class CachedNumberConstructorCallInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   static final Set<String> cachedNumberTypes = new HashSet<>();
 

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/ConfusingFloatingPointLiteralInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/ConfusingFloatingPointLiteralInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.project.Project;
@@ -35,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class ConfusingFloatingPointLiteralInspection extends BaseInspection {
+public class ConfusingFloatingPointLiteralInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @SuppressWarnings("PublicField")
   public boolean ignoreScientificNotation = false;

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/ConstantMathCallInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/ConstantMathCallInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -32,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ConstantMathCallInspection extends BaseInspection {
+public class ConstantMathCallInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NonNls static final Set<String> constantMathCall =
     new HashSet<>(23);

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/DoubleLiteralMayBeFloatLiteralInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/DoubleLiteralMayBeFloatLiteralInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.PsiPrimitiveType;
 import com.intellij.psi.PsiType;
 import org.jetbrains.annotations.NotNull;
@@ -8,7 +9,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author Bas Leijdekkers
  */
-public class DoubleLiteralMayBeFloatLiteralInspection extends CastedLiteralMaybeJustLiteralInspection {
+public class DoubleLiteralMayBeFloatLiteralInspection extends CastedLiteralMaybeJustLiteralInspection implements
+                                                                                                      CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/IntLiteralMayBeLongLiteralInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/IntLiteralMayBeLongLiteralInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.PsiPrimitiveType;
 import com.intellij.psi.PsiType;
 import org.jetbrains.annotations.NonNls;
@@ -9,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author Bas Leijdekkers
  */
-public class IntLiteralMayBeLongLiteralInspection extends CastedLiteralMaybeJustLiteralInspection {
+public class IntLiteralMayBeLongLiteralInspection extends CastedLiteralMaybeJustLiteralInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/IntegerMultiplicationImplicitCastToLongInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/IntegerMultiplicationImplicitCastToLongInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.dataFlow.CommonDataflow;
 import com.intellij.codeInspection.dataFlow.rangeSet.LongRangeSet;
@@ -46,7 +47,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class IntegerMultiplicationImplicitCastToLongInspection extends BaseInspection {
+public class IntegerMultiplicationImplicitCastToLongInspection extends BaseInspection implements CleanupLocalInspectionTool {
   private static final CallMatcher JUNIT4_ASSERT_EQUALS =
     CallMatcher.anyOf(
       CallMatcher.staticCall("org.junit.Assert", "assertEquals").parameterTypes("long", "long"),

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/LongLiteralsEndingWithLowercaseLInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/LongLiteralsEndingWithLowercaseLInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -29,7 +30,7 @@ import com.siyeh.ig.PsiReplacementUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class LongLiteralsEndingWithLowercaseLInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/PointlessArithmeticExpressionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/PointlessArithmeticExpressionInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.project.Project;
@@ -44,7 +45,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public final class PointlessArithmeticExpressionInspection extends BaseInspection {
+public final class PointlessArithmeticExpressionInspection extends BaseInspection implements CleanupLocalInspectionTool {
   private static final Set<IElementType> arithmeticTokens = new HashSet<>(9);
 
   static {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/UnnecessaryExplicitNumericCastInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/UnnecessaryExplicitNumericCastInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.lang.java.parser.ExpressionParser;
 import com.intellij.openapi.project.Project;
@@ -19,7 +20,7 @@ import java.util.Set;
 /**
  * @author Bas Leijdekkers
  */
-public final class UnnecessaryExplicitNumericCastInspection extends BaseInspection {
+public final class UnnecessaryExplicitNumericCastInspection extends BaseInspection implements CleanupLocalInspectionTool {
   private static final Set<IElementType> binaryPromotionOperators = Set.of(
     JavaTokenType.ASTERISK,
     JavaTokenType.DIV,

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/UnpredictableBigDecimalConstructorCallInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/numeric/UnpredictableBigDecimalConstructorCallInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.numeric;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel;
@@ -19,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class UnpredictableBigDecimalConstructorCallInspection extends BaseInspection {
+public class UnpredictableBigDecimalConstructorCallInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @SuppressWarnings("PublicField") public boolean ignoreReferences = true;
   @SuppressWarnings("PublicField") public boolean ignoreComplexLiterals = false;

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ArraysAsListWithZeroOrOneArgumentInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ArraysAsListWithZeroOrOneArgumentInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInsight.Nullability;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
@@ -23,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Bas Leijdekkers
  */
-public class ArraysAsListWithZeroOrOneArgumentInspection extends BaseInspection {
+public class ArraysAsListWithZeroOrOneArgumentInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/BooleanConstructorInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/BooleanConstructorInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.pom.java.LanguageLevel;
@@ -31,7 +32,7 @@ import com.siyeh.ig.psiutils.ParenthesesUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public class BooleanConstructorInspection extends BaseInspection {
+public class BooleanConstructorInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/BoxingBoxedValueInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/BoxingBoxedValueInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
-public class BoxingBoxedValueInspection extends BaseInspection {
+public class BoxingBoxedValueInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NonNls
   static final Map<String, String> boxedPrimitiveMap =

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/IfStatementMissingBreakInLoopInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/IfStatementMissingBreakInLoopInspection.java
@@ -3,6 +3,7 @@ package com.siyeh.ig.performance;
 
 import com.intellij.codeInsight.BlockUtils;
 import com.intellij.codeInsight.daemon.impl.analysis.HighlightControlFlowUtil;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -26,7 +27,7 @@ import java.util.Set;
 
 import static com.intellij.util.ObjectUtils.tryCast;
 
-public class IfStatementMissingBreakInLoopInspection extends BaseInspection {
+public class IfStatementMissingBreakInLoopInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/LengthOneStringInIndexOfInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/LengthOneStringInIndexOfInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -31,7 +32,7 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 public class LengthOneStringInIndexOfInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Pattern(VALID_ID_PATTERN)
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/LengthOneStringsInConcatenationInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/LengthOneStringsInConcatenationInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
@@ -32,7 +33,7 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 public class LengthOneStringsInConcatenationInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ManualArrayCopyInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ManualArrayCopyInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.dataFlow.DfaUtil;
@@ -31,7 +32,7 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ManualArrayCopyInspection extends BaseInspection {
+public class ManualArrayCopyInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean isEnabledByDefault() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ManualArrayToCollectionCopyInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/ManualArrayToCollectionCopyInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -38,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static com.intellij.util.ObjectUtils.tryCast;
 
-public class ManualArrayToCollectionCopyInspection extends BaseInspection {
+public class ManualArrayToCollectionCopyInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean isEnabledByDefault() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/RandomDoubleForRandomIntegerInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/RandomDoubleForRandomIntegerInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -32,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class RandomDoubleForRandomIntegerInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/RedundantStringFormatCallInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/RedundantStringFormatCallInspection.java
@@ -27,7 +27,7 @@ import java.util.Locale;
 import static com.siyeh.ig.callMatcher.CallMatcher.instanceCall;
 import static com.siyeh.ig.callMatcher.CallMatcher.staticCall;
 
-public final class RedundantStringFormatCallInspection extends LocalInspectionTool {
+public final class RedundantStringFormatCallInspection extends LocalInspectionTool implements CleanupLocalInspectionTool {
 
   @Override
   public @NotNull PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, final boolean isOnTheFly) {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/TailRecursionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/TailRecursionInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-public final class TailRecursionInspection extends BaseInspection {
+public final class TailRecursionInspection extends BaseInspection implements CleanupLocalInspectionTool {
   @Override
   @NotNull
   protected String buildErrorString(Object... infos) {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/TrivialStringConcatenationInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/TrivialStringConcatenationInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.util.IntentionName;
 import com.intellij.openapi.project.Project;
@@ -32,7 +33,7 @@ import com.siyeh.ig.psiutils.TypeUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public class TrivialStringConcatenationInspection extends BaseInspection {
+public class TrivialStringConcatenationInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/UnnecessaryTemporaryOnConversionFromStringInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/UnnecessaryTemporaryOnConversionFromStringInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.util.IntentionName;
@@ -38,7 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class UnnecessaryTemporaryOnConversionFromStringInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean isEnabledByDefault() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/UnnecessaryTemporaryOnConversionToStringInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/UnnecessaryTemporaryOnConversionToStringInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.util.IntentionName;
@@ -36,7 +37,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class UnnecessaryTemporaryOnConversionToStringInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean isEnabledByDefault() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/redundancy/UnusedLabelInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/redundancy/UnusedLabelInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.redundancy;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -26,7 +27,7 @@ import com.siyeh.ig.PsiReplacementUtil;
 import com.siyeh.ig.psiutils.CommentTracker;
 import org.jetbrains.annotations.NotNull;
 
-public class UnusedLabelInspection extends BaseInspection {
+public class UnusedLabelInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean isEnabledByDefault() {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/serialization/ComparatorNotSerializableInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/serialization/ComparatorNotSerializableInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.serialization;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.CommonClassNames;
 import com.intellij.psi.PsiAnonymousClass;
 import com.intellij.psi.PsiClass;
@@ -28,7 +29,7 @@ import com.siyeh.ig.psiutils.SerializationUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ComparatorNotSerializableInspection extends BaseInspection {
+public class ComparatorNotSerializableInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/serialization/TransientFieldInNonSerializableClassInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/serialization/TransientFieldInNonSerializableClassInspection.java
@@ -15,6 +15,8 @@
  */
 package com.siyeh.ig.serialization;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
+import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiModifier;
@@ -26,7 +28,7 @@ import com.siyeh.ig.fixes.RemoveModifierFix;
 import com.siyeh.ig.psiutils.SerializationUtils;
 import org.jetbrains.annotations.NotNull;
 
-public class TransientFieldInNonSerializableClassInspection extends BaseInspection {
+public class TransientFieldInNonSerializableClassInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/CallToStringConcatCanBeReplacedByOperatorInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/CallToStringConcatCanBeReplacedByOperatorInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -31,7 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class CallToStringConcatCanBeReplacedByOperatorInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ConstantOnWrongSideOfComparisonInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ConstantOnWrongSideOfComparisonInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.InspectionOptionsPanel;
 import com.intellij.java.analysis.JavaAnalysisBundle;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.event.ItemEvent;
 
-public class ConstantOnWrongSideOfComparisonInspection extends BaseInspection {
+public class ConstantOnWrongSideOfComparisonInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   public boolean myConstantShouldGoLeft = true;
   public boolean myIgnoreNull = false;

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ControlFlowStatementWithoutBracesInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ControlFlowStatementWithoutBracesInspection.java
@@ -16,6 +16,7 @@
 package com.siyeh.ig.style;
 
 import com.intellij.codeInsight.BlockUtils;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ControlFlowStatementWithoutBracesInspection extends BaseInspection {
+public class ControlFlowStatementWithoutBracesInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/EqualsCalledOnEnumConstantInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/EqualsCalledOnEnumConstantInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.psi.*;
 import com.intellij.psi.util.TypeConversionUtil;
 import com.siyeh.InspectionGadgetsBundle;
@@ -28,7 +29,7 @@ import com.siyeh.ig.psiutils.ParenthesesUtils;
 import com.siyeh.ig.psiutils.TypeUtils;
 import org.jetbrains.annotations.NotNull;
 
-public class EqualsCalledOnEnumConstantInspection extends BaseInspection {
+public class EqualsCalledOnEnumConstantInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ExtendsObjectInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ExtendsObjectInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -24,7 +25,7 @@ import com.siyeh.ig.BaseInspectionVisitor;
 import com.siyeh.ig.InspectionGadgetsFix;
 import org.jetbrains.annotations.NotNull;
 
-public class ExtendsObjectInspection extends BaseInspection {
+public class ExtendsObjectInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ListIndexOfReplaceableByContainsInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/ListIndexOfReplaceableByContainsInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ListIndexOfReplaceableByContainsInspection
-  extends BaseInspection {
+  extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/LiteralAsArgToStringEqualsInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/LiteralAsArgToStringEqualsInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public class LiteralAsArgToStringEqualsInspection extends BaseInspection {
+public class LiteralAsArgToStringEqualsInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/SimplifiableIfStatementInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/SimplifiableIfStatementInspection.java
@@ -18,7 +18,7 @@ import javax.swing.*;
 
 import static com.intellij.util.ObjectUtils.tryCast;
 
-public class SimplifiableIfStatementInspection extends AbstractBaseJavaLocalInspectionTool {
+public class SimplifiableIfStatementInspection extends AbstractBaseJavaLocalInspectionTool implements CleanupLocalInspectionTool {
   public boolean DONT_WARN_ON_TERNARY = true;
   public boolean DONT_WARN_ON_CHAINED_ID = true;
 

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/UnclearBinaryExpressionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/style/UnclearBinaryExpressionInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -31,7 +32,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class UnclearBinaryExpressionInspection extends BaseInspection {
+public class UnclearBinaryExpressionInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Pattern(VALID_ID_PATTERN)
   @NotNull

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/testFrameworks/MisorderedAssertEqualsArgumentsInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/testFrameworks/MisorderedAssertEqualsArgumentsInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.testFrameworks;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Ref;
@@ -24,7 +25,7 @@ import java.util.Set;
 /**
  * @author Bas Leijdekkers
  */
-public class MisorderedAssertEqualsArgumentsInspection extends BaseInspection {
+public class MisorderedAssertEqualsArgumentsInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NonNls
   private static final Set<String> methodNames =

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/testFrameworks/SimplifiableAssertionInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/testFrameworks/SimplifiableAssertionInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.testFrameworks;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -16,7 +17,7 @@ import com.siyeh.ig.psiutils.*;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-public class SimplifiableAssertionInspection extends BaseInspection {
+public class SimplifiableAssertionInspection extends BaseInspection implements CleanupLocalInspectionTool {
   @Override
   @NotNull
   protected String buildErrorString(Object... infos) {

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/visibility/AmbiguousFieldAccessInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/visibility/AmbiguousFieldAccessInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.visibility;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -13,7 +14,7 @@ import com.siyeh.ig.psiutils.ClassUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class AmbiguousFieldAccessInspection extends BaseInspection {
+public class AmbiguousFieldAccessInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/visibility/AmbiguousMethodCallInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/visibility/AmbiguousMethodCallInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.visibility;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -14,7 +15,7 @@ import com.siyeh.ig.psiutils.ClassUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class AmbiguousMethodCallInspection extends BaseInspection {
+public class AmbiguousMethodCallInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   @NotNull

--- a/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
+++ b/plugins/InspectionGadgets/src/META-INF/InspectionGadgets.xml
@@ -109,14 +109,14 @@
     <localInspection groupPath="Java" language="JAVA" suppressId="ValueOfIncrementOrDecrementUsed" shortName="IncrementDecrementUsedAsExpression"
                      bundle="messages.InspectionGadgetsBundle" key="increment.decrement.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.assignment.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.assignment.IncrementDecrementUsedAsExpressionInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.assignment.IncrementDecrementUsedAsExpressionInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="NestedAssignment" bundle="messages.InspectionGadgetsBundle" key="nested.assignment.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.assignment.issues" enabledByDefault="false"
                      level="WARNING" implementationClass="com.siyeh.ig.assignment.NestedAssignmentInspection"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="AssignmentReplaceableWithOperatorAssignment" shortName="ReplaceAssignmentWithOperatorAssignment"
                      bundle="messages.InspectionGadgetsBundle" key="assignment.replaceable.with.operator.assignment.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.assignment.issues" enabledByDefault="true"
-                     level="INFORMATION" implementationClass="com.siyeh.ig.assignment.ReplaceAssignmentWithOperatorAssignmentInspection"/>
+                     level="INFORMATION" implementationClass="com.siyeh.ig.assignment.ReplaceAssignmentWithOperatorAssignmentInspection" cleanupTool="true"/>
 
     <!--group.names.bitwise.operation.issues-->
     <localInspection groupPath="Java" language="JAVA" suppressId="IncompatibleBitwiseMaskOperation" shortName="IncompatibleMask" bundle="messages.InspectionGadgetsBundle"
@@ -239,7 +239,7 @@
                      implementationClass="com.siyeh.ig.bugs.InfiniteRecursionInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="InnerClassReferencedViaSubclass" bundle="messages.InspectionGadgetsBundle"
                      key="inner.class.referenced.via.subclass.display.name" groupBundle="messages.InspectionsBundle" groupKey="group.names.probable.bugs"
-                     enabledByDefault="false" level="WARNING" implementationClass="com.siyeh.ig.bugs.InnerClassReferencedViaSubclassInspection"/>
+                     enabledByDefault="false" level="WARNING" implementationClass="com.siyeh.ig.bugs.InnerClassReferencedViaSubclassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="InstanceofIncompatibleInterface" bundle="messages.InspectionGadgetsBundle"
                      key="instanceof.with.incompatible.interface.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.probable.bugs" enabledByDefault="false" level="WARNING"
@@ -390,7 +390,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="UseOfPropertiesAsHashtable" bundle="messages.InspectionGadgetsBundle"
                      key="properties.object.as.hashtable.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.probable.bugs" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.bugs.UseOfPropertiesAsHashtableInspection"/>
+                     implementationClass="com.siyeh.ig.bugs.UseOfPropertiesAsHashtableInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="VariableNotUsedInsideIf" bundle="messages.InspectionGadgetsBundle"
                      key="variable.not.used.inside.if.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.probable.bugs" enabledByDefault="false" level="WARNING"
@@ -430,9 +430,9 @@
                      level="WARNING" implementationClass="com.siyeh.ig.classlayout.FinalClassInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="FinalMethodInFinalClass" bundle="messages.InspectionGadgetsBundle"
                      key="final.method.in.final.class.display.name" groupBundle="messages.InspectionsBundle"
-                     groupKey="group.names.declaration.redundancy" enabledByDefault="true" level="WARNING" 
+                     groupKey="group.names.declaration.redundancy" enabledByDefault="true" level="WARNING"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     implementationClass="com.siyeh.ig.classlayout.FinalMethodInFinalClassInspection"/>
+                     implementationClass="com.siyeh.ig.classlayout.FinalMethodInFinalClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="FinalMethod" bundle="messages.InspectionGadgetsBundle" key="final.method.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.class.structure" enabledByDefault="false"
                      level="WARNING" implementationClass="com.siyeh.ig.classlayout.FinalMethodInspection"/>
@@ -477,7 +477,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ProtectedMemberInFinalClass" bundle="messages.InspectionGadgetsBundle"
                      key="protected.member.in.final.class.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.declaration.redundancy" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.classlayout.ProtectedMemberInFinalClassInspection"/>
+                     implementationClass="com.siyeh.ig.classlayout.ProtectedMemberInFinalClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="PublicConstructor" bundle="messages.InspectionGadgetsBundle"
                      key="public.constructor.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.class.structure" enabledByDefault="false" level="WARNING"
@@ -498,7 +498,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="UtilityClassCanBeEnum" bundle="messages.InspectionGadgetsBundle"
                      key="utility.class.can.be.enum.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.class.structure" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.classlayout.UtilityClassCanBeEnumInspection"/>
+                     implementationClass="com.siyeh.ig.classlayout.UtilityClassCanBeEnumInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UtilityClassWithPublicConstructor" bundle="messages.InspectionGadgetsBundle"
                      key="utility.class.with.public.constructor.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.class.structure" enabledByDefault="false" level="WARNING"
@@ -605,11 +605,11 @@
     <localInspection groupPath="Java" language="JAVA" suppressId="ConfusingElseBranch" shortName="ConfusingElse" bundle="messages.InspectionGadgetsBundle"
                      key="redundant.else.display.name" groupBundle="messages.InspectionsBundle" groupKey="group.names.control.flow.issues"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     enabledByDefault="true" level="INFORMATION" implementationClass="com.siyeh.ig.controlflow.ConfusingElseInspection"/>
+                     enabledByDefault="true" level="INFORMATION" implementationClass="com.siyeh.ig.controlflow.ConfusingElseInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ConstantConditionalExpression" bundle="messages.InspectionGadgetsBundle"
                      key="constant.conditional.expression.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.controlflow.ConstantConditionalExpressionInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.ConstantConditionalExpressionInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ContinueStatement" bundle="messages.InspectionGadgetsBundle" key="continue.statement.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.control.flow.issues" enabledByDefault="false"
                      level="WARNING" implementationClass="com.siyeh.ig.controlflow.ContinueStatementInspection"/>
@@ -620,7 +620,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="DefaultNotLastCaseInSwitch" bundle="messages.InspectionGadgetsBundle"
                      key="default.not.last.case.in.switch.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.controlflow.DefaultNotLastCaseInSwitchInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.DefaultNotLastCaseInSwitchInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="DoubleNegation" bundle="messages.InspectionGadgetsBundle" key="double.negation.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.control.flow.issues" enabledByDefault="true"
                      level="WARNING" implementationClass="com.siyeh.ig.controlflow.DoubleNegationInspection" cleanupTool="true"/>
@@ -635,7 +635,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ExpressionMayBeFactorized" bundle="messages.InspectionGadgetsBundle"
                      key="expression.may.be.factorized.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.siyeh.ig.controlflow.ExpressionMayBeFactorizedInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.ExpressionMayBeFactorizedInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="fallthrough" shortName="FallthruInSwitchStatement" bundle="messages.InspectionGadgetsBundle"
                      key="fallthru.in.switch.statement.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="false" level="WARNING"
@@ -643,7 +643,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ForLoopReplaceableByWhile" bundle="messages.InspectionGadgetsBundle"
                      key="for.loop.replaceable.by.while.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.controlflow.ForLoopReplaceableByWhileInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.ForLoopReplaceableByWhileInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ForLoopWithMissingComponent" bundle="messages.InspectionGadgetsBundle"
                      key="for.loop.with.missing.component.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="false" level="WARNING"
@@ -685,7 +685,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="NegatedEqualityExpression" bundle="messages.InspectionGadgetsBundle"
                      key="negated.equality.expression.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.controlflow.NegatedEqualityExpressionInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.NegatedEqualityExpressionInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="IfStatementWithNegatedCondition" shortName="NegatedIfElse" bundle="messages.InspectionGadgetsBundle"
                      key="negated.if.else.display.name" groupBundle="messages.InspectionsBundle" groupKey="group.names.control.flow.issues"
                      enabledByDefault="false" level="WARNING" implementationClass="com.siyeh.ig.controlflow.NegatedIfElseInspection"/>
@@ -703,14 +703,14 @@
     <localInspection groupPath="Java" language="JAVA" shortName="PointlessBooleanExpression" bundle="messages.InspectionGadgetsBundle"
                      key="pointless.boolean.expression.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.controlflow.PointlessBooleanExpressionInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.PointlessBooleanExpressionInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="PointlessIndexOfComparison" bundle="messages.InspectionGadgetsBundle"
                      key="pointless.indexof.comparison.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="false" level="WARNING"
                      implementationClass="com.siyeh.ig.controlflow.PointlessIndexOfComparisonInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="PointlessNullCheck" bundle="messages.InspectionGadgetsBundle" key="pointless.nullcheck.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.control.flow.issues" enabledByDefault="true"
-                     level="WARNING" implementationClass="com.siyeh.ig.controlflow.PointlessNullCheckInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.controlflow.PointlessNullCheckInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="SimplifiableBooleanExpression" bundle="messages.InspectionGadgetsBundle"
                      key="simplifiable.boolean.expression.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="true" level="WARNING"
@@ -734,7 +734,7 @@
                      bundle="messages.InspectionGadgetsBundle"
                      key="switch.statement.with.too.few.branches.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.control.flow.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.controlflow.SwitchStatementWithTooFewBranchesInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.SwitchStatementWithTooFewBranchesInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="SwitchStatementWithTooManyBranches"
                      bundle="messages.InspectionGadgetsBundle"
                      key="switch.statement.with.too.many.branches.display.name" groupBundle="messages.InspectionsBundle"
@@ -882,7 +882,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="EmptyFinallyBlock" bundle="messages.InspectionGadgetsBundle" key="empty.finally.block.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.error.handling" enabledByDefault="true" level="WARNING"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     implementationClass="com.siyeh.ig.errorhandling.EmptyFinallyBlockInspection"/>
+                     implementationClass="com.siyeh.ig.errorhandling.EmptyFinallyBlockInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="EmptyTryBlock" bundle="messages.InspectionGadgetsBundle" key="empty.try.block.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.error.handling" enabledByDefault="true" level="WARNING"
                      implementationClass="com.siyeh.ig.errorhandling.EmptyTryBlockInspection"/>
@@ -956,7 +956,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="FinalizeNotProtected" bundle="messages.InspectionGadgetsBundle"
                      key="finalize.not.declared.protected.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.finalization.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.finalization.FinalizeNotProtectedInspection"/>
+                     implementationClass="com.siyeh.ig.finalization.FinalizeNotProtectedInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="FinalizeCalledExplicitly" shortName="NoExplicitFinalizeCalls" bundle="messages.InspectionGadgetsBundle"
                      key="finalize.called.explicitly.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.finalization.issues" enabledByDefault="true" level="WARNING"
@@ -1024,7 +1024,7 @@
     <localInspection groupPath="Java" language="JAVA" suppressId="ConstructorNotProtectedInAbstractClass" shortName="NonProtectedConstructorInAbstractClass"
                      bundle="messages.InspectionGadgetsBundle" key="non.protected.constructor.in.abstract.class.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.inheritance.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.inheritance.NonProtectedConstructorInAbstractClassInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.inheritance.NonProtectedConstructorInAbstractClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ParameterTypePreventsOverriding" bundle="messages.InspectionGadgetsBundle"
                      key="parameter.type.prevents.overriding.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.inheritance.issues" enabledByDefault="false" level="WARNING"
@@ -1046,7 +1046,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="TypeParameterExtendsFinalClass" bundle="messages.InspectionGadgetsBundle"
                      key="type.parameter.extends.final.class.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.inheritance.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.inheritance.TypeParameterExtendsFinalClassInspection"/>
+                     implementationClass="com.siyeh.ig.inheritance.TypeParameterExtendsFinalClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="override" shortName="MissingOverrideAnnotation" bundle="messages.InspectionGadgetsBundle"
                      key="missing.override.annotation.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.inheritance.issues" enabledByDefault="true" level="INFORMATION"
@@ -1060,7 +1060,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="DoubleBraceInitialization" bundle="messages.InspectionGadgetsBundle"
                      key="double.brace.initialization.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.initialization.issues" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.siyeh.ig.initialization.DoubleBraceInitializationInspection"/>
+                     implementationClass="com.siyeh.ig.initialization.DoubleBraceInitializationInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="InstanceVariableMayNotBeInitialized" shortName="InstanceVariableInitialization"
                      bundle="messages.InspectionGadgetsBundle" key="instance.variable.may.not.be.initialized.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.initialization.issues" enabledByDefault="false"
@@ -1147,7 +1147,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ImplicitDefaultCharsetUsage" bundle="messages.InspectionGadgetsBundle"
                      key="implicit.default.charset.usage.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.internationalization.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.internationalization.ImplicitDefaultCharsetUsageInspection"/>
+                     implementationClass="com.siyeh.ig.internationalization.ImplicitDefaultCharsetUsageInspection" cleanupTool="true"/>
 
     <!--group.names.j2me.issues-->
     <localInspection groupPathKey="group.path.names.performance" language="JAVA" shortName="AbstractClassWithOnlyOneDirectInheritor" bundle="messages.InspectionGadgetsBundle"
@@ -1177,7 +1177,7 @@
     <localInspection groupPathKey="group.path.names.performance" language="JAVA" shortName="MultiplyOrDivideByPowerOfTwo" bundle="messages.InspectionGadgetsBundle"
                      key="multiply.or.divide.by.power.of.two.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.j2me.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.j2me.MultiplyOrDivideByPowerOfTwoInspection"/>
+                     implementationClass="com.siyeh.ig.j2me.MultiplyOrDivideByPowerOfTwoInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.performance" language="JAVA" shortName="OverlyLargePrimitiveArrayInitializer" bundle="messages.InspectionGadgetsBundle"
                      key="large.initializer.primitive.type.array.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.j2me.issues" enabledByDefault="false" level="WARNING"
@@ -1226,15 +1226,15 @@
     <localInspection groupPath="Java" language="JAVA" shortName="HtmlTagCanBeJavadocTag" bundle="messages.InspectionGadgetsBundle"
                      key="html.tag.can.be.javadoc.tag.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.javadoc.HtmlTagCanBeJavadocTagInspection"/>
+                     implementationClass="com.siyeh.ig.javadoc.HtmlTagCanBeJavadocTagInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="MissingDeprecatedAnnotation" bundle="messages.InspectionGadgetsBundle"
                      key="missing.deprecated.annotation.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING" runForWholeFile="true"
-                     implementationClass="com.siyeh.ig.javadoc.MissingDeprecatedAnnotationInspection"/>
+                     implementationClass="com.siyeh.ig.javadoc.MissingDeprecatedAnnotationInspection" cleanupTool="true"/>
     <globalInspection groupPath="Java" language="JAVA" shortName="MissingPackageInfo" bundle="messages.InspectionGadgetsBundle"
                       key="missing.package.info.display.name" groupBundle="messages.InspectionsBundle"
                       groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING"
-                      implementationClass="com.siyeh.ig.javadoc.MissingPackageInfoInspection"/>
+                      implementationClass="com.siyeh.ig.javadoc.MissingPackageInfoInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="PackageInfoWithoutPackage" bundle="messages.InspectionGadgetsBundle"
                      key="package.info.java.without.package.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.javadoc.issues" enabledByDefault="true" level="WARNING"
@@ -1246,28 +1246,28 @@
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryJavaDocLink" bundle="messages.InspectionGadgetsBundle"
                      key="unnecessary.javadoc.link.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.javadoc.UnnecessaryJavaDocLinkInspection"/>
+                     implementationClass="com.siyeh.ig.javadoc.UnnecessaryJavaDocLinkInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryInheritDoc" bundle="messages.InspectionGadgetsBundle" key="unnecessary.inherit.doc.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.javadoc.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.javadoc.UnnecessaryInheritDocInspection"/>
+                     implementationClass="com.siyeh.ig.javadoc.UnnecessaryInheritDocInspection" cleanupTool="true"/>
 
     <!--group.names.language.level.specific.issues.and.migration.aids-->
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="CollectionsFieldAccessReplaceableByMethodCall" bundle="messages.InspectionGadgetsBundle"
                      key="collections.field.access.replaceable.by.method.call.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.language.level.specific.issues.and.migration.aids5" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.migration.CollectionsFieldAccessReplaceableByMethodCallInspection"/>
+                     implementationClass="com.siyeh.ig.migration.CollectionsFieldAccessReplaceableByMethodCallInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="BigDecimalLegacyMethod" bundle="messages.InspectionGadgetsBundle"
                      key="bigdecimal.legacy.method.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.language.level.specific.issues.and.migration.aids5" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.migration.BigDecimalLegacyMethodInspection"/>
+                     implementationClass="com.siyeh.ig.migration.BigDecimalLegacyMethodInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="EqualsReplaceableByObjectsCall" bundle="messages.InspectionGadgetsBundle"
                      key="equals.replaceable.by.objects.call.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.language.level.specific.issues.and.migration.aids7" enabledByDefault="true" level="WEAK WARNING"
-                     implementationClass="com.siyeh.ig.migration.EqualsReplaceableByObjectsCallInspection"/>
+                     implementationClass="com.siyeh.ig.migration.EqualsReplaceableByObjectsCallInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="EnumerationCanBeIteration" bundle="messages.InspectionGadgetsBundle"
                      key="enumeration.can.be.iteration.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.language.level.specific.issues.and.migration.aids" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.migration.EnumerationCanBeIterationInspection"/>
+                     implementationClass="com.siyeh.ig.migration.EnumerationCanBeIterationInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" suppressId="ForLoopReplaceableByForEach" shortName="ForCanBeForeach" bundle="messages.InspectionGadgetsBundle"
                      key="for.can.be.foreach.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.language.level.specific.issues.and.migration.aids5" enabledByDefault="true" level="WARNING"
@@ -1295,7 +1295,7 @@
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="TryWithIdenticalCatches" bundle="messages.InspectionGadgetsBundle"
                      key="try.with.identical.catches.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.language.level.specific.issues.and.migration.aids7" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.migration.TryWithIdenticalCatchesInspection"/>
+                     implementationClass="com.siyeh.ig.migration.TryWithIdenticalCatchesInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="UnnecessaryBoxing" bundle="messages.InspectionGadgetsBundle" key="unnecessary.boxing.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.language.level.specific.issues.and.migration.aids5"
                      enabledByDefault="true" level="WARNING" implementationClass="com.siyeh.ig.migration.UnnecessaryBoxingInspection"/>
@@ -1341,11 +1341,11 @@
     <localInspection groupPath="Java" language="JAVA" shortName="AssertEqualsMayBeAssertSame" bundle="messages.InspectionGadgetsBundle"
                      key="assertequals.may.be.assertsame.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.junit.AssertEqualsMayBeAssertSameInspection"/>
+                     implementationClass="com.siyeh.ig.junit.AssertEqualsMayBeAssertSameInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="AssertEqualsCalledOnArray" bundle="messages.InspectionGadgetsBundle"
                      key="assertequals.called.on.arrays.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.junit.AssertEqualsCalledOnArrayInspection"/>
+                     implementationClass="com.siyeh.ig.junit.AssertEqualsCalledOnArrayInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="JUnitDatapoint" bundle="messages.InspectionGadgetsBundle"
                      key="junit.datapoint.display.name" implementationClass="com.siyeh.ig.junit.JUnitDatapointInspection"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"/>
@@ -1360,7 +1360,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ParameterizedParametersStaticCollection"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"
                      implementationClass="com.siyeh.ig.junit.ParameterizedParametersStaticCollectionInspection"
-                     key="inspection.parameterized.parameters.static.collection.display.name" bundle="messages.InspectionGadgetsBundle"/>
+                     key="inspection.parameterized.parameters.static.collection.display.name" bundle="messages.InspectionGadgetsBundle" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ConstantAssertArgument" bundle="messages.InspectionGadgetsBundle"
                      key="constant.junit.assert.argument.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.test.frameworks.issues" enabledByDefault="false" level="WARNING"
@@ -1380,7 +1380,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="Junit4Converter" bundle="messages.InspectionGadgetsBundle"
                      key="convert.junit3.test.case.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.junit.issues" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.siyeh.ig.junit.Junit4ConverterInspection"/>
+                     implementationClass="com.siyeh.ig.junit.Junit4ConverterInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA"  shortName="MalformedSetUpTearDown" bundle="messages.InspectionGadgetsBundle"
                      key="malformed.set.up.tear.down.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"
@@ -1388,12 +1388,12 @@
     <localInspection groupPath="Java" language="JAVA" shortName="MisorderedAssertEqualsArguments"
                      bundle="messages.InspectionGadgetsBundle" key="misordered.assert.equals.arguments.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.test.frameworks.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.testFrameworks.MisorderedAssertEqualsArgumentsInspection"/>
+                     implementationClass="com.siyeh.ig.testFrameworks.MisorderedAssertEqualsArgumentsInspection" cleanupTool="true"/>
     <inspectionElementsMerger implementation="com.siyeh.ig.testFrameworks.MisorderedAssertEqualsArgumentsMerger"/>
     <localInspection groupPath="Java" language="JAVA" shortName="MultipleExceptionsDeclaredOnTestMethod" bundle="messages.InspectionGadgetsBundle"
                      key="multiple.exceptions.declared.on.test.method.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.junit.MultipleExceptionsDeclaredOnTestMethodInspection"/>
+                     implementationClass="com.siyeh.ig.junit.MultipleExceptionsDeclaredOnTestMethodInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="JUnitTestCaseWithNonTrivialConstructors" shortName="TestCaseWithConstructor"
                      bundle="messages.InspectionGadgetsBundle" key="test.case.with.constructor.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"
@@ -1401,7 +1401,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="SimplifiableAssertion" bundle="messages.InspectionGadgetsBundle"
                      key="simplifiable.junit.assertion.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.test.frameworks.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.testFrameworks.SimplifiableAssertionInspection"/>
+                     implementationClass="com.siyeh.ig.testFrameworks.SimplifiableAssertionInspection" cleanupTool="true"/>
     <inspectionElementsMerger implementation="com.siyeh.ig.testFrameworks.SimplifiableAssertionMerger"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="SuiteNotDeclaredStatic" shortName="StaticSuite" bundle="messages.InspectionGadgetsBundle"
                      key="static.suite.display.name" groupBundle="messages.InspectionsBundle" groupKey="group.names.junit.issues"
@@ -1431,7 +1431,7 @@
                      implementationClass="com.siyeh.ig.junit.TestMethodWithoutAssertionInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UseOfObsoleteAssert" bundle="messages.InspectionGadgetsBundle" key="usage.of.obsolete.assert.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.junit.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.junit.UseOfObsoleteAssertInspection"/>
+                     implementationClass="com.siyeh.ig.junit.UseOfObsoleteAssertInspection" cleanupTool="true"/>
 
     <!--group.names.logging.issues-->
     <localInspection groupPath="Java" language="JAVA" shortName="ClassWithMultipleLoggers" bundle="messages.InspectionGadgetsBundle" key="multiple.loggers.display.name"
@@ -1447,7 +1447,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="LoggerInitializedWithForeignClass" bundle="messages.InspectionGadgetsBundle"
                      key="logger.initialized.with.foreign.class.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.logging.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.logging.LoggerInitializedWithForeignClassInspection"/>
+                     implementationClass="com.siyeh.ig.logging.LoggerInitializedWithForeignClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="LogStatementGuardedByLogCondition" bundle="messages.InspectionGadgetsBundle"
                      key="log.statement.guarded.by.log.condition.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.logging.issues" enabledByDefault="false" level="WARNING"
@@ -1466,7 +1466,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="StringConcatenationArgumentToLogCall" bundle="messages.InspectionGadgetsBundle"
                      key="string.concatenation.argument.to.log.call.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.logging.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.logging.StringConcatenationArgumentToLogCallInspection"/>
+                     implementationClass="com.siyeh.ig.logging.StringConcatenationArgumentToLogCallInspection" cleanupTool="true"/>
 
     <!--group.names.code.maturity.issues-->
     <localInspection groupPath="Java" language="JAVA" shortName="SuppressionAnnotation" bundle="messages.InspectionGadgetsBundle"
@@ -1529,7 +1529,7 @@
     <localInspection groupPath="Java" language="JAVA" suppressId="ConstantForZeroLengthArrayAllocation" shortName="UnnecessaryEmptyArrayUsage"
                      bundle="messages.InspectionGadgetsBundle" key="constant.for.zero.length.array.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.memory.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.memory.UnnecessaryEmptyArrayUsageInspection"/>
+                     implementationClass="com.siyeh.ig.memory.UnnecessaryEmptyArrayUsageInspection" cleanupTool="true"/>
 
     <!--group.names.method.metrics-->
     <localInspection groupPath="Java" language="JAVA" suppressId="ConstructorWithTooManyParameters" shortName="ParametersPerConstructor"
@@ -1724,7 +1724,7 @@
                      implementationClass="com.siyeh.ig.numeric.BadOddnessInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="BigDecimalEquals" bundle="messages.InspectionGadgetsBundle" key="big.decimal.equals.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.numeric.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.BigDecimalEqualsInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.BigDecimalEqualsInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="BigDecimalMethodWithoutRoundingCalled" bundle="messages.InspectionGadgetsBundle"
                      key="big.decimal.method.without.rounding.called.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.issues" enabledByDefault="true" level="WARNING"
@@ -1732,7 +1732,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="CachedNumberConstructorCall" bundle="messages.InspectionGadgetsBundle"
                      key="cached.number.constructor.call.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.CachedNumberConstructorCallInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.CachedNumberConstructorCallInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.numeric" language="JAVA" suppressId="NumericCastThatLosesPrecision" shortName="CastThatLosesPrecision"
                      bundle="messages.InspectionGadgetsBundle" key="cast.that.loses.precision.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.numeric.cast" enabledByDefault="false" level="WARNING"
@@ -1751,17 +1751,17 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ConfusingFloatingPointLiteral" bundle="messages.InspectionGadgetsBundle"
                      key="confusing.floating.point.literal.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.ConfusingFloatingPointLiteralInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.ConfusingFloatingPointLiteralInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ConstantMathCall" bundle="messages.InspectionGadgetsBundle" key="constant.math.call.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.numeric.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.ConstantMathCallInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.ConstantMathCallInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="divzero" shortName="DivideByZero" bundle="messages.InspectionGadgetsBundle"
                      key="divide.by.zero.display.name" groupBundle="messages.InspectionsBundle" groupKey="group.names.numeric.issues"
                      enabledByDefault="true" level="WARNING" implementationClass="com.siyeh.ig.numeric.DivideByZeroInspection"/>
     <localInspection groupPathKey="group.path.names.numeric" language="JAVA" shortName="DoubleLiteralMayBeFloatLiteral" bundle="messages.InspectionGadgetsBundle"
                      key="double.literal.may.be.float.literal.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.cast" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.DoubleLiteralMayBeFloatLiteralInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.DoubleLiteralMayBeFloatLiteralInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="FloatingPointEquality" bundle="messages.InspectionGadgetsBundle" key="floating.point.equality.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.numeric.issues" enabledByDefault="false" level="WARNING"
                      implementationClass="com.siyeh.ig.numeric.FloatingPointEqualityInspection"/>
@@ -1776,15 +1776,15 @@
     <localInspection groupPathKey="group.path.names.numeric" language="JAVA" shortName="IntegerMultiplicationImplicitCastToLong" bundle="messages.InspectionGadgetsBundle"
                      key="integer.multiplication.implicit.cast.to.long.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.cast" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.IntegerMultiplicationImplicitCastToLongInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.IntegerMultiplicationImplicitCastToLongInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.numeric" language="JAVA" shortName="IntLiteralMayBeLongLiteral" bundle="messages.InspectionGadgetsBundle"
                      key="int.literal.may.be.long.literal.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.cast" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.IntLiteralMayBeLongLiteralInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.IntLiteralMayBeLongLiteralInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="LongLiteralEndingWithLowercaseL" shortName="LongLiteralsEndingWithLowercaseL"
                      bundle="messages.InspectionGadgetsBundle" key="long.literals.ending.with.lowercase.l.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.numeric.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.LongLiteralsEndingWithLowercaseLInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.LongLiteralsEndingWithLowercaseLInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="NonReproducibleMathCall" bundle="messages.InspectionGadgetsBundle"
                      key="non.reproducible.math.call.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.issues" enabledByDefault="false" level="WARNING"
@@ -1803,7 +1803,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="PointlessArithmeticExpression" bundle="messages.InspectionGadgetsBundle"
                      key="pointless.arithmetic.expression.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.PointlessArithmeticExpressionInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.PointlessArithmeticExpressionInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="SuspiciousLiteralUnderscore" bundle="messages.InspectionGadgetsBundle"
                      key="suspicious.literal.underscore.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.issues" enabledByDefault="false" level="WARNING"
@@ -1816,7 +1816,7 @@
                      key="unnecessary.explicit.numeric.cast.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.cast" enabledByDefault="false" level="WARNING"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     implementationClass="com.siyeh.ig.numeric.UnnecessaryExplicitNumericCastInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.UnnecessaryExplicitNumericCastInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryUnaryMinus" bundle="messages.InspectionGadgetsBundle" key="unnecessary.unary.minus.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.numeric.issues" enabledByDefault="true" level="WARNING"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
@@ -1824,7 +1824,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="UnpredictableBigDecimalConstructorCall" bundle="messages.InspectionGadgetsBundle"
                      key="unpredictable.big.decimal.constructor.call.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.numeric.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.numeric.UnpredictableBigDecimalConstructorCallInspection"/>
+                     implementationClass="com.siyeh.ig.numeric.UnpredictableBigDecimalConstructorCallInspection" cleanupTool="true"/>
 
     <!--group.names.packaging.issues-->
     <globalInspection groupPath="Java" language="JAVA" shortName="ClassOnlyUsedInOnePackage" bundle="messages.InspectionGadgetsBundle"
@@ -1858,19 +1858,19 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ArraysAsListWithZeroOrOneArgument" bundle="messages.InspectionGadgetsBundle"
                      key="arrays.as.list.with.zero.or.one.argument.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.performance.ArraysAsListWithZeroOrOneArgumentInspection"/>
+                     implementationClass="com.siyeh.ig.performance.ArraysAsListWithZeroOrOneArgumentInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="BooleanConstructorCall" shortName="BooleanConstructor" bundle="messages.InspectionGadgetsBundle"
                      key="boolean.constructor.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.performance.BooleanConstructorInspection"/>
+                     implementationClass="com.siyeh.ig.performance.BooleanConstructorInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="CallToSimpleGetterFromWithinClass" shortName="CallToSimpleGetterInClass"
                      bundle="messages.InspectionGadgetsBundle" key="call.to.simple.getter.in.class.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.CallToSimpleGetterInClassInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.CallToSimpleGetterInClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="CallToSimpleSetterFromWithinClass" shortName="CallToSimpleSetterInClass"
                      bundle="messages.InspectionGadgetsBundle" key="call.to.simple.setter.in.class.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.CallToSimpleSetterInClassInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.CallToSimpleSetterInClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="CollectionContainsUrl" bundle="messages.InspectionGadgetsBundle" key="collection.contains.url.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="false"
                      level="WARNING" implementationClass="com.siyeh.ig.performance.CollectionContainsUrlInspection"/>
@@ -1900,18 +1900,18 @@
     <localInspection groupPath="Java" language="JAVA" suppressId="SingleCharacterStringConcatenation" shortName="LengthOneStringInIndexOf"
                      bundle="messages.InspectionGadgetsBundle" key="length.one.string.in.indexof.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.LengthOneStringInIndexOfInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.LengthOneStringInIndexOfInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="SingleCharacterStringConcatenation" shortName="LengthOneStringsInConcatenation"
                      bundle="messages.InspectionGadgetsBundle" key="length.one.strings.in.concatenation.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="true"
-                     level="INFORMATION" implementationClass="com.siyeh.ig.performance.LengthOneStringsInConcatenationInspection"/>
+                     level="INFORMATION" implementationClass="com.siyeh.ig.performance.LengthOneStringsInConcatenationInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ManualArrayToCollectionCopy" bundle="messages.InspectionGadgetsBundle"
                      key="manual.array.to.collection.copy.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.performance.ManualArrayToCollectionCopyInspection"/>
+                     implementationClass="com.siyeh.ig.performance.ManualArrayToCollectionCopyInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ManualArrayCopy" bundle="messages.InspectionGadgetsBundle" key="manual.array.copy.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="true"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.ManualArrayCopyInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.ManualArrayCopyInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="MapReplaceableByEnumMap" bundle="messages.InspectionGadgetsBundle"
                      key="map.replaceable.by.enum.map.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="false" level="WARNING"
@@ -1938,11 +1938,11 @@
     <localInspection groupPath="Java" language="JAVA" suppressId="UsingRandomNextDoubleForRandomInteger" shortName="RandomDoubleForRandomInteger"
                      bundle="messages.InspectionGadgetsBundle" key="random.double.for.random.integer.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.RandomDoubleForRandomIntegerInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.RandomDoubleForRandomIntegerInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="RedundantStringFormatCall" bundle="messages.InspectionGadgetsBundle"
                      key="redundant.string.format.call.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.performance.RedundantStringFormatCallInspection"/>
+                     implementationClass="com.siyeh.ig.performance.RedundantStringFormatCallInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="SetReplaceableByEnumSet" bundle="messages.InspectionGadgetsBundle"
                      key="set.replaceable.by.enum.set.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="false" level="WARNING"
@@ -1973,7 +1973,7 @@
                      level="WARNING" implementationClass="com.siyeh.ig.performance.StringReplaceableByStringBufferInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="TailRecursion" bundle="messages.InspectionGadgetsBundle" key="tail.recursion.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="true"
-                     level="INFORMATION" implementationClass="com.siyeh.ig.performance.TailRecursionInspection"/>
+                     level="INFORMATION" implementationClass="com.siyeh.ig.performance.TailRecursionInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ToArrayCallWithZeroLengthArrayArgument" bundle="messages.InspectionGadgetsBundle"
                      key="to.array.call.style.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
@@ -1981,25 +1981,25 @@
     <localInspection groupPath="Java" language="JAVA" suppressId="ConcatenationWithEmptyString" shortName="TrivialStringConcatenation"
                      bundle="messages.InspectionGadgetsBundle" key="trivial.string.concatenation.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.TrivialStringConcatenationInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.TrivialStringConcatenationInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryTemporaryOnConversionToString" bundle="messages.InspectionGadgetsBundle"
                      key="unnecessary.temporary.on.conversion.to.string.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.performance.UnnecessaryTemporaryOnConversionToStringInspection"/>
+                     implementationClass="com.siyeh.ig.performance.UnnecessaryTemporaryOnConversionToStringInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryTemporaryOnConversionFromString" bundle="messages.InspectionGadgetsBundle"
                      key="unnecessary.temporary.on.conversion.from.string.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.performance.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.performance.UnnecessaryTemporaryOnConversionFromStringInspection"/>
+                     implementationClass="com.siyeh.ig.performance.UnnecessaryTemporaryOnConversionFromStringInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="BoxingBoxedValue" bundle="messages.InspectionGadgetsBundle" key="boxing.boxed.value.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="true"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.BoxingBoxedValueInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.BoxingBoxedValueInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ListRemoveInLoop" bundle="messages.InspectionGadgetsBundle" key="inspection.list.remove.in.loop.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="true"
                      level="WARNING" implementationClass="com.siyeh.ig.performance.ListRemoveInLoopInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="IfStatementMissingBreakInLoop" bundle="messages.InspectionGadgetsBundle"
                      key="inspection.if.statement.missing.break.in.loop.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="true"
-                     level="WARNING" implementationClass="com.siyeh.ig.performance.IfStatementMissingBreakInLoopInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.performance.IfStatementMissingBreakInLoopInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="AutoUnboxing" bundle="messages.InspectionGadgetsBundle" key="auto.unboxing.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.performance.issues" enabledByDefault="false"
                      level="WARNING" implementationClass="com.siyeh.ig.jdk.AutoUnboxingInspection"/>
@@ -2047,7 +2047,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="UnusedLabel" bundle="messages.InspectionGadgetsBundle" key="unused.label.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.declaration.redundancy" enabledByDefault="true"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     level="WARNING" implementationClass="com.siyeh.ig.redundancy.UnusedLabelInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.redundancy.UnusedLabelInspection" cleanupTool="true"/>
 
     <!--group.names.resource.management.issues-->
     <localInspection groupPath="Java" language="JAVA" suppressId="resource" shortName="AutoCloseableResource" bundle="messages.InspectionGadgetsBundle"
@@ -2151,7 +2151,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ComparatorNotSerializable" bundle="messages.InspectionGadgetsBundle"
                      key="comparator.not.serializable.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.serialization.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.serialization.ComparatorNotSerializableInspection"/>
+                     implementationClass="com.siyeh.ig.serialization.ComparatorNotSerializableInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ExternalizableWithoutPublicNoArgConstructor" bundle="messages.InspectionGadgetsBundle"
                      key="externalizable.without.public.no.arg.constructor.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.serialization.issues" enabledByDefault="true" level="WARNING"
@@ -2236,7 +2236,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="TransientFieldInNonSerializableClass" bundle="messages.InspectionGadgetsBundle"
                      key="transient.field.in.non.serializable.class.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.serialization.issues" enabledByDefault="false" level="WARNING" editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     implementationClass="com.siyeh.ig.serialization.TransientFieldInNonSerializableClassInspection"/>
+                     implementationClass="com.siyeh.ig.serialization.TransientFieldInNonSerializableClassInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="TransientFieldNotInitialized" bundle="messages.InspectionGadgetsBundle"
                      key="transient.field.not.initialized.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.serialization.issues" enabledByDefault="false" level="WARNING"
@@ -2253,7 +2253,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="CallToStringConcatCanBeReplacedByOperator" bundle="messages.InspectionGadgetsBundle"
                      key="call.to.string.concat.can.be.replaced.by.operator.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.style.CallToStringConcatCanBeReplacedByOperatorInspection"/>
+                     implementationClass="com.siyeh.ig.style.CallToStringConcatCanBeReplacedByOperatorInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="CStyleArrayDeclaration" bundle="messages.InspectionGadgetsBundle"
                      key="c.style.array.declaration.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="WARNING"
@@ -2272,11 +2272,11 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ConstantOnWrongSideOfComparison"
                      bundle="messages.InspectionGadgetsBundle" key="constant.on.side.of.comparison.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.code.style.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.style.ConstantOnWrongSideOfComparisonInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.style.ConstantOnWrongSideOfComparisonInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ControlFlowStatementWithoutBraces" bundle="messages.InspectionGadgetsBundle"
                      key="control.flow.statement.without.braces.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.siyeh.ig.style.ControlFlowStatementWithoutBracesInspection"/>
+                     implementationClass="com.siyeh.ig.style.ControlFlowStatementWithoutBracesInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="SingleStatementInBlock" bundle="messages.InspectionGadgetsBundle"
                      key="single.statement.in.block.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION" cleanupTool="true"
@@ -2284,10 +2284,10 @@
     <localInspection groupPath="Java" language="JAVA" shortName="EqualsCalledOnEnumConstant" bundle="messages.InspectionGadgetsBundle"
                      key="equals.called.on.enum.constant.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.style.EqualsCalledOnEnumConstantInspection"/>
+                     implementationClass="com.siyeh.ig.style.EqualsCalledOnEnumConstantInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" suppressId="ClassExplicitlyExtendsObject" shortName="ExtendsObject" bundle="messages.InspectionGadgetsBundle"
                      key="extends.object.display.name" groupBundle="messages.InspectionsBundle" groupKey="group.names.code.style.issues"
-                     enabledByDefault="true" level="WARNING" implementationClass="com.siyeh.ig.style.ExtendsObjectInspection"/>
+                     enabledByDefault="true" level="WARNING" implementationClass="com.siyeh.ig.style.ExtendsObjectInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="FieldMayBeFinal" bundle="messages.InspectionGadgetsBundle" key="field.may.be.final.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.code.style.issues" enabledByDefault="true" runForWholeFile="true"
                      level="WARNING" implementationClass="com.siyeh.ig.style.FieldMayBeFinalInspection" cleanupTool="true"/>
@@ -2297,11 +2297,11 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ListIndexOfReplaceableByContains" bundle="messages.InspectionGadgetsBundle"
                      key="list.indexof.replaceable.by.contains.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.style.ListIndexOfReplaceableByContainsInspection"/>
+                     implementationClass="com.siyeh.ig.style.ListIndexOfReplaceableByContainsInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="LiteralAsArgToStringEquals" bundle="messages.InspectionGadgetsBundle"
                      key="literal.as.arg.to.string.equals.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="false" level="WARNING"
-                     implementationClass="com.siyeh.ig.style.LiteralAsArgToStringEqualsInspection"/>
+                     implementationClass="com.siyeh.ig.style.LiteralAsArgToStringEqualsInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="MissortedModifiers" bundle="messages.InspectionGadgetsBundle" key="missorted.modifiers.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.code.style.issues" enabledByDefault="false" cleanupTool="true"
                      level="WARNING" implementationClass="com.siyeh.ig.style.MissortedModifiersInspection"/>
@@ -2423,7 +2423,7 @@
                      shortName="UnclearBinaryExpression" bundle="messages.InspectionGadgetsBundle"
                      key="unclear.binary.expression.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.siyeh.ig.style.UnclearBinaryExpressionInspection"/>
+                     implementationClass="com.siyeh.ig.style.UnclearBinaryExpressionInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="SizeReplaceableByIsEmpty" bundle="messages.InspectionGadgetsBundle"
                      key="size.replaceable.by.isempty.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="false" level="WARNING"
@@ -2468,11 +2468,11 @@
     <localInspection groupPath="Java" language="JAVA" shortName="ArrayCreationWithoutNewKeyword" bundle="messages.InspectionGadgetsBundle"
                      key="array.creation.without.new.keyword.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.siyeh.ig.style.ArrayCreationWithoutNewKeywordInspection"/>
+                     implementationClass="com.siyeh.ig.style.ArrayCreationWithoutNewKeywordInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="SimplifiableIfStatement" bundle="messages.InspectionGadgetsBundle"
                      key="inspection.simplifiable.if.statement.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.siyeh.ig.style.SimplifiableIfStatementInspection"/>
+                     implementationClass="com.siyeh.ig.style.SimplifiableIfStatementInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ArrayCanBeReplacedWithEnumValues" bundle="messages.InspectionGadgetsBundle"
                      key="array.can.be.replaced.with.enum.values" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.code.style.issues" enabledByDefault="true" level="INFORMATION"
@@ -2676,7 +2676,7 @@
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.verbose.or.redundant.code.constructs"
                      enabledByDefault="true" level="WARNING"
                      key="inspection.redundant.compare.call.display.name" bundle="messages.InspectionGadgetsBundle" editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     implementationClass="com.intellij.codeInspection.RedundantCompareCallInspection"/>
+                     implementationClass="com.intellij.codeInspection.RedundantCompareCallInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="RedundantClassCall" bundle="messages.InspectionGadgetsBundle"
                      key="inspection.redundant.class.call.display.name" groupBundle="messages.InspectionsBundle" groupKey="group.names.verbose.or.redundant.code.constructs"
                      enabledByDefault="true" level="WARNING" cleanupTool="true" implementationClass="com.siyeh.ig.redundancy.RedundantClassCallInspection"/>
@@ -2695,7 +2695,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="StringBufferReplaceableByString" bundle="messages.InspectionGadgetsBundle"
                      key="string.buffer.replaceable.by.string.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.verbose.or.redundant.code.constructs" enabledByDefault="true" level="WARNING"
-                     implementationClass="com.siyeh.ig.style.StringBufferReplaceableByStringInspection"/>
+                     implementationClass="com.siyeh.ig.style.StringBufferReplaceableByStringInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryBreak" bundle="messages.InspectionGadgetsBundle" key="unnecessary.break.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.verbose.or.redundant.code.constructs" enabledByDefault="true"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
@@ -2712,7 +2712,7 @@
                      key="unnecessary.label.on.break.statement.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.verbose.or.redundant.code.constructs" enabledByDefault="true" level="WARNING"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     implementationClass="com.siyeh.ig.controlflow.UnnecessaryLabelOnBreakStatementInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.UnnecessaryLabelOnBreakStatementInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="UnnecessaryLabelOnContinueStatement" bundle="messages.InspectionGadgetsBundle"
                      key="unnecessary.label.on.continue.statement.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.verbose.or.redundant.code.constructs" enabledByDefault="true" level="WARNING"
@@ -2722,15 +2722,15 @@
                      key="unnecessary.return.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.verbose.or.redundant.code.constructs" enabledByDefault="true" level="WARNING"
                      editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-                     implementationClass="com.siyeh.ig.controlflow.UnnecessaryReturnInspection"/>
+                     implementationClass="com.siyeh.ig.controlflow.UnnecessaryReturnInspection" cleanupTool="true"/>
 
     <!--group.names.visibility.issues-->
     <localInspection groupPath="Java" language="JAVA" shortName="AmbiguousMethodCall" bundle="messages.InspectionGadgetsBundle" key="ambiguous.method.call.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.visibility.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.visibility.AmbiguousMethodCallInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.visibility.AmbiguousMethodCallInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="AmbiguousFieldAccess" bundle="messages.InspectionGadgetsBundle" key="ambiguous.field.access.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.visibility.issues" enabledByDefault="false"
-                     level="WARNING" implementationClass="com.siyeh.ig.visibility.AmbiguousFieldAccessInspection"/>
+                     level="WARNING" implementationClass="com.siyeh.ig.visibility.AmbiguousFieldAccessInspection" cleanupTool="true"/>
     <localInspection groupPath="Java" language="JAVA" shortName="AnonymousClassVariableHidesContainingMethodVariable" bundle="messages.InspectionGadgetsBundle"
                      key="anonymous.class.variable.hides.containing.method.variable.display.name" groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.visibility.issues" enabledByDefault="false" level="WARNING"
@@ -2786,7 +2786,7 @@
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="PatternVariableCanBeUsed" enabledByDefault="true" level="WARNING"
                      bundle="messages.InspectionGadgetsBundle" key="inspection.pattern.variable.can.be.used.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.language.level.specific.issues.and.migration.aids15"
-                     implementationClass="com.intellij.codeInspection.PatternVariableCanBeUsedInspection"/>
+                     implementationClass="com.intellij.codeInspection.PatternVariableCanBeUsedInspection" cleanupTool="true"/>
     <localInspection groupPathKey="group.path.names.java.language.level.specific.issues.and.migration.aids" language="JAVA" shortName="VariableTypeCanBeExplicit" enabledByDefault="true" level="INFORMATION"
                      bundle="messages.InspectionGadgetsBundle" key="variable.type.can.be.explicit.display.name"
                      groupBundle="messages.InspectionsBundle" groupKey="group.names.language.level.specific.issues.and.migration.aids10"

--- a/plugins/InspectionGadgets/src/com/intellij/codeInspection/RedundantCompareCallInspection.java
+++ b/plugins/InspectionGadgets/src/com/intellij/codeInspection/RedundantCompareCallInspection.java
@@ -17,7 +17,7 @@ import com.siyeh.ig.psiutils.ParenthesesUtils;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
-public class RedundantCompareCallInspection extends AbstractBaseJavaLocalInspectionTool {
+public class RedundantCompareCallInspection extends AbstractBaseJavaLocalInspectionTool implements CleanupLocalInspectionTool {
   private static final CallMatcher COMPARE_METHODS = CallMatcher.anyOf(
     CallMatcher.staticCall(CommonClassNames.JAVA_LANG_INTEGER, "compare").parameterTypes("int", "int"),
     CallMatcher.staticCall(CommonClassNames.JAVA_LANG_LONG, "compare").parameterTypes("long", "long"),

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/classlayout/ProtectedMemberInFinalClassInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/classlayout/ProtectedMemberInFinalClassInspection.java
@@ -17,6 +17,7 @@ package com.siyeh.ig.classlayout;
 
 import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo;
 import com.intellij.codeInspection.BatchQuickFix;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonProblemDescriptor;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.progress.ProgressManager;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class ProtectedMemberInFinalClassInspection extends BaseInspection {
+public class ProtectedMemberInFinalClassInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   protected InspectionGadgetsFix @NotNull [] buildFixes(Object... infos) {

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/controlflow/PointlessBooleanExpressionInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/controlflow/PointlessBooleanExpressionInspection.java
@@ -16,6 +16,7 @@
 package com.siyeh.ig.controlflow;
 
 import com.intellij.codeInsight.BlockUtils;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.openapi.project.Project;
@@ -36,7 +37,7 @@ import javax.swing.*;
 import java.util.*;
 import java.util.function.Supplier;
 
-public class PointlessBooleanExpressionInspection extends BaseInspection {
+public class PointlessBooleanExpressionInspection extends BaseInspection implements CleanupLocalInspectionTool {
   private enum BooleanExpressionKind {
     USELESS, USELESS_WITH_SIDE_EFFECTS, UNKNOWN
   }

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/controlflow/SwitchStatementWithTooFewBranchesInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/controlflow/SwitchStatementWithTooFewBranchesInspection.java
@@ -17,6 +17,7 @@ package com.siyeh.ig.controlflow;
 
 import com.intellij.codeInsight.daemon.impl.quickfix.ConvertSwitchToIfIntention;
 import com.intellij.codeInsight.daemon.impl.quickfix.UnwrapSwitchLabelFix;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.SetInspectionOptionFix;
@@ -40,7 +41,7 @@ import javax.swing.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SwitchStatementWithTooFewBranchesInspection extends BaseInspection {
+public class SwitchStatementWithTooFewBranchesInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   private static final int DEFAULT_BRANCH_LIMIT = 2;
 

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/internationalization/ImplicitDefaultCharsetUsageInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/internationalization/ImplicitDefaultCharsetUsageInspection.java
@@ -2,6 +2,7 @@
 package com.siyeh.ig.internationalization;
 
 import com.intellij.codeInsight.intention.FileModifier.SafeTypeForPreview;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.module.LanguageLevelUtil;
 import com.intellij.openapi.project.Project;
@@ -32,7 +33,7 @@ import java.util.stream.Stream;
 /**
  * @author Bas Leijdekkers
  */
-public class ImplicitDefaultCharsetUsageInspection extends BaseInspection {
+public class ImplicitDefaultCharsetUsageInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   private static final List<String> UTF_8_ARG = Collections.singletonList("java.nio.charset.StandardCharsets.UTF_8");
   private static final List<String> FALSE_AND_UTF_8_ARG = Arrays.asList("false", "java.nio.charset.StandardCharsets.UTF_8");

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/javadoc/MissingPackageInfoInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/javadoc/MissingPackageInfoInspection.java
@@ -95,11 +95,11 @@ public class MissingPackageInfoInspection extends PackageGlobalInspection {
         @Override
         protected void doFix(Project project, ProblemDescriptor descriptor) {
           DataManager.getInstance()
-                     .getDataContextFromFocusAsync()
-                     .onSuccess(context -> {
-                       final AnActionEvent event = new AnActionEvent(null, context, "", new Presentation(), ActionManager.getInstance(), 0);
-                       new CreatePackageInfoAction().actionPerformed(event);
-                     });
+            .getDataContextFromFocusAsync()
+            .onSuccess(context -> {
+              final AnActionEvent event = new AnActionEvent(null, context, "", new Presentation(), ActionManager.getInstance(), 0);
+              new CreatePackageInfoAction().actionPerformed(event);
+            });
         }
       };
     }

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/junit/Junit4ConverterInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/junit/Junit4ConverterInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.junit;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -14,7 +15,7 @@ import com.siyeh.ig.InspectionGadgetsFix;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class Junit4ConverterInspection extends BaseInspection {
+public class Junit4ConverterInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @Override
   public boolean shouldInspect(@NotNull PsiFile file) {

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/junit/ParameterizedParametersStaticCollectionInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/junit/ParameterizedParametersStaticCollectionInspection.java
@@ -3,6 +3,7 @@ package com.siyeh.ig.junit;
 
 import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.daemon.impl.quickfix.CreateMethodQuickFix;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.project.Project;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class ParameterizedParametersStaticCollectionInspection extends BaseInspection {
+public class ParameterizedParametersStaticCollectionInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   protected static final String PARAMETERS_FQN = "org.junit.runners.Parameterized.Parameters";
 

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/logging/LoggerInitializedWithForeignClassInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/logging/LoggerInitializedWithForeignClassInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.logging;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ProblemHighlightType;
@@ -35,7 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 
-public class LoggerInitializedWithForeignClassInspection extends BaseInspection {
+public class LoggerInitializedWithForeignClassInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NonNls private static final String DEFAULT_FACTORY_CLASS_NAMES =
     // Log4J 1

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/logging/StringConcatenationArgumentToLogCallInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/logging/StringConcatenationArgumentToLogCallInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.logging;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
@@ -33,7 +34,7 @@ import java.util.Set;
 /**
  * @author Bas Leijdekkers
  */
-public class StringConcatenationArgumentToLogCallInspection extends BaseInspection {
+public class StringConcatenationArgumentToLogCallInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NonNls
   private static final Set<String> logNames = new HashSet<>();

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/migration/EnumerationCanBeIterationInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/migration/EnumerationCanBeIterationInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.migration;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -40,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class EnumerationCanBeIterationInspection extends BaseInspection {
+public class EnumerationCanBeIterationInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   static final int KEEP_NOTHING = 0;
   static final int KEEP_INITIALIZATION = 1;

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/performance/CallToSimpleGetterInClassInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/performance/CallToSimpleGetterInClassInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel;
 import com.intellij.psi.*;
 import com.intellij.psi.search.searches.OverridingMethodsSearch;
@@ -33,7 +34,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class CallToSimpleGetterInClassInspection extends BaseInspection {
+public class CallToSimpleGetterInClassInspection extends BaseInspection implements CleanupLocalInspectionTool {
   @SuppressWarnings("UnusedDeclaration")
   public boolean ignoreGetterCallsOnOtherObjects = false;
   @SuppressWarnings("UnusedDeclaration")

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/performance/CallToSimpleSetterInClassInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/performance/CallToSimpleSetterInClassInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.performance;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel;
 import com.intellij.psi.*;
 import com.intellij.psi.search.searches.OverridingMethodsSearch;
@@ -32,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class CallToSimpleSetterInClassInspection extends BaseInspection {
+public class CallToSimpleSetterInClassInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @SuppressWarnings("UnusedDeclaration")
   public boolean ignoreSetterCallsOnOtherObjects = false;

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCreationWithoutNewKeywordInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/style/ArrayCreationWithoutNewKeywordInspection.java
@@ -15,6 +15,7 @@
  */
 package com.siyeh.ig.style;
 
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
@@ -28,7 +29,7 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ArrayCreationWithoutNewKeywordInspection extends BaseInspection {
+public class ArrayCreationWithoutNewKeywordInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   @NotNull
   @Override

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/style/StringBufferReplaceableByStringInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/style/StringBufferReplaceableByStringInspection.java
@@ -2,6 +2,7 @@
 package com.siyeh.ig.style;
 
 import com.intellij.application.options.CodeStyle;
+import com.intellij.codeInspection.CleanupLocalInspectionTool;
 import com.intellij.codeInspection.CommonQuickFixBundle;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.lang.ASTNode;
@@ -39,7 +40,7 @@ import static com.intellij.util.ObjectUtils.tryCast;
 /**
  * @author Bas Leijdekkers
  */
-public class StringBufferReplaceableByStringInspection extends BaseInspection {
+public class StringBufferReplaceableByStringInspection extends BaseInspection implements CleanupLocalInspectionTool {
 
   static final String STRING_JOINER = "java.util.StringJoiner";
   private static final CallMatcher STRING_JOINER_ADD = CallMatcher.instanceCall(STRING_JOINER, "add").parameterCount(1);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/AmbiguousFieldAccess.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/AmbiguousFieldAccess.html
@@ -23,7 +23,7 @@ when in fact it is an access to a field from the superclass.
       }
     }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
     class First {
       protected String ambiguous;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/AmbiguousMethodCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/AmbiguousMethodCall.html
@@ -24,7 +24,7 @@ when in fact it is a call to a method from the superclass.
     }
   }
   </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   class Parent {
     void ambiguous(){}

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ArrayCreationWithoutNewKeyword.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ArrayCreationWithoutNewKeyword.html
@@ -5,7 +5,7 @@ Reports array initializers without <code>new</code> array expressions and sugges
 <pre><code>
   int[] a = {42}
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   int[] a = new int[]{42}
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ArraysAsListWithZeroOrOneArgument.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ArraysAsListWithZeroOrOneArgument.html
@@ -16,7 +16,7 @@ This may break the code in rare cases.</p>
   List&lt;String&gt; empty = Arrays.asList();
   List&lt;String&gt; one = Arrays.asList("one");
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   List&lt;String&gt; empty = Collections.emptyList();
   List&lt;String&gt; one = Collections.singletonList("one");

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/AssertEqualsCalledOnArray.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/AssertEqualsCalledOnArray.html
@@ -12,7 +12,7 @@ Array contents should be checked with the <code>assertArrayEquals()</code> metho
     Assert.assertEquals(<b>new int</b>[] {0, 56, 248, 496}, actual);
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   @Test
   <b>public void</b> testSort() {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/AssertEqualsMayBeAssertSame.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/AssertEqualsMayBeAssertSame.html
@@ -13,7 +13,7 @@ the <code>Object.equals()</code> method and makes it explicit that the object id
     Assert.assertEquals(String.<b>class</b>, o.getClass());
   }
 </code></pre>
-<p>After the quick fix is applied:</p>
+<p>After the cleanup/quick fix is applied:</p>
 <pre><code>
   @Test
   <b>public void</b> testSort() {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/BigDecimalEquals.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/BigDecimalEquals.html
@@ -5,7 +5,7 @@ Reports <code>.equals()</code> being called to compare two <code>java.math.BigDe
   they are equal in both value and scale.</p>
 <p><b>Example:</b></p>
 <pre><code>if (new BigDecimal("2.0").equals(new BigDecimal("2.00"))) {}</code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>if (new BigDecimal("2.0").compareTo(new BigDecimal("2.00")) == 0) {}</code></pre>
 <!-- tooltip end -->
 </body>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/BigDecimalLegacyMethod.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/BigDecimalLegacyMethod.html
@@ -4,7 +4,7 @@ Reports calls to <code>BigDecimal.divide()</code> or <code>BigDecimal.setScale()
 Since JDK 1.5, consider using methods that take the <code>RoundingMode</code> <code>enum</code> parameter instead.
 <p><b>Example:</b></p>
 <pre><code>new BigDecimal("42").setScale(2, BigDecimal.ROUND_FLOOR);</code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>new BigDecimal("42").setScale(2, RoundingMode.FLOOR);</code></pre>
 <!-- tooltip end -->
 <p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/BooleanConstructor.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/BooleanConstructor.html
@@ -11,7 +11,7 @@ Reports creation of <code>Boolean</code> objects.
   Boolean b1 = new Boolean(true);
   Boolean b2 = new Boolean(str);
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   Boolean b1 = Boolean.TRUE;
   Boolean b2 = Boolean.valueOf(str);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/BoxingBoxedValue.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/BoxingBoxedValue.html
@@ -13,7 +13,7 @@ Reports boxing of already boxed values.
   Integer value = 1;
   method(Integer.valueOf(value));
 </code></pre>
-<p>After the quick fix is applied:</p>
+<p>After the cleanup/quick fix is applied:</p>
 <pre><code>
   Integer value = 1;
   method(value);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/CachedNumberConstructorCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/CachedNumberConstructorCall.html
@@ -14,7 +14,7 @@ argument.
   Integer i = new Integer(1);
   Long l = new Long(1L);
 </code></pre>
-<p>After the quick-fix is applied, the code changes to:</p>
+<p>After the cleanup/quick-fix is applied, the code changes to:</p>
 <pre><code>
   Integer i = Integer.valueOf(1);
   Long l = Long.valueOf(1L);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/CallToSimpleGetterInClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/CallToSimpleGetterInClass.html
@@ -21,7 +21,7 @@ Reports calls to a simple property getter from within the property's class.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   public class Salient {
     private String name;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/CallToSimpleSetterInClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/CallToSimpleSetterInClass.html
@@ -18,7 +18,7 @@ Reports calls to a simple property setter from within the property's class.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   class Foo {
     private int index;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/CallToStringConcatCanBeReplacedByOperator.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/CallToStringConcatCanBeReplacedByOperator.html
@@ -10,7 +10,7 @@ Reports calls to <code>java.lang.String.concat()</code>.
     return name.concat("foo");
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   String foo(String name) {
     return name + "foo";

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/CollectionsFieldAccessReplaceableByMethodCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/CollectionsFieldAccessReplaceableByMethodCall.html
@@ -8,7 +8,7 @@ Such method calls prevent unchecked warnings by the compiler because the type pa
 <pre><code>
   List&lt;Integer&gt; emptyList = Collections.EMPTY_LIST;
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   List&lt;Integer&gt; emptyList = Collections.emptyList();
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ComparatorNotSerializable.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ComparatorNotSerializable.html
@@ -21,7 +21,7 @@ but do not implement <code>java.io.Serializable</code>.
       }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   class Foo implements Comparator, Serializable { // no warning here
       @Override

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ConfusingElse.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ConfusingElse.html
@@ -15,7 +15,7 @@ the statements from the <code>else</code> branch can be placed after the <code>i
       System.out.println(name);
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   if (name == null) {
       throw new IllegalArgumentException();

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ConfusingFloatingPointLiteral.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ConfusingFloatingPointLiteral.html
@@ -5,7 +5,7 @@ or numbers after the decimal point.
 <p>Such literals may be confusing, and violate several coding standards.</p>
 <p><b>Example:</b></p>
 <pre><code>double d = .03;</code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>double d = 0.03;</code></pre>
 <!-- tooltip end -->
 <p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ConstantConditionalExpression.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ConstantConditionalExpression.html
@@ -6,7 +6,7 @@ These expressions sometimes occur as a result of automatic refactorings and may 
 <pre><code>
   return true ? "Yes" : "No";
 </code></pre>
-<p>After quick-fix is applied:</p>
+<p>After cleanup/quick-fix is applied:</p>
 <pre><code>
   return "Yes";
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ConstantMathCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ConstantMathCall.html
@@ -3,7 +3,7 @@
 Reports calls to <code>java.lang.Math</code> or <code>java.lang.StrictMath</code> methods that can be determined as simple compile-time constants.
 <p><b>Example:</b></p>
 <pre><code>double v = Math.sin(0.0);</code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>double v = 0.0;</code></pre>
 <!-- tooltip end -->
 </body>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ConstantOnWrongSideOfComparison.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ConstantOnWrongSideOfComparison.html
@@ -8,7 +8,7 @@ Reports comparison operations where the constant value is on the wrong side.
     return 1 &gt; x; // Constant '1' on the left side of the comparison
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   boolean compare(int x) {
     return x &lt; 1;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ControlFlowStatementWithoutBraces.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ControlFlowStatementWithoutBraces.html
@@ -27,7 +27,7 @@ require braces for all control statements.
     void bar() {}
   }
 </code></pre>
-<p>The quick-fix wraps the statement body with braces:</p>
+<p>The cleanup/quick-fix wraps the statement body with braces:</p>
 <pre><code>
   class Strange {
     void x(boolean one, boolean two) {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/DefaultNotLastCaseInSwitch.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/DefaultNotLastCaseInSwitch.html
@@ -3,7 +3,7 @@
 Reports <code>switch</code> statements or expressions in which the <code>default</code> case
 comes before another case.
 <p>This construct is unnecessarily confusing.
-There is a quick-fix that moves the <code>default</code> case to the last position.
+There is a cleanup/quick-fix that moves the <code>default</code> case to the last position.
   The fix is available only when a given branch has <code>break</code>/<code>yield</code> at the end.</p>
 <p>Example:</p>
 <pre><code>
@@ -15,7 +15,7 @@ There is a quick-fix that moves the <code>default</code> case to the last positi
           break;
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   switch (n) {
     case 1:

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/DoubleBraceInitialization.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/DoubleBraceInitialization.html
@@ -17,7 +17,7 @@ Reports <a href="https://www.c2.com/cgi/wiki?DoubleBraceInitialization">Double B
     add(2);
   }};
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   List&lt;Integer&gt; list = new ArrayList&lt;&gt;();
   list.add(1);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/DoubleLiteralMayBeFloatLiteral.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/DoubleLiteralMayBeFloatLiteral.html
@@ -4,7 +4,7 @@ Reports <code>double</code> literal expressions that are immediately cast to <co
 <p>Such literal expressions can be replaced with equivalent <code>float</code> literals.</p>
 <p><b>Example:</b></p>
 <pre><code>float f = (float)1.1;</code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>float f = 1.1f;</code></pre>
 <!-- tooltip end -->
 </body>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/DoubleNegation.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/DoubleNegation.html
@@ -5,7 +5,7 @@ Reports double negations that can be simplified.
 <pre><code>
   if (!!functionCall()) {}
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   if (functionCall()) {}
 </code></pre>
@@ -13,7 +13,7 @@ Reports double negations that can be simplified.
 <pre><code>
   if (!(a != b)) {}
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   if (a == b) {}
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/EmptyFinallyBlock.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/EmptyFinallyBlock.html
@@ -13,7 +13,7 @@ Reports empty <code>finally</code> blocks.
 
   }
 </code></pre>
-<p>After the quick-fix is applied:
+<p>After the cleanup/quick-fix is applied:
 <pre><code>
   try {
     Files.readString(Paths.get("in.txt"));

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/EnumerationCanBeIteration.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/EnumerationCanBeIteration.html
@@ -8,7 +8,7 @@ Reports calls to <code>Enumeration</code> methods that are used on collections a
     String name = keys.nextElement();
   }</code>
 </pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>Iterator&lt;String&gt; iterator = map.keySet().iterator();
   while (iterator.hasNext()) {
     String name = iterator.next();

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/EqualsCalledOnEnumConstant.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/EqualsCalledOnEnumConstant.html
@@ -3,14 +3,14 @@
 Reports <code>equals()</code> calls on enum constants.
 <p>Such calls can be replaced by an identity comparison (<code>==</code>) because two
   enum constants are equal only when they have the same identity.</p>
-<p>A quick-fix is available to change the call to a comparison.</p>
+<p>A cleanup and a quick-fix are available to change the call to a comparison.</p>
 <p><b>Example:</b></p>
 <pre><code>
   boolean foo(MyEnum value) {
     return value.equals(MyEnum.FOO);
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   boolean foo(MyEnum value) {
     return value == MyEnum.FOO;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/EqualsReplaceableByObjectsCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/EqualsReplaceableByObjectsCall.html
@@ -7,7 +7,7 @@ Reports expressions that can be replaced with a call to <code>java.util.Objects#
     boolean result = a != null && a.equals(b);
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   void f(Object a, Object b) {
     boolean result = Objects.equals(a, b);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ExpressionMayBeFactorized.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ExpressionMayBeFactorized.html
@@ -7,7 +7,7 @@ This reduces redundancy and could improve the readability of your code.
 <pre><code>
   a &amp;&amp; b || a &amp;&amp; c
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   a &amp;&amp; (b || c)
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ExtendsObject.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ExtendsObject.html
@@ -7,7 +7,7 @@ Reports any classes that are explicitly declared to extend <code>java.lang.Objec
   class MyClass extends Object {
   }
 </code></pre>
-<p>The quick-fix removes the redundant <code>extends Object</code> clause:</p>
+<p>The cleanup/quick-fix removes the redundant <code>extends Object</code> clause:</p>
 <pre><code>
   class MyClass {
   }

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/FinalMethodInFinalClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/FinalMethodInFinalClass.html
@@ -11,7 +11,7 @@ Reports <code>final</code> methods in <code>final</code> classes.
 }
 </code>
 </pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>record Bar(int a, int b) {
   public int sum() { 
      return a + b;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/FinalizeNotProtected.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/FinalizeNotProtected.html
@@ -8,7 +8,7 @@ declared <code>public</code>.
   means that the method can be used by users.
 </p>
 <p>
-  The quick-fix makes the method protected to prevent it from being explicitly invoked
+  The cleanup/quick-fix makes the method protected to prevent it from being explicitly invoked
   by other classes.
 </p>
 <!-- tooltip end -->
@@ -20,7 +20,7 @@ declared <code>public</code>.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   <b>class</b> X {
     <b>protected void</b> finalize() {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ForLoopReplaceableByWhile.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ForLoopReplaceableByWhile.html
@@ -8,13 +8,13 @@ loops. This makes the code easier to read.
     process();
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   while(exitCondition()) {
     process();
   }
 </code></pre>
-<p>The quick-fix is also available for other <code>for</code> loops, so you can replace any <code>for</code> loop with a
+<p>The cleanup/quick-fix is also available for other <code>for</code> loops, so you can replace any <code>for</code> loop with a
   <code>while</code> loop.</p>
 <!-- tooltip end -->
 <p>Use the <b>Ignore 'infinite' for loops without conditions</b> option if you want to ignore <code>for</code>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/HtmlTagCanBeJavadocTag.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/HtmlTagCanBeJavadocTag.html
@@ -10,7 +10,7 @@ This allows using angle brackets <code>&lt;</code> and <code>&gt;</code> inside 
    */
   List&lt;Integer&gt; getList(){ ... }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   /**
    * @return empty {@code ArrayList&lt;Integer&gt;}

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/IfStatementMissingBreakInLoop.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/IfStatementMissingBreakInLoop.html
@@ -11,7 +11,7 @@ This prevents redundant loop iterations.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   boolean found = false;
   for (int i = 0; i &lt; arr.length; i++) {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ImplicitDefaultCharsetUsage.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ImplicitDefaultCharsetUsage.html
@@ -7,7 +7,7 @@ systems that use different default charsets. It might result in unexpected behav
   String s = new String(bytes);
 }</code>
 </pre>
-<p>You can use a quick-fix that specifies the explicit UTF-8 charset if the corresponding overloaded method is available.
+<p>You can use a cleanup/quick-fix that specifies the explicit UTF-8 charset if the corresponding overloaded method is available.
   After the quick-fix is applied:</p>
 <pre><code>void foo(byte[] bytes) {
   String s = new String(bytes, StandardCharsets.UTF_8);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/IncrementDecrementUsedAsExpression.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/IncrementDecrementUsedAsExpression.html
@@ -2,7 +2,7 @@
 <body>
 Reports increment or decrement expressions that are nested inside other expressions.
 Such expressions may be confusing and violate the general design principle, which states that any construct should do precisely one thing.
-<p>The quick-fix extracts the increment or decrement operation to a separate expression statement.</p>
+<p>The cleanup/quick-fix extracts the increment or decrement operation to a separate expression statement.</p>
 <p><b>Example:</b></p>
 <pre><code>
   int i = 10;
@@ -10,7 +10,7 @@ Such expressions may be confusing and violate the general design principle, whic
     System.out.println(i);
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   int i = 10;
   while (i > 0) {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/InnerClassReferencedViaSubclass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/InnerClassReferencedViaSubclass.html
@@ -17,7 +17,7 @@ by a subclass of the declaring class, rather than the declaring class itself.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   class Super {
     static class Inner {}

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/IntLiteralMayBeLongLiteral.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/IntLiteralMayBeLongLiteral.html
@@ -4,7 +4,7 @@ Reports <code>int</code> literal expressions that are immediately cast to <code>
 <p>Such literal expressions can be replaced with equivalent <code>long</code> literals.</p>
 <p><b>Example:</b></p>
 <pre><code>Long l = (long)42;</code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>Long l = 42L;</code></pre>
 <!-- tooltip end -->
 </body>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/IntegerMultiplicationImplicitCastToLong.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/IntegerMultiplicationImplicitCastToLong.html
@@ -7,7 +7,7 @@ Reports integer multiplications and left shifts that are implicitly cast to long
     long val = 65536 * i;
   }
 </code></pre>
-<p>After the quick-fix is applied, the code changes to:</p>
+<p>After the cleanup/quick-fix is applied, the code changes to:</p>
 <pre><code>
   void x(int i) {
     long val = 65536<b>L</b> * i;
@@ -19,7 +19,7 @@ Reports integer multiplications and left shifts that are implicitly cast to long
     long value = i &lt;&lt; 24;
   }
 </code></pre>
-<p>After the quick-fix is applied, the code changes to:</p>
+<p>After the cleanup/quick-fix is applied, the code changes to:</p>
 <pre><code>
   void f(int i) {
     long value = (long) i &lt;&lt; 24;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/Junit4Converter.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/Junit4Converter.html
@@ -9,7 +9,7 @@ Reports JUnit 3 test classes that can be converted to JUnit 4 test classes.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   public class MainTestCase {
     @org.junit.Test

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LengthOneStringInIndexOf.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LengthOneStringInIndexOf.html
@@ -7,7 +7,7 @@ Reports single character strings being used as an argument in <code>String.index
 <pre><code>
   return s.indexOf("x");
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   return s.indexOf('x');
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LengthOneStringsInConcatenation.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LengthOneStringsInConcatenation.html
@@ -6,7 +6,7 @@ Reports concatenation with string literals that consist of one character.
 <pre><code>
   String hello = hell + "o";
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   String hello = hell + 'o';
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ListIndexOfReplaceableByContains.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ListIndexOfReplaceableByContains.html
@@ -10,10 +10,10 @@ expressions that can be replaced with the
     return list.indexOf("") &gt;= 0;
   }
 </code></pre>
-<p>The provided quick-fix replaces the <code>indexOf</code> call with the <code>contains</code> call:</p>
+<p>The provided cleanup/quick-fix replaces the <code>indexOf</code> call with the <code>contains</code> call:</p>
 <pre><code>
   boolean hasEmptyString(List&lt;String&gt; list) {
-    // Quick-fix is applied
+    // Cleanup/quick-fix is applied
     return list.contains("");
   }
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LiteralAsArgToStringEquals.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LiteralAsArgToStringEquals.html
@@ -4,14 +4,14 @@ Reports <code>String.equals()</code> or <code>String.equalsIgnoreCase()</code> c
 with a string literal argument.
 <p>Some coding standards specify that string literals should be the qualifier of <code>equals()</code>, rather than
   argument, thus minimizing <code>NullPointerException</code>-s.</p>
-<p>A quick-fix is available to exchange the literal and the expression.</p>
+<p>A cleanup and a quick-fix are available to exchange the literal and the expression.</p>
 <p><b>Example:</b></p>
 <pre><code>
   boolean isFoo(String value) {
     return value.equals("foo");
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   boolean isFoo(String value) {
     return "foo".equals(value);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LoggerInitializedWithForeignClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LoggerInitializedWithForeignClass.html
@@ -3,7 +3,7 @@
 Reports <code>Logger</code> instances that are initialized with a <code>class</code> literal from a different class than the <code>Logger</code>
 is contained in. This can easily happen when copy-pasting some code from another class and
 may result in logging events under an unexpected category and cause filters to be applied incorrectly.
-<p>A quick-fix is provided to replace the foreign class literal with one from the surrounding class.</p>
+<p>A cleanup/quick-fix is provided to replace the foreign class literal with one from the surrounding class.</p>
 <p><b>Example:</b></p>
 <pre><code>
   <b>public class</b> Paramount {
@@ -12,7 +12,7 @@ may result in logging events under an unexpected category and cause filters to b
     // ... other fields and methods
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   <b>public class</b> Paramount {
     <b>protected static final</b> Logger LOG = Logger.getLogger(Paramount.class);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LongLiteralsEndingWithLowercaseL.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LongLiteralsEndingWithLowercaseL.html
@@ -2,7 +2,7 @@
 <body>
 Reports <code>long</code> literals ending with lowercase 'l'. These
 literals may be confusing, as lowercase 'l' looks very similar to '1'.
-<p>The quick-fix for this inspection replaces lowercase 'l' with uppercase 'L'.</p>
+<p>The cleanup/quick-fix for this inspection replaces lowercase 'l' with uppercase 'L'.</p>
 <!-- tooltip end -->
 </body>
 </html>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ManualArrayCopy.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ManualArrayCopy.html
@@ -7,7 +7,7 @@ Reports manual copying of array contents that can be replaced with a call to <co
     newArray[i] = array[i];
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   System.arraycopy(array, 0, newArray, 0, array.length);
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ManualArrayToCollectionCopy.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ManualArrayToCollectionCopy.html
@@ -15,7 +15,7 @@ Reports code that uses a loop to copy the contents of an array into a collection
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   void addAll(List&lt;String&gt; list, String[] arr) {
     Collections.addAll(list, arr);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/MisorderedAssertEqualsArguments.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/MisorderedAssertEqualsArguments.html
@@ -7,13 +7,13 @@ Reports calls to <code>assertEquals()</code> that have the expected argument and
 </p>
 <p>
   Such calls will behave fine for assertions that pass, but may give confusing error reports on failure.
-  Use the quick-fix to flip the order of the arguments.
+  Use the cleanup/quick-fix to flip the order of the arguments.
 </p>
 <p><b>Example (JUnit):</b></p>
 <pre><code>
   assertEquals(actual, expected)
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   assertEquals(expected, actual)
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/MissingDeprecatedAnnotation.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/MissingDeprecatedAnnotation.html
@@ -9,7 +9,7 @@ Javadoc tag but do not have the <code>@java.lang.Deprecated</code> annotation.
    */
   void sample(){ }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   /**
    * @deprecated use {@code example()} instead

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/MultipleExceptionsDeclaredOnTestMethod.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/MultipleExceptionsDeclaredOnTestMethod.html
@@ -13,7 +13,7 @@ Test methods will not be called from other project code, so there is no need to 
     assertEquals("hello", result);
   }
 </code></pre>
-<p>A quick fix is provided to replace the exception declarations with a single exception:</p>
+<p>A cleanup/quick-fix is provided to replace the exception declarations with a single exception:</p>
 <pre><code>
   @Test
   <b>public void</b> testReflection() <b>throws</b> Exception {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/MultiplyOrDivideByPowerOfTwo.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/MultiplyOrDivideByPowerOfTwo.html
@@ -12,7 +12,7 @@ for a possible performance improvement.
 <pre><code>
   int y = x * 4;
 </code></pre>
-<p>A quick-fix is suggested to replace the multiplication or division operation with the shift operation:</p>
+<p>A cleanup/quick-fix is suggested to replace the multiplication or division operation with the shift operation:</p>
 <pre><code>
   int y = x &lt;&lt; 2;
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/NegatedEqualityExpression.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/NegatedEqualityExpression.html
@@ -6,7 +6,7 @@ Reports equality expressions which are negated by a prefix expression.
 <pre><code>
   !(i == 1)
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   i != 1
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/NonProtectedConstructorInAbstractClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/NonProtectedConstructorInAbstractClass.html
@@ -5,7 +5,7 @@ Reports <code>public</code> constructors of <code>abstract</code> classes.
   Constructors of <code>abstract</code> classes can only be called from the constructors of
   their subclasses, declaring them <code>public</code> may be confusing.
 </p>
-<p>The quick-fix makes such constructors protected.</p>
+<p>The cleanup/quick-fix makes such constructors protected.</p>
 <p><b>Example:</b></p>
 <pre><code>
   <b>public abstract class</b> Foo {
@@ -14,7 +14,7 @@ Reports <code>public</code> constructors of <code>abstract</code> classes.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   <b>public abstract class</b> Foo {
     <b>protected</b> Foo () {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/PackageDotHtmlMayBePackageInfo.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/PackageDotHtmlMayBePackageInfo.html
@@ -2,7 +2,7 @@
 <body>
 Reports any <code>package.html</code> files which are used for documenting packages.
 <p>Since JDK 1.5, it is recommended that you use <code>package-info.java</code> files instead, as such
-files can also contain package annotations. This way, package-info.java becomes a
+  files can also contain package annotations. This way, package-info.java becomes a
   sole repository for package level annotations and documentation.</p>
 <p>Example: <code>package.html</code></p>
 <pre><code>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ParameterizedParametersStaticCollection.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ParameterizedParametersStaticCollection.html
@@ -22,7 +22,7 @@ The data provider method should be <code>public</code> and <code>static</code> a
     // ... test cases
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   @RunWith(Parameterized.class)
   <b>public class</b> ImportantTest {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessArithmeticExpression.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessArithmeticExpression.html
@@ -3,7 +3,7 @@
 Reports pointless arithmetic expressions. Such expressions include adding or subtracting zero,
 multiplying by zero or one, and division by one.
 <p>Such expressions may be the result of automated refactorings and they are unlikely to be what the developer intended to do.</p>
-<p>The quick-fix simplifies such expressions.</p>
+<p>The cleanup/quick-fix simplifies such expressions.</p>
 <p><b>Example:</b>
 <pre><code>
   void f(int a) {
@@ -12,7 +12,7 @@ multiplying by zero or one, and division by one.
     int res = x / x;
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   void f(int a) {
     int x = 0;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessBooleanExpression.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessBooleanExpression.html
@@ -10,7 +10,7 @@ Reports unnecessary or overly complicated boolean expressions.
   <b>boolean</b> b = <b>false</b> || x;
   <b>boolean</b> c = x != <b>true</b>;
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   <b>boolean</b> a = <b>true</b>;
   <b>boolean</b> b = x;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessNullCheck.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/PointlessNullCheck.html
@@ -7,7 +7,7 @@ Reports null checks followed by a method call that will definitely return
 <pre><code>
   if (x != null && myClass.isInstance(x)) { ... }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   if (myClass.isInstance(x)) { ... }
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ProtectedMemberInFinalClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ProtectedMemberInFinalClass.html
@@ -11,7 +11,7 @@ Reports <code>protected</code> members in <code>final</code>classes.
 }
 </code>
 </pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>record Bar(int a, int b) {
   int sum() { 
      return a + b;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/RandomDoubleForRandomInteger.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/RandomDoubleForRandomInteger.html
@@ -14,7 +14,7 @@ the call by a factor and casting to an integer.
   }
   </code>
 </pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   int getRandomInt() {
     return (new Random()).nextInt(SIZE);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/RedundantStringFormatCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/RedundantStringFormatCall.html
@@ -5,7 +5,7 @@ Reports calls to methods like <code>format()</code> and <code>printf()</code> th
 <pre><code>
   System.out.println(String.format("Total count: %d", 42));
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   System.out.printf("Total count: %d%n", 42);
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/ReplaceAssignmentWithOperatorAssignment.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/ReplaceAssignmentWithOperatorAssignment.html
@@ -6,7 +6,7 @@ Reports assignment operations which can be replaced by operator-assignment.
 <pre><code>  x = x + 3;
   x = x / 3;
 </code></pre>
-<p>After the quick fix is applied:</p>
+<p>After the cleanup/quick fix is applied:</p>
 <pre><code>  x += 3;
   x /= 3;
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/SimplifiableIfStatement.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/SimplifiableIfStatement.html
@@ -2,12 +2,12 @@
 <body>
 Reports <code>if</code> statements that can be replaced with conditions using the <code>&&</code>, <code>||</code>,
 <code>==</code>, <code>!=</code>, or <code>?:</code> operator.
-<p>The result is usually shorter, but not always clearer, so it's not advised to apply the fix  in every case.</p>
+<p>The result is usually shorter, but not always clearer, so it's not advised to apply the fix in every case.</p>
 <p>Example:</p>
 <pre><code>
   if (condition) return true; else return foo;
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   return condition || foo;
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/StringBufferReplaceableByString.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/StringBufferReplaceableByString.html
@@ -16,7 +16,7 @@ performance drawback on modern JVMs. In many cases, <code>String</code> concaten
   result.append(";");
   return result.toString();
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   String result = "i = " + i + ";";
   return result;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/StringConcatenationArgumentToLogCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/StringConcatenationArgumentToLogCall.html
@@ -14,7 +14,7 @@ It is recommended to use a parameterized log message instead, which will not be 
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   <b>public class</b> Vital {
     <b>private static final</b> Logger LOG = LoggerFactory.getLogger(Vital.class);

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/SwitchStatementWithTooFewBranches.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/SwitchStatementWithTooFewBranches.html
@@ -9,7 +9,7 @@ and <code>else if</code> statements.
     case "bar" -&gt; bar();
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   if ("foo".equals(expression)) {
     foo();

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/TailRecursion.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/TailRecursion.html
@@ -16,7 +16,7 @@ Reports tail recursion, that is, when a method calls itself as its last action b
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   int factorial(int val, int runningVal) {
     while (true) {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/TransientFieldInNonSerializableClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/TransientFieldInNonSerializableClass.html
@@ -7,7 +7,7 @@ Reports <code>transient</code> fields in classes that do not implement <code>jav
     private transient String password;
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   public class NonSerializableClass {
     private String password;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/TrivialStringConcatenation.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/TrivialStringConcatenation.html
@@ -12,7 +12,7 @@ an idiom for formatting non-<code>String</code> objects or primitives into <code
     String s = "" + x + " ; " + y;
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   void foo(int x, int y) {
     String s = x + " ; " + y;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/TryWithIdenticalCatches.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/TryWithIdenticalCatches.html
@@ -15,7 +15,7 @@ Reports identical <code>catch</code> sections in a single <code>try</code> state
         LOG.error(e);
     }
 </code></pre>
-<p>A quick-fix is available to make the code more compact:</p>
+<p>A cleanup/quick-fix is available to make the code more compact:</p>
 <pre><code>
     try {
         doSmth();

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/TypeParameterExtendsFinalClass.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/TypeParameterExtendsFinalClass.html
@@ -9,7 +9,7 @@ Reports type parameters declared to extend a <code>final</code> class.
     List&lt;? <b>extends</b> Integer&gt; list; // Warning: the Integer class is a final class
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   <b>void</b> foo() {
     List&lt;Integer&gt; list;

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnclearBinaryExpression.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnclearBinaryExpression.html
@@ -6,7 +6,7 @@ without parentheses. Such expressions can be less readable due to different prec
 <pre><code>
   int n = 3 + 9 * 8 + 1;
 </code></pre>
-<p>After quick-fix is applied:</p>
+<p>After cleanup/quick-fix is applied:</p>
 <pre><code>
   int n = 3 + (9 * 8) + 1;
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryEmptyArrayUsage.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryEmptyArrayUsage.html
@@ -15,7 +15,7 @@ As zero-length arrays are immutable, you can save memory reusing the same array 
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   class EmptyNode {
     Item[] getChildren() {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryExplicitNumericCast.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryExplicitNumericCast.html
@@ -4,7 +4,7 @@ Reports primitive numeric casts that would be inserted implicitly by the compile
 Also, reports any primitive numeric casts that the compiler will remove.
 <p><b>Example:</b></p>
 <pre><code>int x = (short)5; // The cast will be removed by the javac tool</code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <code>int x = 5;</code>
 <!-- tooltip end -->
 <p>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryInheritDoc.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryInheritDoc.html
@@ -17,7 +17,7 @@ comment containing only <code>{@inheritDoc}</code> adds nothing.
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   class Example implements Comparable&lt;Example&gt; {
     @Override

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryJavaDocLink.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryJavaDocLink.html
@@ -4,8 +4,8 @@ Reports Javadoc <code>@see</code>,
 <code>{@link}</code>, and <code>{@linkplain}</code>
 tags that refer to the method owning the comment, the super method of the
 method owning the comment, or the class containing the comment.
-<p>Such links are unnecessary and can be safely removed with this inspection's quick-fix. The
-  quick-fix will remove the entire Javadoc comment if the tag is its only content.</p>
+<p>Such links are unnecessary and can be safely removed with this inspection's cleanup/quick-fix. The
+  fix will remove the entire Javadoc comment if the tag is its only content.</p>
 <p><b>Example:</b></p>
 <pre><code>
   class Example {
@@ -15,7 +15,7 @@ method owning the comment, or the class containing the comment.
     public void method() { }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
 class Example {
   public void method() { }

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryLabelOnBreakStatement.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryLabelOnBreakStatement.html
@@ -10,7 +10,7 @@ control flow but make the code difficult to follow.
     //doSmth
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   label:
   for(int i = 0; i &lt; 10; i++) {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryReturn.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryReturn.html
@@ -10,7 +10,7 @@ Reports <code>return</code> statements at the end of constructors and methods re
     <b>return</b>;
   }
 </code></pre>
-<p>After the quick-fix is applied:
+<p>After the cleanup/quick-fix is applied:
 <pre><code>
   <b>void</b> message() {
     System.out.println("Hello World");

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryTemporaryOnConversionFromString.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryTemporaryOnConversionFromString.html
@@ -6,7 +6,7 @@ from <code>String</code> to primitive types.
 <pre><code>
   new Integer("3").intValue()
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   Integer.valueOf("3")
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryTemporaryOnConversionToString.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryTemporaryOnConversionToString.html
@@ -6,7 +6,7 @@ from a primitive type to <code>String</code>.
 <pre><code>
   String foo = new Integer(3).toString();
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   String foo = Integer.toString(3);
 </code></pre>

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnpredictableBigDecimalConstructorCall.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnpredictableBigDecimalConstructorCall.html
@@ -16,7 +16,7 @@ However, because doubles are encoded in the IEEE 754 64-bit double-precision bin
     }
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   class Constructor {
     void foo() {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnusedLabel.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnusedLabel.html
@@ -9,7 +9,7 @@ Reports labels that are not targets of any <code>break</code> or <code>continue<
     }
   }
 </code></pre>
-<p>After the quick-fix is applied, the label is removed:</p>
+<p>After the cleanup/quick-fix is applied, the label is removed:</p>
 <pre><code>
   <b>for</b> (int i = 0; i &lt; 10; i++) {
     <b>if</b> (i == 3) {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UseOfObsoleteAssert.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UseOfObsoleteAssert.html
@@ -12,7 +12,7 @@ obsolete and the calls can be replaced by calls to methods from the <code>org.ju
     }
   }
 </code></pre>
-<p>After the quick fix is applied, the result looks like the following:</p>
+<p>After the cleanup/quick-fix is applied, the result looks like the following:</p>
 <pre><code>
   <b>import</b> org.junit;
   <b>public class</b> NecessaryTest {

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UseOfPropertiesAsHashtable.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UseOfPropertiesAsHashtable.html
@@ -24,7 +24,7 @@ Reports calls to the following methods on <code>java.util.Properties</code> obje
     return props.get("Hello");
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   Object f(Properties props) {
     props.setProperty("hello", "world");

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UtilityClassCanBeEnum.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UtilityClassCanBeEnum.html
@@ -9,7 +9,7 @@ Reports utility classes that can be converted to enums.
     public static final String EMPTY = "";
   }
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the cleanup/quick-fix is applied:</p>
 <pre><code>
   enum StringUtils {
     ;


### PR DESCRIPTION
Hi @BasLeijdekkers,

This ticket turns 89 quickfixes into cleanups like we did for `DoubleNegationInspection`. We select an inspection only if:
1. There is only one quickfix at a time
2. No quickfix requires further information from the user like an identifier name (variable, parameter, class, package name)
3. The quickfix is safe to apply for any cases
4. The quickfix is not an actual preparation for further refactoring (for example: convert a method reference to an anonymous class to easily edit it)
5. The quickfix is not a downgrade
6. A cleanup should not be the opposite rule of another cleanup (those inspections will be handled later)

The new cleanups are:
1. `AmbiguousFieldAccess`
1. `AmbiguousMethodCall`
1. `ArrayCreationWithoutNewKeyword`
1. `ArraysAsListWithZeroOrOneArgument`
1. `AssertEqualsCalledOnArray`
1. `AssertEqualsMayBeAssertSame`
1. `BigDecimalEquals`
1. `BigDecimalLegacyMethod`
1. `BooleanConstructor`
1. `BoxingBoxedValue`
1. `CachedNumberConstructorCall`
1. `CallToSimpleGetterInClass`
1. `CallToSimpleSetterInClass`
1. `CallToStringConcatCanBeReplacedByOperator`
1. `CollectionsFieldAccessReplaceableByMethodCall`
1. `ComparatorNotSerializable`
1. `ConfusingElseInspection`
1. `ConfusingFloatingPointLiteral`
1. `ConstantConditionalExpression`
1. `ConstantMathCall`
1. `ConstantOnWrongSideOfComparison`
1. `ControlFlowStatementWithoutBracesInspection`
1. `DefaultNotLastCaseInSwitch`
1. `DoubleBraceInitialization`
1. `DoubleLiteralMayBeFloatLiteral`
1. `EmptyFinallyBlock`
1. `EnumerationCanBeIteration`
1. `EqualsCalledOnEnumConstant`
1. `EqualsReplaceableByObjectsCall`
1. `ExpressionMayBeFactorized`
1. `ExtendsObject`
1. `FinalizeNotProtected`
1. `FinalMethodInFinalClass`
1. `ForLoopReplaceableByWhile`
1. `HtmlTagCanBeJavadocTag`
1. `IfStatementMissingBreakInLoop`
1. `ImplicitDefaultCharsetUsage`
1. `IncrementDecrementUsedAsExpression`
1. `InnerClassReferencedViaSubclass`
1. `IntegerMultiplicationImplicitCastToLong`
1. `IntLiteralMayBeLongLiteral`
1. `Junit4Converter`
1. `LengthOneStringInIndexOf`
1. `LengthOneStringsInConcatenation`
1. `ListIndexOfReplaceableByContains`
1. `LiteralAsArgToStringEquals`
1. `LoggerInitializedWithForeignClass`
1. `LongLiteralsEndingWithLowercaseL`
1. `ManualArrayCopy`
1. `ManualArrayToCollectionCopy`
1. `MisorderedAssertEqualsArguments`
1. `MissingDeprecatedAnnotation`
1. `MultipleExceptionsDeclaredOnTestMethod`
1. `MultiplyOrDivideByPowerOfTwo`
1. `NegatedEqualityExpression`
1. `NonProtectedConstructorInAbstractClass`
1. `ParameterizedParametersStaticCollection`
1. `PointlessArithmeticExpression`
1. `PointlessBooleanExpression`
1. `PointlessNullCheck`
1. `ProtectedMemberInFinalClass`
1. `RandomDoubleForRandomInteger`
1. `RedundantStringFormatCall`
1. `ReplaceAssignmentWithOperatorAssignment`
1. `SimplifiableAssertion`
1. `SimplifiableIfStatement`
1. `StringBufferReplaceableByString`
1. `StringConcatenationArgumentToLogCall`
1. `SwitchStatementWithTooFewBranches`
1. `TailRecursion`
1. `TransientFieldInNonSerializableClass`
1. `TrivialStringConcatenation`
1. `TryWithIdenticalCatches`
1. `TypeParameterExtendsFinalClass`
1. `UnclearBinaryExpressionInspection`
1. `UnnecessaryEmptyArrayUsage`
1. `UnnecessaryExplicitNumericCast`
1. `UnnecessaryInheritDoc`
1. `UnnecessaryJavaDocLink`
1. `UnnecessaryLabelOnBreakStatement`
1. `UnnecessaryReturn`
1. `UnnecessaryTemporaryOnConversionFromString`
1. `UnnecessaryTemporaryOnConversionToString`
1. `UnpredictableBigDecimalConstructorCall`
1. `UnusedLabel`
1. `UseOfObsoleteAssert`
1. `UseOfPropertiesAsHashtable`
1. `UtilityClassCanBeEnum`
1. `RedundantCompareCall`

All the new cleanups have been successfully tested as a cleanup.