### PR TITLE
fix: VS Code shift alt down wrong action

### DIFF
--- a/platform/platform-resources/src/keymaps/VSCode.xml
+++ b/platform/platform-resources/src/keymaps/VSCode.xml
@@ -148,7 +148,8 @@
   <action id="EditorDeleteLine">
     <keyboard-shortcut first-keystroke="shift ctrl k" />
   </action>
-  <action id="EditorDuplicate">
+  <action id="EditorDuplicate" />
+  <action id="EditorDuplicateLines">
     <keyboard-shortcut first-keystroke="shift alt down" />
   </action>
   <action id="EditorIndentLineOrSelection">


### PR DESCRIPTION
The shift alt down shortcut in vscode is much closer to EditorDuplicateLines than EditorDuplicate

## Shift alt down in VS Code (Copy Line Down):

![image](https://user-images.githubusercontent.com/16233697/164264248-241432b2-78f5-409a-b767-b14d0a6ad06c.png)
![image](https://user-images.githubusercontent.com/16233697/164264282-ece51493-8b65-44c9-a22d-ec2860a86151.png)

## EditorDuplicate in Jetbrains:

![image](https://user-images.githubusercontent.com/16233697/164264370-f6daec5f-1cd5-4bb0-a327-33d24c6caf5f.png)
![image](https://user-images.githubusercontent.com/16233697/164264600-d2207185-0847-4efc-9fb0-31a22a80795a.png)


## EditorDuplicateLines in Jetbrains:

![image](https://user-images.githubusercontent.com/16233697/164264370-f6daec5f-1cd5-4bb0-a327-33d24c6caf5f.png)
![image](https://user-images.githubusercontent.com/16233697/164264411-338ed1cd-6647-4e3b-af10-57ad89736038.png)





