### PR TITLE
[maven] Navigate to managing dependency on GotoSuperAction shortcut

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/navigation/MavenGotoSuperHandler.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/dom/navigation/MavenGotoSuperHandler.java
@@ -1,0 +1,41 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.idea.maven.dom.navigation;
+
+import com.intellij.util.PsiNavigateUtil;
+import com.intellij.util.xml.DomElement;
+import com.intellij.util.xml.DomElementNavigationProvider;
+import org.jetbrains.idea.maven.dom.MavenDomProjectProcessorUtils;
+import org.jetbrains.idea.maven.dom.model.*;
+
+public class MavenGotoSuperHandler extends DomElementNavigationProvider {
+  @Override
+  public String getProviderName() {
+    return "MAVEN_GOTO_SUPER";
+  }
+
+  @Override
+  public void navigate(DomElement domElement, boolean requestFocus) {
+    DomElement target = null;
+    if (domElement instanceof MavenDomDependency) {
+      target = MavenDomProjectProcessorUtils.searchManagingDependency((MavenDomDependency)domElement);
+    }
+    else if (domElement instanceof MavenDomPlugin) {
+      target = MavenDomProjectProcessorUtils.searchManagingPlugin((MavenDomPlugin)domElement);
+    }
+    else if (domElement instanceof MavenDomParent) {
+      target = MavenDomProjectProcessorUtils.findParent((MavenDomParent)domElement, domElement.getManager().getProject());
+    }
+    if (target != null) {
+      PsiNavigateUtil.navigate(target.getXmlTag(), requestFocus);
+    }
+  }
+
+  @Override
+  public boolean canNavigate(DomElement domElement) {
+    return (domElement instanceof MavenDomDependency
+            && domElement.getParentOfType(MavenDomDependencyManagement.class, false) == null)
+           || (domElement instanceof MavenDomPlugin
+               && domElement.getParentOfType(MavenDomPluginManagement.class, false) == null)
+           || domElement instanceof MavenDomParent;
+  }
+}

--- a/plugins/maven/src/main/resources/META-INF/plugin.xml
+++ b/plugins/maven/src/main/resources/META-INF/plugin.xml
@@ -185,6 +185,8 @@
     <dom.extender domClass="org.jetbrains.idea.maven.dom.model.MavenDomConfigurationParameter"
                   extenderClass="org.jetbrains.idea.maven.dom.MavenPluginConfigurationParameterDomExtender"/>
 
+    <dom.gotoSuper implementation="org.jetbrains.idea.maven.dom.navigation.MavenGotoSuperHandler"/>
+
     <completion.contributor language="any"
                             implementationClass="org.jetbrains.idea.maven.dom.references.MavenPropertyCompletionContributor"
                             id="Maven" order="after propertiesCompletion, before javaClassReference"/>

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/dom/MavenSuperNavigationTest.java
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/dom/MavenSuperNavigationTest.java
@@ -1,0 +1,275 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.idea.maven.dom;
+
+import com.intellij.maven.testFramework.MavenDomTestCase;
+import com.intellij.maven.testFramework.MavenTestCase;
+import org.junit.Test;
+
+public class MavenSuperNavigationTest extends MavenDomTestCase {
+
+  @Test
+  public void testNavigationToManagingDependencyWithoutModules() {
+    configureProjectPom(
+      "<groupId>test</groupId>" +
+      "<artifactId>project</artifactId>" +
+      "<version>1</version>" +
+
+      "<dependencyManagement>" +
+      "  <dependencies>" +
+      "    <dependency>" +
+      "      <groupId>junit</groupId>" +
+      "      <artifactId>junit</artifactId>" +
+      "      <version>4.0</version>" +
+      "    </dependency>" +
+      "  </dependencies>" +
+      "</dependencyManagement>" +
+
+      "<dependencies>" +
+      "  <dependency>" +
+      "    <groupId>junit</groupId>" +
+      "    <artifactId>junit<caret></artifactId>" +
+      "  </dependency>" +
+      "</dependencies>");
+
+    myFixture.performEditorAction("GotoSuperMethod");
+
+    myFixture.checkResultWithInlays(
+      MavenTestCase.createPomXml(
+        "<groupId>test</groupId>" +
+        "<artifactId>project</artifactId>" +
+        "<version>1</version>" +
+
+        "<dependencyManagement>" +
+        "  <dependencies>" +
+        "    <caret><dependency>" +
+        "      <groupId>junit</groupId>" +
+        "      <artifactId>junit</artifactId>" +
+        "      <version>4.0</version>" +
+        "    </dependency>" +
+        "  </dependencies>" +
+        "</dependencyManagement>" +
+
+        "<dependencies>" +
+        "  <dependency>" +
+        "    <groupId>junit</groupId>" +
+        "    <artifactId>junit</artifactId>" +
+        "  </dependency>" +
+        "</dependencies>"));
+  }
+
+  @Test
+  public void testNavigationToManagingPluginWithoutModules() {
+    configureProjectPom(
+      "<groupId>test</groupId>" +
+      "<artifactId>project</artifactId>" +
+      "<version>1</version>" +
+      "<build>" +
+      "  <pluginManagement>" +
+      "    <plugins>" +
+      "      <plugin>" +
+      "        <groupId>org.apache.maven.plugins</groupId>" +
+      "        <artifactId>maven-compiler-plugin</artifactId>" +
+      "      </plugin>" +
+      "    </plugins>" +
+      "  </pluginManagement>" +
+      "  <plugins>" +
+      "    <plugin>" +
+      "      <gro<caret>upId>org.apache.maven.plugins</groupId>" +
+      "      <artifactId>maven-compiler-plugin</artifactId>" +
+      "    </plugin>" +
+      "  </plugins>" +
+      "</build>"
+    );
+
+    myFixture.performEditorAction("GotoSuperMethod");
+
+    myFixture.checkResultWithInlays(
+      MavenTestCase.createPomXml(
+        "<groupId>test</groupId>" +
+        "<artifactId>project</artifactId>" +
+        "<version>1</version>" +
+        "<build>" +
+        "  <pluginManagement>" +
+        "    <plugins>" +
+        "      <caret><plugin>" +
+        "        <groupId>org.apache.maven.plugins</groupId>" +
+        "        <artifactId>maven-compiler-plugin</artifactId>" +
+        "      </plugin>" +
+        "    </plugins>" +
+        "  </pluginManagement>" +
+        "  <plugins>" +
+        "    <plugin>" +
+        "      <groupId>org.apache.maven.plugins</groupId>" +
+        "      <artifactId>maven-compiler-plugin</artifactId>" +
+        "    </plugin>" +
+        "  </plugins>" +
+        "</build>"
+      ));
+  }
+
+  @Test
+  public void testGotoToParentProject() {
+    var parent = createProjectPom(
+      "<groupId>test</groupId>" +
+      "<artifactId>project</artifactId>" +
+      "<version>1</version>" +
+      "<packaging>pom</packaging>" +
+
+      "<modules>" +
+      "  <module>m1</module>" +
+      "</modules>");
+
+    var m1 = createModulePom(
+      "m1",
+      "<parent>" +
+      "  <groupId>test</groupId>" +
+      "  <artifactId>project</artifactId>" +
+      "  <version><caret>1</version>" +
+      "</parent>" +
+      "<artifactId>m1</artifactId>");
+
+    configTest(m1);
+    myFixture.performEditorAction("GotoSuperMethod");
+
+    var offset = getEditorOffset(parent);
+    assertEquals(0, offset);
+  }
+
+  @Test
+  public void testNavigationToManagingDependencyWithModules() {
+    var parent = createProjectPom(
+      "<groupId>test</groupId>" +
+      "<artifactId>project</artifactId>" +
+      "<version>1</version>" +
+      "<packaging>pom</packaging>" +
+
+      "<dependencyManagement>" +
+      "  <dependencies>" +
+      "    <dependency>" +
+      "      <groupId>junit</groupId>" +
+      "      <artifactId>junit</artifactId>" +
+      "      <version>4.0</version>" +
+      "    </dependency>" +
+      "  </dependencies>" +
+      "</dependencyManagement>" +
+
+      "<modules>" +
+      "  <module>m1</module>" +
+      "</modules>");
+
+    var m1 = createModulePom(
+      "m1",
+      "<parent>" +
+      "  <groupId>test</groupId>" +
+      "  <artifactId>project</artifactId>" +
+      "  <version>1</version>" +
+      "</parent>" +
+      "<artifactId>m1</artifactId>" +
+
+      "<dependencies>" +
+      "  <dependency>" +
+      "    <groupId><caret>junit</groupId>" +
+      "    <artifactId>junit<caret></artifactId>" +
+      "  </dependency>" +
+      "</dependencies>"
+    );
+
+    configTest(m1);
+    myFixture.performEditorAction("GotoSuperMethod");
+
+    configTest(parent);
+    myFixture.checkResultWithInlays(
+      MavenTestCase.createPomXml(
+        "<groupId>test</groupId>" +
+        "<artifactId>project</artifactId>" +
+        "<version>1</version>" +
+        "<packaging>pom</packaging>" +
+
+        "<dependencyManagement>" +
+        "  <dependencies>" +
+        "    <caret><dependency>" +
+        "      <groupId>junit</groupId>" +
+        "      <artifactId>junit</artifactId>" +
+        "      <version>4.0</version>" +
+        "    </dependency>" +
+        "  </dependencies>" +
+        "</dependencyManagement>" +
+
+        "<modules>" +
+        "  <module>m1</module>" +
+        "</modules>"));
+  }
+
+  @Test
+  public void testNavigationToManagingPluginWithModules() {
+    var parent = createProjectPom(
+      "<groupId>test</groupId>" +
+      "<artifactId>project</artifactId>" +
+      "<version>1</version>" +
+      "<packaging>pom</packaging>" +
+
+      "<modules>" +
+      "  <module>m1</module>" +
+      "</modules>" +
+
+      "<build>" +
+      "  <pluginManagement>" +
+      "    <plugins>" +
+      "    	 <plugin>" +
+      "  		   <groupId>org.apache.maven.plugins</groupId>" +
+      "  		   <artifactId>maven-compiler-plugin</artifactId>" +
+      "  		   <version>3.8.1</version>" +
+      "  	   </plugin>" +
+      "    </plugins>" +
+      "  </pluginManagement>" +
+      "</build>"
+    );
+
+    var m1 = createModulePom(
+      "m1",
+      "<parent>" +
+      "  <groupId>test</groupId>" +
+      "  <artifactId>project</artifactId>" +
+      "  <version>1</version>" +
+      "</parent>" +
+      "<artifactId>m1</artifactId>" +
+
+      "<build>" +
+      "  <plugins>" +
+      "  	 <plugin>" +
+      "		   <groupId><caret>org.apache.maven.plugins</groupId>" +
+      "		   <artifactId>maven-compiler-plugin</artifactId>" +
+      "	   </plugin>" +
+      "  </plugins>" +
+      "</build>"
+    );
+
+    configTest(m1);
+    myFixture.performEditorAction("GotoSuperMethod");
+
+    configTest(parent);
+    myFixture.checkResultWithInlays(
+      MavenTestCase.createPomXml(
+        "<groupId>test</groupId>" +
+        "<artifactId>project</artifactId>" +
+        "<version>1</version>" +
+        "<packaging>pom</packaging>" +
+
+        "<modules>" +
+        "  <module>m1</module>" +
+        "</modules>" +
+
+        "<build>" +
+        "  <pluginManagement>" +
+        "    <plugins>" +
+        "    	 <caret><plugin>" +
+        "  		   <groupId>org.apache.maven.plugins</groupId>" +
+        "  		   <artifactId>maven-compiler-plugin</artifactId>" +
+        "  		   <version>3.8.1</version>" +
+        "  	   </plugin>" +
+        "    </plugins>" +
+        "  </pluginManagement>" +
+        "</build>"
+      ));
+  }
+}

--- a/xml/dom-impl/src/META-INF/DomPlugin.xml
+++ b/xml/dom-impl/src/META-INF/DomPlugin.xml
@@ -35,9 +35,12 @@
                     interface="com.intellij.util.Consumer"/>
 
     <extensionPoint name="moduleContextProvider" interface="com.intellij.util.xml.ModuleContextProvider" dynamic="true"/>
+    <extensionPoint name="dom.gotoSuper" interface="com.intellij.util.xml.DomElementNavigationProvider" dynamic="true"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.intellij">
+    <codeInsight.gotoSuper language="XML" implementationClass="com.intellij.codeInsight.navigation.DomGotoSuperHandler"/>
+
     <fileBasedIndex implementation="com.intellij.util.xml.DomFileIndex"/>
 
     <filetype.stubBuilder filetype="XML" implementationClass="com.intellij.util.xml.stubs.builder.DomStubBuilder"/>

--- a/xml/dom-impl/src/com/intellij/codeInsight/navigation/DomGotoSuperHandler.java
+++ b/xml/dom-impl/src/com/intellij/codeInsight/navigation/DomGotoSuperHandler.java
@@ -1,0 +1,36 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.codeInsight.navigation;
+
+import com.intellij.codeInsight.CodeInsightActionHandler;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.xml.DomElement;
+import com.intellij.util.xml.DomUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class DomGotoSuperHandler implements CodeInsightActionHandler {
+  @Override
+  public void invoke(@NotNull Project project,
+                     @NotNull Editor editor,
+                     @NotNull PsiFile file) {
+
+    var currentElement = DomUtil.getDomElement(editor, file);
+    if (currentElement == null) {
+      return;
+    }
+
+    Stream.iterate(currentElement, Objects::nonNull, DomElement::getParent)
+      .flatMap(element -> {
+        return DomGotoActions.DOM_GOTO_SUPER.getExtensionList()
+          .stream()
+          .filter(p -> p.canNavigate(element))
+          .<Runnable>map(p -> () -> p.navigate(element, true));
+      })
+      .findFirst()
+      .ifPresent(Runnable::run);
+  }
+}

--- a/xml/dom-openapi/src/com/intellij/codeInsight/navigation/DomGotoActions.java
+++ b/xml/dom-openapi/src/com/intellij/codeInsight/navigation/DomGotoActions.java
@@ -1,0 +1,14 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.codeInsight.navigation;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.util.xml.DomElementNavigationProvider;
+
+public final class DomGotoActions {
+
+  public static final ExtensionPointName<DomElementNavigationProvider>
+    DOM_GOTO_SUPER = ExtensionPointName.create("com.intellij.dom.gotoSuper");
+
+  private DomGotoActions() {
+  }
+}


### PR DESCRIPTION
The icon on the gutter already did this navigation on a click. Now the
shortcut also works.