### PR TITLE
KTIJ-21177 `.arg` postfix template add return into parentheses

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/postfix/stringBasedPostfixTemplates.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/postfix/stringBasedPostfixTemplates.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.idea.resolve.ideService
 import org.jetbrains.kotlin.idea.util.getResolutionScope
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.KtThrowExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.types.KotlinType
@@ -111,7 +112,7 @@ internal object KtArgumentPostfixTemplate : ConstantStringBasedPostfixTemplate(
     "arg",
     "functionCall(expr)",
     "\$call$(\$expr$\$END$)",
-    createExpressionSelector(statementsOnly = true)
+    createExpressionSelectorWithComplexFilter { expression, _ -> expression !is KtReturnExpression && expression !is KtThrowExpression }
 ) {
     override fun setVariables(template: Template, element: PsiElement) {
         template.addVariable("call", "", "", true)

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/postfix/PostfixTemplateProviderTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/postfix/PostfixTemplateProviderTestGenerated.java
@@ -31,6 +31,16 @@ public abstract class PostfixTemplateProviderTestGenerated extends AbstractPostf
             runTest("testData/codeInsight/postfix/arg.kt");
         }
 
+        @TestMetadata("argWithReturn.kt")
+        public void testArgWithReturn() throws Exception {
+            runTest("testData/codeInsight/postfix/argWithReturn.kt");
+        }
+
+        @TestMetadata("argWithThrow.kt")
+        public void testArgWithThrow() throws Exception {
+            runTest("testData/codeInsight/postfix/argWithThrow.kt");
+        }
+
         @TestMetadata("assert.kt")
         public void testAssert() throws Exception {
             runTest("testData/codeInsight/postfix/assert.kt");

--- a/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithReturn.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithReturn.kt
@@ -1,0 +1,4 @@
+// TEMPLATE: \tfunctionCall\t
+fun foo(s: String) {
+    return s.arg<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithReturn.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithReturn.kt.after
@@ -1,0 +1,4 @@
+// TEMPLATE: \tfunctionCall\t
+fun foo(s: String) {
+    return functionCall(s<caret>)
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithThrow.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithThrow.kt
@@ -1,0 +1,7 @@
+// TEMPLATE: \tRuntimeException\t
+fun foo(s: String) {
+    try {
+    } catch (e: Exception) {
+        throw s.arg<caret>
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithThrow.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/postfix/argWithThrow.kt.after
@@ -1,0 +1,7 @@
+// TEMPLATE: \tRuntimeException\t
+fun foo(s: String) {
+    try {
+    } catch (e: Exception) {
+        throw RuntimeException(s<caret>)
+    }
+}


### PR DESCRIPTION
[^KTIJ-21177 Fixed](https://youtrack.jetbrains.com/issue/KTIJ-21177)