### PR TITLE
KTIJ-20332 Formatter: space after `throw` keyword is not handled

### DIFF
--- a/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -348,6 +348,8 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
             around(NOT_IN).spaces(1)
             aroundInside(IDENTIFIER, BINARY_EXPRESSION).spaces(1)
 
+            after(THROW_KEYWORD).spacesNoLineBreak(1)
+
             // before LPAR in constructor(): this() {}
             after(CONSTRUCTOR_DELEGATION_REFERENCE).spacing(0, 0, 0, false, 0)
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -1284,6 +1284,11 @@ public abstract class FormatterTestGenerated extends AbstractFormatterTest {
                 runTest("testData/formatter/SuperListIndent.after.kt");
             }
 
+            @TestMetadata("Throw.after.kt")
+            public void testThrow() throws Exception {
+                runTest("testData/formatter/Throw.after.kt");
+            }
+
             @TestMetadata("TryCatchLineBreak.after.kt")
             public void testTryCatchLineBreak() throws Exception {
                 runTest("testData/formatter/TryCatchLineBreak.after.kt");

--- a/plugins/kotlin/idea/tests/testData/formatter/Throw.after.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/Throw.after.kt
@@ -1,0 +1,8 @@
+fun main() {
+    try {
+    } catch (e: RuntimeException) {
+        throw e
+    } catch (e: Exception) {
+        throw e
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/formatter/Throw.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/Throw.kt
@@ -1,0 +1,9 @@
+fun main() {
+    try {
+    } catch (e: RuntimeException) {
+        throw     e
+    } catch (e: Exception) {
+        throw
+        e
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-20332