### PR TITLE
Expose scheduling selection to sub-classes in AutoScrollFromSourceHandler

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/AutoScrollFromSourceHandler.java
+++ b/platform/platform-api/src/com/intellij/ui/AutoScrollFromSourceHandler.java
@@ -72,7 +72,7 @@ public abstract class AutoScrollFromSourceHandler {
     updateCurrentSelection();
   }
 
-  private void selectInAlarm(final FileEditor editor) {
+  protected void selectInAlarm(final FileEditor editor) {
     // Code WithMe: do not process changes from remote (client) editor switching
     if (!ClientId.isCurrentlyUnderLocalId()) return;
 


### PR DESCRIPTION
Allow sub-classes of AutoScrollFromSourceHandler to schedule selection changes from other sources such as caret listeners or when the UI element becomes visible