### PR TITLE
KTIJ-21025 "Existing backing field without assignment" inspection should not be reported on unconditionally throwing setters

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SetterBackingFieldAssignmentInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SetterBackingFieldAssignmentInspection.kt
@@ -21,6 +21,7 @@ class SetterBackingFieldAssignmentInspection : AbstractKotlinInspection(), Clean
         propertyAccessorVisitor(fun(accessor) {
             if (!accessor.isSetter) return
             val bodyExpression = accessor.bodyBlockExpression ?: return
+            if (bodyExpression.statements.lastOrNull() is KtThrowExpression) return
 
             val property = accessor.property
             val propertyContext = property.analyze()

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -13736,6 +13736,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/setterBackingFieldAssignment/plusAssign.kt");
         }
 
+        @TestMetadata("throw.kt")
+        public void testThrow() throws Exception {
+            runTest("testData/inspectionsLocal/setterBackingFieldAssignment/throw.kt");
+        }
+
         @TestMetadata("timesAssign.kt")
         public void testTimesAssign() throws Exception {
             runTest("testData/inspectionsLocal/setterBackingFieldAssignment/timesAssign.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/throw.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/throw.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+class Test {
+    var test = "OK"
+        <caret>set(value) {
+            throw UnsupportedOperationException()
+        }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21025