### PR TITLE
[KTIJ-21907] Repro included in test suite

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
@@ -1212,6 +1212,11 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
                 runTest("testData/evaluation/singleBreakpoint/kt7046localVarInInline.kt");
             }
 
+            @TestMetadata("ktij21907.kt")
+            public void testKtij21907() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/ktij21907.kt");
+            }
+
             @TestMetadata("lambdaToString.kt")
             public void testLambdaToString() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdaToString.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -1212,6 +1212,11 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
                 runTest("testData/evaluation/singleBreakpoint/kt7046localVarInInline.kt");
             }
 
+            @TestMetadata("ktij21907.kt")
+            public void testKtij21907() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/ktij21907.kt");
+            }
+
             @TestMetadata("lambdaToString.kt")
             public void testLambdaToString() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdaToString.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
@@ -1212,6 +1212,11 @@ public abstract class KotlinEvaluateExpressionInMppTestGenerated extends Abstrac
                 runTest("testData/evaluation/singleBreakpoint/kt7046localVarInInline.kt");
             }
 
+            @TestMetadata("ktij21907.kt")
+            public void testKtij21907() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/ktij21907.kt");
+            }
+
             @TestMetadata("lambdaToString.kt")
             public void testLambdaToString() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdaToString.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
@@ -1212,6 +1212,11 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
                 runTest("testData/evaluation/singleBreakpoint/kt7046localVarInInline.kt");
             }
 
+            @TestMetadata("ktij21907.kt")
+            public void testKtij21907() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/ktij21907.kt");
+            }
+
             @TestMetadata("lambdaToString.kt")
             public void testLambdaToString() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdaToString.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/ktij21907.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/ktij21907.kt
@@ -1,0 +1,24 @@
+
+
+// FILE: ktij21907.kt
+package ktij21907
+import libOne.*
+
+val x = inlineFunction { 1 }
+
+fun main(args: Array<String>) {
+    //Breakpoint!
+    val a = 1
+}
+
+// EXPRESSION: args.size
+// RESULT: 0: I
+
+// FILE: libOne.kt
+package libOne
+
+inline fun inlineFunction(block: () -> Int): Int {
+    return block()
+}
+
+

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/ktij21907.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/ktij21907.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at ktij21907.kt:11
+Run Java
+Connected to the target VM
+ktij21907.kt:11
+Compile bytecode for args.size
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
This is a test demonstrating a fix in the compiler at jetbrains/kotlin#4841. It resolves [KTIJ-21907](https://youtrack.jetbrains.com/issue/KTIJ-21907).

Files with _unrelated_ inline function dependencies (not used in fragment, not used in context of breakpoint) cause errors in codegen
because the sources are not included in the compilation unit.

Use the generation filter to avoid generating code for this.

^KTIJ-21907 open