### PR TITLE
Fix equals()-hashCode() contract

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
@@ -84,6 +84,11 @@ public class AnnotationExprent extends Exprent {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(className, parNames, parValues);
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (o == this) return true;
     if (!(o instanceof AnnotationExprent)) return false;


### PR DESCRIPTION
I am maintaining a fork which still provides support for Java 8.
An issue arised in the unit tests when using the method `toSet` instead of `toUnmodifiableSet` in `StructMember#memberAnnCollidesWithTypeAnnotation` and `StructMember#paramAnnCollidesWithTypeAnnotation`.
This is because the `Set` produced by `toSet` uses the `hashCode` method implicitly whilst the one from `toUnmodifiableSet` does not.
This PR will "fix" this issue for me and make the code future-proof in case the `hashCode` method will be needed at some point.