### PR TITLE
ProjectStructureMapping.groovy: close the JsonGenerator

### DIFF
--- a/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/projectStructureMapping/ProjectStructureMapping.groovy
+++ b/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/projectStructureMapping/ProjectStructureMapping.groovy
@@ -88,6 +88,7 @@ final class ProjectStructureMapping {
         writer.writeEndObject()
       }
       writer.writeEndArray()
+      writer.close()
     }
   }
 


### PR DESCRIPTION
Otherwise, it won't know to flush the buffers, and we could end up missing the tail end of the file.