### PR TITLE
KTIJ-15399 "Add abstract fun" quick-fix produces errors for annotated methods if annotation parameter is a vararg values

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -1282,6 +1282,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/addPropertyToSupertype/abstractClass.kt");
         }
 
+        @TestMetadata("hasAnnotations.kt")
+        public void testHasAnnotations() throws Exception {
+            runTest("testData/quickfix/addPropertyToSupertype/hasAnnotations.kt");
+        }
+
         @TestMetadata("interface.kt")
         public void testInterface() throws Exception {
             runTest("testData/quickfix/addPropertyToSupertype/interface.kt");
@@ -10518,6 +10523,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             @TestMetadata("addFunctionTwoTraits.kt")
             public void testAddFunctionTwoTraits() throws Exception {
                 runTest("testData/quickfix/override/nothingToOverride/addFunctionTwoTraits.kt");
+            }
+
+            @TestMetadata("addFunctionWithAnnotations.kt")
+            public void testAddFunctionWithAnnotations() throws Exception {
+                runTest("testData/quickfix/override/nothingToOverride/addFunctionWithAnnotations.kt");
             }
 
             @TestMetadata("addFunctionWithoutDefaultValue.kt")

--- a/plugins/kotlin/idea/tests/testData/quickfix/addPropertyToSupertype/hasAnnotations.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addPropertyToSupertype/hasAnnotations.kt
@@ -1,0 +1,12 @@
+// "Add 'val bar: Int' to 'I'" "true"
+annotation class A(vararg val names: String)
+annotation class B(val i: Int)
+
+interface I {
+}
+
+class C : I {
+    @A("x", "y")
+    @B(1)
+    <caret>override val bar = 1
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addPropertyToSupertype/hasAnnotations.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addPropertyToSupertype/hasAnnotations.kt.after
@@ -1,0 +1,15 @@
+// "Add 'val bar: Int' to 'I'" "true"
+annotation class A(vararg val names: String)
+annotation class B(val i: Int)
+
+interface I {
+    @A("x", "y")
+    @B(1)
+    val bar: Int
+}
+
+class C : I {
+    @A("x", "y")
+    @B(1)
+    override val bar = 1
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/override/nothingToOverride/addFunctionWithAnnotations.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/override/nothingToOverride/addFunctionWithAnnotations.kt
@@ -1,0 +1,11 @@
+// "Add 'abstract fun foo()' to 'I'" "true"
+annotation class A(vararg val names: String)
+annotation class B(val i: Int)
+
+interface I
+
+class C : I {
+    @A("x", "y")
+    @B(1)
+    <caret>override fun foo() {}
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/override/nothingToOverride/addFunctionWithAnnotations.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/override/nothingToOverride/addFunctionWithAnnotations.kt.after
@@ -1,0 +1,15 @@
+// "Add 'abstract fun foo()' to 'I'" "true"
+annotation class A(vararg val names: String)
+annotation class B(val i: Int)
+
+interface I {
+    @A("x", "y")
+    @B(1)
+    fun foo()
+}
+
+class C : I {
+    @A("x", "y")
+    @B(1)
+    override fun foo() {}
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-15399

<img width="433" alt="スクリーンショット 2022-04-03 12 45 43" src="https://user-images.githubusercontent.com/1121855/161410469-a8eb3650-d36a-4798-9502-37169cf557c8.png">

↓

<img width="420" alt="スクリーンショット 2022-04-03 12 45 52" src="https://user-images.githubusercontent.com/1121855/161410479-cac25424-a423-4c46-9e20-a546bf4939a6.png">

