### PR TITLE
Remove legacy LenientConfiguration API usage

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImpl.java
@@ -2,25 +2,29 @@
 package org.jetbrains.plugins.gradle.tooling.util.resolve;
 
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.ArtifactCollection;
+import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.*;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
-import org.gradle.api.artifacts.result.*;
+import org.gradle.api.artifacts.result.ArtifactResult;
+import org.gradle.api.artifacts.result.ComponentArtifactsResult;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.plugins.WarPlugin;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.internal.impldep.com.google.common.collect.ArrayListMultimap;
 import org.gradle.internal.impldep.com.google.common.collect.HashMultimap;
 import org.gradle.internal.impldep.com.google.common.collect.Multimap;
+import org.gradle.internal.impldep.org.apache.commons.io.FilenameUtils;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
@@ -30,8 +34,6 @@ import org.gradle.util.Path;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.plugins.gradle.model.ExternalDependency;
-import org.jetbrains.plugins.gradle.model.FileCollectionDependency;
 import org.jetbrains.plugins.gradle.model.*;
 import org.jetbrains.plugins.gradle.tooling.serialization.internal.adapter.Supplier;
 import org.jetbrains.plugins.gradle.tooling.util.DependencyResolver;
@@ -118,7 +120,7 @@ public final class DependencyResolverImpl implements DependencyResolver {
         .resolveDependencies(sourceSet);
     }
 
-    Collection<ExternalDependency> result = new ArrayList<ExternalDependency>();
+    Collection<ExternalDependency> result = new LinkedHashSet<ExternalDependency>();
 
     // resolve compile dependencies
     FileCollection compileClasspath = getCompileClasspath(sourceSet);
@@ -182,298 +184,158 @@ public final class DependencyResolverImpl implements DependencyResolver {
       return emptySet();
     }
 
-    // following statement should trigger parallel resolution of configurations artifacts
-    // all subsequent iteration are expected to use cached results.
-    try {
-      configuration.getIncoming().artifactView(new Action<ArtifactView.ViewConfiguration>() {
-        @Override
-        public void execute(@NotNull ArtifactView.ViewConfiguration configuration) {
-          configuration.setLenient(true);
-        }
-      }).getArtifacts().getArtifacts();
-    } catch (Exception ignore) {}
+    Set<ExternalDependency> result = new LinkedHashSet<ExternalDependency>();
 
-    LenientConfiguration lenientConfiguration = configuration.getResolvedConfiguration().getLenientConfiguration();
-    ResolutionResult resolutionResult = configuration.getIncoming().getResolutionResult();
-    List<ComponentIdentifier> components = new ArrayList<ComponentIdentifier>();
-    Map<ResolvedDependency, Set<ResolvedArtifact>> resolvedArtifacts = new LinkedHashMap<ResolvedDependency, Set<ResolvedArtifact>>();
-    Map<ModuleVersionIdentifier, ResolvedDependencyResult> transformedProjectDependenciesResultMap = null;
-    for (ResolvedDependency dependency : lenientConfiguration.getAllModuleDependencies()) {
-      try {
-        Set<ResolvedArtifact> moduleArtifacts = dependency.getModuleArtifacts();
-        for (ResolvedArtifact artifact : moduleArtifacts) {
-          if ((artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier)) continue;
-          components.add(toComponentIdentifier(artifact.getModuleVersion().getId()));
-        }
-        resolvedArtifacts.put(dependency, moduleArtifacts);
+    ArtifactCollection artifactResults = configuration.getIncoming().artifactView(new Action<ArtifactView.ViewConfiguration>() {
+      @Override
+      public void execute(@NotNull ArtifactView.ViewConfiguration configuration) {
+        configuration.setLenient(true);
       }
-      catch (GradleException e) {
-        if (transformedProjectDependenciesResultMap == null) {
-          transformedProjectDependenciesResultMap = new HashMap<ModuleVersionIdentifier, ResolvedDependencyResult>();
-          for (DependencyResult dependencyResult : resolutionResult.getAllDependencies()) {
-            ComponentSelector resultRequested = dependencyResult.getRequested();
-            if (dependencyResult instanceof ResolvedDependencyResult && resultRequested instanceof ProjectComponentSelector) {
-              ResolvedComponentResult resolvedComponentResult = ((ResolvedDependencyResult)dependencyResult).getSelected();
-              ModuleVersionIdentifier selectedResultVersion = resolvedComponentResult.getModuleVersion();
-              transformedProjectDependenciesResultMap.put(selectedResultVersion, (ResolvedDependencyResult)dependencyResult);
-            }
-          }
-        }
-        resolvedArtifacts.put(dependency, Collections.<ResolvedArtifact>emptySet());
-      }
-      catch (Exception ignore) {
-        // ignore other artifact resolution exceptions
-      }
-    }
-    Map<ComponentIdentifier, ComponentArtifactsResult> auxiliaryArtifactsMap = buildAuxiliaryArtifactsMap(configuration, components);
-    Collection<FileCollectionDependency> sourceSetsOutputDirsRuntimeFileDependencies = new LinkedHashSet<FileCollectionDependency>();
-    Collection<ExternalDependency> artifactDependencies = new LinkedHashSet<ExternalDependency>();
+    }).getArtifacts();
+
+    Map<ComponentIdentifier, ComponentArtifactsResult> auxiliaryArtifactsMap = buildAuxiliaryArtifactsMap(configuration, artifactResults);
     Set<String> resolvedFiles = new HashSet<String>();
     Map<String, DefaultExternalProjectDependency> resolvedProjectDependencies = new HashMap<String, DefaultExternalProjectDependency>();
-    for (Map.Entry<ResolvedDependency, Set<ResolvedArtifact>> resolvedDependencySetEntry : resolvedArtifacts.entrySet()) {
-      ResolvedDependency resolvedDependency = resolvedDependencySetEntry.getKey();
-      Set<ResolvedArtifact> artifacts = resolvedDependencySetEntry.getValue();
-      for (ResolvedArtifact artifact : artifacts) {
-        File artifactFile = artifact.getFile();
-        if (resolvedFiles.contains(artifactFile.getPath())) {
+    for (ResolvedArtifactResult artifactResult : artifactResults) {
+      File artifactFile = artifactResult.getFile();
+      if (!resolvedFiles.add(artifactFile.getPath())) {
+        continue;
+      }
+      String artifactPath = mySourceSetFinder.findArtifactBySourceSetOutputDir(artifactFile.getPath());
+      if (artifactPath != null) {
+        artifactFile = new File(artifactPath);
+        if (!resolvedFiles.add(artifactFile.getPath())) {
           continue;
         }
-        resolvedFiles.add(artifactFile.getPath());
-        String artifactPath = mySourceSetFinder.findArtifactBySourceSetOutputDir(artifactFile.getPath());
-        if (artifactPath != null) {
-          artifactFile = new File(artifactPath);
-          if (resolvedFiles.contains(artifactFile.getPath())) {
-            continue;
-          }
-          resolvedFiles.add(artifactFile.getPath());
-        }
+      }
 
-        AbstractExternalDependency dependency;
-        ModuleVersionIdentifier moduleVersionIdentifier = artifact.getModuleVersion().getId();
-        if (artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier) {
-          if (scope == RUNTIME_SCOPE) {
-            SourceSet sourceSet = mySourceSetFinder.findByArtifact(artifactFile.getPath());
-            if (sourceSet != null) {
-              FileCollectionDependency outputDirsRuntimeFileDependency =
-                resolveSourceSetOutputDirsRuntimeFileDependency(sourceSet.getOutput());
-              if (outputDirsRuntimeFileDependency != null) {
-                sourceSetsOutputDirsRuntimeFileDependencies.add(outputDirsRuntimeFileDependency);
-              }
+      ComponentIdentifier componentIdentifier = artifactResult.getId().getComponentIdentifier();
+      if (componentIdentifier instanceof ProjectComponentIdentifier) {
+        ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier)componentIdentifier;
+        if (scope == RUNTIME_SCOPE) {
+          SourceSet sourceSet = mySourceSetFinder.findByArtifact(artifactFile.getPath());
+          if (sourceSet != null) {
+            FileCollectionDependency outputDirsRuntimeFileDependency =
+              resolveSourceSetOutputDirsRuntimeFileDependency(sourceSet.getOutput());
+            if (outputDirsRuntimeFileDependency != null) {
+              result.add(outputDirsRuntimeFileDependency);
             }
           }
+        }
 
-          ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier)artifact.getId().getComponentIdentifier();
-          String buildName = projectComponentIdentifier.getBuild().getName();
-          String projectPath = projectComponentIdentifier.getProjectPath();
-          String key = buildName + "_" + projectPath + "_" + resolvedDependency.getConfiguration();
-          DefaultExternalProjectDependency projectDependency = resolvedProjectDependencies.get(key);
-          if (projectDependency != null) {
-            Set<File> projectDependencyArtifacts = new LinkedHashSet<File>(projectDependency.getProjectDependencyArtifacts());
-            projectDependencyArtifacts.add(artifactFile);
-            projectDependency.setProjectDependencyArtifacts(projectDependencyArtifacts);
-            Set<File> artifactSources = new LinkedHashSet<File>(projectDependency.getProjectDependencyArtifactsSources());
-            artifactSources.addAll(findArtifactSources(singleton(artifactFile), mySourceSetFinder));
-            projectDependency.setProjectDependencyArtifactsSources(artifactSources);
-            continue;
-          }
-          else {
-            projectDependency = new DefaultExternalProjectDependency();
-            resolvedProjectDependencies.put(key, projectDependency);
-          }
-          dependency = projectDependency;
+        String key = artifactResult.getId().getDisplayName();
+        DefaultExternalProjectDependency projectDependency = resolvedProjectDependencies.get(key);
+        if (projectDependency != null) {
+          Set<File> projectDependencyArtifacts = new LinkedHashSet<File>(projectDependency.getProjectDependencyArtifacts());
+          projectDependencyArtifacts.add(artifactFile);
+          projectDependency.setProjectDependencyArtifacts(projectDependencyArtifacts);
+          Set<File> artifactSources = new LinkedHashSet<File>(projectDependency.getProjectDependencyArtifactsSources());
+          artifactSources.addAll(findArtifactSources(singleton(artifactFile), mySourceSetFinder));
+          projectDependency.setProjectDependencyArtifactsSources(artifactSources);
+        }
+        else {
+          projectDependency = new DefaultExternalProjectDependency();
+          resolvedProjectDependencies.put(key, projectDependency);
           String projectName = projectComponentIdentifier.getProjectName(); // since 4.5
           projectDependency.setName(projectName);
-          projectDependency.setGroup(resolvedDependency.getModuleGroup());
-          projectDependency.setVersion(resolvedDependency.getModuleVersion());
           projectDependency.setScope(scope);
-          projectDependency.setProjectPath(projectPath);
-          projectDependency.setConfigurationName(resolvedDependency.getConfiguration());
+          projectDependency.setProjectPath(projectComponentIdentifier.getProjectPath());
           Set<File> projectArtifacts = singleton(artifactFile);
           projectDependency.setProjectDependencyArtifacts(projectArtifacts);
           projectDependency.setProjectDependencyArtifactsSources(findArtifactSources(projectArtifacts, mySourceSetFinder));
+          result.add(projectDependency);
         }
-        else {
-          DefaultExternalLibraryDependency libraryDependency = new DefaultExternalLibraryDependency();
-          libraryDependency.setName(moduleVersionIdentifier.getName());
-          libraryDependency.setGroup(moduleVersionIdentifier.getGroup());
-          libraryDependency.setVersion(moduleVersionIdentifier.getVersion());
-          libraryDependency.setFile(artifactFile);
-          ComponentArtifactsResult artifactsResult = auxiliaryArtifactsMap.get(artifact.getId().getComponentIdentifier());
-          if (artifactsResult != null) {
-            Set<ArtifactResult> sourceArtifactResults = artifactsResult.getArtifacts(SourcesArtifact.class);
-            for (ArtifactResult sourceArtifactResult : sourceArtifactResults) {
-              if (sourceArtifactResult instanceof ResolvedArtifactResult) {
-                libraryDependency.setSource(((ResolvedArtifactResult)sourceArtifactResult).getFile());
-                break;
-              }
-            }
-            Set<ArtifactResult> javadocArtifactResults = artifactsResult.getArtifacts(JavadocArtifact.class);
-            for (ArtifactResult javadocArtifactResult : javadocArtifactResults) {
-              if (javadocArtifactResult instanceof ResolvedArtifactResult) {
-                libraryDependency.setJavadoc(((ResolvedArtifactResult)javadocArtifactResult).getFile());
-                break;
-              }
+      }
+      else if (componentIdentifier instanceof ModuleComponentIdentifier){
+        ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier)componentIdentifier;
+        DefaultExternalLibraryDependency libraryDependency = new DefaultExternalLibraryDependency();
+        libraryDependency.setName(moduleComponentIdentifier.getModule());
+        libraryDependency.setGroup(moduleComponentIdentifier.getGroup());
+        libraryDependency.setVersion(moduleComponentIdentifier.getVersion());
+        libraryDependency.setFile(artifactFile);
+        ComponentArtifactsResult artifactsResult = auxiliaryArtifactsMap.get(componentIdentifier);
+        if (artifactsResult != null) {
+          Set<ArtifactResult> sourceArtifactResults = artifactsResult.getArtifacts(SourcesArtifact.class);
+          for (ArtifactResult sourceArtifactResult : sourceArtifactResults) {
+            if (sourceArtifactResult instanceof ResolvedArtifactResult) {
+              libraryDependency.setSource(((ResolvedArtifactResult)sourceArtifactResult).getFile());
+              break;
             }
           }
-          libraryDependency.setPackaging(artifact.getExtension());
-          libraryDependency.setScope(scope);
-          libraryDependency.setClassifier(artifact.getClassifier());
-
-          dependency = libraryDependency;
-        }
-        artifactDependencies.add(dependency);
-      }
-
-      if (transformedProjectDependenciesResultMap == null || !artifacts.isEmpty()) continue;
-      ExternalProjectDependency projectDependency = getFailedToTransformProjectArtifactDependency(
-        resolvedDependency, transformedProjectDependenciesResultMap, resolvedProjectDependencies, scope);
-      if (projectDependency != null) {
-        artifactDependencies.add(projectDependency);
-      }
-    }
-
-    Collection<FileCollectionDependency> otherFileDependencies = resolveOtherFileDependencies(resolvedFiles, configuration, scope);
-
-    Collection<ExternalDependency> result = new LinkedHashSet<ExternalDependency>();
-    result.addAll(sourceSetsOutputDirsRuntimeFileDependencies);
-    result.addAll(otherFileDependencies);
-    result.addAll(artifactDependencies);
-    addUnresolvedDependencies(result, lenientConfiguration, scope);
-    return result;
-  }
-
-  @Nullable
-  private ExternalProjectDependency getFailedToTransformProjectArtifactDependency(@NotNull ResolvedDependency resolvedDependency,
-                                                                                  @NotNull Map<ModuleVersionIdentifier, ResolvedDependencyResult> transformedProjectDependenciesResultMap,
-                                                                                  @NotNull Map<String, DefaultExternalProjectDependency> resolvedProjectDependencies,
-                                                                                  @Nullable String scope) {
-    ModuleVersionIdentifier moduleVersionIdentifier = resolvedDependency.getModule().getId();
-    ResolvedDependencyResult resolvedDependencyResult = transformedProjectDependenciesResultMap.get(moduleVersionIdentifier);
-    if (resolvedDependencyResult == null) return null;
-
-    ProjectComponentSelector dependencyResultRequested = (ProjectComponentSelector)resolvedDependencyResult.getRequested();
-    String projectPath = dependencyResultRequested.getProjectPath();
-    String key = projectPath + "_" + resolvedDependency.getConfiguration();
-    DefaultExternalProjectDependency projectDependency = resolvedProjectDependencies.get(key);
-    if (projectDependency != null) return null;
-
-    projectDependency = new DefaultExternalProjectDependency();
-    resolvedProjectDependencies.put(key, projectDependency);
-    String projectName = Path.path(projectPath).getName();
-    projectDependency.setName(projectName);
-    projectDependency.setGroup(resolvedDependency.getModuleGroup());
-    projectDependency.setVersion(resolvedDependency.getModuleVersion());
-    projectDependency.setScope(scope);
-    projectDependency.setProjectPath(projectPath);
-    projectDependency.setConfigurationName(resolvedDependency.getConfiguration());
-    Project project = myProject.findProject(projectPath);
-    if (project == null) return null;
-
-    Configuration configuration1 = project.getConfigurations().findByName(resolvedDependency.getConfiguration());
-    if (configuration1 == null) return null;
-
-    Set<File> projectArtifacts = configuration1.getArtifacts().getFiles().getFiles();
-    projectDependency.setProjectDependencyArtifacts(projectArtifacts);
-    projectDependency.setProjectDependencyArtifactsSources(findArtifactSources(projectArtifacts, mySourceSetFinder));
-    return projectDependency;
-  }
-
-  @NotNull
-  private Map<ComponentIdentifier, ComponentArtifactsResult> buildAuxiliaryArtifactsMap(@NotNull Configuration configuration,
-                                                                                        List<ComponentIdentifier> components) {
-    Map<ComponentIdentifier, ComponentArtifactsResult> artifactsResultMap;
-    if (!components.isEmpty()) {
-      List<Class<? extends Artifact>> artifactTypes = new ArrayList<Class<? extends Artifact>>(2);
-      if (myDownloadSources) {
-        artifactTypes.add(SourcesArtifact.class);
-      }
-      if (myDownloadJavadoc) {
-        artifactTypes.add(JavadocArtifact.class);
-      }
-      boolean isBuildScriptConfiguration = myProject.getBuildscript().getConfigurations().contains(configuration);
-      DependencyHandler dependencyHandler =
-        isBuildScriptConfiguration ? myProject.getBuildscript().getDependencies() : myProject.getDependencies();
-      Set<ComponentArtifactsResult> componentResults = dependencyHandler.createArtifactResolutionQuery()
-        .forComponents(components)
-        .withArtifacts(JvmLibrary.class, artifactTypes)
-        .execute()
-        .getResolvedComponents();
-
-      artifactsResultMap = new HashMap<ComponentIdentifier, ComponentArtifactsResult>(componentResults.size());
-      for (ComponentArtifactsResult artifactsResult : componentResults) {
-        artifactsResultMap.put(artifactsResult.getId(), artifactsResult);
-      }
-    }
-    else {
-      artifactsResultMap = emptyMap();
-    }
-    return artifactsResultMap;
-  }
-
-  private static Collection<FileCollectionDependency> resolveOtherFileDependencies(@NotNull Set<String> resolvedFiles,
-                                                                                   @NotNull Configuration configuration,
-                                                                                   @Nullable String scope) {
-    ArtifactView artifactView = configuration.getIncoming().artifactView(new Action<ArtifactView.ViewConfiguration>() {
-      @Override
-      public void execute(@SuppressWarnings("NullableProblems") ArtifactView.ViewConfiguration configuration) {
-        configuration.setLenient(true);
-        configuration.componentFilter(new Spec<ComponentIdentifier>() {
-          @Override
-          public boolean isSatisfiedBy(ComponentIdentifier identifier) {
-            return !(identifier instanceof ProjectComponentIdentifier || identifier instanceof ModuleComponentIdentifier);
+          Set<ArtifactResult> javadocArtifactResults = artifactsResult.getArtifacts(JavadocArtifact.class);
+          for (ArtifactResult javadocArtifactResult : javadocArtifactResults) {
+            if (javadocArtifactResult instanceof ResolvedArtifactResult) {
+              libraryDependency.setJavadoc(((ResolvedArtifactResult)javadocArtifactResult).getFile());
+              break;
+            }
           }
-        });
+        }
+        libraryDependency.setPackaging(FilenameUtils.getExtension(artifactResult.getFile().getAbsolutePath()));
+        libraryDependency.setScope(scope);
+        result.add(libraryDependency);
       }
-    });
-    Set<ResolvedArtifactResult> artifactResults = artifactView.getArtifacts().getArtifacts();
-    Collection<FileCollectionDependency> result = new LinkedHashSet<FileCollectionDependency>();
-    for (ResolvedArtifactResult artifactResult : artifactResults) {
-      File file = artifactResult.getFile();
-      if (!resolvedFiles.contains(file.getPath())) {
-        DefaultFileCollectionDependency fileCollectionDependency = new DefaultFileCollectionDependency(singleton(file));
+      else {
+        DefaultFileCollectionDependency fileCollectionDependency = new DefaultFileCollectionDependency(singleton(artifactResult.getFile()));
         fileCollectionDependency.setScope(scope);
         result.add(fileCollectionDependency);
       }
     }
+
+    for (Throwable failure : artifactResults.getFailures()) {
+      if (failure instanceof ModuleVersionResolveException) {
+        ComponentSelector attempted = ((ModuleVersionResolveException)failure).getSelector();
+        if (attempted instanceof ModuleComponentSelector) {
+          ModuleComponentSelector attemptedModule = (ModuleComponentSelector) attempted;
+          DefaultUnresolvedExternalDependency externalDependency = new DefaultUnresolvedExternalDependency();
+          externalDependency.setName(attemptedModule.getModule());
+          externalDependency.setGroup(attemptedModule.getGroup());
+          externalDependency.setVersion(attemptedModule.getVersion());
+          externalDependency.setScope(scope);
+          externalDependency.setFailureMessage(failure.getMessage());
+          result.add(externalDependency);
+        }
+      }
+    }
+
     return result;
   }
 
-  private static void addUnresolvedDependencies(@NotNull Collection<ExternalDependency> result,
-                                                @NotNull LenientConfiguration lenientConfiguration,
-                                                @Nullable String scope) {
-    Set<UnresolvedDependency> unresolvedModuleDependencies = lenientConfiguration.getUnresolvedModuleDependencies();
-    for (UnresolvedDependency unresolvedDependency : unresolvedModuleDependencies) {
-      MyModuleVersionSelector myModuleVersionSelector = null;
-      Throwable problem = unresolvedDependency.getProblem();
-      if (problem.getCause() != null) {
-        problem = problem.getCause();
+
+  @NotNull
+  private Map<ComponentIdentifier, ComponentArtifactsResult> buildAuxiliaryArtifactsMap(@NotNull Configuration configuration,
+                                                                                        ArtifactCollection mainArtifacts) {
+    Set<ComponentIdentifier> components = new LinkedHashSet<ComponentIdentifier>();
+    for (ResolvedArtifactResult artifact : mainArtifacts) {
+      ComponentIdentifier componentIdentifier = artifact.getId().getComponentIdentifier();
+      if (componentIdentifier instanceof ModuleComponentIdentifier) {
+        components.add(componentIdentifier);
       }
-      try {
-        if (problem instanceof ModuleVersionResolveException) {
-          ComponentSelector componentSelector = ((ModuleVersionResolveException)problem).getSelector();
-          if (componentSelector instanceof ModuleComponentSelector) {
-            ModuleComponentSelector moduleComponentSelector = (ModuleComponentSelector)componentSelector;
-            myModuleVersionSelector = new MyModuleVersionSelector(moduleComponentSelector.getModule(),
-                                                                  moduleComponentSelector.getGroup(),
-                                                                  moduleComponentSelector.getVersion());
-          }
-        }
-      }
-      catch (Throwable ignore) {
-      }
-      if (myModuleVersionSelector == null) {
-        problem = unresolvedDependency.getProblem();
-        ModuleVersionSelector selector = unresolvedDependency.getSelector();
-        myModuleVersionSelector = new MyModuleVersionSelector(selector.getName(), selector.getGroup(), selector.getVersion());
-      }
-      DefaultUnresolvedExternalDependency dependency = new DefaultUnresolvedExternalDependency();
-      dependency.setName(myModuleVersionSelector.name);
-      dependency.setGroup(myModuleVersionSelector.group);
-      dependency.setVersion(myModuleVersionSelector.version);
-      dependency.setScope(scope);
-      dependency.setFailureMessage(problem.getMessage());
-      result.add(dependency);
     }
+    if (components.isEmpty()) {
+      return emptyMap();
+    }
+    List<Class<? extends Artifact>> artifactTypes = new ArrayList<Class<? extends Artifact>>(2);
+    if (myDownloadSources) {
+      artifactTypes.add(SourcesArtifact.class);
+    }
+    if (myDownloadJavadoc) {
+      artifactTypes.add(JavadocArtifact.class);
+    }
+    boolean isBuildScriptConfiguration = myProject.getBuildscript().getConfigurations().contains(configuration);
+    DependencyHandler dependencyHandler =
+      isBuildScriptConfiguration ? myProject.getBuildscript().getDependencies() : myProject.getDependencies();
+    Set<ComponentArtifactsResult> componentResults = dependencyHandler.createArtifactResolutionQuery()
+      .forComponents(components)
+      .withArtifacts(JvmLibrary.class, artifactTypes)
+      .execute()
+      .getResolvedComponents();
+
+    Map<ComponentIdentifier, ComponentArtifactsResult> artifactsResultMap =
+      new HashMap<ComponentIdentifier, ComponentArtifactsResult>(componentResults.size());
+    for (ComponentArtifactsResult artifactsResult : componentResults) {
+      artifactsResultMap.put(artifactsResult.getId(), artifactsResult);
+    }
+    return artifactsResultMap;
   }
 
   private static Collection<ExternalDependency> resolveSourceOutputFileDependencies(@NotNull SourceSetOutput sourceSetOutput,
@@ -598,7 +460,7 @@ public final class DependencyResolverImpl implements DependencyResolver {
   }
 
   private Collection<ExternalDependency> getDependencies(@NotNull Iterable<?> fileCollections, @NotNull String scope) {
-    Set<ExternalDependency> result = new LinkedHashSet<ExternalDependency>();
+    Collection<ExternalDependency> result = new LinkedHashSet<ExternalDependency>();
     for (Object fileCollection : fileCollections) {
       if (fileCollection instanceof FileCollection) {
         result.addAll(getDependencies((FileCollection)fileCollection, scope));
@@ -644,15 +506,4 @@ public final class DependencyResolverImpl implements DependencyResolver {
     return new ModuleComponentIdentifierImpl(group, module, version);
   }
 
-  private static final class MyModuleVersionSelector {
-    private final String name;
-    private final String group;
-    private final String version;
-
-    private MyModuleVersionSelector(String name, String group, String version) {
-      this.name = name;
-      this.group = group;
-      this.version = version;
-    }
-  }
 }


### PR DESCRIPTION
This API is outdated and inefficient, adding overhead to the sync process.

The ArtifactView API deliberately hides concepts like classifiers, packaging and configurations,
as these are Maven/Ivy implementation details. Gradle internally uses the concept of variants
instead. It also exposes this variant information via the ResolvedVariant API that IntelliJ could use if
you wanted to provide more detail about which variant of a library was resolved.

This change is more of a basis for discussion than being intended to be merged. I think we
should finally let the old LenientConfiguration API go and the first step would be IntelliJ
no longer using it on modern Gradle versions.

@vladsoroka @nskvortsov Can you run the CI build on this so I get an idea how big the gap to
the current functionality is?