### PR TITLE
[EE] Force Evaluator tests to run in Unspecified JVM platform

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/AbstractKotlinEvaluateExpressionInMppTest.kt
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/AbstractKotlinEvaluateExpressionInMppTest.kt
@@ -27,8 +27,6 @@ import java.io.File
 abstract class AbstractKotlinEvaluateExpressionInMppTest : AbstractKotlinEvaluateExpressionTest() {
     override fun useIrBackend() = true
 
-    override fun fragmentCompilerBackend() = FragmentCompilerBackend.JVM
-
     override fun setUpModule() {
         super.setUpModule()
         val jvmSrcPath = testAppPath + File.separator + ExecutionTestCase.SOURCES_DIRECTORY_NAME

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/DebuggerTestCompilerFacility.kt
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/DebuggerTestCompilerFacility.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.idea.test.KotlinBaseTest.TestFile
 import org.jetbrains.kotlin.idea.test.KotlinCompilerStandalone
 import org.jetbrains.kotlin.idea.test.testFramework.KtUsefulTestCase
+import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import java.io.File
 
 class DebuggerTestCompilerFacility(
@@ -208,7 +209,7 @@ class DebuggerTestCompilerFacility(
     }
 
     private fun analyzeAndCompileFiles(project: Project, files: List<KtFile>, compile: (AnalysisResult) -> Unit): String {
-        val resolutionFacade = KotlinCacheService.getInstance(project).getResolutionFacade(files)
+        val resolutionFacade = KotlinCacheService.getInstance(project).getResolutionFacadeWithForcedPlatform(files, JvmPlatforms.unspecifiedJvmPlatform)
 
         val analysisResult = resolutionFacade.analyzeWithAllCompilerChecks(files)
         analysisResult.throwIfError()


### PR DESCRIPTION
The Kotlin expression evaluator runs _on top_ of the loaded project. Hence, it needs to reuse the resolution facade for both IDE compilation and during analysis of code fragment for compilation.

The evaluator is forced to use `unspecifiedJvmPlatform` to improve the user experience of the evaluator.

This also happened to align with all evalautor test suites until now.

The MPP tests used a different platform, hence got a different resolution facade, so the analysis was "fresh" and descriptors was not reused across project and fragment code leading to unbound references in psi2ir.