### PR TITLE
Set total num disks to 1 in the zip64 EOCD locator

### DIFF
--- a/build/tasks/src/org/jetbrains/intellij/build/io/ZipArchiveOutputStream.kt
+++ b/build/tasks/src/org/jetbrains/intellij/build/io/ZipArchiveOutputStream.kt
@@ -334,7 +334,7 @@ internal class ZipArchiveOutputStream(private val channel: WritableByteChannel,
     // relative offset of the zip64 end of central directory record
     buffer.putLong(eocd64Position)
     // total number of disks
-    buffer.putInt(0)
+    buffer.putInt(1)
 
     // write EOCD (EOCD is required even if we write EOCD64)
     buffer.putInt(0x06054b50)


### PR DESCRIPTION
...otherwise some tools get confused and think that the zip
is a split archive.

For example, when ijar sees that zip64_total_disks != 1,
it complains, "multi-disk JAR files are not supported":
github.com/bazelbuild/bazel/blob/master/third_party/ijar/zip.cc

Similarly, running `zip --test` on the lib/app.jar file in IJ 221
produces a warning: "archive name must end in .zip for splits".

---

cc @develar 
Let me know what you think. Since it is a trivial fix, I did not bother filing a YouTrack issue.