### PR TITLE
KTIJ-20831 "Call chain on collection type may be simplified" to replace `map` and `toMap` with `associate` produces "overload resolution ambiguity"

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2142,6 +2142,21 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                     runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapToMap4.kt");
                 }
 
+                @TestMetadata("mapToMapWithDestination.kt")
+                public void testMapToMapWithDestination() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination.kt");
+                }
+
+                @TestMetadata("mapToMapWithDestination2.kt")
+                public void testMapToMapWithDestination2() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination2.kt");
+                }
+
+                @TestMetadata("mapToMapWithDestination3.kt")
+                public void testMapToMapWithDestination3() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination3.kt");
+                }
+
                 @TestMetadata("mapWithReturn.kt")
                 public void testMapWithReturn() throws Exception {
                     runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapWithReturn.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination.kt
@@ -1,0 +1,9 @@
+// FIX: Merge call chain to 'associateTo'
+// WITH_STDLIB
+fun getKey(i: Int): Long = 1L
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val target = mutableMapOf<Long, String>()
+    list.<caret>map { getKey(it) to getValue(it) }.toMap(target)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination.kt.after
@@ -1,0 +1,9 @@
+// FIX: Merge call chain to 'associateTo'
+// WITH_STDLIB
+fun getKey(i: Int): Long = 1L
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val target = mutableMapOf<Long, String>()
+    list.associateTo(target) { getKey(it) to getValue(it) }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination2.kt
@@ -1,0 +1,8 @@
+// FIX: Merge call chain to 'associateByTo'
+// WITH_STDLIB
+fun getKey(i: Int): Long = 1L
+
+fun test(list: List<Int>) {
+    val target = mutableMapOf<Long, Int>()
+    list.<caret>map { getKey(it) to it }.toMap(target)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination2.kt.after
@@ -1,0 +1,8 @@
+// FIX: Merge call chain to 'associateByTo'
+// WITH_STDLIB
+fun getKey(i: Int): Long = 1L
+
+fun test(list: List<Int>) {
+    val target = mutableMapOf<Long, Int>()
+    list.associateByTo(target) { getKey(it) }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination3.kt
@@ -1,0 +1,8 @@
+// FIX: Merge call chain to 'associateWithTo'
+// WITH_STDLIB
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val target = mutableMapOf<Int, String>()
+    list.<caret>map { it to getValue(it) }.toMap(target)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination3.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapToMapWithDestination3.kt.after
@@ -1,0 +1,8 @@
+// FIX: Merge call chain to 'associateWithTo'
+// WITH_STDLIB
+fun getValue(i: Int): String = ""
+
+fun test(list: List<Int>) {
+    val target = mutableMapOf<Int, String>()
+    list.associateWithTo(target) { getValue(it) }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-20831