### PR TITLE
Add ByteBuffer's get*() methods to NotPropertiesService

### DIFF
--- a/plugins/kotlin/base/code-insight/src/org/jetbrains/kotlin/idea/core/NotPropertiesService.kt
+++ b/plugins/kotlin/base/code-insight/src/org/jetbrains/kotlin/idea/core/NotPropertiesService.kt
@@ -25,6 +25,9 @@ interface NotPropertiesService {
                     add("java.util.concurrent.atomic.$atomicClass.$atomicMethod")
                 }
             }
+            for (byteBufferMethod in listOf("getChar", "getDouble", "getFloat", "getInt", "getLong", "getShort")) {
+                add("java.nio.ByteBuffer.$byteBufferMethod")
+            }
         }
 
         fun getNotProperties(element: PsiElement): Set<FqNameUnsafe> {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -18357,6 +18357,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/usePropertyAccessSyntax/suppressedByAtomicLongList.kt");
         }
 
+        @TestMetadata("suppressedByByteBufferList.kt")
+        public void testSuppressedByByteBufferList() throws Exception {
+            runTest("testData/intentions/usePropertyAccessSyntax/suppressedByByteBufferList.kt");
+        }
+
         @TestMetadata("suppressedByNotPropertyList.kt")
         public void testSuppressedByNotPropertyList() throws Exception {
             runTest("testData/intentions/usePropertyAccessSyntax/suppressedByNotPropertyList.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/usePropertyAccessSyntax/suppressedByByteBufferList.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/usePropertyAccessSyntax/suppressedByByteBufferList.kt
@@ -1,0 +1,9 @@
+// WITH_STDLIB
+// RUNTIME_WITH_FULL_JDK
+// IS_APPLICABLE: false
+import java.nio.ByteBuffer
+
+fun main(args: Array<String>) {
+    val bb = ByteBuffer.allocate(16)
+    val value = bb.getShort()<caret>
+}


### PR DESCRIPTION
I’m using `ByteBuffer` a lot and it’s a bit annoying when IDEA asks me to use property access syntax instead, which makes no sense, so I add ByteBuffer's methods to the list of exceptions. Figured it’s not a bad idea to include it in the standard list of exceptions as `ByteBuffer` is a standard library class.