### PR TITLE
[IDEA-197202] Fix hiding undocked/unpinned tool windows when an inline editor is activated

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowManagerImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowManagerImpl.kt
@@ -2137,11 +2137,11 @@ private const val LAYOUT_TO_RESTORE = "layout-to-restore"
 private const val RECENT_TW_TAG = "recentWindows"
 
 private fun isInActiveToolWindow(component: Any?, activeToolWindow: ToolWindowImpl): Boolean {
-  var source = if (component is JComponent) component else null
+  var source: Component? = if (component is JComponent) component else null
   val activeToolWindowComponent = activeToolWindow.decoratorComponent
   if (activeToolWindowComponent != null) {
     while (source != null && source !== activeToolWindowComponent) {
-      source = ClientProperty.get(source, ToolWindowManagerImpl.PARENT_COMPONENT) ?: source.parent as? JComponent
+      source = ClientProperty.get(source, ToolWindowManagerImpl.PARENT_COMPONENT) ?: source.parent as? Component
     }
   }
   return source != null


### PR DESCRIPTION
Fixes [IDEA-197202](https://youtrack.jetbrains.com/issue/IDEA-197202).

Example of this is in Git - Shelf when renaming a shelf:
![obrazek](https://user-images.githubusercontent.com/3685160/166962185-6604f2a0-a836-4d6a-9d96-1589b76e1a6b.png)

The inline editor's parent is `DefaultTreeCellEditor$EditorContainer` which extends `Container` and not `JComponent`, so the code thought that focus was outside the tool window and hid it.