### PR TITLE
Mark code fragments as USED_AS_EXPRESSION

### DIFF
--- a/plugins/kotlin/analysis/src/org/jetbrains/kotlin/idea/caches/resolve/CodeFragmentAnalyzer.kt
+++ b/plugins/kotlin/analysis/src/org/jetbrains/kotlin/idea/caches/resolve/CodeFragmentAnalyzer.kt
@@ -24,6 +24,8 @@ import org.jetbrains.kotlin.resolve.scopes.utils.addImportingScopes
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.idea.core.util.externalDescriptors
+import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
+import org.jetbrains.kotlin.resolve.BindingContext.USED_AS_EXPRESSION
 import org.jetbrains.kotlin.types.expressions.ExpressionTypingServices
 import javax.inject.Inject
 
@@ -56,6 +58,7 @@ class CodeFragmentAnalyzer(
                     expressionTypingServices = expressionTypingServices
                 )
                 analyzeControlFlow(resolveSession, contentElement, bindingTrace)
+                bindingTrace.record(USED_AS_EXPRESSION, contentElement.lastBlockStatementOrThis())
             }
 
             is KtTypeReference -> {

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/whenEvaluation.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/whenEvaluation.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at whenEvaluation.kt:6
 Run Java
 Connected to the target VM


### PR DESCRIPTION
Code fragments submitted to the evaluator are analyzed by the front-end.

psi2ir relies on the `USED_AS_EXPRESSION` analysis to correctly determine the type of a when expression. If it's not used, the result is coerced to Unit.

This caused when expressions as the last statement (and thus, result) in a block submitted to the evaluator to be discarded.

Tagging the fragment as used resolves this.