### PR TITLE
Highlight empty finally as unused

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/errorhandling/EmptyFinallyBlockInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/errorhandling/EmptyFinallyBlockInspection.java
@@ -17,6 +17,7 @@ package com.siyeh.ig.errorhandling;
 
 import com.intellij.codeInsight.BlockUtils;
 import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
 import com.intellij.psi.tree.IElementType;
@@ -152,7 +153,7 @@ public class EmptyFinallyBlockInspection extends BaseInspection {
         final String childText = child.getText();
         if (PsiKeyword.FINALLY.equals(childText)) {
           final boolean canDeleteTry = statement.getCatchBlocks().length == 0 && statement.getResourceList() == null;
-          registerError(child, Boolean.valueOf(canDeleteTry));
+          registerError(child, ProblemHighlightType.LIKE_UNUSED_SYMBOL, Boolean.valueOf(canDeleteTry));
           return;
         }
       }

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/errorhandling/EmptyFinallyBlockFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/errorhandling/EmptyFinallyBlockFixTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.siyeh.ig.errorhandling;
+
+import com.siyeh.InspectionGadgetsBundle;
+import com.siyeh.ig.BaseInspection;
+import com.siyeh.ig.IGQuickFixesTestCase;
+
+/**
+ * @author Fabrice TIERCELIN
+ */
+public class EmptyFinallyBlockFixTest extends IGQuickFixesTestCase {
+  @Override
+  protected BaseInspection getInspection() {
+    return new EmptyFinallyBlockInspection();
+  }
+
+  public void testRemoveTry() {
+    doMemberTest(InspectionGadgetsBundle.message("remove.try.finally.block.quickfix"),
+                 "void m() throws Exception {\n" +
+                 "  try { throw new Exception(); }\n" +
+                 "  finally/**/ { }\n" +
+                 "}",
+                 "void m() throws Exception {\n" +
+                 "    throw new Exception();\n" +
+                 "}"
+    );
+  }
+
+  public void testWithResource() {
+    doMemberTest(InspectionGadgetsBundle.message("remove.finally.block.quickfix"),
+                 "void m() throws Exception {\n" +
+                 "  try (AutoCloseable r = null) { throw new Exception(); }\n" +
+                 "  finally/**/ { }\n" +
+                 "}",
+                 "void m() throws Exception {\n" +
+                 "  try (AutoCloseable r = null) { throw new Exception(); }\n" +
+                 "}"
+    );
+  }
+
+  public void testWithCatch() {
+    doMemberTest(InspectionGadgetsBundle.message("remove.finally.block.quickfix"),
+                 "void m() throws Exception {\n" +
+                 "  try { throw new Exception(); }\n" +
+                 "  catch (Exception e) { e.printStackTrace(); }\n" +
+                 "  finally/**/ { }\n" +
+                 "}",
+                 "void m() throws Exception {\n" +
+                 "  try { throw new Exception(); }\n" +
+                 "  catch (Exception e) { e.printStackTrace(); }\n" +
+                 "}"
+    );
+  }
+
+  public void testDoNotCleanupWithFilledFinally() {
+    assertQuickfixNotAvailable(InspectionGadgetsBundle.message("remove.finally.block.quickfix"),
+                               "class X {\n" +
+                               "void m() throws Exception {\n" +
+                               "  try { throw new Exception(); }\n" +
+                               "  finally/**/ { System.out.println(\"foo\"); }\n" +
+                               "}" +
+                               "}\n");
+  }
+}


### PR DESCRIPTION
Hi @BasLeijdekkers,

`EmptyFinallyBlockInspection` warns about a useless code so it should be highlighted as unused. I have also written tests for it.