### PR TITLE
support generating Android Icons with other project structures

### DIFF
--- a/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/IconsClassGenerator.kt
+++ b/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/IconsClassGenerator.kt
@@ -91,10 +91,14 @@ internal open class IconsClassGenerator(private val projectHome: Path,
         imageCollector = ImageCollector(projectHome, moduleConfig = moduleConfig)
         val imagesS = imageCollector.collectSubDir(resourceRoot, "studio/icons", includePhantom = true)
         imageCollector.printUsedIconRobots()
+        imageCollector = ImageCollector(projectHome, moduleConfig = moduleConfig)
+        val imagesI = imageCollector.collectSubDir(resourceRoot, "studio/illustrations", includePhantom = true)
+        imageCollector.printUsedIconRobots()
 
         return listOf(
           IconClassInfo(true, packageName, "AndroidIcons", Path.of(sourceRoot, "icons", "AndroidIcons.java"), imagesA),
           IconClassInfo(true, packageName, "StudioIcons", Path.of(sourceRoot, "icons", "StudioIcons.java"), imagesS),
+          IconClassInfo(true, packageName, "StudioIllustrations", Path.of(sourceRoot, "icons", "StudioIllustrations.java"), imagesI),
         )
       }
       else -> {
@@ -488,11 +492,11 @@ private fun generateIconFieldName(file: Path): CharSequence {
   val imageFileName = file.fileName.toString()
   val path = file.toString()
   when {
-    path.contains("android/artwork/resources/studio") -> {
-      return toStreamingSnakeCaseJavaIdentifier(imageFileName, imageFileName.lastIndexOf('.'))
-    }
-    path.contains("android/artwork/resources/icons") -> {
+    path.contains("$androidIcons/icons") -> {
       return toCamelCaseJavaIdentifier(imageFileName, imageFileName.lastIndexOf('.'))
+    }
+    path.contains("$androidIcons") -> {
+      return toStreamingSnakeCaseJavaIdentifier(imageFileName, imageFileName.lastIndexOf('.'))
     }
     else -> {
       val id = if ((imageFileName.length - 4) == 2) {

--- a/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/util.kt
+++ b/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/util.kt
@@ -22,10 +22,8 @@ internal val File.children: List<File>
 internal fun isImage(file: Path, iconsOnly: Boolean): Boolean {
   return if (iconsOnly) isIcon(file) else isImage(file)
 }
-
-private val androidIcons by lazy {
-  Paths.get(PathManager.getCommunityHomePath(), "android/artwork/resources")
-}
+// allow other project path setups to generate Android Icons
+var androidIcons: Path = Paths.get(PathManager.getCommunityHomePath(), "android/artwork/resources")
 
 internal fun isIcon(file: Path): Boolean {
   if (!isImage(file)) {


### PR DESCRIPTION
Allows other users to generate Android Icons when the Android project doesn't exist at intellij-community/android/artwork 

Other users can then generate Android Icons by:
- extending IconsClasses and overriding the homePath to their Android project path
- changing value of androidIcons in their build script to point to their Android project path