### PR TITLE
Kotlin unwrap improvements KTIJ-21561 KTIJ-21562 KTIJ-11687

### DIFF
--- a/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
@@ -249,6 +249,7 @@ overridden.marker.overrides.choose.implementation.find.usages=Super Implementati
 
 remove.expression=Remove ''{0}''
 unwrap.expression=Unwrap ''{0}''
+unwrap.parameter=Unwrap ''{0}'' arg ''{1}''
 remove.else=Remove else in ''{0}''
 unwrap.else=Unwrap else in ''{0}''
 

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinFunctionParameterUnwrapper.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinFunctionParameterUnwrapper.kt
@@ -196,6 +196,9 @@ class KotlinFunctionParameterUnwrapper(val key: String) : KotlinUnwrapRemoveBase
         // but because we support the caret to be on LPAR/COMMA and other tokens this doesn't work
 
         val target = argumentToUnwrap(e) ?: return "<unknown>" // should not be possible
-        return message(key, getExpressionShortText(target))
+        val callee = target.getStrictParentOfType<KtCallExpression>()?.calleeExpression
+            ?.let(::getExpressionShortText) ?: "?"
+
+        return message(key, callee, getExpressionShortText(target))
     }
 }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinFunctionParameterUnwrapper.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinFunctionParameterUnwrapper.kt
@@ -2,26 +2,200 @@
 
 package org.jetbrains.kotlin.idea.codeInsight.unwrap
 
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtValueArgument
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.elementType
+import org.jetbrains.kotlin.idea.KotlinBundle.message
+import org.jetbrains.kotlin.idea.refactoring.getExpressionShortText
+import org.jetbrains.kotlin.idea.util.ifTrue
+import org.jetbrains.kotlin.idea.util.isComma
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespaceAndComments
+import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
-class KotlinFunctionParameterUnwrapper(key: String) : KotlinUnwrapRemoveBase(key) {
+class KotlinFunctionParameterUnwrapper(val key: String) : KotlinUnwrapRemoveBase(key) {
 
     override fun isApplicableTo(element: PsiElement): Boolean {
-        if (element !is KtCallExpression) return false
-        if (element.valueArguments.size != 1) return false
-        val argument = element.parent as? KtValueArgument ?: return false
-        if (argument.getStrictParentOfType<KtCallExpression>() == null) return false
+        val argumentToUnwrap = argumentToUnwrap(element) ?: return false
+        deletionTarget(argumentToUnwrap) ?: return false
+
+        return true
+    }
+
+    private fun argumentToUnwrap(element: PsiElement?): KtValueArgument? {
+        if (element == null) return null
+
+        nearbySingleArg(element)?.let {
+            return it
+        }
+        when (element) {
+            is KtValueArgument -> return element
+            else -> {
+                if (element.parent !is KtValueArgumentList) return null
+
+                if (element.isComma || element.elementType == KtTokens.RPAR || element is PsiWhiteSpace || element is PsiComment) {
+                    return findAdjacentValueArgumentInsideParen(element)
+                } else return null
+            }
+        }
+    }
+
+    /**
+     * When outside a function call's parenthesized arguments but the function has a single argument, choose that
+     * ```
+     *           ┌ LPAR
+     *           │
+     *           v
+     * methodCall(arguments)
+     * ^^^^^^^^^^
+     * │
+     * └ Identifier
+     * ```
+     *
+     */
+    private fun nearbySingleArg(element: PsiElement): KtValueArgument? {
+        fun caretOnQualifier(qualifiedExpression: KtQualifiedExpression): KtCallExpression? {
+            var candidate: KtQualifiedExpression = qualifiedExpression
+
+            // a.b.c.d(123)
+            // ^^^^^^^
+            // walk up chained dot expressions until we find the one that has a call as rhs
+            // we use this complicated rather than just have isApplicableTo apply to a KtQualifiedExpression to get priority over
+            // "Remove"
+            while (candidate.selectorExpression !is KtCallExpression) {
+                candidate = candidate.parent.safeAs<KtQualifiedExpression>() ?: return null
+            }
+            return candidate.selectorExpression as KtCallExpression
+        }
+
+        val callExpression: KtCallExpression = when (element.elementType) {
+            KtTokens.LPAR -> {
+                //  methodName<caret>(123)
+                element.parent?.safeAs<KtValueArgumentList>()
+                    ?.parent?.safeAs<KtCallExpression>() ?: return null
+            }
+            KtTokens.DOT, KtTokens.SAFE_ACCESS -> {
+                element.parent?.safeAs<KtQualifiedExpression>()
+                    ?.let { caretOnQualifier(it) } ?: return null
+            }
+            KtTokens.IDENTIFIER -> {
+                // method<caret>Name(123)
+                // <caret>methodName(123)
+                val referenceExpression = element.parent?.safeAs<KtReferenceExpression>()
+                when (val parent = referenceExpression?.parent) {
+                    is KtCallExpression -> parent
+                    is KtQualifiedExpression -> {
+                        // a.b?.c(123)
+                        // ^ ^  ^
+                        caretOnQualifier(parent)
+                    }
+                    else -> null
+                } ?: return null
+                // we could just handle this on
+            }
+            else -> return null
+        }
+
+        val ktValueArgumentList = callExpression.valueArgumentList
+        if (ktValueArgumentList?.arguments.isNullOrEmpty()) {
+            // if there's no parenthesized arguments, unwrap trailing lambda if any
+            return callExpression
+                .lambdaArguments.singleOrNull()
+        }
+
+        // there are parenthesized arguments, only consider if there's exactly one
+        return ktValueArgumentList?.arguments?.singleOrNull()
+    }
+
+    /**
+     * When inside a function call's parenthesized arguments.
+     *
+     * * for Comma and RPAR, we scan towards the left
+     * * for whitespace, we scan leftwards and rightwards
+     *
+     * ```
+     *                 ┌ COMMA
+     *                 │   ┌ RPAR
+     *                 │   │
+     *                 v   v
+     * methodCall(1, 2 , 3 )
+     *              ^   ^ ^
+     *              │   │ │
+     *   Whitespace ┴───┴─┘
+     * ```
+     *
+     */
+    private fun findAdjacentValueArgumentInsideParen(element: PsiElement): KtValueArgument? {
+        if (element.parent !is KtValueArgumentList) {
+            return null
+        }
+
+        return when {
+            element.elementType == KtTokens.RPAR -> {
+                // caret after last argument before closing paren, argument is the last element
+                val valueArgumentList = element.parent as? KtValueArgumentList ?: return null
+                if (valueArgumentList.parent !is KtCallExpression) return null
+                return valueArgumentList.arguments.lastOrNull()
+            }
+            element.isComma -> {
+                // caret before comma, choose previous argument
+                val previous = element.getPrevSiblingIgnoringWhitespaceAndComments()
+                isCallArgument(previous).ifTrue { previous as KtValueArgument }
+            }
+            element is PsiWhiteSpace || element is PsiComment -> {
+                // caret before blank or in comment, argument could be towards the left or the right
+                val previous = element.getPrevSiblingIgnoringWhitespaceAndComments()
+                if (isCallArgument(previous)) return previous as KtValueArgument
+
+                val next = element.getNextSiblingIgnoringWhitespaceAndComments()
+                if (isCallArgument(next)) return next as KtValueArgument
+
+                null
+            }
+            else -> null
+        }
+    }
+
+    private fun isCallArgument(element: PsiElement?): Boolean {
+        if (element is KtLambdaArgument) return false
+        if (element !is KtValueArgument) return false
+        val argumentList = element.parent as KtValueArgumentList
+        if (argumentList.parent !is KtCallExpression) return false
+
         return true
     }
 
     override fun doUnwrap(element: PsiElement?, context: Context?) {
-        val function = element as? KtCallExpression ?: return
-        val argument = element.valueArguments.firstOrNull()?.getArgumentExpression() ?: return
-        context?.extractFromExpression(argument, function)
-        context?.delete(function)
+        val valueArgument = argumentToUnwrap(element) ?: return
+        val deletionTarget = deletionTarget(valueArgument) ?: return
+        val argument = valueArgument.getArgumentExpression() ?: return
+        context?.extractFromExpression(argument, deletionTarget)
+        context?.delete(deletionTarget)
     }
 
+    private fun deletionTarget(valueArgument: KtValueArgument): KtElement? {
+        var function: KtElement = valueArgument.getStrictParentOfType<KtCallExpression>() ?: return null
+        val parent = function.parent
+        if (parent is KtQualifiedExpression) {
+            function = parent
+        }
+        return function
+    }
+
+    override fun collectAffectedElements(e: PsiElement, toExtract: MutableList<PsiElement>): PsiElement {
+        super.collectAffectedElements(e, toExtract)
+        return argumentToUnwrap(e)?.let { deletionTarget(it) } ?: e
+    }
+
+    override fun getDescription(e: PsiElement): String {
+        // necessary because the base implementation expects to be called for KtElement
+        // but because we support the caret to be on LPAR/COMMA and other tokens this doesn't work
+
+        val target = argumentToUnwrap(e) ?: return "<unknown>" // should not be possible
+        return message(key, getExpressionShortText(target))
+    }
 }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinLambdaUnwrapper.java
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinLambdaUnwrapper.java
@@ -19,7 +19,14 @@ public class KotlinLambdaUnwrapper extends KotlinUnwrapRemoveBase {
         PsiElement parent = lambda.getParent();
 
         if (parent instanceof KtValueArgument) {
-            return PsiTreeUtil.getParentOfType(parent, KtCallExpression.class, true);
+            KtCallExpression callExpression = PsiTreeUtil.getParentOfType(parent, KtCallExpression.class, true);
+            if (callExpression != null) {
+                PsiElement parentParent = callExpression.getParent();
+                if (parentParent instanceof KtQualifiedExpression) {
+                    return (KtElement) parentParent;
+                }
+            }
+            return callExpression;
         }
 
         if (parent instanceof KtCallExpression) {
@@ -39,7 +46,7 @@ public class KotlinLambdaUnwrapper extends KotlinUnwrapRemoveBase {
 
         KtLambdaExpression lambda = (KtLambdaExpression) e;
         KtBlockExpression body = lambda.getBodyExpression();
-        KtElement enclosingElement = getLambdaEnclosingElement((KtLambdaExpression) e);
+        KtElement enclosingElement = getLambdaEnclosingElement(lambda);
 
         if (body == null || enclosingElement == null) return false;
 

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinLambdaUnwrapper.java
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinLambdaUnwrapper.java
@@ -8,6 +8,8 @@ import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.psi.*;
 
+import java.util.List;
+
 public class KotlinLambdaUnwrapper extends KotlinUnwrapRemoveBase {
     public KotlinLambdaUnwrapper(String key) {
         super(key);
@@ -52,5 +54,11 @@ public class KotlinLambdaUnwrapper extends KotlinUnwrapRemoveBase {
 
         context.extractFromBlock(body, enclosingExpression);
         context.delete(enclosingExpression);
+    }
+
+    @Override
+    public PsiElement collectAffectedElements(@NotNull PsiElement e, @NotNull List<PsiElement> toExtract) {
+        super.collectAffectedElements(e, toExtract);
+        return getLambdaEnclosingElement((KtLambdaExpression) e);
     }
 }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinUnwrapDescriptor.java
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/unwrap/KotlinUnwrapDescriptor.java
@@ -20,7 +20,7 @@ public class KotlinUnwrapDescriptor extends UnwrapDescriptorBase {
                 new KotlinUnwrappers.KotlinFinallyUnwrapper("unwrap.expression"),
                 new KotlinUnwrappers.KotlinFinallyRemover("remove.expression"),
                 new KotlinLambdaUnwrapper("unwrap.expression"),
-                new KotlinFunctionParameterUnwrapper("unwrap.expression")
+                new KotlinFunctionParameterUnwrapper("unwrap.parameter")
         };
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/unwrap/UnwrapRemoveTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/unwrap/UnwrapRemoveTestGenerated.java
@@ -289,6 +289,11 @@ public abstract class UnwrapRemoveTestGenerated extends AbstractUnwrapRemoveTest
         public void testLambdaPropertyInBlock() throws Exception {
             runTest("testData/codeInsight/unwrapAndRemove/unwrapLambda/lambdaPropertyInBlock.kt");
         }
+
+        @TestMetadata("lambdaWithQualifiedReceiver.kt")
+        public void testLambdaWithQualifiedReceiver() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapLambda/lambdaWithQualifiedReceiver.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/unwrap/UnwrapRemoveTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/unwrap/UnwrapRemoveTestGenerated.java
@@ -303,9 +303,64 @@ public abstract class UnwrapRemoveTestGenerated extends AbstractUnwrapRemoveTest
             KotlinTestUtils.runTest(this::doTestFunctionParameterUnwrapper, this, testDataFilePath);
         }
 
+        @TestMetadata("caretBeforeComma.kt")
+        public void testCaretBeforeComma() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretBeforeComma.kt");
+        }
+
+        @TestMetadata("caretInComment1.kt")
+        public void testCaretInComment1() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment1.kt");
+        }
+
+        @TestMetadata("caretInComment2.kt")
+        public void testCaretInComment2() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment2.kt");
+        }
+
+        @TestMetadata("caretInQualifier1.kt")
+        public void testCaretInQualifier1() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier1.kt");
+        }
+
+        @TestMetadata("caretInQualifier2.kt")
+        public void testCaretInQualifier2() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier2.kt");
+        }
+
+        @TestMetadata("caretInQualifier3.kt")
+        public void testCaretInQualifier3() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier3.kt");
+        }
+
+        @TestMetadata("caretInQualifier4.kt")
+        public void testCaretInQualifier4() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier4.kt");
+        }
+
+        @TestMetadata("caretInQualifier5.kt")
+        public void testCaretInQualifier5() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier5.kt");
+        }
+
+        @TestMetadata("caretInQualifier6.kt")
+        public void testCaretInQualifier6() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier6.kt");
+        }
+
         @TestMetadata("functionHasMultiParam.kt")
         public void testFunctionHasMultiParam() throws Exception {
             runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam.kt");
+        }
+
+        @TestMetadata("functionHasMultiParam1.kt")
+        public void testFunctionHasMultiParam1() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam1.kt");
+        }
+
+        @TestMetadata("functionHasMultiParam2.kt")
+        public void testFunctionHasMultiParam2() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam2.kt");
         }
 
         @TestMetadata("functionHasSingleParam.kt")
@@ -313,9 +368,44 @@ public abstract class UnwrapRemoveTestGenerated extends AbstractUnwrapRemoveTest
             runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasSingleParam.kt");
         }
 
-        @TestMetadata("functionWithReceiver.kt")
-        public void testFunctionWithReceiver() throws Exception {
-            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionWithReceiver.kt");
+        @TestMetadata("nestedFunctionWithReceiver.kt")
+        public void testNestedFunctionWithReceiver() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedFunctionWithReceiver.kt");
+        }
+
+        @TestMetadata("nestedSingleParamCall.kt")
+        public void testNestedSingleParamCall() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.kt");
+        }
+
+        @TestMetadata("nestedSingleParamCall.option1.kt")
+        public void testNestedSingleParamCall_option1() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.option1.kt");
+        }
+
+        @TestMetadata("topLevelMultiParamCall_beforeIdentifier.kt")
+        public void testTopLevelMultiParamCall_beforeIdentifier() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeIdentifier.kt");
+        }
+
+        @TestMetadata("topLevelMultiParamCall_beforeLeftParen.kt")
+        public void testTopLevelMultiParamCall_beforeLeftParen() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeLeftParen.kt");
+        }
+
+        @TestMetadata("topLevelMultiParamCall_beforeRightParen.kt")
+        public void testTopLevelMultiParamCall_beforeRightParen() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeRightParen.kt");
+        }
+
+        @TestMetadata("topLevelMultiParamCall_onIdentifier.kt")
+        public void testTopLevelMultiParamCall_onIdentifier() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_onIdentifier.kt");
+        }
+
+        @TestMetadata("topLevelSingleParamCall_onIdentifier.kt")
+        public void testTopLevelSingleParamCall_onIdentifier() throws Exception {
+            runTest("testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelSingleParamCall_onIdentifier.kt");
         }
     }
 }

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretBeforeComma.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretBeforeComma.kt
@@ -1,0 +1,7 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    foo(1 <caret>, 2)
+}
+
+fun foo(i: Int, i2: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretBeforeComma.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretBeforeComma.kt.after
@@ -1,0 +1,7 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    1<caret>
+}
+
+fun foo(i: Int, i2: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment1.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment1.kt
@@ -1,0 +1,7 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    foo(/* <caret> */ 1, 2)
+}
+
+fun foo(i: Int, i2: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment1.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment1.kt.after
@@ -1,0 +1,7 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    1
+}
+
+fun foo(i: Int, i2: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment2.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment2.kt
@@ -1,0 +1,7 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    foo(1 /* <caret> */, 2)
+}
+
+fun foo(i: Int, i2: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInComment2.kt.after
@@ -1,0 +1,7 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    1
+}
+
+fun foo(i: Int, i2: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier1.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier1.kt
@@ -1,0 +1,10 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    te<caret>st.qux(i)
+}
+
+class Test {
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier1.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier1.kt.after
@@ -1,0 +1,10 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    i
+}
+
+class Test {
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier2.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier2.kt
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    test.te<caret>st.qux(i)
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier2.kt.after
@@ -1,12 +1,12 @@
-// IS_APPLICABLE: false
+// OPTION: 0
 fun test() {
     val i = 1
     val test = Test()
-    foo(test.qux<caret>(i))
+    i
 }
 
-fun foo(i: Int) {}
-
 class Test {
+    val test: Test
+        get() = Test()
     fun qux(i: Int) = 1
 }

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier3.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier3.kt
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    te<caret>st.test.qux(i)
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier3.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier3.kt.after
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    i
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier4.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier4.kt
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    test<caret>.test.qux(i)
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier4.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier4.kt.after
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    i
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier5.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier5.kt
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    test?<caret>.test.qux(i)
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier5.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier5.kt.after
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    i
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier6.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier6.kt
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    test<caret>.test.test.qux(i)
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier6.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/caretInQualifier6.kt.after
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    i
+}
+
+class Test {
+    val test: Test
+        get() = Test()
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam.kt.after
@@ -1,7 +1,7 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    baz(i, 2)<caret>
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam1.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam1.kt
@@ -1,7 +1,7 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    foo(baz(<caret>i, 2))
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam1.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam1.kt.after
@@ -1,7 +1,7 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    foo(i<caret>)
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam2.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam2.kt
@@ -1,7 +1,7 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    foo(123, 456<caret>)
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/functionHasMultiParam2.kt.after
@@ -1,7 +1,7 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    456<caret>
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedFunctionWithReceiver.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedFunctionWithReceiver.kt
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    foo(test.qux<caret>(i))
+}
+
+fun foo(i: Int) {}
+
+class Test {
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedFunctionWithReceiver.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedFunctionWithReceiver.kt.after
@@ -1,0 +1,12 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    val test = Test()
+    foo(i<caret>)
+}
+
+fun foo(i: Int) {}
+
+class Test {
+    fun qux(i: Int) = 1
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.kt
@@ -1,9 +1,9 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    foo(bar<caret>(1))
 }
 
 fun foo(i: Int) {}
 
-fun baz(i: Int, j: Int) = 1
+fun bar(i: Int) = 1

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.kt.after
@@ -1,9 +1,9 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    foo(1<caret>)
 }
 
 fun foo(i: Int) {}
 
-fun baz(i: Int, j: Int) = 1
+fun bar(i: Int) = 1

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.option1.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.option1.kt
@@ -1,7 +1,7 @@
-// OPTION: 0
+// OPTION: 1
 fun test() {
     val i = 1
-    foo(bar(<caret>1))
+    foo(bar<caret>(1))
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.option1.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/nestedSingleParamCall.option1.kt.after
@@ -1,7 +1,7 @@
-// OPTION: 0
+// OPTION: 1
 fun test() {
     val i = 1
-    foo(bar(<caret>1))
+    bar(1)<caret>
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeIdentifier.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeIdentifier.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: false
+fun test() {
+    val i = 1
+    <caret>foo(123, 456)
+}
+
+fun foo(i: Int) {}
+

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeLeftParen.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeLeftParen.kt
@@ -1,0 +1,8 @@
+// IS_APPLICABLE: false
+fun test() {
+    val i = 1
+    foo<caret>(123, 456)
+}
+
+fun foo(i: Int, j: Int) {}
+

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeRightParen.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeRightParen.kt
@@ -1,0 +1,8 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    foo(123, 456<caret>)
+}
+
+fun foo(i: Int, j: Int) {}
+

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeRightParen.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_beforeRightParen.kt.after
@@ -1,0 +1,8 @@
+// OPTION: 0
+fun test() {
+    val i = 1
+    456<caret>
+}
+
+fun foo(i: Int, j: Int) {}
+

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_onIdentifier.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelMultiParamCall_onIdentifier.kt
@@ -1,7 +1,7 @@
-// OPTION: 0
+// IS_APPLICABLE: false
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    fo<caret>o(123, 456)
 }
 
 fun foo(i: Int) {}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelSingleParamCall_onIdentifier.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelSingleParamCall_onIdentifier.kt
@@ -1,9 +1,7 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    fo<caret>o(123)
 }
 
 fun foo(i: Int) {}
-
-fun baz(i: Int, j: Int) = 1

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelSingleParamCall_onIdentifier.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapFunctionParameter/topLevelSingleParamCall_onIdentifier.kt.after
@@ -1,9 +1,7 @@
 // OPTION: 0
 fun test() {
     val i = 1
-    foo(baz<caret>(i, 2))
+    123<caret>
 }
 
 fun foo(i: Int) {}
-
-fun baz(i: Int, j: Int) = 1

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapLambda/lambdaWithQualifiedReceiver.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapLambda/lambdaWithQualifiedReceiver.kt
@@ -1,0 +1,6 @@
+// OPTION: 0
+fun test() {
+    kotlin.run <caret>{
+        println(123)
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapLambda/lambdaWithQualifiedReceiver.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/unwrapAndRemove/unwrapLambda/lambdaWithQualifiedReceiver.kt.after
@@ -1,0 +1,4 @@
+// OPTION: 0
+fun test() {
+    println(123)<caret>
+}


### PR DESCRIPTION
Various fixes and improvements to Kotlin's "Unwrap" actions.

- Unwrap parameters now works for most sensible situations (with tests to prove it)
- Remove qualified receiver when unwrapping parameters / lambdas (with tests)
- Strike through text to be removed
- Usability improvements: better speed search / make choices more distinguishable

Most of the work went into improving the unwrapping of parameters. The previous implementation only supported unwrapping a single argument call when it was contained inside another function call, e.g. 


    notUnwrappable(other, canBeRemoved(123), other) 
    ↓ 
    notUnwrappable(other, 123, other)

The new implementation supports any sensible scenario I could think of.

- Top level call unwrapping
- Non-nested call unwrapping
- Delete receiver when unwrapping qualified call
- Support multi argument calls
- Allow caret on method name, paren, comma or whitespace
- Prefer parameter unwrapping over removal for top level function calls
- Fix strikethrough preview

Fixes KTIJ-21561 KTIJ-21562 KTIJ-11687