### PR TITLE
KTIJ-21870 Intention 'Replace || with &&' generates wrong code for inner call of function that return Nothing

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -4968,6 +4968,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasContinue.kt");
         }
 
+        @TestMetadata("hasNothing.kt")
+        public void testHasNothing() throws Exception {
+            runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasNothing.kt");
+        }
+
         @TestMetadata("hasReturn.kt")
         public void testHasReturn() throws Exception {
             runTest("testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasReturn.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasNothing.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertBinaryExpressionWithDemorgansLaw/hasNothing.kt
@@ -1,0 +1,7 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun main(args: Array<String>) {
+    args.isNotEmpty() ||<caret> foo()
+}
+
+fun foo(): Nothing = throw RuntimeException()


### PR DESCRIPTION
[KTIJ-21870](https://youtrack.jetbrains.com/issue/KTIJ-21870) Intention 'Replace || with &&' generates wrong code for inner call of function that return Nothing