### PR TITLE
use default update channel when selection combobox is not present

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateSettingsConfigurable.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateSettingsConfigurable.kt
@@ -81,7 +81,9 @@ class UpdateSettingsConfigurable @JvmOverloads constructor (private val checkNow
             settingsCopy.state.copyFrom(settings.state)
             settingsCopy.state.isCheckNeeded = true
             settingsCopy.state.isPluginsCheckNeeded = true
-            settingsCopy.selectedChannelStatus = selectedChannel(channelModel.selected)
+            if (channelSelectionLockedMessage == null) {
+              settingsCopy.selectedChannelStatus = selectedChannel(channelModel.selected)
+            }
             UpdateChecker.updateAndShowResult(project, settingsCopy)
             updateLastCheckedLabel(settings.lastTimeChecked)
           }


### PR DESCRIPTION
UpdateSettings#getActiveChannels always adds EAP and RELEASE channels.
so when channel selection is locked in UpdateSettingsConfigurable dialog, it always checks EAP channels for updates.

changing to be UpdateSettings.getInstance().state.updateChannelType, so that it match behavior when checking for updates from other location (e.g. Welcome screen)