### PR TITLE
Some fixes to gradle resolution

### DIFF
--- a/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ExternalModuleBuildClasspathPojo.java
+++ b/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/project/ExternalModuleBuildClasspathPojo.java
@@ -11,8 +11,8 @@ import java.util.List;
  */
 public class ExternalModuleBuildClasspathPojo {
 
-  @NotNull private final List<String> myEntries;
   @NotNull private String myPath;
+  @NotNull private List<String> myEntries;
 
   @SuppressWarnings("UnusedDeclaration")
   public ExternalModuleBuildClasspathPojo() {
@@ -37,6 +37,10 @@ public class ExternalModuleBuildClasspathPojo {
   @NotNull
   public List<String> getEntries() {
     return myEntries;
+  }
+
+  public void setEntries(@NotNull List<String> entries) {
+    myEntries = entries;
   }
 
   @Override

--- a/plugins/gradle/java/src/service/resolve/GradleProjectExtensionContributor.kt
+++ b/plugins/gradle/java/src/service/resolve/GradleProjectExtensionContributor.kt
@@ -54,6 +54,7 @@ class GradleProjectExtensionContributor : NonCodeMembersContributor() {
       if (processMethods) {
         val extensionMethod = GrLightMethodBuilder(manager, extension.name).apply {
           returnType = type
+          containingClass = aClass
           addAndGetParameter("configuration", createType(GROOVY_LANG_CLOSURE, containingFile))
             .putUserData(DELEGATES_TO_KEY, DelegatesToInfo(type, Closure.DELEGATE_FIRST))
         }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/GradleInstallationManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/GradleInstallationManager.java
@@ -565,7 +565,7 @@ public class GradleInstallationManager implements Disposable {
 
   private static boolean isGroovyJar(@NotNull String name) {
     name = StringUtil.toLowerCase(name);
-    return name.startsWith("groovy-all-") && name.endsWith(".jar") && !name.contains("src") && !name.contains("doc");
+    return name.startsWith("groovy-") && name.endsWith(".jar") && !name.contains("src") && !name.contains("doc");
   }
 
   @Nullable


### PR DESCRIPTION
These changes begin to fix some of the issues described in IDEA-290182.  They're not complete; I have encountered caches which I think need to be cleared (in `GradleClassFinder` and `ResolveScopeManagerImpl`) and I don't have a solution for the scope of individual files in jars on the build classpath.  But hopefully these are a useful start.