### PR TITLE
Include parent properties when doing late replacement of `argLine`

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcher.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcher.java
@@ -88,6 +88,7 @@ public final class MavenJUnitPatcher extends JUnitPatcher {
       return s -> s;
     }
     Properties staticProperties = MavenPropertyResolver.collectPropertiesFromDOM(mavenProject, domModel);
+    Properties modelProperties = mavenProject.getProperties();
     String jaCoCoConfigProperty = getJaCoCoArgLineProperty(mavenProject);
     ParametersList vmParameters = javaParameters.getVMParametersList();
     return name -> {
@@ -98,6 +99,10 @@ public final class MavenJUnitPatcher extends JUnitPatcher {
       String staticPropertyValue = staticProperties.getProperty(name);
       if (staticPropertyValue != null) {
         return MavenPropertyResolver.resolve(staticPropertyValue, domModel);
+      }
+      String modelPropertyValue = modelProperties.getProperty(name);
+      if (modelPropertyValue != null) {
+        return modelPropertyValue;
       }
       if (name.equals(jaCoCoConfigProperty)) {
         return "";


### PR DESCRIPTION
When doing late replacement of properties in `argLine`, the Maven plugin correctly considers properties defined in the POM, but it fails to consider properties defined in the parent POM. This PR corrects the problem by consulting the model for such properties. The included test case fails without the changes to `plugins/maven/src/main` with this stack trace:

```
junit.framework.AssertionFailedError: 
Expected :[-ea, module.value, parent.value]
Actual   :[-ea, module.value, @{parentProp}]
	at junit.framework.Assert.fail(Assert.java:57)
	at junit.framework.Assert.failNotEquals(Assert.java:329)
	at junit.framework.Assert.assertEquals(Assert.java:78)
	at junit.framework.Assert.assertEquals(Assert.java:86)
	at junit.framework.TestCase.assertEquals(TestCase.java:253)
	at org.jetbrains.idea.maven.execution.MavenJUnitPatcherTest.ArgLineLateReplacementParentProperty(MavenJUnitPatcherTest.java:397)
```

With the changes to `plugins/maven/src/main`, the test passes.