### PR TITLE
KTIJ-21082 False positive "Redundant 'suspend' modifier" when invoking a suspend lambda contained in a list which is an explicit receiver

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuspendCallLineMarkerProvider.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinSuspendCallLineMarkerProvider.kt
@@ -77,11 +77,13 @@ class KotlinSuspendCallLineMarkerProvider : LineMarkerProvider {
 }
 
 private fun KtExpression.isValidCandidateExpression(): Boolean {
-    if (this is KtParenthesizedExpression) return false
+    if (this is KtParenthesizedExpression || this is KtQualifiedExpression) return false
     if (this is KtOperationReferenceExpression || this is KtForExpression || this is KtProperty || this is KtNameReferenceExpression) return true
     val parent = parent
     if (parent is KtCallExpression && parent.calleeExpression == this) return true
-    if (this is KtCallExpression && (calleeExpression is KtCallExpression || calleeExpression is KtParenthesizedExpression)) return true
+    if (this is KtCallExpression &&
+        (calleeExpression is KtCallExpression || calleeExpression is KtParenthesizedExpression || calleeExpression is KtQualifiedExpression)
+    ) return true
     return false
 }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -9720,6 +9720,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantSuspend/coroutineContext.kt");
         }
 
+        @TestMetadata("invokingByQualified.kt")
+        public void testInvokingByQualified() throws Exception {
+            runTest("testData/inspectionsLocal/redundantSuspend/invokingByQualified.kt");
+        }
+
         @TestMetadata("override.kt")
         public void testOverride() throws Exception {
             runTest("testData/inspectionsLocal/redundantSuspend/override.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/invokingByQualified.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/invokingByQualified.kt
@@ -1,0 +1,3 @@
+// PROBLEM: none
+// WITH_STDLIB
+<caret>suspend fun List<suspend () -> Unit>.invokeFirst() = this.first()()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21082