### PR TITLE
Ignore non-jar files when creating resource loaders

### DIFF
--- a/platform/util-class-loader/src/com/intellij/util/lang/ClassPath.java
+++ b/platform/util-class-loader/src/com/intellij/util/lang/ClassPath.java
@@ -408,6 +408,9 @@ public final class ClassPath {
     else if (!fileAttributes.isRegularFile()) {
       return null;
     }
+    else if (!file.toString().endsWith("jar")) {
+      return null;
+    }
 
     ResourceFile zipFile = resourceFileFactory == null ? new JdkZipResourceFile(file, lockJars) : resourceFileFactory.apply(file);
     JarLoader loader = new JarLoader(file, this, zipFile);


### PR DESCRIPTION
There can be cases where a non-jar file is added to the classpath / `java.class.path` system property.
See https://github.com/JetBrains/gradle-intellij-plugin/issues/1009
This diff ignores non-jar files when loading the classpath, similar to
https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/commit/9dcc6e22bcec9264cb5f06d5299e9df5fd8446fc