### PR TITLE
Protect shared sourceSet cache from concurrent access

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/SourceSetCachedFinder.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/SourceSetCachedFinder.groovy
@@ -15,6 +15,7 @@
  */
 package org.jetbrains.plugins.gradle.tooling.util
 
+import java.util.concurrent.ConcurrentHashMap
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.initialization.IncludedBuild
@@ -41,7 +42,7 @@ class SourceSetCachedFinder {
   private static final DataProvider<ArtifactsMap> ARTIFACTS_PROVIDER = new DataProvider<ArtifactsMap>() {
     @NotNull
     @Override
-    ArtifactsMap create(@NotNull Gradle gradle, @NotNull MessageReporter messageReporter) {
+    synchronized ArtifactsMap create(@NotNull Gradle gradle, @NotNull MessageReporter messageReporter) {
       return createArtifactsMap(gradle)
     }
   }
@@ -49,7 +50,7 @@ class SourceSetCachedFinder {
     @NotNull
     @Override
     Map<String, Set<File>> create(@NotNull Gradle gradle, @NotNull MessageReporter messageReporter) {
-      return new HashMap<String, Set<File>>()
+      return new ConcurrentHashMap<String, Set<File>>()
     }
   }
 


### PR DESCRIPTION
The sourceSet cache initializer can be called from several threads, but Gradle's
project model is not thread safe, so we need to make sure only one thread at a time
can initialize this.

This makes parallel model fetch work in the project I'm currently working on.


FYI @vladsoroka @nskvortsov 