### PR TITLE
KTIJ-21518 False negative "Verbose nullability and emptiness check" in case expression is in parentheses

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -16682,6 +16682,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                 KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
             }
 
+            @TestMetadata("binaryExpressionInParentheses.kt")
+            public void testBinaryExpressionInParentheses() throws Exception {
+                runTest("testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/binaryExpressionInParentheses.kt");
+            }
+
+            @TestMetadata("nullCheckExpressionInParentheses.kt")
+            public void testNullCheckExpressionInParentheses() throws Exception {
+                runTest("testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/nullCheckExpressionInParentheses.kt");
+            }
+
             @TestMetadata("nullOrIsEmpty.kt")
             public void testNullOrIsEmpty() throws Exception {
                 runTest("testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/nullOrIsEmpty.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/binaryExpressionInParentheses.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/binaryExpressionInParentheses.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>?, b: Boolean) {
+    if ((<caret>list == null || list.isEmpty()) && b) println(1) else println(0)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/binaryExpressionInParentheses.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/binaryExpressionInParentheses.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>?, b: Boolean) {
+    if (list.isNullOrEmpty() && b) println(1) else println(0)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/nullCheckExpressionInParentheses.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/nullCheckExpressionInParentheses.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>?) {
+    if ((<caret>list == null) || list.isEmpty()) println(1) else println(0)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/nullCheckExpressionInParentheses.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/verboseNullabilityAndEmptiness/wrapped/nullCheckExpressionInParentheses.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>?) {
+    if (list.isNullOrEmpty()) println(1) else println(0)
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21518
https://youtrack.jetbrains.com/issue/KTIJ-21519