### PR TITLE
IDEA-293666 do not hardcode color of modified keybinds Tree entires to BLUE

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/keymap/impl/ui/ActionsTree.java
+++ b/platform/platform-impl/src/com/intellij/openapi/keymap/impl/ui/ActionsTree.java
@@ -594,7 +594,7 @@ public final class ActionsTree {
         }
         else {
           if (changed) {
-            foreground = PlatformColors.BLUE;
+            foreground = JBColor.namedColor("Tree.modifiedItemForeground", PlatformColors.BLUE);
           }
           else {
             foreground = UIUtil.getTreeForeground();


### PR DESCRIPTION
This fixes https://youtrack.jetbrains.com/issue/IDEA-293666/Foreground-color-of-modified-keybinds-is-not-themable-probably-T