### PR TITLE
Do not steal KEY_TYPED in PotemkinProgress.EventStealer

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/progress/util/PotemkinProgress.java
+++ b/platform/platform-impl/src/com/intellij/openapi/progress/util/PotemkinProgress.java
@@ -213,7 +213,7 @@ public final class PotemkinProgress extends ProgressWindow implements PingProgre
     private EventStealer(@NotNull Disposable parent, @NotNull Consumer<? super InputEvent> inputConsumer) {
       myInputEventDispatcher = inputConsumer;
       IdeEventQueue.getInstance().addPostEventListener(event -> {
-        if (event instanceof MouseEvent || event instanceof KeyEvent) {
+        if (event instanceof MouseEvent || event instanceof KeyEvent && event.getID() != KeyEvent.KEY_TYPED) {
           myInputEvents.offer((InputEvent)event);
           return true;
         }


### PR DESCRIPTION
I was having intermittent space typing failures: when I press space, it’s often is not typed at all. Other characters are typed just fine. After some deep debugging, I was able to track it to the commit 6bed082, which changes `PotemkinProgress.EventStealer` in such a way that it steals all `KeyEvent`s, not just `VK_ESCAPE`, as it was before. If I understand it correctly, the reason for this change is that `EventStealer` may need to process different shortcuts in the future. This makes sense, so I think a good way to solve this is to steal all key *presses,* but never steal `KEY_TYPED` events that follow. Which is exactly what I did in this PR.