### PR TITLE
KTIJ-21801 Intention 'Replace || with &&' generates wrong code for inner return/throw/break/continue expression

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertBinaryExpressionWithDemorgansLawIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertBinaryExpressionWithDemorgansLawIntention.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
+import org.jetbrains.kotlin.psi2ir.deparenthesize
 
 class ConvertBinaryExpressionWithDemorgansLawIntention : SelfTargetingOffsetIndependentIntention<KtBinaryExpression>(
     KtBinaryExpression::class.java,
@@ -70,6 +71,10 @@ class ConvertBinaryExpressionWithDemorgansLawIntention : SelfTargetingOffsetInde
             var remainingExpression: KtExpression = expression
             while (true) {
                 if (remainingExpression !is KtBinaryExpression) break
+
+                if (KtPsiUtil.deparenthesize(remainingExpression.left) is KtStatementExpression ||
+                    KtPsiUtil.deparenthesize(remainingExpression.right) is KtStatementExpression
+                ) return null
 
                 val operation = remainingExpression.operationToken
                 if (operation != KtTokens.ANDAND && operation != KtTokens.OROR) break

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4958,6 +4958,31 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/doubleNegation.kt");
         }
 
+        @TestMetadata("hasBreak.kt")
+        public void testHasBreak() throws Exception {
+            runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasBreak.kt");
+        }
+
+        @TestMetadata("hasContinue.kt")
+        public void testHasContinue() throws Exception {
+            runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasContinue.kt");
+        }
+
+        @TestMetadata("hasReturn.kt")
+        public void testHasReturn() throws Exception {
+            runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasReturn.kt");
+        }
+
+        @TestMetadata("hasThrow.kt")
+        public void testHasThrow() throws Exception {
+            runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasThrow.kt");
+        }
+
+        @TestMetadata("hasThrow2.kt")
+        public void testHasThrow2() throws Exception {
+            runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasThrow2.kt");
+        }
+
         @TestMetadata("inapplicableOperator.kt")
         public void testInapplicableOperator() throws Exception {
             runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/inapplicableOperator.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasBreak.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasBreak.kt
@@ -1,0 +1,7 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test(xs: List<String>) {
+    for (x in xs) {
+        x.isNotEmpty() ||<caret> (break)
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasContinue.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasContinue.kt
@@ -1,0 +1,7 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test(xs: List<String>) {
+    for (x in xs) {
+        x.isNotEmpty() ||<caret> continue
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasReturn.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasReturn.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test(xs: List<Int>) {
+    xs.isNotEmpty() ||<caret> return
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasThrow.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasThrow.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test(xs: List<Int>) {
+    xs.isNotEmpty() ||<caret> throw IllegalArgumentException()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasThrow2.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasThrow2.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test(xs: List<Int>) {
+    (throw IllegalArgumentException()) ||<caret> xs.isNotEmpty()
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21801