### PR TITLE
IDEA-240111 Do not enforce re-running of tests in Gradle

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilterInit.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilterInit.gradle
@@ -13,7 +13,6 @@ gradle.taskGraph.whenReady { taskGraph ->
   taskGraph.allTasks.each { Task task ->
     if (task instanceof Test || (abstractTestTaskClass != null && abstractTestTaskClass.isAssignableFrom(task.class))) {
       try {
-        task.outputs.upToDateWhen { false }
         String[] strings = ['*']
         if(ijTestIncludes.size() > 0 && ijTestIncludes != strings) {
           def filter = task.getFilter()


### PR DESCRIPTION
Do not re-run tests when outputs did not change.

More background explanation as to why rerunning tests is the wrong approach: https://blog.gradle.org/stop-rerunning-tests