### PR TITLE
[EE-IR] Handle function declarations in the fragment

### DIFF
--- a/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/ClassLoadingAdapter.kt
+++ b/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/classLoading/ClassLoadingAdapter.kt
@@ -76,6 +76,11 @@ interface ClassLoadingAdapter {
                             return info.copy(containsCodeUnsupportedInEval4J = true)
                         }
                     }
+                    is MethodInsnNode -> {
+                        if (insn.opcode == Opcodes.INVOKESTATIC && insn.owner == classToLoad.className) {
+                                return info.copy(containsCodeUnsupportedInEval4J = true)
+                        }
+                    }
                 }
 
                 val nextInsn = insn.next ?: return info

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/functionWithBodyExpression.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/functionWithBodyExpression.out
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JVM_WITH_IR_EVALUATOR, JVM_IR_WITH_IR_EVALUATOR
 LineBreakpoint created at functionWithBodyExpression.kt:5
 Run Java
 Connected to the target VM


### PR DESCRIPTION
Function declarations _in the fragment_ become _local_ functions in the
compilation strategy for fragments. On the old backend, local functions are
treated as, essentially, lambdas, and cause the generation of closure classes
etc causing the evalautor to prefer loading the fragment code onto the host JVM
due to multiple classes.

The IR strategy of lifting local functions to static members of the surrounding
class means now that these cases _do not_ trigger avoiding eval4j, which reveals
that invocations of static members targetting code loaded on eval4j does not
work. The codepath of all invokeStatics in eval4j insist that the target be
loaded on the host VM.

Here we detect this case and prefer the "compiling evaluator" in this case.