### PR TITLE
Update the wording of the SuspiciousCollectionReassignment inspection

### DIFF
--- a/plugins/kotlin/idea/resources-en/inspectionDescriptions/SuspiciousCollectionReassignment.html
+++ b/plugins/kotlin/idea/resources-en/inspectionDescriptions/SuspiciousCollectionReassignment.html
@@ -1,14 +1,14 @@
 <html>
 <body>
 Reports augmented assignment (<code>+=</code>) expressions on read-only <code>Collection</code>.
-<p>Augment assignment (<code>+=</code>) expression on read-only <code>Collection</code> doesn't modify the target collection,
-    it creates a new one under the hood which can be misleading and lead to performance issues.</p>
+<p>Augmented assignment (<code>+=</code>) expression on read-only <code>Collection</code> create a new collection, temporary allocating 
+    two lists and potentially leading to performance issues.</p>
 <p><b>Change type to mutable</b> quick-fix can be used to amend the code automatically.</p>
 <p>Example:</p>
 <pre><code>
   fun test() {
       var list = listOf(0)
-      list += 42 // new list is created, variable 'list' still contains only '0'
+      list += 42 // A new list is allocated here, equivalent to list = list + 42
   }
 </code></pre>
 <p>After the quick-fix is applied:</p>


### PR DESCRIPTION
The wording could imply that "list" ultimately still contain only '0', which is not the case ([playground](https://pl.kotl.in/QWPzLwir8))

See https://kotlinlang.slack.com/archives/C0B8Q383C/p1655911474996669 for more context