### PR TITLE
Typo mistake in forward compatibility inspection

### DIFF
--- a/java/java-impl/src/inspectionDescriptions/ForwardCompatibility.html
+++ b/java/java-impl/src/inspectionDescriptions/ForwardCompatibility.html
@@ -3,7 +3,7 @@
 Reports Java code constructs that may fail to compile in future Java versions.
 <p>The following problems are reported:</p>
 <ul>
-  <li>Use of <code>assert</code>>, <code>enum</code> or </code>_</code> as an identifier</li>
+  <li>Use of <code>assert</code>, <code>enum</code> or <code>_</code> as an identifier</li>
   <li>Use of the <code>var</code>, <code>yield</code>, or <code>record</code> restricted identifier as a type name</li>
   <li>Unqualified calls to the <code>yield</code> method</li>
   <li>Modifiers on the <code>requires java.base</code> statement inside of <code>module-info.java</code></li>


### PR DESCRIPTION
Hi @BasLeijdekkers,

In the _Forward compatibility_ inspection description, a chevron and a slash were wandering in the middle of nothing.

I have successfully tested the rendering in my _IntelliJ_.