### PR TITLE
Remove container callback usages from model builders

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalProjectBuilderImpl.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalProjectBuilderImpl.groovy
@@ -238,7 +238,7 @@ class ExternalProjectBuilderImpl extends AbstractModelBuilderService {
     if (generatedSourceDirs && !generatedSourceDirs.isEmpty()) {
       additionalIdeaGenDirs.addAll(generatedSourceDirs)
     }
-    sourceSets.all { SourceSet sourceSet ->
+    sourceSets.each { SourceSet sourceSet ->
       ExternalSourceSet externalSourceSet = new DefaultExternalSourceSet()
       externalSourceSet.name = sourceSet.name
 

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/TasksFactory.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/TasksFactory.java
@@ -15,7 +15,6 @@
  */
 package org.jetbrains.plugins.gradle.tooling.builder;
 
-import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.DefaultTaskContainer;
@@ -45,21 +44,17 @@ public class TasksFactory {
   @NotNull
   private Map<Project, Set<Task>> getAllTasks(@NotNull Project root) {
     final Map<Project, Set<Task>> foundTargets = new TreeMap<Project, Set<Task>>();
-    Action<Project> action = new Action<Project>() {
-      @Override
-      public void execute(@NotNull Project project) {
-        try {
-          maybeRefreshTasks(project);
-          TaskContainer projectTasks = project.getTasks();
-          foundTargets.put(project, new TreeSet<Task>(projectTasks));
-        }
-        catch (Exception e) {
-          String title = "Can not load tasks for " + project;
-          myMessageReporter.report(project, MessageBuilder.create(title, title).warning().withException(e).build());
-        }
+    for (Project project : root.getAllprojects()) {
+      try {
+        maybeRefreshTasks(project);
+        TaskContainer projectTasks = project.getTasks();
+        foundTargets.put(project, new TreeSet<Task>(projectTasks));
       }
-    };
-    root.allprojects(action);
+      catch (Exception e) {
+        String title = "Can not load tasks for " + project;
+        myMessageReporter.report(project, MessageBuilder.create(title, title).warning().withException(e).build());
+      }
+    }
     return foundTargets;
   }
 


### PR DESCRIPTION
Container callbacks like .all{} and .allprojects{} are meant to be used
during configuration by plugins and build scripts, so they can react to
newly added objects. These methods are instrumented with build operations
for detailed analytics in build scans.

When a model builder runs, all configuration has already taken place and
the simpler .each{} method can be used. This avoids creating extra "noise"
that build scans would capture. It doesn't affect performance much, but it
makes profiling IDEA sync slightly more pleasant.

FYI @vladsoroka and @nskvortsov 