### PR TITLE
Kotlin: Do not hide duplicate variables in InlineStackFrameVariableHolder

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTrace.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTrace.out
@@ -114,6 +114,7 @@ InlineStackFrame lambda 'with' in 'fun8' (inlineStackTrace.kt:94)
     JavaValue[local] x8: int = 1 (inlineStackTrace.kt:85)
     JavaValue[local] w1: int = 1 (inlineStackTrace.kt:90)
 InlineStackFrame fun8 (inlineStackTrace.kt:89)
+    JavaValue[local] this: java.lang.String = A
     JavaValue[local] x8: int = 1 (inlineStackTrace.kt:85)
 InlineStackFrame fun7 (inlineStackTrace.kt:81)
     JavaValue[local] x7: int = 1
@@ -133,6 +134,7 @@ InlineStackFrame lambda 'with' in 'fun8' (inlineStackTrace.kt:94)
     JavaValue[local] x8: int = 1
     JavaValue[local] w1: int = 1
 InlineStackFrame fun8 (inlineStackTrace.kt:89)
+    JavaValue[local] this: java.lang.String = A
     JavaValue[local] x8: int = 1
 InlineStackFrame fun7 (inlineStackTrace.kt:81)
     JavaValue[local] x7: int = 1

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/frame/capturedValues2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/frame/capturedValues2.out
@@ -9,8 +9,10 @@ InlineStackFrame lambda 'block' in 'main' (capturedValues2.kt:14)
     JavaValue[local] a: int = 3 (capturedValues2.kt:13)
 InlineStackFrame block (capturedValues2.kt:23)
 InlineStackFrame lambda 'block' in 'main' (capturedValues2.kt:10)
+    JavaValue[local] a: int = 2 (capturedValues2.kt:13)
 InlineStackFrame block (capturedValues2.kt:16)
 KotlinStackFrameWithProvidedVariables (capturedValues2.kt:6)
+    JavaValue[local] a: int = 1 (capturedValues2.kt:13)
 Disconnected from the target VM
 
 Process finished with exit code 0


### PR DESCRIPTION
Fixes KTIJ-20828

---

This is already tested in `testCapturedValues2`, where I've fixed the test expectations. There seems to be a separate problem with `@InlineOnly` functions in `testInlineStackTrace` (the inline call stack shows the wrong "this" variables), but that doesn't appear to be a new issue.