### PR TITLE
KTIJ-19032 Inspection 'Lambda can be converted to a method reference' creates uncompilable code with a super call

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertLambdaToReferenceIntention.kt
@@ -81,7 +81,7 @@ open class ConvertLambdaToReferenceIntention(textGetter: () -> String) : SelfTar
         }
         val context = callableExpression.safeAnalyzeNonSourceRootCode()
 
-        if (explicitReceiver?.isReferenceToPackage(context) == true) return false
+        if (explicitReceiver is KtSuperExpression || explicitReceiver?.isReferenceToPackage(context) == true) return false
 
         val calleeDescriptor =
             calleeReferenceExpression.getResolvedCall(context)?.resultingDescriptor as? CallableMemberDescriptor ?: return false

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6507,6 +6507,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
                 runTest("testData/intentions/convertLambdaToReference/simple.kt");
             }
 
+            @TestMetadata("super.kt")
+            public void testSuper() throws Exception {
+                runTest("testData/intentions/convertLambdaToReference/super.kt");
+            }
+
             @TestMetadata("suspendFun.kt")
             public void testSuspendFun() throws Exception {
                 runTest("testData/intentions/convertLambdaToReference/suspendFun.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertLambdaToReference/super.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertLambdaToReference/super.kt
@@ -1,0 +1,14 @@
+// IS_APPLICABLE: false
+open class A {
+    open fun method() {}
+}
+
+class B : A() {
+    override fun method() {
+        call <caret>{ super.method() }
+    }
+}
+
+fun call(f: () -> Unit) {
+    f()
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19032