### PR TITLE
KTIJ-21964 False positive "unused symbol" for items of nested enum with `valueOf` call

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt
@@ -369,7 +369,11 @@ fun KtElement.isReferenceToBuiltInEnumFunction(): Boolean {
                 else -> false
             }
         }
-        is KtQualifiedExpression -> this.callExpression?.calleeExpression?.text in ENUM_STATIC_METHODS
+        is KtQualifiedExpression -> {
+            var target: KtQualifiedExpression = this
+            while (target.callExpression == null) target = target.parent as? KtQualifiedExpression ?: break
+            target.callExpression?.calleeExpression?.text in ENUM_STATIC_METHODS
+        }
         is KtCallExpression -> this.calleeExpression?.text in ENUM_STATIC_METHODS
         is KtCallableReferenceExpression -> this.callableReference.text in ENUM_STATIC_METHODS
         else -> false

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -16158,6 +16158,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction9.kt");
         }
 
+        @TestMetadata("usedEnumFunctionWithNestedEnum.kt")
+        public void testUsedEnumFunctionWithNestedEnum() throws Exception {
+            runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithNestedEnum.kt");
+        }
+
         @TestMetadata("valueClassParameter.kt")
         public void testValueClassParameter() throws Exception {
             runTest("testData/inspectionsLocal/unusedSymbol/valueClassParameter.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithNestedEnum.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithNestedEnum.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+class Wrapper {
+    class Wrapper2 {
+        enum class MyEnum {
+            <caret>Bar, Baz;
+        }
+    }
+}
+
+fun main() {
+    Wrapper.Wrapper2.MyEnum.valueOf("Bar")
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21964