### PR TITLE
VS Code Keymap: use ctrl shift up/down to move with selection 

### DIFF
--- a/platform/platform-resources/src/keymaps/VSCode OSX.xml
+++ b/platform/platform-resources/src/keymaps/VSCode OSX.xml
@@ -183,6 +183,10 @@
     <action id="EditorDeleteLine">
         <keyboard-shortcut first-keystroke="shift meta k" />
     </action>
+    <action id="EditorDownWithSelection">
+        <keyboard-shortcut first-keystroke="shift down" />
+        <keyboard-shortcut first-keystroke="shift ctrl down" />
+    </action>
     <action id="EditorDeleteToLineEnd">
         <keyboard-shortcut first-keystroke="ctrl k" />
         <keyboard-shortcut first-keystroke="meta delete" />
@@ -259,6 +263,10 @@
     <action id="EditorUnindentSelection">
         <keyboard-shortcut first-keystroke="meta open_bracket" />
         <keyboard-shortcut first-keystroke="shift tab" />
+    </action>
+    <action id="EditorUpWithSelection">
+        <keyboard-shortcut first-keystroke="shift up" />
+        <keyboard-shortcut first-keystroke="shift ctrl up" />
     </action>
     <action id="ExpandAll">
         <keyboard-shortcut first-keystroke="meta add" />

--- a/platform/platform-resources/src/keymaps/VSCode.xml
+++ b/platform/platform-resources/src/keymaps/VSCode.xml
@@ -148,6 +148,10 @@
   <action id="EditorDeleteLine">
     <keyboard-shortcut first-keystroke="shift ctrl k" />
   </action>
+  <action id="EditorDownWithSelection">
+    <keyboard-shortcut first-keystroke="shift down" />
+    <keyboard-shortcut first-keystroke="shift ctrl down" />
+  </action>
   <action id="EditorDuplicate">
     <keyboard-shortcut first-keystroke="shift alt down" />
   </action>
@@ -209,6 +213,10 @@
   <action id="EditorUnindentSelection">
     <keyboard-shortcut first-keystroke="ctrl open_bracket" />
     <keyboard-shortcut first-keystroke="shift tab" />
+  </action>
+  <action id="EditorUpWithSelection">
+    <keyboard-shortcut first-keystroke="shift up" />
+    <keyboard-shortcut first-keystroke="shift ctrl up" />
   </action>
   <action id="EvaluateExpression" />
   <action id="ExpandAll">


### PR DESCRIPTION
Using shift ctrl up works fine in VS Code but does not work in Jetbrains IDE. I'm often using shift + ctrl + up/right/down/left to move around with selection, and this does not work right now for up/down.