### PR TITLE
allow for more security in built-in web server by changing properties

### DIFF
--- a/platform/built-in-server-api/resources/messages/BuiltInServerBundle.properties
+++ b/platform/built-in-server-api/resources/messages/BuiltInServerBundle.properties
@@ -9,3 +9,6 @@ reload.on.save.got.it.title=Reloading in Browser on Save
 reload.on.save.got.it.content=The page will be reloaded automatically in the browser when the changes are saved.
 reload.on.save.preview.got.it.title=Reloading Page Preview on Save
 reload.on.save.preview.got.it.content=To see the updated preview of the page, save the changes.
+trust.localhost=true
+cache.trusted.origins=true
+validate.all.requests=false

--- a/platform/built-in-server/src/org/jetbrains/builtInWebServer/WebServerPathHandler.kt
+++ b/platform/built-in-server/src/org/jetbrains/builtInWebServer/WebServerPathHandler.kt
@@ -24,7 +24,8 @@ abstract class WebServerPathHandler {
                        context: ChannelHandlerContext,
                        projectName: String,
                        decodedRawPath: String,
-                       isCustomHost: Boolean): Boolean
+                       isCustomHost: Boolean,
+                       extraHeaders: HttpHeaders?): Boolean
 }
 
 internal fun redirectToDirectory(request: HttpRequest, channel: Channel, path: String, extraHeaders: HttpHeaders?) {
@@ -42,7 +43,8 @@ abstract class WebServerPathHandlerAdapter : WebServerPathHandler() {
                        context: ChannelHandlerContext,
                        projectName: String,
                        decodedRawPath: String,
-                       isCustomHost: Boolean): Boolean {
+                       isCustomHost: Boolean,
+                       extraHeaders: HttpHeaders?): Boolean {
     return process(path, project, request, context)
   }
 }


### PR DESCRIPTION
 Android Studio has different security requirements. Adding three new properties that can be easily modified to change built-in server security.
 The current patch in Android Studio adds a large technical debt