### PR TITLE
Exclude other plugins from the Kotlin plugin build

### DIFF
--- a/build/scripts/KotlinPluginBuildTarget.kt
+++ b/build/scripts/KotlinPluginBuildTarget.kt
@@ -8,6 +8,14 @@ object KotlinPluginBuildTarget {
   @JvmStatic
   fun main(args: Array<String>) {
     val communityHome = IdeaProjectLoaderUtil.guessCommunityHome(javaClass)
-    KotlinPluginBuilder(communityHome, communityHome, IdeaCommunityProperties(communityHome)).build()
+    KotlinPluginBuilder(communityHome, communityHome, KotlinIdeaProperties(communityHome)).build()
+  }
+}
+
+class KotlinIdeaProperties(home: String) : IdeaCommunityProperties(home) {
+  init {
+    // Only build the Kotlin plugin, nothing else.
+    productLayout.bundledPluginModules = emptyList()
+    productLayout.allNonTrivialPlugins = listOf(KotlinPluginBuilder.kotlinPlugin())
   }
 }


### PR DESCRIPTION
This is a small patch that we have at Google in order to simplify building the Kotlin IDE plugin in isolation. This change allows the Kotlin build to succeed without downloading all sources (e.g. without the Android plugin).

It would be convenient to upstream this change if possible. Thanks!

This change should probably be reviewed by @nikitabobko or @erokhins 