### PR TITLE
Kotlin auto-completion: don't show aliased Java types

### DIFF
--- a/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/AllClassesCompletion.kt
+++ b/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/AllClassesCompletion.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.descriptors.ClassifierDescriptorWithTypeParameters
 import org.jetbrains.kotlin.idea.base.facet.platform.platform
 import org.jetbrains.kotlin.idea.base.utils.fqname.getKotlinFqName
 import org.jetbrains.kotlin.idea.base.utils.fqname.isJavaClassNotToBeUsedInKotlin
+import org.jetbrains.kotlin.idea.base.utils.fqname.isJavaClassWithKotlinTypeAlias
 import org.jetbrains.kotlin.idea.caches.KotlinShortNamesCache
 import org.jetbrains.kotlin.idea.core.KotlinIndicesHelper
 import org.jetbrains.kotlin.idea.resolve.ResolutionFacade
@@ -31,7 +32,8 @@ class AllClassesCompletion(
     private val resolutionFacade: ResolutionFacade,
     private val kindFilter: (ClassKind) -> Boolean,
     private val includeTypeAliases: Boolean,
-    private val includeJavaClassesNotToBeUsed: Boolean
+    private val includeJavaClassesNotToBeUsed: Boolean,
+    private val includeJavaClassesWithKotlinTypeAliases: Boolean,
 ) {
     fun collect(classifierDescriptorCollector: (ClassifierDescriptorWithTypeParameters) -> Unit, javaClassCollector: (PsiClass) -> Unit) {
 
@@ -88,7 +90,7 @@ class AllClassesCompletion(
                         psiClass.isEnum -> ClassKind.ENUM_CLASS
                         else -> ClassKind.CLASS
                     }
-                    if (kindFilter(kind) && !isNotToBeUsed(psiClass)) {
+                    if (kindFilter(kind) && !isNotToBeUsed(psiClass) && !hasPreferableKotlinTypeAlias(psiClass)) {
                         collector(psiClass)
                     }
                 }
@@ -102,5 +104,11 @@ class AllClassesCompletion(
         if (includeJavaClassesNotToBeUsed) return false
         val fqName = javaClass.getKotlinFqName()
         return fqName?.isJavaClassNotToBeUsedInKotlin() == true
+    }
+
+    private fun hasPreferableKotlinTypeAlias(javaClass: PsiClass): Boolean {
+        if (includeJavaClassesWithKotlinTypeAliases) return false
+        val fqName = javaClass.getKotlinFqName()
+        return fqName?.isJavaClassWithKotlinTypeAlias() == true
     }
 }

--- a/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt
+++ b/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/BasicCompletionSession.kt
@@ -818,6 +818,7 @@ class BasicCompletionSession(
             kindFilter = kindFilter,
             includeTypeAliases = true,
             includeJavaClassesNotToBeUsed = configuration.javaClassesNotToBeUsed,
+            includeJavaClassesWithKotlinTypeAliases = configuration.javaClassesWithKotlinTypeAliases,
         ).collect({ processWithShadowedFilter(it, classifierDescriptorCollector) }, javaClassCollector)
     }
 

--- a/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt
+++ b/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/CompletionSession.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.idea.base.utils.fqname.isJavaClassNotToBeUsedInKotlin
 import org.jetbrains.kotlin.idea.base.projectStructure.moduleInfo.ModuleOrigin
 import org.jetbrains.kotlin.idea.base.projectStructure.moduleInfo.OriginCapability
+import org.jetbrains.kotlin.idea.base.utils.fqname.isJavaClassWithKotlinTypeAlias
 import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.caches.resolve.util.getResolveScope
 import org.jetbrains.kotlin.idea.codeInsight.ReferenceVariantsHelper
@@ -45,7 +46,8 @@ class CompletionSessionConfiguration(
     val javaGettersAndSetters: Boolean,
     val javaClassesNotToBeUsed: Boolean,
     val staticMembers: Boolean,
-    val dataClassComponentFunctions: Boolean
+    val dataClassComponentFunctions: Boolean,
+    val javaClassesWithKotlinTypeAliases: Boolean,
 )
 
 fun CompletionSessionConfiguration(parameters: CompletionParameters) = CompletionSessionConfiguration(
@@ -54,7 +56,8 @@ fun CompletionSessionConfiguration(parameters: CompletionParameters) = Completio
     javaGettersAndSetters = parameters.invocationCount >= 2,
     javaClassesNotToBeUsed = parameters.invocationCount >= 2,
     staticMembers = parameters.invocationCount >= 2,
-    dataClassComponentFunctions = parameters.invocationCount >= 2
+    dataClassComponentFunctions = parameters.invocationCount >= 2,
+    javaClassesWithKotlinTypeAliases = parameters.invocationCount >= 2,
 )
 
 abstract class CompletionSession(
@@ -190,6 +193,10 @@ abstract class CompletionSession(
     private fun isVisibleDescriptor(descriptor: DeclarationDescriptor, completeNonAccessible: Boolean): Boolean {
         if (!configuration.javaClassesNotToBeUsed && descriptor is ClassDescriptor) {
             if (descriptor.importableFqName?.isJavaClassNotToBeUsedInKotlin() == true) return false
+        }
+
+        if (!configuration.javaClassesWithKotlinTypeAliases && descriptor is ClassDescriptor) {
+            if (descriptor.importableFqName?.isJavaClassWithKotlinTypeAlias() == true) return false
         }
 
         if (descriptor is TypeParameterDescriptor && !isTypeParameterVisible(descriptor)) return false

--- a/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt
+++ b/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/KotlinCompletionContributor.kt
@@ -197,7 +197,8 @@ class KotlinCompletionContributor : CompletionContributor() {
                     javaGettersAndSetters = true,
                     javaClassesNotToBeUsed = false,
                     staticMembers = parameters.invocationCount > 0,
-                    dataClassComponentFunctions = true
+                    dataClassComponentFunctions = true,
+                    javaClassesWithKotlinTypeAliases = false,
                 )
 
                 val newSession = BasicCompletionSession(newConfiguration, parameters, result)

--- a/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/VariableOrParameterNameWithTypeCompletion.kt
+++ b/plugins/kotlin/completion/src/org/jetbrains/kotlin/idea/completion/VariableOrParameterNameWithTypeCompletion.kt
@@ -79,7 +79,8 @@ class VariableOrParameterNameWithTypeCompletion(
         for ((classNameMatcher, userPrefix) in classNamePrefixMatchers.zip(userPrefixes)) {
             AllClassesCompletion(
                 parameters, indicesHelper, classNameMatcher, resolutionFacade, { !it.isSingleton },
-                includeTypeAliases = true, includeJavaClassesNotToBeUsed = false
+                includeTypeAliases = true, includeJavaClassesNotToBeUsed = false,
+                includeJavaClassesWithKotlinTypeAliases = false,
             ).collect(
                 { addSuggestionsForClassifier(it, userPrefix, notImported = true) },
                 { addSuggestionsForJavaClass(it, userPrefix, notImported = true) }

--- a/plugins/kotlin/frontend-independent/src/org/jetbrains/kotlin/idea/base/utils/fqname/fqNameUtil.kt
+++ b/plugins/kotlin/frontend-independent/src/org/jetbrains/kotlin/idea/base/utils/fqname/fqNameUtil.kt
@@ -56,3 +56,37 @@ val KotlinType.fqName: FqName?
 
 fun FqName.isJavaClassNotToBeUsedInKotlin(): Boolean =
     JavaToKotlinClassMap.isJavaPlatformClass(this) || javaToKotlinNameMap[this] != null
+
+fun FqName.isJavaClassWithKotlinTypeAlias(): Boolean = this in KOTLIN_TYPE_ALIASES
+
+private val KOTLIN_TYPE_ALIASES = listOf(
+    // kotlin.TypeAliases.kt
+    "java.lang.Error",
+    "java.lang.Exception",
+    "java.lang.RuntimeException",
+    "java.lang.IllegalArgumentException",
+    "java.lang.IllegalStateException",
+    "java.lang.IndexOutOfBoundsException",
+    "java.lang.UnsupportedOperationException",
+    "java.lang.ArithmeticException",
+    "java.lang.NumberFormatException",
+    "java.lang.NullPointerException",
+    "java.lang.ClassCastException",
+    "java.lang.AssertionError",
+    "java.util.NoSuchElementException",
+    "java.util.ConcurrentModificationException",
+    "java.util.Comparator",
+    // kotlin.collections.TypeAliases.kt
+    "java.util.RandomAccess",
+    "java.util.ArrayList",
+    "java.util.LinkedHashMap",
+    "java.util.HashMap",
+    "java.util.LinkedHashSet",
+    "java.util.HashSet",
+    // kotlin.text.TypeAliases.kt
+    "java.lang.Appendable",
+    "java.lang.StringBuilder",
+    "java.nio.charset.CharacterCodingException",
+).map {
+    FqName(it)
+}.toSet()


### PR DESCRIPTION
Types like `java.lang.StringBuilder` or `java.lang.AssertionError` often pop up in Kotlin auto completion, causing unnecessary ugly imports. Here, I’ve tried to fix it by disabling type aliases on the first auto completion attempt.

It could use some improvements, though.

Putting the list of aliased types in the `fqNameUtil.kt` looks inelegant. Ideally it would’ve been better to delegate it to the compiler library, but I haven’t found anything like that there.

On the second attempt those types still pop up in pretty much random order. It would’ve been better to give them a lower priority.

But it works, and to me it’s already a great help, not having to figure out which type is Kotlin and which is Java every time I see an auto-completion list pop up.