### PR TITLE
[IDEA-290134] Preserve textbox selection after toggling case

### DIFF
--- a/platform/platform-tests/testSrc/com/intellij/openapi/editor/actions/EditorActionTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/editor/actions/EditorActionTest.java
@@ -269,10 +269,28 @@ public class EditorActionTest extends AbstractEditorTest {
     checkResultByText(" <caret>text with [multiline\nfold region]");
   }
 
+  public void testToggleCaseToLower() {
+    init("<selection>LOWER</selection>", PlainTextFileType.INSTANCE);
+    executeAction(IdeActions.ACTION_EDITOR_TOGGLE_CASE);
+    checkResultByText("<selection><caret>lower</selection>");
+  }
+
+  public void testToggleCaseToUpper() {
+    init("<selection>upper</selection>", PlainTextFileType.INSTANCE);
+    executeAction(IdeActions.ACTION_EDITOR_TOGGLE_CASE);
+    checkResultByText("<selection><caret>UPPER</selection>");
+  }
+
+  public void testToggleCaseWithoutSelection() {
+    init("CamelCase Camel<caret>Case CamelCase", PlainTextFileType.INSTANCE);
+    executeAction(IdeActions.ACTION_EDITOR_TOGGLE_CASE);
+    checkResultByText("CamelCase camel<caret>case CamelCase");
+  }
+
   public void testToggleCaseForEszett() {
     init("<selection>\u00df</selection>", PlainTextFileType.INSTANCE);
     executeAction(IdeActions.ACTION_EDITOR_TOGGLE_CASE);
-    checkResultByText("<selection>SS</selection>");
+    checkResultByText("<selection><caret>SS</selection>");
   }
 
   public void testJoinSeveralLinesAtDocumentEnd() {


### PR DESCRIPTION
***What steps will reproduce the issue?***

1. Type a text in a textbox like the editor find textbox (`Ctrl+F`)
2. Select a part or the whole text
3. Toggle the case (`Ctrl+Shift+U`)

***What is the expected result?***
The selected part should still be selected.

***What happens instead?***
There is no selection any more.

This is very annoying as, sometimes, you have to press `Ctrl+Shift+U` twice to get uppercase. This way, it is not working.

I have put the recompiled `ToggleCaseAction.class` file into my own _IntelliJ_ installation and have successfully kept my selection in the _Find in files_, _Replace in files_, _Find in editor_, _Replace in editor_ textboxes. The case change behavior is exactly the same. I have tested with and without a selection. The code also handles the case of several carets. The code is generic and is applied to any textboxes that handle `Ctrl+Shift+U`. I have successfully run the tests of `JavaEditorActionTest.java` but, @ignatov, is there a test for toggle case action in the textbox?