### PR TITLE
[kotlin] Convert parameter to receiver: enclose definitely not-null types in parentheses

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.psi.psiUtil.quoteIfNeeded
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.jvm.annotations.findJvmOverloadsAnnotation
 import org.jetbrains.kotlin.resolve.source.getPsi
+import org.jetbrains.kotlin.types.DefinitelyNotNullType
 import org.jetbrains.kotlin.types.isError
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 import org.jetbrains.kotlin.utils.keysToMap
@@ -309,7 +310,9 @@ open class KotlinChangeInfo(
     }
 
     fun renderReceiverType(inheritedCallable: KotlinCallableDefinitionUsage<*>): String? {
-        val receiverTypeText = receiverParameterInfo?.currentTypeInfo?.render() ?: return null
+        val receiverTypeText = receiverParameterInfo?.currentTypeInfo?.let {
+            if (it.type is DefinitelyNotNullType) "(${it.render()})" else it.render()
+        } ?: return null
         val typeSubstitutor = inheritedCallable.typeSubstitutor ?: return receiverTypeText
         val currentBaseFunction = inheritedCallable.baseFunction.currentCallableDescriptor ?: return receiverTypeText
         val receiverType = currentBaseFunction.extensionReceiverParameter!!.type

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureConflictSearcher.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeSignatureConflictSearcher.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.classId
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.resolve.source.getPsi
+import org.jetbrains.kotlin.types.DefinitelyNotNullType
 
 class KotlinChangeSignatureConflictSearcher(
     private val originalInfo: ChangeInfo,
@@ -234,7 +235,10 @@ class KotlinChangeSignatureConflictSearcher(
             val psiFactory = KtPsiFactory(callable.project)
             val tempFile = (callable.containingFile as KtFile).createTempCopy()
             val functionWithReceiver = tempFile.findElementAt(callable.textOffset)?.getNonStrictParentOfType<KtNamedFunction>() ?: return
-            val receiverTypeRef = psiFactory.createType(newReceiverInfo.currentTypeInfo.render())
+            val receiverTypeText = newReceiverInfo.currentTypeInfo.let {
+                if (it.type is DefinitelyNotNullType) "(${it.render()})" else it.render()
+            }
+            val receiverTypeRef = psiFactory.createType(receiverTypeText)
             functionWithReceiver.setReceiverTypeReference(receiverTypeRef)
             val newContext = functionWithReceiver.bodyExpression!!.analyze(BodyResolveMode.FULL)
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6819,6 +6819,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertParameterToReceiver/companionAsReceiver.kt");
         }
 
+        @TestMetadata("definitelyNotNullType.kt")
+        public void testDefinitelyNotNullType() throws Exception {
+            runTest("testData/intentions/convertParameterToReceiver/definitelyNotNullType.kt");
+        }
+
         @TestMetadata("explicitThis.kt")
         public void testExplicitThis() throws Exception {
             runTest("testData/intentions/convertParameterToReceiver/explicitThis.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertParameterToReceiver/definitelyNotNullType.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertParameterToReceiver/definitelyNotNullType.kt
@@ -1,0 +1,3 @@
+fun <T> foo(<caret>x: T & Any): T & Any {
+    return x
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertParameterToReceiver/definitelyNotNullType.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertParameterToReceiver/definitelyNotNullType.kt.after
@@ -1,0 +1,3 @@
+fun <T> (T & Any).foo(): T & Any {
+    return this
+}


### PR DESCRIPTION
[KTIJ-20849](https://youtrack.jetbrains.com/issue/KTIJ-20849) Definitely not-null types parameter converts to receiver type incorrectly