### PR TITLE
KTIJ-22139 False negative "Receiver parameter is never used" with type parameter used as class literal

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedReceiverParameterInspection.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.idea.caches.resolve.safeAnalyzeWithContentNonSourceRootCode
 import org.jetbrains.kotlin.idea.core.isOverridable
 import org.jetbrains.kotlin.idea.intentions.callExpression
+import org.jetbrains.kotlin.idea.intentions.receiverType
 import org.jetbrains.kotlin.idea.isMainFunction
 import org.jetbrains.kotlin.idea.quickfix.RemoveUnusedFunctionParameterFix
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.KotlinChangeSignatureConfiguration
@@ -189,7 +190,7 @@ fun isUsageOfDescriptor(descriptor: DeclarationDescriptor, element: KtElement, c
     if (element is KtClassLiteralExpression) {
         val typeParameter = element.receiverExpression?.mainReference?.resolve() as? KtTypeParameter
         val typeParameterDescriptor = context[BindingContext.TYPE_PARAMETER, typeParameter]
-        if (descriptor.safeAs<CallableDescriptor>()?.typeParameters?.any { it == typeParameterDescriptor } == true) return true
+        if (descriptor.safeAs<CallableDescriptor>()?.receiverType()?.constructor == typeParameterDescriptor?.typeConstructor) return true
     }
 
     return when (element) {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -15964,6 +15964,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         public void testReifiedWithClassLiteral() throws Exception {
             runTest("testData/inspectionsLocal/unusedReceiverParameter/reifiedWithClassLiteral.kt");
         }
+
+        @TestMetadata("reifiedWithClassLiteral2.kt")
+        public void testReifiedWithClassLiteral2() throws Exception {
+            runTest("testData/inspectionsLocal/unusedReceiverParameter/reifiedWithClassLiteral2.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedReceiverParameter/reifiedWithClassLiteral2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedReceiverParameter/reifiedWithClassLiteral2.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+inline fun <reified T> <caret>String.testFun(): String {
+    return (T::class.java).name
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedReceiverParameter/reifiedWithClassLiteral2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedReceiverParameter/reifiedWithClassLiteral2.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+inline fun <reified T> testFun(): String {
+    return (T::class.java).name
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-22139