### PR TITLE
Java UAST: internalize Java UAST elements

### DIFF
--- a/uast/uast-java/src/org/jetbrains/uast/java/JavaAbstractUElement.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/JavaAbstractUElement.kt
@@ -5,11 +5,14 @@ package org.jetbrains.uast.java
 import com.intellij.lang.Language
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.psi.*
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.internal.JavaUElementWithComments
 
-
-abstract class JavaAbstractUElement(givenParent: UElement?) : JavaUElementWithComments, UElement {
+@ApiStatus.Internal
+abstract class JavaAbstractUElement(
+  givenParent: UElement?
+) : JavaUElementWithComments, UElement {
 
   override fun equals(other: Any?): Boolean {
     if (other !is UElement || other.javaClass != this.javaClass) return false
@@ -118,7 +121,10 @@ private inline fun branchHasElement(child: PsiElement?, parent: PsiElement?, pre
   return false
 }
 
-abstract class JavaAbstractUExpression(givenParent: UElement?) : JavaAbstractUElement(givenParent), UExpression {
+@ApiStatus.Internal
+abstract class JavaAbstractUExpression(
+  givenParent: UElement?
+) : JavaAbstractUElement(givenParent), UExpression {
 
   override fun evaluate(): Any? {
     val project = sourcePsi?.project ?: return null

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUDoWhileExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUDoWhileExpression.kt
@@ -16,13 +16,14 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiDoWhileStatement
-import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.ChildRole
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UDoWhileExpression
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UIdentifier
 
+@ApiStatus.Internal
 class JavaUDoWhileExpression(
   override val sourcePsi: PsiDoWhileStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUForEachExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUForEachExpression.kt
@@ -15,11 +15,12 @@
  */
 package org.jetbrains.uast.java
 
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiForeachStatement
 import com.intellij.psi.impl.source.tree.ChildRole
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUForEachExpression(
   override val sourcePsi: PsiForeachStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUForExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUForExpression.kt
@@ -15,14 +15,15 @@
  */
 package org.jetbrains.uast.java
 
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiForStatement
 import com.intellij.psi.impl.source.tree.ChildRole
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UForExpression
 import org.jetbrains.uast.UIdentifier
 
+@ApiStatus.Internal
 class JavaUForExpression(
   override val sourcePsi: PsiForStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUIfExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUIfExpression.kt
@@ -15,14 +15,15 @@
  */
 package org.jetbrains.uast.java
 
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiIfStatement
 import com.intellij.psi.impl.source.tree.ChildRole
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UIdentifier
 import org.jetbrains.uast.UIfExpression
 
+@ApiStatus.Internal
 class JavaUIfExpression(
   override val sourcePsi: PsiIfStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUSwitchExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUSwitchExpression.kt
@@ -3,10 +3,12 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.tree.ChildRole
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.expressions.JavaUExpressionList
 import org.jetbrains.uast.java.kinds.JavaSpecialExpressionKinds
 
+@ApiStatus.Internal
 class JavaUSwitchExpression(
   override val sourcePsi: PsiSwitchBlock,
   givenParent: UElement?
@@ -20,8 +22,11 @@ class JavaUSwitchExpression(
 
 }
 
-class JavaUSwitchEntryList(override val sourcePsi: PsiSwitchBlock, override val uastParent: JavaUSwitchExpression) :
-  JavaAbstractUExpression(uastParent), UExpressionList {
+@ApiStatus.Internal
+class JavaUSwitchEntryList(
+  override val sourcePsi: PsiSwitchBlock,
+  override val uastParent: JavaUSwitchExpression
+) : JavaAbstractUExpression(uastParent), UExpressionList {
 
   override val kind: UastSpecialExpressionKind
     get() = JavaSpecialExpressionKinds.SWITCH
@@ -30,8 +35,8 @@ class JavaUSwitchEntryList(override val sourcePsi: PsiSwitchBlock, override val 
     it.asRenderString().withMargin
   }
 
-  private val switchEntries: Lazy<List<JavaUSwitchEntry>> = lazy {
-    val statements = sourcePsi.body?.statements ?: return@lazy emptyList<JavaUSwitchEntry>()
+  private val switchEntries: Lazy<List<JavaUSwitchEntry>> = lz {
+    val statements = sourcePsi.body?.statements ?: return@lz emptyList<JavaUSwitchEntry>()
     var currentLabels = listOf<PsiSwitchLabelStatementBase>()
     var currentBody = listOf<PsiStatement>()
     val result = mutableListOf<JavaUSwitchEntry>()
@@ -53,7 +58,7 @@ class JavaUSwitchEntryList(override val sourcePsi: PsiSwitchBlock, override val 
         else if (currentLabels.isNotEmpty()) {
           result += JavaUSwitchEntry(currentLabels, currentBody, this)
           currentLabels = listOf(statement)
-          currentBody = listOf<PsiStatement>()
+          currentBody = listOf()
         }
       }
       else {
@@ -67,9 +72,10 @@ class JavaUSwitchEntryList(override val sourcePsi: PsiSwitchBlock, override val 
 
   }
 
-  override val expressions: List<JavaUSwitchEntry> get() = switchEntries.value
+  override val expressions: List<UExpression>
+      get() = switchEntries.value
 
-  fun findUSwitchEntryForLabel(switchLabelStatement: PsiSwitchLabelStatementBase): JavaUSwitchEntry? {
+  internal fun findUSwitchEntryForLabel(switchLabelStatement: PsiSwitchLabelStatementBase): JavaUSwitchEntry? {
     if (switchEntries.isInitialized()) return switchEntries.value.find { it.labels.contains(switchLabelStatement) }
 
     if (switchLabelStatement is PsiSwitchLabeledRuleStatement) {
@@ -83,7 +89,7 @@ class JavaUSwitchEntryList(override val sourcePsi: PsiSwitchBlock, override val 
     return JavaUSwitchEntry(labels, body, this)
   }
 
-  fun findUSwitchEntryForBodyStatementMember(psi: PsiElement): JavaUSwitchEntry? {
+  internal fun findUSwitchEntryForBodyStatementMember(psi: PsiElement): JavaUSwitchEntry? {
     if (switchEntries.isInitialized()) return switchEntries.value.find { it.body.expressions.any { it.sourcePsi == psi } }
 
     val statement = psi as? PsiStatement ?: // PsiBreakStatement for instance
@@ -98,7 +104,7 @@ class JavaUSwitchEntryList(override val sourcePsi: PsiSwitchBlock, override val 
 private val PsiElement.nextSiblings: Sequence<PsiElement> get() = generateSequence(this) { it.nextSibling }
 private val PsiElement.prevSiblings: Sequence<PsiElement> get() = generateSequence(this) { it.prevSibling }
 
-
+@ApiStatus.Internal
 class JavaUSwitchEntry(
   val labels: List<PsiSwitchLabelStatementBase>,
   val statements: List<PsiStatement>,
@@ -141,15 +147,18 @@ class JavaUSwitchEntry(
       }
 
       override fun asRenderString() = buildString {
-        appendln("{")
-        expressions.forEach { appendln(it.asRenderString().withMargin) }
-        appendln("}")
+        appendLine("{")
+        expressions.forEach { appendLine(it.asRenderString().withMargin) }
+        appendLine("}")
       }
     }
   }
 }
 
-internal class DummyYieldExpression(val expressionPsi: PsiExpression, override val uastParent: UElement?) : UYieldExpression {
+internal class DummyYieldExpression(
+  val expressionPsi: PsiExpression,
+  override val uastParent: UElement?
+) : UYieldExpression {
   override val javaPsi: PsiElement? = null
   override val sourcePsi: PsiElement? = null
   override val psi: PsiElement?
@@ -159,7 +168,7 @@ internal class DummyYieldExpression(val expressionPsi: PsiExpression, override v
   override val uAnnotations: List<UAnnotation>
     get() = emptyList()
 
-  override val expression: UExpression? by lazy { JavaConverter.convertExpression(expressionPsi, this) }
+  override val expression: UExpression? by lz { JavaConverter.convertExpression(expressionPsi, this) }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -172,8 +181,11 @@ internal class DummyYieldExpression(val expressionPsi: PsiExpression, override v
   override fun hashCode(): Int = expressionPsi.hashCode()
 }
 
-class JavaUDefaultCaseExpression(override val sourcePsi: PsiElement?, givenParent: UElement?)
-  : JavaAbstractUExpression(givenParent), UElement {
+@ApiStatus.Internal
+class JavaUDefaultCaseExpression(
+  override val sourcePsi: PsiElement?,
+  givenParent: UElement?
+) : JavaAbstractUExpression(givenParent), UElement {
 
   override val uAnnotations: List<UAnnotation>
     get() = emptyList()

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUTernaryIfExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUTernaryIfExpression.kt
@@ -16,11 +16,13 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiConditionalExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UIdentifier
 import org.jetbrains.uast.UIfExpression
 
+@ApiStatus.Internal
 class JavaUTernaryIfExpression(
   override val sourcePsi: PsiConditionalExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUTryExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUTryExpression.kt
@@ -17,14 +17,16 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.tree.ChildRole
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUTryExpression(
   override val sourcePsi: PsiTryStatement,
   givenParent: UElement?
 ) : JavaAbstractUExpression(givenParent), UTryExpression {
   override val tryClause: UExpression by lz { JavaConverter.convertOrEmpty(sourcePsi.tryBlock, this) }
-  override val catchClauses: List<JavaUCatchClause> by lz { sourcePsi.catchSections.map { JavaUCatchClause(it, this) } }
+  override val catchClauses: List<UCatchClause> by lz { sourcePsi.catchSections.map { JavaUCatchClause(it, this) } }
   override val finallyClause: UBlockExpression? by lz { sourcePsi.finallyBlock?.let { JavaConverter.convertBlock(it, this) } }
 
   override val resourceVariables: List<UVariable> by lz {
@@ -44,13 +46,14 @@ class JavaUTryExpression(
     get() = sourcePsi.getChildByRole(ChildRole.FINALLY_KEYWORD)?.let { UIdentifier(it, this) }
 }
 
+@ApiStatus.Internal
 class JavaUCatchClause(
   override val sourcePsi: PsiCatchSection,
   givenParent: UElement?
 ) : JavaAbstractUElement(givenParent), UCatchClause {
   override val body: UExpression by lz { JavaConverter.convertOrEmpty(sourcePsi.catchBlock, this) }
 
-  override val parameters: List<JavaUParameter> by lz {
+  override val parameters: List<UParameter> by lz {
     (sourcePsi.parameter?.let { listOf(it) } ?: emptyList()).map { JavaUParameter(it, this) }
   }
 

--- a/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUWhileExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/controlStructures/JavaUWhileExpression.kt
@@ -15,14 +15,15 @@
  */
 package org.jetbrains.uast.java
 
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhileStatement
 import com.intellij.psi.impl.source.tree.ChildRole
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UIdentifier
 import org.jetbrains.uast.UWhileExpression
 
+@ApiStatus.Internal
 class JavaUWhileExpression(
   override val sourcePsi: PsiWhileStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUAnnotation.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUAnnotation.kt
@@ -18,9 +18,11 @@ package org.jetbrains.uast.java
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiClass
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.expressions.JavaUNamedExpression
 
+@ApiStatus.Internal
 class JavaUAnnotation(
   override val sourcePsi: PsiAnnotation,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUClass.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUClass.kt
@@ -3,11 +3,14 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.*
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.internal.JavaUElementWithComments
 
-abstract class AbstractJavaUClass(givenParent: UElement?) : JavaAbstractUElement(
-  givenParent), UClass, JavaUElementWithComments, UAnchorOwner, UDeclarationEx {
+@ApiStatus.Internal
+abstract class AbstractJavaUClass(
+  givenParent: UElement?
+) : JavaAbstractUElement(givenParent), UClass, JavaUElementWithComments, UAnchorOwner, UDeclarationEx {
 
   abstract override val javaPsi: PsiClass
 
@@ -43,8 +46,11 @@ abstract class AbstractJavaUClass(givenParent: UElement?) : JavaAbstractUElement
   override fun hashCode(): Int = javaPsi.hashCode()
 }
 
-class JavaUClass private constructor(override val sourcePsi: PsiClass, val givenParent: UElement?) :
-  AbstractJavaUClass(givenParent), UAnchorOwner, PsiClass by sourcePsi {
+@ApiStatus.Internal
+class JavaUClass(
+  override val sourcePsi: PsiClass,
+  val givenParent: UElement?
+) : AbstractJavaUClass(givenParent), UAnchorOwner, PsiClass by sourcePsi {
 
   override val javaPsi: PsiClass = unwrap<UClass, PsiClass>(sourcePsi)
 
@@ -66,6 +72,7 @@ class JavaUClass private constructor(override val sourcePsi: PsiClass, val given
   override fun getOriginalElement(): PsiElement? = sourcePsi.originalElement
 }
 
+@ApiStatus.Internal
 class JavaUAnonymousClass(
   override val sourcePsi: PsiAnonymousClass,
   uastParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUClassInitializer.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUClassInitializer.kt
@@ -4,9 +4,11 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiClassInitializer
 import com.intellij.psi.PsiElement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.internal.JavaUElementWithComments
 
+@ApiStatus.Internal
 class JavaUClassInitializer(
   override val sourcePsi: PsiClassInitializer,
   uastParent: UElement?
@@ -24,7 +26,7 @@ class JavaUClassInitializer(
     UastFacade.findPlugin(sourcePsi.body)?.convertElement(sourcePsi.body, this, null) as? UExpression ?: UastEmptyExpression(this)
   }
 
-  override val uAnnotations: List<JavaUAnnotation> by lz { sourcePsi.annotations.map { JavaUAnnotation(it, this) } }
+  override val uAnnotations: List<UAnnotation> by lz { sourcePsi.annotations.map { JavaUAnnotation(it, this) } }
 
   override fun equals(other: Any?): Boolean = this === other
   override fun hashCode(): Int = sourcePsi.hashCode()

--- a/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUFile.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUFile.kt
@@ -4,10 +4,12 @@ package org.jetbrains.uast.java
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.internal.JavaUElementWithComments
 import java.util.*
 
+@ApiStatus.Internal
 class JavaUFile(
   override val sourcePsi: PsiJavaFile,
   override val languagePlugin: UastLanguagePlugin
@@ -16,7 +18,7 @@ class JavaUFile(
   override val packageName: String
     get() = sourcePsi.packageName
 
-  override val imports: List<JavaUImportStatement> by lz {
+  override val imports: List<UImportStatement> by lz {
     sourcePsi.importList?.allImportStatements?.map { JavaUImportStatement(it, this) } ?: listOf()
   }
 

--- a/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUImportStatement.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUImportStatement.kt
@@ -18,17 +18,19 @@ package org.jetbrains.uast.java
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiImportStatementBase
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UImportStatement
 import org.jetbrains.uast.UMultiResolvable
 
+@ApiStatus.Internal
 class JavaUImportStatement(
   override val sourcePsi: PsiImportStatementBase,
   uastParent: UElement?
 ) : JavaAbstractUElement(uastParent), UImportStatement, UMultiResolvable {
   override val isOnDemand: Boolean
     get() = sourcePsi.isOnDemand
-  override val importReference: JavaDumbUElement? by lz { sourcePsi.importReference?.let { JavaDumbUElement(it, this, it.qualifiedName) } }
+  override val importReference: UElement? by lz { sourcePsi.importReference?.let { JavaDumbUElement(it, this, it.qualifiedName) } }
   override fun resolve(): PsiElement? = sourcePsi.resolve()
   override fun multiResolve(): Iterable<ResolveResult> =
     sourcePsi.importReference?.multiResolve(false)?.asIterable() ?: emptyList()

--- a/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUMethod.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUMethod.kt
@@ -6,10 +6,12 @@ import com.intellij.psi.*
 import com.intellij.psi.impl.light.LightRecordCanonicalConstructor
 import com.intellij.psi.impl.source.PsiMethodImpl
 import com.intellij.util.castSafelyTo
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.internal.convertOrReport
 import org.jetbrains.uast.java.internal.JavaUElementWithComments
 
+@ApiStatus.Internal
 open class JavaUMethod(
   override val javaPsi: PsiMethod,
   uastParent: UElement?
@@ -29,7 +31,7 @@ open class JavaUMethod(
     UastFacade.findPlugin(body)?.convertElement(body, this) as? UExpression
   }
 
-  override val uAnnotations: List<JavaUAnnotation> by lz { javaPsi.annotations.map { JavaUAnnotation(it, this) } }
+  override val uAnnotations: List<UAnnotation> by lz { javaPsi.annotations.map { JavaUAnnotation(it, this) } }
 
   override val uastParameters: List<UParameter> by lz {
     javaPsi.parameterList.parameters.mapNotNull { convertOrReport(it, this) }
@@ -91,6 +93,7 @@ private class JavaRecordConstructorUMethod(
 internal fun canBeSourcePsi(psiMethod: PsiMethod): Boolean =
   psiMethod.isPhysical || psiMethod is PsiMethodImpl && psiMethod.containingClass != null
 
+@ApiStatus.Internal
 class JavaUAnnotationMethod(
   override val javaPsi: PsiAnnotationMethod,
   languagePlugin: UastLanguagePlugin,

--- a/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUVariable.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/declarations/JavaUVariable.kt
@@ -10,13 +10,16 @@ import com.intellij.psi.impl.source.tree.java.PsiLocalVariableImpl
 import com.intellij.psi.util.PsiTypesUtil
 import com.intellij.psi.util.parentOfType
 import com.intellij.util.castSafelyTo
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.internal.accommodate
 import org.jetbrains.uast.internal.alternative
 import org.jetbrains.uast.java.internal.JavaUElementWithComments
 
-abstract class AbstractJavaUVariable(givenParent: UElement?) : JavaAbstractUElement(
-  givenParent), PsiVariable, UVariableEx, JavaUElementWithComments, UAnchorOwner {
+@ApiStatus.Internal
+abstract class AbstractJavaUVariable(
+  givenParent: UElement?
+) : JavaAbstractUElement(givenParent), PsiVariable, UVariableEx, JavaUElementWithComments, UAnchorOwner {
 
   abstract override val javaPsi: PsiVariable
 
@@ -29,7 +32,7 @@ abstract class AbstractJavaUVariable(givenParent: UElement?) : JavaAbstractUElem
     UastFacade.findPlugin(initializer)?.convertElement(initializer, this) as? UExpression
   }
 
-  override val uAnnotations: List<JavaUAnnotation> by lz { javaPsi.annotations.map { JavaUAnnotation(it, this) } }
+  override val uAnnotations: List<UAnnotation> by lz { javaPsi.annotations.map { JavaUAnnotation(it, this) } }
   override val typeReference: UTypeReferenceExpression? by lz {
     javaPsi.typeElement?.let { UastFacade.findPlugin(it)?.convertOpt<UTypeReferenceExpression>(javaPsi.typeElement, this) }
   }
@@ -43,6 +46,7 @@ abstract class AbstractJavaUVariable(givenParent: UElement?) : JavaAbstractUElem
   override fun hashCode(): Int = javaPsi.hashCode()
 }
 
+@ApiStatus.Internal
 class JavaUVariable(
   override val javaPsi: PsiVariable,
   givenParent: UElement?
@@ -67,6 +71,7 @@ class JavaUVariable(
   override fun getOriginalElement(): PsiElement? = javaPsi.originalElement
 }
 
+@ApiStatus.Internal
 class JavaUParameter(
   override val javaPsi: PsiParameter,
   givenParent: UElement?
@@ -98,8 +103,11 @@ private class JavaRecordUParameter(
   override fun getPsiParentForLazyConversion(): PsiElement? = javaPsi.context
 }
 
-fun convertRecordConstructorParameterAlternatives(element: PsiElement, givenParent: UElement?,
-                                                  expectedTypes: Array<out Class<out UElement>>): Sequence<UVariable> {
+internal fun convertRecordConstructorParameterAlternatives(
+  element: PsiElement,
+  givenParent: UElement?,
+  expectedTypes: Array<out Class<out UElement>>
+): Sequence<UVariable> {
 
   val (psiRecordComponent, lightRecordField, lightConstructorParameter) = when (element) {
     is PsiRecordComponent -> Triple(element, null, null)
@@ -131,7 +139,7 @@ fun convertRecordConstructorParameterAlternatives(element: PsiElement, givenPare
   }
 }
 
-
+@ApiStatus.Internal
 class JavaUField(
   override val sourcePsi: PsiField,
   givenParent: UElement?
@@ -163,6 +171,7 @@ private class JavaRecordUField(
   override fun getPsiParentForLazyConversion(): PsiElement? = javaPsi.context
 }
 
+@ApiStatus.Internal
 class JavaULocalVariable(
   override val sourcePsi: PsiLocalVariable,
   givenParent: UElement?
@@ -185,11 +194,12 @@ class JavaULocalVariable(
 
 }
 
+@ApiStatus.Internal
 class JavaUEnumConstant(
   override val sourcePsi: PsiEnumConstant,
   givenParent: UElement?
-) : AbstractJavaUVariable(givenParent), UEnumConstantEx, UCallExpressionEx, PsiEnumConstant by sourcePsi, UMultiResolvable {
-  override val initializingClass: UClass? by lz { UastFacade.findPlugin(sourcePsi)?.convertOpt<UClass>(sourcePsi.initializingClass, this) }
+) : AbstractJavaUVariable(givenParent), UEnumConstantEx, UCallExpression, PsiEnumConstant by sourcePsi, UMultiResolvable {
+  override val initializingClass: UClass? by lz { UastFacade.findPlugin(sourcePsi)?.convertOpt(sourcePsi.initializingClass, this) }
 
   @Suppress("OverridingDeprecatedMember")
   override val psi: PsiEnumConstant

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaDumbUElement.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaDumbUElement.kt
@@ -16,9 +16,11 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.internal.log
 
+@ApiStatus.Internal
 class JavaDumbUElement(
   override val sourcePsi: PsiElement,
   givenParent: UElement?,

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUAnnotationCallExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUAnnotationCallExpression.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiType
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.JavaAbstractUExpression
 import org.jetbrains.uast.java.JavaConverter
@@ -14,11 +15,14 @@ import org.jetbrains.uast.java.JavaUAnnotation
 import org.jetbrains.uast.java.lz
 import org.jetbrains.uast.visitor.UastVisitor
 
+@ApiStatus.Internal
 class JavaUAnnotationCallExpression(
   override val sourcePsi: PsiAnnotation,
   givenParent: UElement?
-) : JavaAbstractUExpression(givenParent), UCallExpressionEx, UMultiResolvable {
+) : JavaAbstractUExpression(givenParent), UCallExpression, UMultiResolvable {
 
+  // TODO: once there is no more external usage, this property can be `private`.
+  @get:ApiStatus.Internal
   val uAnnotation: JavaUAnnotation by lz {
     JavaUAnnotation(sourcePsi, this)
   }

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUArrayAccessExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUArrayAccessExpression.kt
@@ -16,10 +16,12 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiArrayAccessExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UArrayAccessExpression
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 
+@ApiStatus.Internal
 class JavaUArrayAccessExpression(
   override val sourcePsi: PsiArrayAccessExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUAssertExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUAssertExpression.kt
@@ -17,16 +17,16 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiAssertStatement
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiType
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
-
+@ApiStatus.Internal
 class JavaUAssertExpression(
   override val sourcePsi: PsiAssertStatement,
   givenParent: UElement?
-) : JavaAbstractUExpression(givenParent), UCallExpressionEx, UMultiResolvable {
+) : JavaAbstractUExpression(givenParent), UCallExpression, UMultiResolvable {
   val condition: UExpression by lz { JavaConverter.convertOrEmpty(sourcePsi.assertCondition, this) }
   val message: UExpression? by lz { JavaConverter.convertOrNull(sourcePsi.assertDescription, this) }
 

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUAssignmentExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUAssignmentExpression.kt
@@ -16,8 +16,10 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiAssignmentExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUAssignmentExpression(
   override val sourcePsi: PsiAssignmentExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUBinaryExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUBinaryExpression.kt
@@ -16,8 +16,10 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiBinaryExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUBinaryExpression(
   override val sourcePsi: PsiBinaryExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUBlockExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUBlockExpression.kt
@@ -16,10 +16,12 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiBlockStatement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UBlockExpression
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 
+@ApiStatus.Internal
 class JavaUBlockExpression(
   override val sourcePsi: PsiBlockStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUBreakExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUBreakExpression.kt
@@ -2,9 +2,11 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiBreakStatement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UBreakExpression
 import org.jetbrains.uast.UElement
 
+@ApiStatus.Internal
 class JavaUBreakExpression(
   override val sourcePsi: PsiBreakStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUCallableReferenceExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUCallableReferenceExpression.kt
@@ -16,11 +16,13 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.*
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UCallableReferenceExpression
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UMultiResolvable
 
+@ApiStatus.Internal
 class JavaUCallableReferenceExpression(
   override val sourcePsi: PsiMethodReferenceExpression,
   givenParent: UElement?
@@ -43,6 +45,5 @@ class JavaUCallableReferenceExpression(
   override val referenceNameElement: UElement? by lz {
     sourcePsi.referenceNameElement?.let { JavaUSimpleNameReferenceExpression(it, callableName, this, it.reference) }
   }
-
 
 }

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUClassLiteralExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUClassLiteralExpression.kt
@@ -17,9 +17,11 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiClassObjectAccessExpression
 import com.intellij.psi.PsiType
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UClassLiteralExpression
 import org.jetbrains.uast.UElement
 
+@ApiStatus.Internal
 class JavaUClassLiteralExpression(
   override val sourcePsi: PsiClassObjectAccessExpression,
   givenParent: UElement?
@@ -27,5 +29,9 @@ class JavaUClassLiteralExpression(
   override val type: PsiType
     get() = sourcePsi.operand.type
 
-  override val expression: JavaUTypeReferenceExpression by lz { JavaUTypeReferenceExpression(sourcePsi.operand, this) }
+  // TODO: return type JavaUTypeReferenceExpression doesn't have anything special,
+  //  so UTypeReferenceExpression should be good enough (or checking if the underlying sourcePsi is from Java).
+  override val expression: JavaUTypeReferenceExpression by lz {
+    JavaUTypeReferenceExpression(sourcePsi.operand, this)
+  }
 }

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUCodeBlockExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUCodeBlockExpression.kt
@@ -16,10 +16,12 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiCodeBlock
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UBlockExpression
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 
+@ApiStatus.Internal
 class JavaUCodeBlockExpression(
   override val sourcePsi: PsiCodeBlock,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUCompositeQualifiedExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUCompositeQualifiedExpression.kt
@@ -18,8 +18,10 @@ package org.jetbrains.uast.java
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUCompositeQualifiedExpression(
   override val sourcePsi: PsiElement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUContinueExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUContinueExpression.kt
@@ -17,9 +17,11 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiContinueStatement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UContinueExpression
 import org.jetbrains.uast.UElement
 
+@ApiStatus.Internal
 class JavaUContinueExpression(
   override val sourcePsi: PsiContinueStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUDeclarationsExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUDeclarationsExpression.kt
@@ -2,8 +2,10 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUDeclarationsExpression(
   uastParent: UElement?
 ) : JavaAbstractUElement(uastParent), UDeclarationsExpression, UElement {

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUExpressionList.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUExpressionList.kt
@@ -16,12 +16,14 @@
 package org.jetbrains.uast.java.expressions
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UExpressionList
 import org.jetbrains.uast.UastSpecialExpressionKind
 import org.jetbrains.uast.java.JavaAbstractUExpression
 
+@ApiStatus.Internal
 open class JavaUExpressionList(
   override val sourcePsi: PsiElement?,
   override val kind: UastSpecialExpressionKind, // original element

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUInstanceCheckExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUInstanceCheckExpression.kt
@@ -17,8 +17,10 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiInstanceOfExpression
 import com.intellij.psi.PsiType
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUInstanceCheckExpression(
   override val sourcePsi: PsiInstanceOfExpression,
   givenParent: UElement?
@@ -29,6 +31,6 @@ class JavaUInstanceCheckExpression(
   override val type: PsiType
     get() = sourcePsi.checkType?.type ?: UastErrorType
 
-  override val operationKind: UastBinaryExpressionWithTypeKind.InstanceCheck
+  override val operationKind: UastBinaryExpressionWithTypeKind
     get() = UastBinaryExpressionWithTypeKind.InstanceCheck.INSTANCE
 }

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaULabeledExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaULabeledExpression.kt
@@ -16,11 +16,13 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiLabeledStatement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UIdentifier
 import org.jetbrains.uast.ULabeledExpression
 
+@ApiStatus.Internal
 class JavaULabeledExpression(
   override val sourcePsi: PsiLabeledStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaULambdaExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaULambdaExpression.kt
@@ -16,8 +16,10 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.*
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaULambdaExpression(
   override val sourcePsi: PsiLambdaExpression,
   givenParent: UElement?
@@ -25,7 +27,7 @@ class JavaULambdaExpression(
   override val functionalInterfaceType: PsiType?
     get() = sourcePsi.functionalInterfaceType
 
-  override val valueParameters: List<JavaUParameter> by lz {
+  override val valueParameters: List<UParameter> by lz {
     sourcePsi.parameterList.parameters.map { JavaUParameter(it, this) }
   }
 

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaULiteralExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaULiteralExpression.kt
@@ -17,10 +17,12 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.impl.source.tree.java.PsiLiteralExpressionImpl
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.ULiteralExpression
 import org.jetbrains.uast.expressions.UInjectionHost
 
+@ApiStatus.Internal
 class JavaULiteralExpression(
   override val sourcePsi: PsiLiteralExpressionImpl,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUNamedExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUNamedExpression.kt
@@ -16,6 +16,7 @@
 package org.jetbrains.uast.java.expressions
 
 import com.intellij.psi.PsiNameValuePair
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UNamedExpression
@@ -24,6 +25,7 @@ import org.jetbrains.uast.java.JavaAbstractUExpression
 import org.jetbrains.uast.java.JavaConverter
 import org.jetbrains.uast.java.lz
 
+@ApiStatus.Internal
 class JavaUNamedExpression(
   override val sourcePsi: PsiNameValuePair,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUObjectLiteralExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUObjectLiteralExpression.kt
@@ -19,12 +19,14 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiNewExpression
 import com.intellij.psi.PsiType
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUObjectLiteralExpression(
   override val sourcePsi: PsiNewExpression,
   givenParent: UElement?
-) : JavaAbstractUExpression(givenParent), UObjectLiteralExpression, UCallExpressionEx, UMultiResolvable {
+) : JavaAbstractUExpression(givenParent), UObjectLiteralExpression, UCallExpression, UMultiResolvable {
   override val declaration: UClass by lz { JavaUClass.create(sourcePsi.anonymousClass!!, this) }
 
   override val classReference: UReferenceExpression? by lz {

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUParenthesizedExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUParenthesizedExpression.kt
@@ -16,10 +16,12 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiParenthesizedExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UParenthesizedExpression
 
+@ApiStatus.Internal
 class JavaUParenthesizedExpression(
   override val sourcePsi: PsiParenthesizedExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUPolyadicExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUPolyadicExpression.kt
@@ -16,13 +16,14 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiPolyadicExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UPolyadicExpression
 import org.jetbrains.uast.UastBinaryOperator
 import org.jetbrains.uast.java.internal.PsiArrayToUElementListMappingView
 
-
+@ApiStatus.Internal
 class JavaUPolyadicExpression(
   override val sourcePsi: PsiPolyadicExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUPostfixExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUPostfixExpression.kt
@@ -17,8 +17,10 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.JavaTokenType
 import com.intellij.psi.PsiPostfixExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUPostfixExpression(
   override val sourcePsi: PsiPostfixExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUPrefixExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUPrefixExpression.kt
@@ -17,8 +17,10 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.JavaTokenType
 import com.intellij.psi.PsiPrefixExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUPrefixExpression(
   override val sourcePsi: PsiPrefixExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUQualifiedReferenceExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUQualifiedReferenceExpression.kt
@@ -19,8 +19,10 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJavaCodeReferenceElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUQualifiedReferenceExpression(
   override val sourcePsi: PsiJavaCodeReferenceElement,
   givenParent: UElement?
@@ -29,7 +31,7 @@ class JavaUQualifiedReferenceExpression(
     sourcePsi.qualifier?.let { JavaConverter.convertPsiElement(it, this) as? UExpression } ?: UastEmptyExpression(this)
   }
 
-  override val selector: JavaUSimpleNameReferenceExpression by lz {
+  override val selector: USimpleNameReferenceExpression by lz {
     JavaUSimpleNameReferenceExpression(sourcePsi.referenceNameElement, sourcePsi.referenceName ?: "<error>", this, sourcePsi)
   }
 

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUReturnExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUReturnExpression.kt
@@ -17,11 +17,10 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.*
-import com.intellij.psi.util.PsiMethodUtil
-import com.intellij.psi.util.PsiUtil
-import com.intellij.psi.util.parentOfType
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUReturnExpression(
   override val sourcePsi: PsiReturnStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUSimpleNameReferenceExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUSimpleNameReferenceExpression.kt
@@ -17,8 +17,10 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.*
 import com.intellij.psi.infos.CandidateInfo
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUSimpleNameReferenceExpression(
   override val sourcePsi: PsiElement?,
   override val identifier: String,
@@ -54,6 +56,7 @@ class JavaUSimpleNameReferenceExpression(
 
 }
 
+@ApiStatus.Internal
 class JavaUTypeReferenceExpression(
   override val sourcePsi: PsiTypeElement,
   givenParent: UElement?
@@ -62,6 +65,7 @@ class JavaUTypeReferenceExpression(
     get() = sourcePsi.type
 }
 
+@ApiStatus.Internal
 class LazyJavaUTypeReferenceExpression(
   override val sourcePsi: PsiElement,
   givenParent: UElement?,

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUSuperExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUSuperExpression.kt
@@ -18,11 +18,13 @@ package org.jetbrains.uast.java
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiSuperExpression
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UIdentifier
 import org.jetbrains.uast.UMultiResolvable
 import org.jetbrains.uast.USuperExpression
 
+@ApiStatus.Internal
 class JavaUSuperExpression(
   override val sourcePsi: PsiSuperExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUSynchronizedExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUSynchronizedExpression.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.uast.java.expressions
 
 import com.intellij.psi.PsiSynchronizedStatement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UBlockExpression
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
@@ -26,12 +27,16 @@ import org.jetbrains.uast.java.JavaConverter
 import org.jetbrains.uast.java.lz
 import org.jetbrains.uast.visitor.UastVisitor
 
+@ApiStatus.Internal
 class JavaUSynchronizedExpression(
   override val sourcePsi: PsiSynchronizedStatement,
   givenParent: UElement?
 ) : JavaAbstractUExpression(givenParent), UBlockExpression {
-  override val expressions: List<UExpression> by lz { sourcePsi.body?.statements?.map { JavaConverter.convertOrEmpty(it, this) } ?: listOf() }
-  val lockExpression: UExpression by lz { JavaConverter.convertOrEmpty(sourcePsi.lockExpression, this) }
+  override val expressions: List<UExpression> by lz {
+    sourcePsi.body?.statements?.map { JavaConverter.convertOrEmpty(it, this) } ?: listOf()
+  }
+
+  private val lockExpression: UExpression by lz { JavaConverter.convertOrEmpty(sourcePsi.lockExpression, this) }
 
   override fun accept(visitor: UastVisitor) {
     if (visitor.visitBlockExpression(this)) return

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUThisExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUThisExpression.kt
@@ -18,11 +18,13 @@ package org.jetbrains.uast.java
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiThisExpression
 import com.intellij.psi.ResolveResult
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UIdentifier
 import org.jetbrains.uast.UMultiResolvable
 import org.jetbrains.uast.UThisExpression
 
+@ApiStatus.Internal
 class JavaUThisExpression(
   override val sourcePsi: PsiThisExpression,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUThrowExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUThrowExpression.kt
@@ -17,10 +17,12 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiThrowStatement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UThrowExpression
 
+@ApiStatus.Internal
 class JavaUThrowExpression(
   override val sourcePsi: PsiThrowStatement,
   givenParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUTypeCastExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUTypeCastExpression.kt
@@ -17,8 +17,10 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiTypeCastExpression
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 
+@ApiStatus.Internal
 class JavaUTypeCastExpression(
   override val sourcePsi: PsiTypeCastExpression,
   givenParent: UElement?
@@ -28,8 +30,8 @@ class JavaUTypeCastExpression(
   override val type: PsiType
     get() = sourcePsi.castType?.type ?: UastErrorType
 
-  override val typeReference: JavaUTypeReferenceExpression? by lz { sourcePsi.castType?.let { JavaUTypeReferenceExpression(it, this) } }
+  override val typeReference: UTypeReferenceExpression? by lz { sourcePsi.castType?.let { JavaUTypeReferenceExpression(it, this) } }
 
-  override val operationKind: UastBinaryExpressionWithTypeKind.TypeCast
+  override val operationKind: UastBinaryExpressionWithTypeKind
     get() = UastBinaryExpressionWithTypeKind.TypeCast.INSTANCE
 }

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUYieldExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/JavaUYieldExpression.kt
@@ -3,10 +3,12 @@ package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiYieldStatement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UYieldExpression
 
+@ApiStatus.Internal
 class JavaUYieldExpression(
   override val sourcePsi: PsiYieldStatement,
   private val psiExpression: PsiExpression?,

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/UnknownJavaExpression.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/UnknownJavaExpression.kt
@@ -2,10 +2,12 @@
 package org.jetbrains.uast.java
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 
+@ApiStatus.Internal
 class UnknownJavaExpression(
   override val sourcePsi: PsiElement,
   uastParent: UElement?

--- a/uast/uast-java/src/org/jetbrains/uast/java/expressions/javaUCallExpressions.kt
+++ b/uast/uast-java/src/org/jetbrains/uast/java/expressions/javaUCallExpressions.kt
@@ -18,15 +18,17 @@ package org.jetbrains.uast.java
 import com.intellij.psi.*
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiTypesUtil
+import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.uast.*
 import org.jetbrains.uast.java.expressions.JavaUExpressionList
 import org.jetbrains.uast.java.internal.PsiArrayToUElementListMappingView
 import org.jetbrains.uast.psi.UElementWithLocation
 
+@ApiStatus.Internal
 class JavaUCallExpression(
   override val sourcePsi: PsiMethodCallExpression,
   givenParent: UElement?
-) : JavaAbstractUExpression(givenParent), UCallExpressionEx, UElementWithLocation, UMultiResolvable {
+) : JavaAbstractUExpression(givenParent), UCallExpression, UElementWithLocation, UMultiResolvable {
   override val kind: UastCallKind
     get() {
       val element = nameReferenceElement
@@ -127,10 +129,11 @@ class JavaUCallExpression(
     }
 }
 
+@ApiStatus.Internal
 class JavaConstructorUCallExpression(
   override val sourcePsi: PsiNewExpression,
   givenParent: UElement?
-) : JavaAbstractUExpression(givenParent), UCallExpressionEx, UMultiResolvable {
+) : JavaAbstractUExpression(givenParent), UCallExpression, UMultiResolvable {
   override val kind: UastCallKind by lz {
     when {
       sourcePsi.arrayInitializer != null -> UastCallKind.NEW_ARRAY_WITH_INITIALIZER
@@ -199,10 +202,11 @@ class JavaConstructorUCallExpression(
   }
 }
 
+@ApiStatus.Internal
 class JavaArrayInitializerUCallExpression(
   override val sourcePsi: PsiArrayInitializerExpression,
   givenParent: UElement?
-) : JavaAbstractUExpression(givenParent), UCallExpressionEx, UMultiResolvable {
+) : JavaAbstractUExpression(givenParent), UCallExpression, UMultiResolvable {
   override val methodIdentifier: UIdentifier?
     get() = null
 
@@ -239,10 +243,11 @@ class JavaArrayInitializerUCallExpression(
     get() = null
 }
 
+@ApiStatus.Internal
 class JavaAnnotationArrayInitializerUCallExpression(
   override val sourcePsi: PsiArrayInitializerMemberValue,
   givenParent: UElement?
-) : JavaAbstractUExpression(givenParent), UCallExpressionEx, UMultiResolvable {
+) : JavaAbstractUExpression(givenParent), UCallExpression, UMultiResolvable {
 
   override fun getArgumentForParameter(i: Int): UExpression? = valueArguments.getOrNull(i)
 

--- a/uast/uast-tests/src/org/jetbrains/uast/test/common/ValuesTestBase.kt
+++ b/uast/uast-tests/src/org/jetbrains/uast/test/common/ValuesTestBase.kt
@@ -17,6 +17,9 @@ interface ValuesTestBase {
   fun getTestDataPath(): String
   fun getEvaluatorExtension(): UEvaluatorExtension? = null
 
+  // TODO: when JavaUFile (and/or its constructor) becomes `internal`, this should move into JavaUFile.
+  private fun JavaUFile.copy() : JavaUFile = JavaUFile(sourcePsi, languagePlugin)
+
   private fun UFile.analyzeAll() = analyzeAll(extensions = getEvaluatorExtension()?.let { listOf(it) } ?: emptyList())
 
   private fun UFile.asLogValues(evaluationContext: UEvaluationContext, cachedOnly: Boolean) =
@@ -31,7 +34,7 @@ interface ValuesTestBase {
     assertEqualsToFile("Log values", valuesFile, file.asLogValues(evaluationContext, cachedOnly = false))
 
     if (file is JavaUFile) {
-      val copyFile = JavaUFile(file.sourcePsi, file.languagePlugin)
+      val copyFile = file.copy()
       assertEqualsToFile("Log cached values", valuesFile, copyFile.asLogValues(evaluationContext, cachedOnly = true))
     }
   }

--- a/uast/uast-tests/test/org/jetbrains/uast/test/java/JavaUJumpExpressionTest.kt
+++ b/uast/uast-tests/test/org/jetbrains/uast/test/java/JavaUJumpExpressionTest.kt
@@ -6,7 +6,6 @@ import com.intellij.testFramework.UsefulTestCase
 import com.intellij.util.castSafelyTo
 import junit.framework.TestCase
 import org.jetbrains.uast.*
-import org.jetbrains.uast.java.*
 
 abstract class JavaUJumpExpressionBase : AbstractJavaUastLightTest() {
   protected inline fun <reified TElement : UElement, reified TJumpFromElement> doTest(fileSource: String) {
@@ -25,7 +24,7 @@ abstract class JavaUJumpExpressionBase : AbstractJavaUastLightTest() {
 }
 
 class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
-  fun `test break`() = doTest<UBreakExpression, JavaUForExpression>("""
+  fun `test break`() = doTest<UBreakExpression, UForExpression>("""
       class Break {
         static void a() {
           while (true) {
@@ -37,7 +36,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
       }
     """)
 
-  fun `test break with label`() = doTest<UBreakExpression, JavaUWhileExpression>("""
+  fun `test break with label`() = doTest<UBreakExpression, UWhileExpression>("""
       class Break {
         static void a() {
           a: while (true) {
@@ -49,7 +48,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
       }
     """)
 
-  fun `test break in switch`() = doTest<UBreakExpression, JavaUSwitchExpression>("""
+  fun `test break in switch`() = doTest<UBreakExpression, USwitchExpression>("""
       class Break {
         static void a() {
           while (true) {
@@ -61,7 +60,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
       }
     """)
 
-  fun `test continue`() = doTest<UContinueExpression, JavaUForExpression>("""
+  fun `test continue`() = doTest<UContinueExpression, UForExpression>("""
       class Break {
         static void a() {
           while (true) {
@@ -73,7 +72,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
       }
     """)
 
-  fun `test continue with label`() = doTest<UContinueExpression, JavaUWhileExpression>("""
+  fun `test continue with label`() = doTest<UContinueExpression, UWhileExpression>("""
       class Break {
         static void a() {
           a: while (true) {
@@ -85,7 +84,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
       }
     """)
 
-  fun `test return`() = doTest<UReturnExpression, JavaUMethod>("""
+  fun `test return`() = doTest<UReturnExpression, UMethod>("""
     class Break {
         static void a() {
           ret<caret>urn;
@@ -93,7 +92,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
       }
   """)
 
-  fun `test return from lambda`() = doTest<UReturnExpression, JavaULambdaExpression>("""
+  fun `test return from lambda`() = doTest<UReturnExpression, ULambdaExpression>("""
     class Break {
         static void a() {
           Supplier a = () -> {
@@ -103,7 +102,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
       }
   """)
 
-  fun `test return from inner method`() = doTest<UReturnExpression, JavaUMethod>("""
+  fun `test return from inner method`() = doTest<UReturnExpression, UMethod>("""
     class Break {
       static Consumer a = (b) -> {
         new Object() {
@@ -150,7 +149,7 @@ class JavaUJumpExpressionTest : JavaUJumpExpressionBase() {
 
 class Java13UJumpExpressionTest : JavaUJumpExpressionBase() {
 
-  fun `test break in switch`() = doTest<UYieldExpression, JavaUSwitchExpression>("""
+  fun `test break in switch`() = doTest<UYieldExpression, USwitchExpression>("""
       class Break {
         static void a() {
           while (true) {


### PR DESCRIPTION
Some parts of massive refactoring that altered internal structures of Kotlin UAST implementations were bundled to Android Lint, which was in turn rolled out to clients, such as Metalava and Google internal checkers. The good news is that there were no behavioral regressions. The bad (or maybe good) news is that there were a couple hiccups that required Android Lint, Lint checker writers, and UAST clients to remove uses of UAST implementation details before roll outs.

Over the past couple months,
* Such uses of UAST implementations have been rewritten to use `UElement`-level abstractions instead
* Lint detectors that detects the use of UAST implementations are developed and deployed, so new uses of UAST implementations can be detected during compilation

And now, this PR `internal`izes implementation details in Java UAST. The counter part for Kotlin UAST is done in a separate space [CR](https://kotlin.jetbrains.space/p/kotlin/reviews/292).