### PR TITLE
bugfix: Support PathLike objects for subprocess

### DIFF
--- a/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
+++ b/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
@@ -108,6 +108,8 @@ def starts_with_python_shebang(path):
 
 
 def is_python(path):
+    if isinstance(path, os.PathLike):
+        path = path.__fspath__()
     if path.endswith("'") or path.endswith('"'):
         path = path[1:len(path) - 1]
     filename = os.path.basename(path).lower()


### PR DESCRIPTION
This fixes https://youtrack.jetbrains.com/issue/PY-48506/error-on-pydevmonkey-in-debug-mode-AttributeError-PosixPath-object-has-no-attribute-endswith by checking if the path is `PathLike`, and calling `__fspath__()` to get the string version of the path.