### PR TITLE
KTIJ-21238 False positive "try-finally can be replaced with 'use()'" when close() is overloaded

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTryFinallyToUseCallIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTryFinallyToUseCallIntention.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver
 import org.jetbrains.kotlin.resolve.scopes.receivers.ImplicitReceiver
 import org.jetbrains.kotlin.types.typeUtil.supertypes
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 @Suppress("DEPRECATION")
 class ConvertTryFinallyToUseCallInspection : IntentionBasedInspection<KtTryExpression>(
@@ -73,12 +74,14 @@ class ConvertTryFinallyToUseCallIntention : SelfTargetingRangeIntention<KtTryExp
     override fun applicabilityRange(element: KtTryExpression): TextRange? {
         // Single statement in finally, no catch blocks
         val finallySection = element.finallyBlock ?: return null
-        val finallyExpression = finallySection.finalExpression.statements.singleOrNull() ?: return null
+        val finallyExpression = finallySection.finalExpression.statements.singleOrNull()?.let {
+            it.safeAs<KtQualifiedExpression>()?.callExpression ?: it.safeAs<KtCallExpression>()
+        } ?: return null
+        if (finallyExpression.calleeExpression?.text != "close" || finallyExpression.valueArguments.isNotEmpty()) return null
         if (element.catchClauses.isNotEmpty()) return null
 
         val context = element.analyze()
         val resolvedCall = finallyExpression.getResolvedCall(context) ?: return null
-        if (resolvedCall.candidateDescriptor.name.asString() != "close") return null
         if (resolvedCall.extensionReceiver != null) return null
         val receiver = resolvedCall.dispatchReceiver ?: return null
         if (receiver.type.supertypes().all {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -9423,6 +9423,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertTryFinallyToUseCall/notClose.kt");
         }
 
+        @TestMetadata("notCloseableClose.kt")
+        public void testNotCloseableClose() throws Exception {
+            runTest("testData/intentions/convertTryFinallyToUseCall/notCloseableClose.kt");
+        }
+
         @TestMetadata("notOnlyClose.kt")
         public void testNotOnlyClose() throws Exception {
             runTest("testData/intentions/convertTryFinallyToUseCall/notOnlyClose.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTryFinallyToUseCall/notCloseableClose.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTryFinallyToUseCall/notCloseableClose.kt
@@ -1,0 +1,18 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+import java.io.Closeable
+
+class Resource : Closeable {
+    fun doStuff(): Unit = TODO()
+    override fun close(): Unit = close(status = 0)
+    fun close(status: Int): Unit = TODO()
+}
+
+fun test() {
+    val resource = Resource()
+    <caret>try {
+        resource.doStuff()
+    } finally {
+        resource.close(status = 1)
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21238