### PR TITLE
KTIJ-13949 Provide quick fix for [EQUALITY_NOT_APPLICABLE] compilation error on Long (Short etc) == Int literal

### DIFF
--- a/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
@@ -2538,3 +2538,7 @@ provide.return.value=Provide the return value
 
 
 wrap.expression.in.parentheses=Wrap expression in parentheses
+
+convert.left.hand.side.to.0=Convert left-hand side to ''{0}''
+convert.right.hand.side.to.0=Convert right-hand side to ''{0}''
+convert.string.to.character.literal=Convert string to character literal

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertStringToCharLiteralFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertStringToCharLiteralFix.kt
@@ -1,0 +1,37 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.caches.resolve.analyzeAsReplacement
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.resolve.constants.evaluate.ConstantExpressionEvaluator
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+
+class ConvertStringToCharLiteralFix(element: KtStringTemplateExpression) : KotlinQuickFixAction<KtStringTemplateExpression>(element) {
+    override fun getText() = KotlinBundle.message("convert.string.to.character.literal")
+
+    override fun getFamilyName() = text
+
+    override fun invoke(project: Project, editor: Editor?, file: KtFile) {
+        val stringTemplate = element ?: return
+        stringTemplate.replace(stringTemplate.charLiteral())
+    }
+
+    companion object {
+        private fun KtStringTemplateExpression.charLiteral(): KtExpression {
+            return KtPsiFactory(this).createExpression("'${this.text.replace("\"", "")}'")
+        }
+
+        fun isApplicable(stringTemplate: KtStringTemplateExpression): Boolean {
+            val charLiteral = stringTemplate.charLiteral()
+            val context = charLiteral.analyzeAsReplacement(stringTemplate, stringTemplate.analyze(BodyResolveMode.PARTIAL))
+            return ConstantExpressionEvaluator.getConstant(charLiteral, context) != null
+        }
+    }
+}

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/EqualityNotApplicableFactory.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/EqualityNotApplicableFactory.kt
@@ -50,5 +50,5 @@ object EqualityNotApplicableFactory : KotlinIntentionActionsFactory() {
         return fixes
     }
 
-    private fun KotlinType.isNumberType() = this.makeNotNullable().isSignedOrUnsignedNumberType()
+    fun KotlinType.isNumberType() = this.makeNotNullable().isSignedOrUnsignedNumberType()
 }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/EqualityNotApplicableFactory.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/EqualityNotApplicableFactory.kt
@@ -1,0 +1,54 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.codeInsight.intention.IntentionAction
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.typeUtil.isChar
+import org.jetbrains.kotlin.types.typeUtil.isSignedOrUnsignedNumberType
+import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
+
+object EqualityNotApplicableFactory : KotlinIntentionActionsFactory() {
+    override fun doCreateActions(diagnostic: Diagnostic): List<IntentionAction> {
+        val diagnosticWithParameters = Errors.EQUALITY_NOT_APPLICABLE.cast(diagnostic)
+        val binary = diagnostic.psiElement as? KtBinaryExpression ?: return emptyList()
+        val left = binary.left ?: return emptyList()
+        val right = binary.right ?: return emptyList()
+        val leftType = diagnosticWithParameters.b
+        val rightType = diagnosticWithParameters.c
+
+        val fixes = mutableListOf<IntentionAction>()
+
+        if (leftType.isNumberType() && rightType.isNumberType()) {
+            fixes.add(
+                NumberConversionFix(left, leftType, rightType, enableNullableType = true) {
+                    KotlinBundle.message("convert.left.hand.side.to.0", it)
+                }
+            )
+            fixes.add(
+                NumberConversionFix(right, rightType, leftType, enableNullableType = true) {
+                    KotlinBundle.message("convert.right.hand.side.to.0", it)
+                }
+            )
+        }
+
+        val leftHandSideIsChar = leftType.isChar()
+        val rightHandSideIsChar = rightType.isChar()
+        if ((leftHandSideIsChar && right is KtStringTemplateExpression) ||
+            (rightHandSideIsChar && left is KtStringTemplateExpression)
+        ) {
+            val stringTemplate = (if (leftHandSideIsChar) right else left) as KtStringTemplateExpression
+            if (ConvertStringToCharLiteralFix.isApplicable(stringTemplate)) {
+                fixes.add(ConvertStringToCharLiteralFix(stringTemplate))
+            }
+        }
+
+        return fixes
+    }
+
+    private fun KotlinType.isNumberType() = this.makeNotNullable().isSignedOrUnsignedNumberType()
+}

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/IncompatibleTypesFactory.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/IncompatibleTypesFactory.kt
@@ -1,0 +1,27 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.codeInsight.intention.IntentionAction
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.idea.quickfix.EqualityNotApplicableFactory.isNumberType
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.types.typeUtil.isChar
+
+object IncompatibleTypesFactory : KotlinIntentionActionsFactory() {
+    override fun doCreateActions(diagnostic: Diagnostic): List<IntentionAction> {
+        val diagnosticWithParameters = Errors.INCOMPATIBLE_TYPES.cast(diagnostic)
+        val element = diagnostic.psiElement
+        val actualType = diagnosticWithParameters.a
+        val expectedType = diagnosticWithParameters.b
+        return buildList {
+            when {
+                element is KtExpression && actualType.isNumberType() && expectedType.isNumberType() ->
+                    add(NumberConversionFix(element, actualType, expectedType, enableNullableType = true))
+                element is KtStringTemplateExpression && expectedType.isChar() ->
+                    add(ConvertStringToCharLiteralFix(element))
+            }
+        }
+    }
+}

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/NumberConversionFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/NumberConversionFix.kt
@@ -16,50 +16,59 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.createExpressionByPattern
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.types.typeUtil.*
 
 class NumberConversionFix(
     element: KtExpression,
     fromType: KotlinType,
     toType: KotlinType,
-    private val disableIfAvailable: IntentionAction? = null
+    private val disableIfAvailable: IntentionAction? = null,
+    private val enableNullableType: Boolean = false,
+    private val intentionText: (String) -> String = { KotlinBundle.message("convert.expression.to.0", it) }
 ) : KotlinQuickFixAction<KtExpression>(element) {
-    private val isConversionAvailable =
-        fromType != toType && fromType.isSignedOrUnsignedNumberType() && toType.isSignedOrUnsignedNumberType()
+    private val isConversionAvailable = fromType != toType && fromType.isNumberType() && toType.isNumberType()
 
-    private val typePresentation = IdeDescriptorRenderers.SOURCE_CODE_SHORT_NAMES_NO_ANNOTATIONS.renderType(toType)
+    private val typePresentation = IdeDescriptorRenderers.SOURCE_CODE_SHORT_NAMES_NO_ANNOTATIONS.renderType(toType.makeNotNullable())
 
     private val fromInt = fromType.isInt()
     private val fromChar = fromType.isChar()
     private val fromFloatOrDouble = fromType.isFloat() || fromType.isDouble()
+    private val fromNullable = fromType.isNullable()
 
     private val toChar = toType.isChar()
     private val toInt = toType.isInt()
     private val toByteOrShort = toType.isByte() || toType.isShort()
 
+    private fun KotlinType.isNumberType(): Boolean {
+        val type = if (enableNullableType) this.makeNotNullable() else this
+        return type.isSignedOrUnsignedNumberType()
+    }
+
     override fun isAvailable(project: Project, editor: Editor?, file: KtFile) =
         disableIfAvailable?.isAvailable(project, editor, file) != true && isConversionAvailable
 
     override fun getFamilyName() = KotlinBundle.message("insert.number.conversion")
-    override fun getText() = KotlinBundle.message("convert.expression.to.0", typePresentation)
+    override fun getText() = intentionText(typePresentation)
 
     override fun invoke(project: Project, editor: Editor?, file: KtFile) {
         val element = element ?: return
         val psiFactory = KtPsiFactory(file)
         val apiVersion = element.languageVersionSettings.apiVersion
+        val dot = if (fromNullable) "?." else "."
         val expressionToInsert = when {
             fromChar && apiVersion >= ApiVersion.KOTLIN_1_5 ->
                 if (toInt) {
-                    psiFactory.createExpressionByPattern("$0.code", element)
+                    psiFactory.createExpressionByPattern("$0${dot}code", element)
                 } else {
-                    psiFactory.createExpressionByPattern("$0.code.to$1()", element, typePresentation)
+                    psiFactory.createExpressionByPattern("$0${dot}code${dot}to$1()", element, typePresentation)
                 }
             !fromInt && toChar && apiVersion >= ApiVersion.KOTLIN_1_5 ->
-                psiFactory.createExpressionByPattern("$0.toInt().toChar()", element)
+                psiFactory.createExpressionByPattern("$0${dot}toInt()${dot}toChar()", element)
             fromFloatOrDouble && toByteOrShort && apiVersion >= ApiVersion.KOTLIN_1_3 ->
-                psiFactory.createExpressionByPattern("$0.toInt().to$1()", element, typePresentation)
+                psiFactory.createExpressionByPattern("$0${dot}toInt()${dot}to$1()", element, typePresentation)
             else ->
-                psiFactory.createExpressionByPattern("$0.to$1()", element, typePresentation)
+                psiFactory.createExpressionByPattern("$0${dot}to$1()", element, typePresentation)
         }
         val newExpression = element.replaced(expressionToInsert)
         editor?.caretModel?.moveToOffset(newExpression.endOffset)

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -746,5 +746,7 @@ class QuickFixRegistrar : QuickFixContributor {
         WRONG_NULLABILITY_FOR_JAVA_OVERRIDE.registerFactory(ChangeMemberFunctionSignatureFix)
         CONFUSING_BRANCH_CONDITION.registerFactory(ConfusingExpressionInWhenBranchFix)
         PROGRESSIONS_CHANGING_RESOLVE.registerFactory(OverloadResolutionChangeFix)
+
+        EQUALITY_NOT_APPLICABLE.registerFactory(EqualityNotApplicableFactory)
     }
 }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -748,5 +748,6 @@ class QuickFixRegistrar : QuickFixContributor {
         PROGRESSIONS_CHANGING_RESOLVE.registerFactory(OverloadResolutionChangeFix)
 
         EQUALITY_NOT_APPLICABLE.registerFactory(EqualityNotApplicableFactory)
+        INCOMPATIBLE_TYPES.registerFactory(IncompatibleTypesFactory)
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -8617,6 +8617,29 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("testData/quickfix/incompatibleTypes")
+    public static class IncompatibleTypes extends AbstractQuickFixTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        @TestMetadata("byte.kt")
+        public void testByte() throws Exception {
+            runTest("testData/quickfix/incompatibleTypes/byte.kt");
+        }
+
+        @TestMetadata("char.kt")
+        public void testChar() throws Exception {
+            runTest("testData/quickfix/incompatibleTypes/char.kt");
+        }
+
+        @TestMetadata("int.kt")
+        public void testInt() throws Exception {
+            runTest("testData/quickfix/incompatibleTypes/int.kt");
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("testData/quickfix/increaseVisibility")
     public abstract static class IncreaseVisibility extends AbstractQuickFixTest {
         @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -8045,6 +8045,66 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("testData/quickfix/equalityNotApplicable")
+    public abstract static class EqualityNotApplicable extends AbstractQuickFixTest {
+        @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/quickfix/equalityNotApplicable/charLiteralConversion")
+        public static class CharLiteralConversion extends AbstractQuickFixTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("charEqString.kt")
+            public void testCharEqString() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString.kt");
+            }
+
+            @TestMetadata("charEqString2.kt")
+            public void testCharEqString2() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString2.kt");
+            }
+
+            @TestMetadata("charEqString3.kt")
+            public void testCharEqString3() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString3.kt");
+            }
+
+            @TestMetadata("charEqString4.kt")
+            public void testCharEqString4() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString4.kt");
+            }
+        }
+
+        @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/quickfix/equalityNotApplicable/numberConversion")
+        public static class NumberConversion extends AbstractQuickFixTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("left.kt")
+            public void testLeft() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/numberConversion/left.kt");
+            }
+
+            @TestMetadata("nullableLeft.kt")
+            public void testNullableLeft() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/numberConversion/nullableLeft.kt");
+            }
+
+            @TestMetadata("nullableRight.kt")
+            public void testNullableRight() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/numberConversion/nullableRight.kt");
+            }
+
+            @TestMetadata("right.kt")
+            public void testRight() throws Exception {
+                runTest("testData/quickfix/equalityNotApplicable/numberConversion/right.kt");
+            }
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("testData/quickfix/expressions")
     public static class Expressions extends AbstractQuickFixTest {
         private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString.kt
@@ -1,0 +1,4 @@
+// "Convert string to character literal" "true"
+fun test(c: Char): Boolean {
+    return <caret>c == "a"
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString.kt.after
@@ -1,0 +1,4 @@
+// "Convert string to character literal" "true"
+fun test(c: Char): Boolean {
+    return c == 'a'
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString2.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString2.kt
@@ -1,0 +1,4 @@
+// "Convert string to character literal" "true"
+fun test(c: Char): Boolean {
+    return <caret>"\t" == c
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString2.kt.after
@@ -1,0 +1,4 @@
+// "Convert string to character literal" "true"
+fun test(c: Char): Boolean {
+    return '\t' == c
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString3.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString3.kt
@@ -1,0 +1,4 @@
+// "Convert string to character literal" "true"
+fun test(c: Char): Boolean {
+    return <caret>c == """a"""
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString3.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString3.kt.after
@@ -1,0 +1,4 @@
+// "Convert string to character literal" "true"
+fun test(c: Char): Boolean {
+    return c == 'a'
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString4.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/charLiteralConversion/charEqString4.kt
@@ -1,0 +1,6 @@
+// "Convert string to character literal" "false"
+// ACTION: Expand boolean expression to 'if else'
+// ERROR: Operator '==' cannot be applied to 'Char' and 'String'
+fun test(c: Char): Boolean {
+    return <caret>c == "aa"
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/left.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/left.kt
@@ -1,0 +1,4 @@
+// "Convert left-hand side to 'Int'" "true"
+fun test(b: Byte, i: Int): Boolean {
+    return <caret>b == i
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/left.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/left.kt.after
@@ -1,0 +1,4 @@
+// "Convert left-hand side to 'Int'" "true"
+fun test(b: Byte, i: Int): Boolean {
+    return b.toInt() == i
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableLeft.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableLeft.kt
@@ -1,0 +1,4 @@
+// "Convert left-hand side to 'Long'" "true"
+fun test(s: Short?, l: Long?): Boolean {
+    return <caret>s == l
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableLeft.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableLeft.kt.after
@@ -1,0 +1,4 @@
+// "Convert left-hand side to 'Long'" "true"
+fun test(s: Short?, l: Long?): Boolean {
+    return s?.toLong() == l
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableRight.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableRight.kt
@@ -1,0 +1,4 @@
+// "Convert right-hand side to 'Short'" "true"
+fun test(s: Short?, l: Long?): Boolean {
+    return <caret>s == l
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableRight.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/nullableRight.kt.after
@@ -1,0 +1,4 @@
+// "Convert right-hand side to 'Short'" "true"
+fun test(s: Short?, l: Long?): Boolean {
+    return s == l?.toShort()
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/right.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/right.kt
@@ -1,0 +1,4 @@
+// "Convert right-hand side to 'Byte'" "true"
+fun test(b: Byte, i: Int): Boolean {
+    return <caret>b == i
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/right.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/equalityNotApplicable/numberConversion/right.kt.after
@@ -1,0 +1,4 @@
+// "Convert right-hand side to 'Byte'" "true"
+fun test(b: Byte, i: Int): Boolean {
+    return b == i.toByte()
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/byte.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/byte.kt
@@ -1,0 +1,6 @@
+// "Convert expression to 'Byte'" "true"
+fun test(b: Byte, i: Int) {
+    when (b) {
+        <caret>i -> {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/byte.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/byte.kt.after
@@ -1,0 +1,6 @@
+// "Convert expression to 'Byte'" "true"
+fun test(b: Byte, i: Int) {
+    when (b) {
+        i.toByte() -> {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/char.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/char.kt
@@ -1,0 +1,6 @@
+// "Convert string to character literal" "true"
+fun test(c: Char) {
+    when (c) {
+        <caret>"." -> {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/char.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/char.kt.after
@@ -1,0 +1,6 @@
+// "Convert string to character literal" "true"
+fun test(c: Char) {
+    when (c) {
+        '.' -> {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/int.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/int.kt
@@ -1,0 +1,6 @@
+// "Convert expression to 'Int'" "true"
+fun test(b: Byte, i: Int) {
+    when (i) {
+        <caret>b -> {}
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/int.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/incompatibleTypes/int.kt.after
@@ -1,0 +1,6 @@
+// "Convert expression to 'Int'" "true"
+fun test(b: Byte, i: Int) {
+    when (i) {
+        b.toInt() -> {}
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-13949

```kotlin
fun test(b: Byte, i: Int): Boolean {
    return b == i
}
```
<img width="453" alt="スクリーンショット 2022-01-24 14 25 52" src="https://user-images.githubusercontent.com/1121855/150727493-198b93a0-e0e0-4d8f-86b6-e0ee1bfcee86.png">


```kotlin
fun test(c: Char): Boolean {
    return c == "a"
}
```
<img width="525" alt="スクリーンショット 2022-01-24 14 26 51" src="https://user-images.githubusercontent.com/1121855/150727506-6fc6a27b-5817-4619-9ea2-5580eb62156c.png">

