### PR TITLE
Add null check to JdScope equals implementation

### DIFF
--- a/platform/analysis-impl/src/com/intellij/openapi/module/impl/scopes/JdkScope.java
+++ b/platform/analysis-impl/src/com/intellij/openapi/module/impl/scopes/JdkScope.java
@@ -32,6 +32,7 @@ public class JdkScope extends LibraryScopeBase {
 
   @Override
   public boolean equals(Object object) {
+    if (object == null) return false;
     if (object == this) return true;
     if (object.getClass() != getClass()) return false;
 


### PR DESCRIPTION
As per https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Object.html#equals(java.lang.Object)

Reason for this PR: We actually experienced NPEs in some conditions (albeit in tests, but still...).

Credits to @unkarjedy for suggesting this fix, rather than only fixing it in https://github.com/JetBrains/intellij-scala/commit/545b9b7d90c9563f3f186ac99cff479e021ada30