### PR TITLE
KTIJ-21428 False positive "move lambda argument out of parentheses"

### DIFF
--- a/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
+++ b/plugins/kotlin/core/src/org/jetbrains/kotlin/idea/core/psiModificationUtils.kt
@@ -35,6 +35,7 @@ import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.addRemoveModifier.MODIFIERS_ORDER
 import org.jetbrains.kotlin.psi.psiUtil.*
 import org.jetbrains.kotlin.psi.typeRefHelpers.setReceiverTypeReference
+import org.jetbrains.kotlin.psi2ir.deparenthesize
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.calls.model.ArgumentMatch
@@ -131,6 +132,7 @@ fun KtCallExpression.getLastLambdaExpression(): KtLambdaExpression? {
 fun KtCallExpression.canMoveLambdaOutsideParentheses(): Boolean {
     if (getStrictParentOfType<KtDelegatedSuperTypeEntry>() != null) return false
     val lastLambdaExpression = getLastLambdaExpression() ?: return false
+    if (lastLambdaExpression.parentLabeledExpression()?.parentLabeledExpression() != null) return false
 
     val callee = calleeExpression
     if (callee is KtNameReferenceExpression) {
@@ -173,6 +175,10 @@ fun KtCallExpression.canMoveLambdaOutsideParentheses(): Boolean {
     }
 
     return true
+}
+
+private fun KtExpression.parentLabeledExpression(): KtLabeledExpression? {
+    return getStrictParentOfType<KtLabeledExpression>()?.takeIf { it.baseExpression == this }
 }
 
 private fun KotlinType.allowsMoveOutsideParentheses(

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7325,6 +7325,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/moveLambdaOutsideParentheses/suspendLambda.kt");
         }
 
+        @TestMetadata("towLabels.kt")
+        public void testTowLabels() throws Exception {
+            runTest("testData/inspectionsLocal/moveLambdaOutsideParentheses/towLabels.kt");
+        }
+
         @TestMetadata("typeParameter.kt")
         public void testTypeParameter() throws Exception {
             runTest("testData/inspectionsLocal/moveLambdaOutsideParentheses/typeParameter.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/moveLambdaOutsideParentheses/towLabels.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/moveLambdaOutsideParentheses/towLabels.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+fun test() {
+    foo(bar@ foo@{ bar(it) }<caret>)
+}
+
+fun foo(f: (String) -> Int) {
+    f("")
+}
+
+fun bar(s: String) = s.length


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21428