### PR TITLE
KTIJ-21979 False positive intention "Can be replaced with function reference" with fully qualified constructor call

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
@@ -17,12 +17,13 @@ import org.jetbrains.kotlin.idea.core.setType
 import org.jetbrains.kotlin.idea.imports.importableFqName
 import org.jetbrains.kotlin.idea.inspections.IntentionBasedInspection
 import org.jetbrains.kotlin.idea.refactoring.fqName.fqName
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.idea.references.resolveToDescriptors
 import org.jetbrains.kotlin.idea.search.usagesSearch.descriptor
 import org.jetbrains.kotlin.idea.util.IdeDescriptorRenderers
 import org.jetbrains.kotlin.idea.util.approximateFlexibleTypes
 import org.jetbrains.kotlin.idea.util.getResolutionScope
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
-import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
@@ -79,6 +80,9 @@ open class ConvertLambdaToReferenceIntention(textGetter: () -> String) : SelfTar
             else -> return false
         }
         val context = callableExpression.safeAnalyzeNonSourceRootCode()
+
+        if (explicitReceiver?.isReferenceToPackage(context) == true) return false
+
         val calleeDescriptor =
             calleeReferenceExpression.getResolvedCall(context)?.resultingDescriptor as? CallableMemberDescriptor ?: return false
 
@@ -107,11 +111,6 @@ open class ConvertLambdaToReferenceIntention(textGetter: () -> String) : SelfTar
         }
         val explicitReceiverDescriptor = (explicitReceiver as? KtNameReferenceExpression)?.let { context[REFERENCE_TARGET, it] }
 
-        if (!descriptorHasReceiver &&
-            explicitReceiver != null &&
-            explicitReceiverDescriptor !is JavaClassDescriptor &&
-            calleeDescriptor !is ClassConstructorDescriptor
-        ) return false
         val noBoundReferences = !languageVersionSettings.supportsFeature(LanguageFeature.BoundCallableReferences)
         if (noBoundReferences && descriptorHasReceiver && explicitReceiver == null) return false
 
@@ -178,6 +177,12 @@ open class ConvertLambdaToReferenceIntention(textGetter: () -> String) : SelfTar
             }
         }
         return true
+    }
+
+    private fun KtExpression.isReferenceToPackage(context: BindingContext): Boolean {
+        val selectorOrThis = (this as? KtQualifiedExpression)?.selectorExpression ?: this
+        val descriptors = selectorOrThis.mainReference?.resolveToDescriptors(context) ?: return false
+        return descriptors.any { it is PackageViewDescriptor }
     }
 
     override fun isApplicableTo(element: KtLambdaExpression): Boolean {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6257,6 +6257,16 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
                 runTest("testData/intentions/convertLambdaToReference/fqNameForReceiver.kt");
             }
 
+            @TestMetadata("fullyQualifiedConstructorCall.kt")
+            public void testFullyQualifiedConstructorCall() throws Exception {
+                runTest("testData/intentions/convertLambdaToReference/fullyQualifiedConstructorCall.kt");
+            }
+
+            @TestMetadata("fullyQualifiedFunctionCall.kt")
+            public void testFullyQualifiedFunctionCall() throws Exception {
+                runTest("testData/intentions/convertLambdaToReference/fullyQualifiedFunctionCall.kt");
+            }
+
             @TestMetadata("generic.kt")
             public void testGeneric() throws Exception {
                 runTest("testData/intentions/convertLambdaToReference/generic.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertLambdaToReference/fullyQualifiedConstructorCall.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertLambdaToReference/fullyQualifiedConstructorCall.kt
@@ -1,0 +1,10 @@
+// IS_APPLICABLE: false
+package com.example
+
+class MyClass(val value: Int)
+
+fun f(body: (Int) -> com.example.MyClass) {}
+
+fun test() {
+    f { i -> <caret>com.example.MyClass(i) }
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertLambdaToReference/fullyQualifiedFunctionCall.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertLambdaToReference/fullyQualifiedFunctionCall.kt
@@ -1,0 +1,12 @@
+// IS_APPLICABLE: false
+package com.example
+
+class MyClass(val value: Int)
+
+fun foo(x: Int) = MyClass(1)
+
+fun f(body: (Int) -> com.example.MyClass) {}
+
+fun test() {
+    f { i -> <caret>com.example.foo(i) }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21979