### PR TITLE
KTIJ-21197 Postfix templates may change semantics of expressions containing `.Companion`

### DIFF
--- a/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt
+++ b/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/ShortenReferences.kt
@@ -752,8 +752,7 @@ class ShortenReferences(val options: (KtElement) -> Options = { Options.DEFAULT 
             bindingContext: BindingContext
         ): AnalyzeQualifiedElementResult {
             val parent = element.parent
-            // TODO: Delete this code when KT-13934 is fixed
-            if (parent is KtCallableReferenceExpression && parent.receiverExpression == element) return AnalyzeQualifiedElementResult.Skip
+            if (parent is KtDoubleColonExpression && parent.receiverExpression == element) return AnalyzeQualifiedElementResult.Skip
 
             val receiver = element.receiverExpression
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/postfix/PostfixTemplateProviderTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/postfix/PostfixTemplateProviderTestGenerated.java
@@ -136,6 +136,11 @@ public abstract class PostfixTemplateProviderTestGenerated extends AbstractPostf
             runTest("testData/codeInsight/postfix/sout.kt");
         }
 
+        @TestMetadata("soutCompanionClassLiteral.kt")
+        public void testSoutCompanionClassLiteral() throws Exception {
+            runTest("testData/codeInsight/postfix/soutCompanionClassLiteral.kt");
+        }
+
         @TestMetadata("soutInIf.kt")
         public void testSoutInIf() throws Exception {
             runTest("testData/codeInsight/postfix/soutInIf.kt");

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/shortenRefs/ShortenRefsTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/shortenRefs/ShortenRefsTestGenerated.java
@@ -427,6 +427,11 @@ public abstract class ShortenRefsTestGenerated extends AbstractShortenRefsTest {
             runTest("testData/shortenRefs/classInCompanionObject.kt");
         }
 
+        @TestMetadata("classLiteralOnCompanion.kt")
+        public void testClassLiteralOnCompanion() throws Exception {
+            runTest("testData/shortenRefs/classLiteralOnCompanion.kt");
+        }
+
         @TestMetadata("ClassNameConflict.kt")
         public void testClassNameConflict() throws Exception {
             runTest("testData/shortenRefs/ClassNameConflict.kt");

--- a/plugins/kotlin/idea/tests/testData/codeInsight/postfix/soutCompanionClassLiteral.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/postfix/soutCompanionClassLiteral.kt
@@ -1,0 +1,9 @@
+class Enclosing {
+    companion object {
+        const val x = 1
+    }
+}
+
+fun main() {
+    Enclosing.Companion::class.sout<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/postfix/soutCompanionClassLiteral.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/postfix/soutCompanionClassLiteral.kt.after
@@ -1,0 +1,9 @@
+class Enclosing {
+    companion object {
+        const val x = 1
+    }
+}
+
+fun main() {
+    println(Enclosing.Companion::class)
+}

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/classLiteralOnCompanion.kt
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/classLiteralOnCompanion.kt
@@ -1,0 +1,14 @@
+package test
+
+class A {
+    companion object {
+        fun foo() {
+
+        }
+    }
+}
+
+fun test() {
+    <selection>A.Companion::class
+    (A.Companion)::class</selection>
+}

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/classLiteralOnCompanion.kt.after
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/classLiteralOnCompanion.kt.after
@@ -1,0 +1,14 @@
+package test
+
+class A {
+    companion object {
+        fun foo() {
+
+        }
+    }
+}
+
+fun test() {
+    A.Companion::class
+    (A)::class
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21197