### PR TITLE
suppress unused property for gradle.properties file

### DIFF
--- a/plugins/gradle/plugin-resources/META-INF/gradle-properties.xml
+++ b/plugins/gradle/plugin-resources/META-INF/gradle-properties.xml
@@ -2,5 +2,7 @@
   <extensions defaultExtensionNs="com.intellij.properties">
     <implicitPropertyUsageProvider
       implementation="org.jetbrains.plugins.gradle.service.project.GradleWrapperImplicitPropertyUsageProvider"/>
+    <implicitPropertyUsageProvider
+      implementation="org.jetbrains.plugins.gradle.service.project.GradleImplicitPropertyUsageProvider"/>
   </extensions>
 </idea-plugin>

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleImplicitPropertyUsageProvider.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleImplicitPropertyUsageProvider.kt
@@ -1,0 +1,11 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.service.project
+
+import com.intellij.lang.properties.codeInspection.unused.ImplicitPropertyUsageProvider
+import com.intellij.lang.properties.psi.Property
+
+class GradleImplicitPropertyUsageProvider: ImplicitPropertyUsageProvider {
+  override fun isUsed(property: Property): Boolean {
+    return property.containingFile.name == "gradle.properties"
+  }
+}


### PR DESCRIPTION
## Motivation

Gradle could set build enviromnent properties using `gradle.properties`.

https://docs.gradle.org/7.4.2/userguide/build_environment.html#sec:gradle_configuration_properties

the properties is used by gradle, but the properties mark as unused.

## Changes

Fix not to warn unused properties. using `ImplicitPropertyUsageProvider` extension point.

## ASIS

<img width="364" alt="ASIS screenshot" src="https://user-images.githubusercontent.com/366888/166434978-976d2281-11dc-4641-8c42-633254e878f8.png">

## TOBE

<img width="310" alt="TOBE screenshot" src="https://user-images.githubusercontent.com/366888/166435007-80df9a27-3c87-4688-ab3f-de4376c4a163.png">

