### PR TITLE
[PY-21883] Combine docstring parameter sections

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/documentation/docstrings/SectionBasedDocString.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/documentation/docstrings/SectionBasedDocString.java
@@ -54,29 +54,29 @@ public abstract class SectionBasedDocString extends DocStringLineParser implemen
 
   protected static final Map<String, String> SECTION_ALIASES =
     ImmutableMap.<String, String>builder()
-                .put("arguments", PARAMETERS_SECTION)
-                .put("args", PARAMETERS_SECTION)
-                .put("parameters", PARAMETERS_SECTION)
-                .put("keyword args", KEYWORD_ARGUMENTS_SECTION)
-                .put("keyword arguments", KEYWORD_ARGUMENTS_SECTION)
-                .put("other parameters", OTHER_PARAMETERS_SECTION)
-                .put("attributes", ATTRIBUTES_SECTION)
-                .put("methods", METHODS_SECTION)
-                .put("note", "notes")
-                .put("notes", "notes")
-                .put("example", "examples")
-                .put("examples", "examples")
-                .put("return", RETURNS_SECTION)
-                .put("returns", RETURNS_SECTION)
-                .put("yield", YIELDS_SECTION)
-                .put("yields", "yields")
-                .put("raises", RAISES_SECTION)
-                .put("references", "references")
-                .put("see also", "see also")
-                .put("warning", "warnings")
-                .put("warns", "warnings")
-                .put("warnings", "warnings")
-                .build();
+      .put("arguments", PARAMETERS_SECTION)
+      .put("args", PARAMETERS_SECTION)
+      .put("parameters", PARAMETERS_SECTION)
+      .put("keyword args", KEYWORD_ARGUMENTS_SECTION)
+      .put("keyword arguments", KEYWORD_ARGUMENTS_SECTION)
+      .put("other parameters", OTHER_PARAMETERS_SECTION)
+      .put("attributes", ATTRIBUTES_SECTION)
+      .put("methods", METHODS_SECTION)
+      .put("note", "notes")
+      .put("notes", "notes")
+      .put("example", "examples")
+      .put("examples", "examples")
+      .put("return", RETURNS_SECTION)
+      .put("returns", RETURNS_SECTION)
+      .put("yield", YIELDS_SECTION)
+      .put("yields", "yields")
+      .put("raises", RAISES_SECTION)
+      .put("references", "references")
+      .put("see also", "see also")
+      .put("warning", "warnings")
+      .put("warns", "warnings")
+      .put("warnings", "warnings")
+      .build();
   private static final Pattern SPHINX_REFERENCE_RE = Pattern.compile("(:\\w+:\\S+:`.+?`|:\\S+:`.+?`|`.+?`)");
 
   public static final Set<String> SECTION_NAMES = SECTION_ALIASES.keySet();
@@ -365,7 +365,11 @@ public abstract class SectionBasedDocString extends DocStringLineParser implemen
 
   @NotNull
   public List<Section> getParameterSections() {
-    return getSectionsWithNormalizedTitle(PARAMETERS_SECTION);
+    final List<Section> parameters = new ArrayList<>();
+    parameters.addAll(getSectionsWithNormalizedTitle(PARAMETERS_SECTION));
+    parameters.addAll(getSectionsWithNormalizedTitle(OTHER_PARAMETERS_SECTION));
+    parameters.addAll(getSectionsWithNormalizedTitle(KEYWORD_ARGUMENTS_SECTION));
+    return parameters;
   }
 
   @NotNull

--- a/python/testData/docstrings/googleCombinesParameterSections.py
+++ b/python/testData/docstrings/googleCombinesParameterSections.py
@@ -1,0 +1,10 @@
+def func(param1):
+    """
+    Args:
+        x:
+        y:
+
+    Keyword Args:
+        z:
+    """
+    pass

--- a/python/testData/docstrings/numpyCombinesParameterSections.py
+++ b/python/testData/docstrings/numpyCombinesParameterSections.py
@@ -1,0 +1,12 @@
+def func(param1):
+    """
+    Parameters
+    ----------
+    x : int
+    y : str
+        
+    Other Parameters
+    ----------------
+    z : int
+    """
+    pass

--- a/python/testSrc/com/jetbrains/python/PySectionBasedDocStringTest.java
+++ b/python/testSrc/com/jetbrains/python/PySectionBasedDocStringTest.java
@@ -235,6 +235,14 @@ public class PySectionBasedDocStringTest extends PyTestCase {
                  "Line after single break", param1.getDescription());
   }
 
+  public void testNumpyCombinesParameterSections() {
+    final NumpyDocString docString = findAndParseNumpyStyleDocString();
+
+    final List<String> parameters = docString.getParameters();
+
+    assertEquals(List.of("x", "y", "z"), parameters);
+  }
+
   public void testGoogleEmptyParamTypeInParenthesis() {
     final GoogleCodeStyleDocString docString = findAndParseGoogleStyleDocString();
     assertSize(1, docString.getSections());
@@ -394,12 +402,11 @@ public class PySectionBasedDocStringTest extends PyTestCase {
                                                                           "    Example:\n" +
                                                                           "        addresses = field.Collection(AddressObject)\n" +
                                                                           "\"\"\""));
-    
+
     assertEquals(DocStringFormat.REST, DocStringUtil.guessDocStringFormat("\"\"\"\n" +
                                                                           "Args:\n" +
                                                                           "    :param Tuple[int, int] name: Some description\n" +
                                                                           "\"\"\""));
-    
   }
 
   // PY-31025
@@ -419,6 +426,14 @@ public class PySectionBasedDocStringTest extends PyTestCase {
   public void testGoogleDescriptionOfReturnValueOnNextLine() {
     final GoogleCodeStyleDocString docString = findAndParseGoogleStyleDocString();
     assertEquals("return value description", docString.getReturnDescription());
+  }
+
+  public void testGoogleCombinesParameterSections() {
+    final GoogleCodeStyleDocString docString = findAndParseGoogleStyleDocString();
+
+    final List<String> parameters = docString.getParameters();
+
+    assertEquals(List.of("x", "y", "z"), parameters);
   }
 
   @Override


### PR DESCRIPTION
`OTHER_PARAMETERS_SECTION` is ignored when getting the parameter sections, even tho it is part of them. This leads to false positive in warnings and removes helpful warnings associated with them

Issue link: https://youtrack.jetbrains.com/issue/PY-21883/Support-numpydocs-Other-Parameters-section