### PR TITLE
Allow overriding parallel.models.fetch with a system property

### DIFF
--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
@@ -42,6 +42,7 @@ import java.util.concurrent.*;
 public class ProjectImportAction implements BuildAction<ProjectImportAction.AllModels>, Serializable {
   private static final ModelConverter NOOP_CONVERTER = new NoopConverter();
   public static final String IDEA_BACKGROUND_CONVERT = "idea.background.convert";
+  public static final String IDEA_MODELS_PARALLEL_FETCH = "idea.models.parallel.fetch";
 
   private final Set<ProjectImportModelProvider> myProjectsLoadedModelProviders = new HashSet<ProjectImportModelProvider>();
   private final Set<ProjectImportModelProvider> myBuildFinishedModelProviders = new HashSet<ProjectImportModelProvider>();
@@ -106,6 +107,9 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
   @Nullable
   @Override
   public AllModels execute(final BuildController controller) {
+    if (System.getProperties().containsKey(IDEA_MODELS_PARALLEL_FETCH)) {
+      myParallelModelsFetch = Boolean.getBoolean(IDEA_MODELS_PARALLEL_FETCH);
+    }
     if (!System.getProperties().containsKey(IDEA_BACKGROUND_CONVERT) || Boolean.getBoolean(IDEA_BACKGROUND_CONVERT)) {
       myConverterExecutor =  Executors.newSingleThreadExecutor(new ThreadFactory() {
         @Override


### PR DESCRIPTION
Whether this feature works depends a lot on the individual Gradle project,
so it makes sense for this to be configurable on a per-project basis rather
than globally at the IDE level.