### PR TITLE
IDEA-292847 does not work with ASDF installed Java

### DIFF
--- a/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
+++ b/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
@@ -367,7 +367,7 @@ public class JavaHomeFinderBasic {
 
     // finally, try the usual location in Unix or MacOS
     if (!(this instanceof JavaHomeFinderWindows) && !(this instanceof JavaHomeFinderWsl)) {
-      Path installsDir = getPathInUserHome("asdf/installs");
+      Path installsDir = getPathInUserHome(".asdf/installs");
       if (installsDir != null && safeIsDirectory(installsDir)) return installsDir;
     }
 


### PR DESCRIPTION
## Changes

fix typo in folder name `.asdf`


## Fixes

Fixes: [#IDEA-292847 ASDF-Java-does-not-work-with-ASDF-installed-by-homebrew](https://youtrack.jetbrains.com/issue/IDEA-292847/ASDF-Java-does-not-work-with-ASDF-installed-by-homebrew)

## Description

- ASDF support is introduced with https://github.com/JetBrains/intellij-community/pull/1423/files#diff-17e9288facd8a5bc331e1683479897181a1d39b189f1cc9872b969f11b965ee3R244-R252
- in https://github.com/JetBrains/intellij-community/commit/2c21c8b931e462542e7dc48fedd242d07c1b1988 there is introduced a regression:
```Java
File installsDir = homeDir.toPath().resolve(".asdf").resolve("installs").toFile();
Path installsDir = getPathInUserHome("asdf/installs");
```
the line should be:
```java
Path installsDir = getPathInUserHome(".asdf/installs");
```

## Workarounds 

workarounds until its fixed: add this line to your settings file (like `.zshrc`):

```bash
export ASDF_DATA_DIR=~/.asdf
```
or create a sym-link:

```bash
ln -s ~/.asdf ~/asdf
```