### PR TITLE
Extend Selection: prioritize blank lines above

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/editorActions/ExtendWordSelectionHandlerBase.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/editorActions/ExtendWordSelectionHandlerBase.java
@@ -134,20 +134,20 @@ public abstract class ExtendWordSelectionHandlerBase implements ExtendWordSelect
     TextRange last = result.isEmpty() ? range : result.get(result.size() - 1);
     int start = last.getStartOffset();
     int end = last.getEndOffset();
-    while (true) {
-      int blankLineEnd = CharArrayUtil.shiftForward(text, end, " \t");
-      if (blankLineEnd >= text.length() || text.charAt(blankLineEnd) != '\n') {
+    while (start > 0 && text.charAt(start - 1) == '\n') {
+      int blankLineStart = CharArrayUtil.shiftBackward(text, start - 2, " \t");
+      if (blankLineStart <= 0 || text.charAt(blankLineStart) != '\n') {
         break;
       }
-      end = blankLineEnd + 1;
+      start = blankLineStart + 1;
     }
-    if (end == last.getEndOffset()) {
-      while (start > 0 && text.charAt(start - 1) == '\n') {
-        int blankLineStart = CharArrayUtil.shiftBackward(text, start - 2, " \t");
-        if (blankLineStart <= 0 || text.charAt(blankLineStart) != '\n') {
+    if (start == last.getStartOffset()) {
+      while (true) {
+        int blankLineEnd = CharArrayUtil.shiftForward(text, end, " \t");
+        if (blankLineEnd >= text.length() || text.charAt(blankLineEnd) != '\n') {
           break;
         }
-        start = blankLineStart + 1;
+        end = blankLineEnd + 1;
       }
     }
     if (start != last.getStartOffset() || end != last.getEndOffset()) {


### PR DESCRIPTION
There’s a minor annoyance in how Extend Selection works in Java: when a whole method (or class) is selected, extending the selection once more extends downwards, selecting the blank line below. If the selected code is then cut into the clipboard and pasted somewhere else when the cursor is _exactly on a line between methods,_ then the end result is not quite what is desired: there will be two blank lines above the pasted methods and none below.

This PR aims to fix this issue by prioritizing extending selection upwards if possible. It turned out to be easier than I initially thought: there is already code that is responsible for extending in both directions. All I did was swap the parts that extend upwards and downwards. It was: try to extend downwards, and fall back to extending upwards if that failed. It’s now: try to extend upwards, and fall back to extending downwards if that failed.

Unfortunately, it only works in Java, as Kotlin is handled by a different class in the Kotlin plugin (it still uses this code, but skips the select-one-more-blank-line stage completely). I plan to get to it later, if this PR is accepted.