### PR TITLE
Add new Git update methods for convenient fetching

### DIFF
--- a/plugins/git4idea/resources/messages/GitBundle.properties
+++ b/plugins/git4idea/resources/messages/GitBundle.properties
@@ -675,6 +675,8 @@ settings.git.update.method.merge=Merge
 settings.git.update.method.branch.default=Branch Default
 settings.git.update.method.fetch.default.description=Don't update, just fetch from the default remote
 settings.git.update.method.fetch.default=Fetch default
+settings.git.update.method.fetch.all.description=Don't update, just fetch from all remotes
+settings.git.update.method.fetch.all=Fetch all
 settings.enable.staging.area=Enable staging area
 settings.enable.staging.area.comment=This will disable changelists support and delete all changelists in the project. Only for non-modal commit interface.
 

--- a/plugins/git4idea/resources/messages/GitBundle.properties
+++ b/plugins/git4idea/resources/messages/GitBundle.properties
@@ -673,6 +673,8 @@ settings.git.update.method.rebase=Rebase
 settings.git.update.method.merge.description=Merge incoming changes into the current branch
 settings.git.update.method.merge=Merge
 settings.git.update.method.branch.default=Branch Default
+settings.git.update.method.fetch.default.description=Don't update, just fetch from the default remote
+settings.git.update.method.fetch.default=Fetch default
 settings.enable.staging.area=Enable staging area
 settings.enable.staging.area.comment=This will disable changelists support and delete all changelists in the project. Only for non-modal commit interface.
 

--- a/plugins/git4idea/src/git4idea/config/UpdateMethod.java
+++ b/plugins/git4idea/src/git4idea/config/UpdateMethod.java
@@ -44,6 +44,11 @@ public enum UpdateMethod {
    */
   FETCH_DEFAULT("settings.git.update.method.fetch.default",
          "settings.git.update.method.fetch.default.description"),
+  /**
+   * Don't update, just fetch from all remotes.
+   */
+  FETCH_ALL("settings.git.update.method.fetch.all",
+         "settings.git.update.method.fetch.all.description"),
   ;
 
   @NotNull private final String myName;

--- a/plugins/git4idea/src/git4idea/config/UpdateMethod.java
+++ b/plugins/git4idea/src/git4idea/config/UpdateMethod.java
@@ -38,7 +38,13 @@ public enum UpdateMethod {
    * Rebase local commits upon the fetched branch
    */
   REBASE("settings.git.update.method.rebase",
-         "settings.git.update.method.rebase.description");
+         "settings.git.update.method.rebase.description"),
+  /**
+   * Don't update, just fetch from the default remote.
+   */
+  FETCH_DEFAULT("settings.git.update.method.fetch.default",
+         "settings.git.update.method.fetch.default.description"),
+  ;
 
   @NotNull private final String myName;
   @NotNull private final String myPresentation;

--- a/plugins/git4idea/src/git4idea/update/GitFetchUpdater.kt
+++ b/plugins/git4idea/src/git4idea/update/GitFetchUpdater.kt
@@ -6,15 +6,18 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.update.UpdatedFiles
 import git4idea.commands.Git
+import git4idea.config.UpdateMethod
+import git4idea.fetch.GitFetchResult
 import git4idea.fetch.GitFetchSupport.fetchSupport
 import git4idea.repo.GitRepository
 
-internal class GitFetchUpdater(
+internal class GitFetchUpdater private constructor(
   project: Project,
   git: Git,
   repository: GitRepository,
   progressIndicator: ProgressIndicator,
-  updatedFiles: UpdatedFiles
+  updatedFiles: UpdatedFiles,
+  private val fetchMethod: () -> GitFetchResult
 ) : GitUpdater(
   project,
   git,
@@ -27,7 +30,7 @@ internal class GitFetchUpdater(
 
   override fun doUpdate(): GitUpdateResult {
     try {
-      val fetchResult = fetchSupport(myProject).fetchDefaultRemote(listOf(myRepository))
+      val fetchResult = fetchMethod()
       return if (fetchResult.showNotificationIfFailed()) { // showNotificationIfFailed() returns true if notification was NOT shown
         GitUpdateResult.SUCCESS
       } else {
@@ -35,6 +38,26 @@ internal class GitFetchUpdater(
       }
     } catch (e: ProcessCanceledException) {
       return GitUpdateResult.CANCEL
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun newInstance(
+      updateMethod: UpdateMethod,
+      project: Project,
+      git: Git,
+      repository: GitRepository,
+      progressIndicator: ProgressIndicator,
+      updatedFiles: UpdatedFiles
+    ): GitUpdater = when (updateMethod) {
+      UpdateMethod.FETCH_DEFAULT -> GitFetchUpdater(project, git, repository, progressIndicator, updatedFiles) {
+        fetchSupport(project).fetchDefaultRemote(listOf(repository))
+      }
+      UpdateMethod.FETCH_ALL -> GitFetchUpdater(project, git, repository, progressIndicator, updatedFiles) {
+        fetchSupport(project).fetchAllRemotes(listOf(repository))
+      }
+      else -> throw IllegalArgumentException("Update method $updateMethod is not supported by GitFetchUpdater")
     }
   }
 

--- a/plugins/git4idea/src/git4idea/update/GitFetchUpdater.kt
+++ b/plugins/git4idea/src/git4idea/update/GitFetchUpdater.kt
@@ -1,0 +1,41 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package git4idea.update
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.update.UpdatedFiles
+import git4idea.commands.Git
+import git4idea.fetch.GitFetchSupport.fetchSupport
+import git4idea.repo.GitRepository
+
+internal class GitFetchUpdater(
+  project: Project,
+  git: Git,
+  repository: GitRepository,
+  progressIndicator: ProgressIndicator,
+  updatedFiles: UpdatedFiles
+) : GitUpdater(
+  project,
+  git,
+  repository,
+  progressIndicator,
+  updatedFiles
+) {
+
+  override fun isSaveNeeded(): Boolean = false
+
+  override fun doUpdate(): GitUpdateResult {
+    try {
+      val fetchResult = fetchSupport(myProject).fetchDefaultRemote(listOf(myRepository))
+      return if (fetchResult.showNotificationIfFailed()) { // showNotificationIfFailed() returns true if notification was NOT shown
+        GitUpdateResult.SUCCESS
+      } else {
+        GitUpdateResult.ERROR
+      }
+    } catch (e: ProcessCanceledException) {
+      return GitUpdateResult.CANCEL
+    }
+  }
+
+}

--- a/plugins/git4idea/src/git4idea/update/GitUpdateOptionsPanel.kt
+++ b/plugins/git4idea/src/git4idea/update/GitUpdateOptionsPanel.kt
@@ -46,4 +46,5 @@ internal fun getUpdateMethods(): List<UpdateMethod> = listOf(
   UpdateMethod.MERGE,
   UpdateMethod.REBASE,
   UpdateMethod.FETCH_DEFAULT,
+  UpdateMethod.FETCH_ALL,
 )

--- a/plugins/git4idea/src/git4idea/update/GitUpdateOptionsPanel.kt
+++ b/plugins/git4idea/src/git4idea/update/GitUpdateOptionsPanel.kt
@@ -42,4 +42,8 @@ internal class GitUpdateOptionsPanel(private val settings: GitVcsSettings) {
   fun updateFrom() = panel.reset()
 }
 
-internal fun getUpdateMethods(): List<UpdateMethod> = listOf(UpdateMethod.MERGE, UpdateMethod.REBASE)
+internal fun getUpdateMethods(): List<UpdateMethod> = listOf(
+  UpdateMethod.MERGE,
+  UpdateMethod.REBASE,
+  UpdateMethod.FETCH_DEFAULT,
+)

--- a/plugins/git4idea/src/git4idea/update/GitUpdater.java
+++ b/plugins/git4idea/src/git4idea/update/GitUpdater.java
@@ -93,9 +93,16 @@ public abstract class GitUpdater {
     if (updateMethod == UpdateMethod.BRANCH_DEFAULT) {
       updateMethod = resolveUpdateMethod(repository);
     }
-    return updateMethod == UpdateMethod.REBASE ?
-           new GitRebaseUpdater(project, git, repository, trackedBranches, progressIndicator, updatedFiles):
-           new GitMergeUpdater(project, git, repository, trackedBranches, progressIndicator, updatedFiles);
+    switch (updateMethod) {
+      case REBASE:
+        return new GitRebaseUpdater(project, git, repository, trackedBranches, progressIndicator, updatedFiles);
+      case MERGE:
+        return new GitMergeUpdater(project, git, repository, trackedBranches, progressIndicator, updatedFiles);
+      case FETCH_DEFAULT:
+        return new GitFetchUpdater(project, git, repository, progressIndicator, updatedFiles);
+      default:
+        throw new UnsupportedOperationException("Update method " + updateMethod + " is not implemented");
+    }
   }
 
   @NotNull

--- a/plugins/git4idea/src/git4idea/update/GitUpdater.java
+++ b/plugins/git4idea/src/git4idea/update/GitUpdater.java
@@ -99,7 +99,8 @@ public abstract class GitUpdater {
       case MERGE:
         return new GitMergeUpdater(project, git, repository, trackedBranches, progressIndicator, updatedFiles);
       case FETCH_DEFAULT:
-        return new GitFetchUpdater(project, git, repository, progressIndicator, updatedFiles);
+      case FETCH_ALL:
+        return GitFetchUpdater.newInstance(updateMethod, project, git, repository, progressIndicator, updatedFiles);
       default:
         throw new UnsupportedOperationException("Update method " + updateMethod + " is not implemented");
     }


### PR DESCRIPTION
It is often desirable to fetch upstream commits first and then decide what is best: merge, rebase, or maybe even postpone updating and discuss your changes with other developers first.

However, at the moment IDEA doesn’t provide an easy way to just fetch. There is the Fetch action, but it’s not bound to a keystroke by default, which is inconvenient. It’s possible to bind it manually, but it’s not without drawbacks: it won’t work on someone else’s PC, you need a spare keystroke for that, and it won’t be consistent with other Git GUIs, like Git Extensions, for example, which just provides a list of possible update actions in a single drop-down menu, including Merge, Rebase, Fetch, Fetch All and Fetch and Prune.

So what I did here is add a couple of new “fake” Git update methods: Fetch Default and Fetch All. Seems to be working nicely to me, except for one usability quirk: after fetching is done, an “All files are up-to-date” notification pops up, which can be a bit confusing, as something like “Fetched N new commits from ...” would be more useful. However, this isn’t possible to do without reworking the VCS Update API considerably, and I’m not sure if such a minor annoyance is enough to justify that.