### PR TITLE
Fix resetting terminal when using "Split and Move" actions

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/actions/MoveTabDownAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/MoveTabDownAction.java
@@ -6,8 +6,8 @@ import javax.swing.*;
 /**
  * @author Konstantin Bulenkov
  */
-final class MoveTabDownAction extends SplitAction {
+final class MoveTabDownAction extends SplitMoveAction {
   MoveTabDownAction() {
-    super(SwingConstants.HORIZONTAL, true);
+    super(SwingConstants.HORIZONTAL);
   }
 }

--- a/platform/platform-impl/src/com/intellij/ide/actions/MoveTabRightAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/MoveTabRightAction.java
@@ -6,8 +6,8 @@ import javax.swing.*;
 /**
  * @author Konstantin Bulenkov
  */
-final class MoveTabRightAction extends SplitAction {
+final class MoveTabRightAction extends SplitMoveAction {
   MoveTabRightAction() {
-    super(SwingConstants.VERTICAL, true);
+    super(SwingConstants.VERTICAL);
   }
 }

--- a/platform/platform-impl/src/com/intellij/ide/actions/SplitMoveAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/SplitMoveAction.java
@@ -1,0 +1,36 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.ide.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.fileEditor.impl.EditorWindow;
+import com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class SplitMoveAction extends SplitAction {
+
+  protected SplitMoveAction(int orientation) {
+    super(orientation);
+  }
+
+  @Override
+  public void actionPerformed(@NotNull final AnActionEvent event) {
+    final EditorWindow window = event.getRequiredData(EditorWindow.DATA_KEY);
+    final VirtualFile file = window.getSelectedFile();
+
+    if (file != null) {
+      file.putUserData(EditorWindow.DRAG_START_PINNED_KEY, window.isFilePinned(file));
+      file.putUserData(FileEditorManagerImpl.CLOSING_TO_REOPEN, Boolean.TRUE);
+
+      window.closeFile(file, true, false);
+      window.split(myOrientation, true, file, true);
+
+      file.putUserData(FileEditorManagerImpl.CLOSING_TO_REOPEN, null);
+    }
+  }
+
+  @Override
+  protected boolean isEnabled(@NotNull VirtualFile vFile, @NotNull EditorWindow window) {
+    return window.getTabCount() >= 2;
+  }
+}


### PR DESCRIPTION
Fixes [IDEA-228753](https://youtrack.jetbrains.com/issue/IDEA-228753/Terminal-is-reset-when-splitting-editor), and should also fix [IDEA-252249](https://youtrack.jetbrains.com/issue/IDEA-252249/Splitting-SSH-session-produces-local-shell) although I haven't tested that since I don't know if I can enable SSH connections in the community edition repo.