### PR TITLE
Fix Project leak through VcsToolWindowDnDTarget

### DIFF
--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/DnDActivateOnHoldTarget.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/DnDActivateOnHoldTarget.java
@@ -3,14 +3,16 @@ package com.intellij.openapi.vcs.changes;
 
 import com.intellij.ide.dnd.DnDEvent;
 import com.intellij.ide.dnd.DnDTarget;
+import com.intellij.openapi.Disposable;
+import com.intellij.util.Alarm;
 import com.intellij.util.SingleAlarm;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class DnDActivateOnHoldTarget implements DnDTarget {
   private final SingleAlarm myAlarm;
 
-  protected DnDActivateOnHoldTarget() {
-    myAlarm = new SingleAlarm(() -> activateContent(), 700);
+  protected DnDActivateOnHoldTarget(Disposable parentDisposable) {
+    myAlarm = new SingleAlarm(() -> activateContent(), 700, Alarm.ThreadToUse.SWING_THREAD, parentDisposable);
   }
 
   @Override

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/VcsToolwindowDnDTarget.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/VcsToolwindowDnDTarget.java
@@ -14,6 +14,7 @@ public abstract class VcsToolwindowDnDTarget extends DnDActivateOnHoldTarget {
   @NotNull protected final Content myContent;
 
   protected VcsToolwindowDnDTarget(@NotNull Project project, @NotNull Content content) {
+    super(content);
     myProject = project;
     myContent = content;
   }


### PR DESCRIPTION
Commit 4f5f8e3c0f42d0d62b36bfdc724495c0e53be85a changed the
default parent disposable for SingleAlarm from null to
ApplicationManager.getApplication(). The runnable for the alarm in
VcsToolWindowDndTarget captures 'this', which contains a reference to
the project.

Instead, use the Content object as the parent disposable for the alarm.