### PR TITLE
[EE-IR] Support local classes

### DIFF
--- a/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/compilation/CodeFragmentCompiler.kt
+++ b/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/compilation/CodeFragmentCompiler.kt
@@ -2,10 +2,8 @@
 
 package org.jetbrains.kotlin.idea.debugger.evaluate.compilation
 
-import com.intellij.debugger.engine.DebugProcess
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.progress.ProcessCanceledException
-import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.registry.Registry
 import org.jetbrains.kotlin.backend.common.output.OutputFile
 import org.jetbrains.kotlin.codegen.ClassBuilderFactories

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localClass.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localClass.kt
@@ -9,6 +9,3 @@ fun main() {
 
 // EXPRESSION: LocalClass()
 // RESULT: instance of localClass.LocalClassKt$main$LocalClass(id=ID): LlocalClass/LocalClassKt$main$LocalClass;
-
-
-// TODO: Support local classes in the IR Evaluator backend.

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localClass.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localClass.out
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: JVM_IR_WITH_IR_EVALUATOR
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR
 LineBreakpoint created at localClass.kt:7
 Run Java
 Connected to the target VM


### PR DESCRIPTION
!! Depends on #1973 !!

---

The source of local classes needs to be included in the IR compilation in order to compute the "binary" names for the local classes in the compiled code, rather than have fragment compilation attempt to "predict" the names.
