### PR TITLE
PY-41061: use __aiter__ for typing in an async for loop

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/psi/impl/PyTargetExpressionImpl.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/psi/impl/PyTargetExpressionImpl.java
@@ -369,7 +369,10 @@ public class PyTargetExpressionImpl extends PyBaseElementImpl<PyTargetExpression
     else if (iterableType instanceof PyUnionType) {
       return ((PyUnionType)iterableType).map(member -> getIterationType(member, source, anchor, context));
     }
-    else if (iterableType != null && PyABCUtil.isSubtype(iterableType, PyNames.ITERABLE, context)) {
+
+    final PyForStatement forStatement = PsiTreeUtil.getParentOfType(source, PyForStatement.class);
+    final boolean isAsync = forStatement != null && forStatement.isAsync();
+    if (iterableType != null && !isAsync && PyABCUtil.isSubtype(iterableType, PyNames.ITERABLE, context)) {
       final PyFunction iterateMethod = findMethodByName(iterableType, PyNames.ITER, context);
       if (iterateMethod != null) {
         final PyType iterateReturnType = getContextSensitiveType(iterateMethod, context, source);
@@ -384,7 +387,7 @@ public class PyTargetExpressionImpl extends PyBaseElementImpl<PyTargetExpression
         return getContextSensitiveType(getItem, context, source);
       }
     }
-    else if (iterableType != null && PyABCUtil.isSubtype(iterableType, PyNames.ASYNC_ITERABLE, context)) {
+    else if (iterableType != null && isAsync && PyABCUtil.isSubtype(iterableType, PyNames.ASYNC_ITERABLE, context)) {
       final PyFunction iterateMethod = findMethodByName(iterableType, PyNames.AITER, context);
       if (iterateMethod != null) {
         final PyType iterateReturnType = getContextSensitiveType(iterateMethod, context, source);

--- a/python/testSrc/com/jetbrains/python/PyTypingTest.java
+++ b/python/testSrc/com/jetbrains/python/PyTypingTest.java
@@ -486,6 +486,31 @@ public class PyTypingTest extends PyTestCase {
            "    pass\n");
   }
 
+  // PY-41061
+  public void testHybridIterForLoop() {
+    doTest("str",
+           "from typing import AsyncIterator, Iterator\n" +
+           "\n" +
+           "class HybridIterator:\n" +
+           "    def __iter__() -> Iterator[str]: ...\n" +
+           "    def __aiter__() -> AsyncIterator[int]: ...\n" +
+           "\n" +
+           "for expr in HybridIterator():\n" +
+           "    pass\n");
+  }
+
+  public void testHybridIterAsyncForLoop() {
+    doTest("int",
+           "from typing import AsyncIterator, Iterator\n" +
+           "\n" +
+           "class HybridIterator:\n" +
+           "    def __iter__() -> Iterator[str]: ...\n" +
+           "    def __aiter__() -> AsyncIterator[int]: ...\n" +
+           "\n" +
+           "async for expr in HybridIterator():\n" +
+           "    pass\n");
+  }
+
   // PY-16353
   public void testAssignedType() {
     doTest("Iterable[int]",


### PR DESCRIPTION
This PR fixes the typing of iterands in async for loops being derived from `__iter__` instead of `__aiter__`.

Previously, typing info of an iterand was retrieved in the same way for both `for` and `async for` loops — namely, if the iterable declared an `__iter__` method, typing info would be retrieved from it; otherwise, if the iterable declared an `__aiter__` method, typing info would be pulled from it. For example:

```py
from typing import AsyncIterator, Iterator

class Foo:
    def __iter__(self) -> Iterator[list]: ...
    def __aiter__(self) -> AsyncIterator[dict]: ...

for expr in Foo():
    expr.append(1)

async for expr in Foo():
    expr.update({'tacos': 'muffins'})
    # PyCharm analysis: Unresolved attribute reference 'update' for class 'list'
```
![image](https://user-images.githubusercontent.com/33840/154860601-0c4791f2-7d2c-4f7e-8f8e-e27bada30b86.png)

This PR resolves this incorrect behaviour by altering `PyTargetExpression::getIterationType` to peer into the source expression's context to determine if it's within an `async for` statement. If and only if it's within an `async for` will typing from `__aiter__` be used; if it's _not_ within an `async for` (or this could not be determined), the typing from `__iter__` will be used.

The reasoning being: `__iter__` and `__aiter__` are completely separate iterables, and Python never "falls back" — i.e. you _never_ get `__iter__`'s typing with an `async for`, and you _never_ get `__aiter__`'s typing with a sync `for`.