### PR TITLE
KTIJ-20728 False positive "'foo' always returns non-null type" for function with non-local return in expression body

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNullableReturnTypeInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantNullableReturnTypeInspection.kt
@@ -99,7 +99,7 @@ class RedundantNullableReturnTypeInspection : AbstractKotlinInspection() {
         val moduleDescriptor = findModuleDescriptor()
         val languageVersionSettings = languageVersionSettings
         val returnTypes = collectDescendantsOfType<KtReturnExpression> {
-            it.labelQualifier == null && it.getTargetFunctionDescriptor(context) == declarationDescriptor
+            it.getTargetFunctionDescriptor(context) == declarationDescriptor
         }.flatMap {
             it.returnedExpression.types(context, dataFlowValueFactory, moduleDescriptor, languageVersionSettings)
         }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -9052,6 +9052,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                 runTest("testData/inspectionsLocal/redundantNullableReturnType/function/overridable.kt");
             }
 
+            @TestMetadata("returnNulableFromLambdaToOuterFunction.kt")
+            public void testReturnNulableFromLambdaToOuterFunction() throws Exception {
+                runTest("testData/inspectionsLocal/redundantNullableReturnType/function/returnNulableFromLambdaToOuterFunction.kt");
+            }
+
             @TestMetadata("returnNullableForLambda.kt")
             public void testReturnNullableForLambda() throws Exception {
                 runTest("testData/inspectionsLocal/redundantNullableReturnType/function/returnNullableForLambda.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantNullableReturnType/function/returnNulableFromLambdaToOuterFunction.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantNullableReturnType/function/returnNulableFromLambdaToOuterFunction.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun foo(): Int?<caret> = doActionAndReturnInt(action = { return@foo it })
+
+inline fun <T> doActionAndReturnInt(action: (Int?) -> T): T = action(42)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-20728