### PR TITLE
KTIJ-22026 Add quick-fix to delete forbidden annotation retention SOURCE in opt-ins declaration

### DIFF
--- a/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
@@ -194,6 +194,7 @@ fix.opt_in.text.propagate.constructor=Propagate ''{0}'' opt-in requirement to co
 fix.opt_in.text.propagate.containing.class=Propagate ''{0}'' opt-in requirement to containing class ''{1}''
 
 fix.opt_in.remove.all.forbidden.targets=Remove forbidden opt-in annotation targets
+fix.opt_in.remove.forbidden.retention=Remove forbidden opt-in annotation retention
 
 fix.opt_in.move.requirement.from.value.parameter.to.property=Move ''{0}'' opt-in requirement from value parameter to property
 fix.opt_in.move.requirement.from.getter.to.property=Move ''{0}'' opt-in requirement from getter to property

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/QuickFixRegistrar.kt
@@ -642,6 +642,7 @@ class QuickFixRegistrar : QuickFixContributor {
         OPT_IN_IS_NOT_ENABLED.registerFactory(MakeModuleExperimentalFix)
         OPT_IN_MARKER_ON_WRONG_TARGET.registerFactory(ExperimentalAnnotationWrongTargetFixesFactory)
         OPT_IN_MARKER_WITH_WRONG_TARGET.registerFactory(RemoveWrongOptInAnnotationTargetFactory)
+        OPT_IN_MARKER_WITH_WRONG_RETENTION.registerFactory(RemoveWrongOptInAnnotationRetentionFactory)
         OPT_IN_MARKER_ON_OVERRIDE.registerFactory(RemoveAnnotationFix)
         OPT_IN_MARKER_ON_OVERRIDE_WARNING.registerFactory(RemoveAnnotationFix)
         OPT_IN_WITHOUT_ARGUMENTS.registerFactory(RemoveAnnotationFix)

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWrongOptInAnnotationRetentionFactory.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWrongOptInAnnotationRetentionFactory.kt
@@ -1,0 +1,34 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.jetbrains.kotlin.idea.quickfix
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
+object RemoveWrongOptInAnnotationRetentionFactory : KotlinIntentionActionsFactory() {
+    override fun doCreateActions(diagnostic: Diagnostic): List<IntentionAction> {
+        if (diagnostic.factory != Errors.OPT_IN_MARKER_WITH_WRONG_RETENTION) return emptyList()
+        val annotationEntry = diagnostic.psiElement.safeAs<KtAnnotationEntry>() ?: return emptyList()
+        return listOf(RemoveForbiddenOptInRetentionFix(annotationEntry))
+    }
+
+    private class RemoveForbiddenOptInRetentionFix(annotationEntry: KtAnnotationEntry) :
+        KotlinQuickFixAction<KtAnnotationEntry>(annotationEntry) {
+
+        override fun getText(): String {
+            return KotlinBundle.message("fix.opt_in.remove.forbidden.retention")
+        }
+
+        override fun getFamilyName(): String = text
+
+        override fun invoke(project: Project, editor: Editor?, file: KtFile) {
+            element?.delete()
+        }
+    }
+}

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWrongOptInAnnotationTargetFactory.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveWrongOptInAnnotationTargetFactory.kt
@@ -36,8 +36,12 @@ object RemoveWrongOptInAnnotationTargetFactory : KotlinIntentionActionsFactory()
                 WRONG_TARGETS.any { name -> it.text?.contains(name) == true }
             }
 
-            forbiddenArguments.forEach {
-                argumentList.removeArgument(it)
+            if (forbiddenArguments.size == argumentList.arguments.size) {
+                annotationEntry.delete()
+            } else {
+                forbiddenArguments.forEach {
+                    argumentList.removeArgument(it)
+                }
             }
         }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -8101,9 +8101,19 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/experimental/experimentalUnused.kt");
         }
 
+        @TestMetadata("forbiddenRetensionSource.kt")
+        public void testForbiddenRetensionSource() throws Exception {
+            runTest("testData/quickfix/experimental/forbiddenRetensionSource.kt");
+        }
+
         @TestMetadata("forbiddenTargetsExpression.kt")
         public void testForbiddenTargetsExpression() throws Exception {
             runTest("testData/quickfix/experimental/forbiddenTargetsExpression.kt");
+        }
+
+        @TestMetadata("forbiddenTargetsExpression2.kt")
+        public void testForbiddenTargetsExpression2() throws Exception {
+            runTest("testData/quickfix/experimental/forbiddenTargetsExpression2.kt");
         }
 
         @TestMetadata("forbiddenTargetsInAnnotation.kt")

--- a/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenRetensionSource.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenRetensionSource.kt
@@ -1,0 +1,6 @@
+// "Remove forbidden opt-in annotation retention" "true"
+// COMPILER_ARGUMENTS: -opt-in=kotlin.RequiresOptIn
+// WITH_STDLIB
+@RequiresOptIn
+<caret>@Retention(AnnotationRetention.SOURCE)
+annotation class SomeAnnotation

--- a/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenRetensionSource.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenRetensionSource.kt.after
@@ -1,0 +1,5 @@
+// "Remove forbidden opt-in annotation retention" "true"
+// COMPILER_ARGUMENTS: -opt-in=kotlin.RequiresOptIn
+// WITH_STDLIB
+@RequiresOptIn
+annotation class SomeAnnotation

--- a/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenTargetsExpression2.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenTargetsExpression2.kt
@@ -1,0 +1,6 @@
+// "Remove forbidden opt-in annotation targets" "true"
+// COMPILER_ARGUMENTS: -opt-in=kotlin.RequiresOptIn
+// WITH_STDLIB
+@RequiresOptIn
+@Target(<caret>AnnotationTarget.EXPRESSION)
+annotation class SomeOptInAnnotation

--- a/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenTargetsExpression2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/experimental/forbiddenTargetsExpression2.kt.after
@@ -1,0 +1,5 @@
+// "Remove forbidden opt-in annotation targets" "true"
+// COMPILER_ARGUMENTS: -opt-in=kotlin.RequiresOptIn
+// WITH_STDLIB
+@RequiresOptIn
+annotation class SomeOptInAnnotation


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-22026

```kotlin
@RequiresOptIn
@Retention(AnnotationRetention.SOURCE)
annotation class SomeAnnotation
```
<img width="677" alt="スクリーンショット 2022-06-23 23 33 16" src="https://user-images.githubusercontent.com/1121855/175324832-29c326fe-1bc6-44af-bfab-0adfa122aae4.png">

↓

<img width="343" alt="スクリーンショット 2022-06-23 23 34 42" src="https://user-images.githubusercontent.com/1121855/175325073-d308f2ad-2bdc-4f1f-adb3-13b98f39c878.png">

