### PR TITLE
Fix a typo for "Variable type can be explicit" inspection

### DIFF
--- a/java/java-impl/src/inspectionDescriptions/VariableTypeCanBeExplicit.html
+++ b/java/java-impl/src/inspectionDescriptions/VariableTypeCanBeExplicit.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Reports local variables of the <code>var</code> type that can be replaced withvan explicit type.
+Reports local variables of the <code>var</code> type that can be replaced with an explicit type.
 <p>The inspection can help find and eliminate usages of implicit types in case of downgrading.</p>
 <!-- tooltip end -->
 <p><b>Example:</b></p>


### PR DESCRIPTION
Hi @BasLeijdekkers,

This replaces:

_"Reports local variables of the <code>var</code> type that can be replaced **withvan** explicit type."_

by:

_"Reports local variables of the <code>var</code> type that can be replaced **with an** explicit type."_