### PR TITLE
KTIJ-20748 False negative "Redundant lambda arrow" with safe call

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLambdaArrowInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLambdaArrowInspection.kt
@@ -86,8 +86,8 @@ class RedundantLambdaArrowInspection : AbstractKotlinInspection() {
 }
 
 private fun KtCallExpression.isApplicableCall(lambdaExpression: KtLambdaExpression, lambdaContext: BindingContext): Boolean {
-    val dotQualifiedExpression = parent as? KtDotQualifiedExpression
-    return if (dotQualifiedExpression == null) {
+    val qualifiedExpression = parent as? KtQualifiedExpression
+    return if (qualifiedExpression == null) {
         val offset = lambdaExpression.textOffset - textOffset
         replaceWithCopyWithResolveCheck(
             resolveStrategy = { expr, context ->
@@ -99,8 +99,8 @@ private fun KtCallExpression.isApplicableCall(lambdaExpression: KtLambdaExpressi
             }
         )
     } else {
-        val offset = lambdaExpression.textOffset - dotQualifiedExpression.textOffset
-        dotQualifiedExpression.replaceWithCopyWithResolveCheck(
+        val offset = lambdaExpression.textOffset - qualifiedExpression.textOffset
+        qualifiedExpression.replaceWithCopyWithResolveCheck(
             resolveStrategy = { expr, context ->
                 expr.selectorExpression.getResolvedCall(context)?.resultingDescriptor
             },

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8793,6 +8793,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantLambdaArrow/notApplicableVararg_ni.kt");
         }
 
+        @TestMetadata("nullableReceiver.kt")
+        public void testNullableReceiver() throws Exception {
+            runTest("testData/inspectionsLocal/redundantLambdaArrow/nullableReceiver.kt");
+        }
+
         @TestMetadata("overload4.kt")
         public void testOverload4() throws Exception {
             runTest("testData/inspectionsLocal/redundantLambdaArrow/overload4.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantLambdaArrow/nullableReceiver.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantLambdaArrow/nullableReceiver.kt
@@ -1,0 +1,4 @@
+// PROBLEM: Redundant lambda arrow
+// WITH_STDLIB
+
+fun test(list: List<String>?) = list?.map { <caret>it -> it.length }

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantLambdaArrow/nullableReceiver.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantLambdaArrow/nullableReceiver.kt.after
@@ -1,0 +1,4 @@
+// PROBLEM: Redundant lambda arrow
+// WITH_STDLIB
+
+fun test(list: List<String>?) = list?.map { it.length }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-20748