### PR TITLE
Make background model conversion safe

### DIFF
--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/ProjectImportAction.java
@@ -132,21 +132,18 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
 
     assert myGradleBuild != null;
     assert myModelConverter != null;
+    //We only need these later, but need to fetch them before fetching other models because of https://github.com/gradle/gradle/issues/20008
+    final Set<GradleBuild> nestedBuilds = getNestedBuilds(myGradleBuild);
     final MyBuildController wrappedController = new MyBuildController(controller, myGradleBuild);
     fetchProjectBuildModels(wrappedController, isProjectsLoadedAction, myGradleBuild);
     addBuildModels(wrappedController, myAllModels, myGradleBuild, isProjectsLoadedAction);
 
-    if (myIsCompositeBuildsSupported) {
-      forEachNestedBuild(myGradleBuild, new GradleBuildConsumer() {
-        @Override
-        public void accept(@NotNull GradleBuild includedBuild) {
-          if (!isProjectsLoadedAction) {
-            myAllModels.getIncludedBuilds().add(convert(includedBuild));
-          }
-          fetchProjectBuildModels(wrappedController, isProjectsLoadedAction, includedBuild);
-          addBuildModels(wrappedController, myAllModels, includedBuild, isProjectsLoadedAction);
-        }
-      });
+    for (GradleBuild includedBuild : nestedBuilds) {
+      if (!isProjectsLoadedAction) {
+        myAllModels.getIncludedBuilds().add(convert(includedBuild));
+      }
+      fetchProjectBuildModels(wrappedController, isProjectsLoadedAction, includedBuild);
+      addBuildModels(wrappedController, myAllModels, includedBuild, isProjectsLoadedAction);
     }
     if (isProjectsLoadedAction) {
       wrappedController.getModel(TurnOffDefaultTasks.class);
@@ -199,8 +196,12 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
     void accept(@NotNull GradleBuild build);
   }
 
-  private static void forEachNestedBuild(@NotNull GradleBuild rootBuild, @NotNull GradleBuildConsumer buildConsumer) {
+  private Set<GradleBuild> getNestedBuilds(@NotNull GradleBuild rootBuild) {
+    if (!myIsCompositeBuildsSupported) {
+      return Collections.emptySet();
+    }
     Set<String> processedBuildsPaths = new HashSet<String>();
+    Set<GradleBuild> nestedBuilds = new HashSet<GradleBuild>();
     String rootBuildPath = rootBuild.getBuildIdentifier().getRootDir().getPath();
     processedBuildsPaths.add(rootBuildPath);
     Queue<GradleBuild> queue = new LinkedList<GradleBuild>(rootBuild.getIncludedBuilds());
@@ -208,10 +209,11 @@ public class ProjectImportAction implements BuildAction<ProjectImportAction.AllM
       GradleBuild includedBuild = queue.remove();
       String includedBuildPath = includedBuild.getBuildIdentifier().getRootDir().getPath();
       if (processedBuildsPaths.add(includedBuildPath)) {
-        buildConsumer.accept(includedBuild);
+        nestedBuilds.add(includedBuild);
         queue.addAll(includedBuild.getIncludedBuilds());
       }
     }
+    return nestedBuilds;
   }
 
   private void fetchProjectBuildModels(BuildController controller, final boolean isProjectsLoadedAction, GradleBuild build) {


### PR DESCRIPTION
Gradle's Tooling API models aren't thread-safe, because they use a HashMap to represent
the different views created over the same object. Since we can't retroactively fix all
Gradle versions, we can instead work around this by doing all the model access to the
root project model before we kick off any of the additional work that might access this
model as well.

See https://github.com/gradle/gradle/issues/20008