### PR TITLE
KTIJ-19509 IDE inspection to replace readLine() usages to readln() or readlnOrNull()

### DIFF
--- a/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/frontend-independent/resources-en/messages/KotlinBundle.properties
@@ -2542,3 +2542,5 @@ wrap.expression.in.parentheses=Wrap expression in parentheses
 convert.left.hand.side.to.0=Convert left-hand side to ''{0}''
 convert.right.hand.side.to.0=Convert right-hand side to ''{0}''
 convert.string.to.character.literal=Convert string to character literal
+
+inspection.replace.readline.with.readln.display.name='readLine' can be replaced with 'readln' or 'readlnOrNull'

--- a/plugins/kotlin/idea/resources-en/inspectionDescriptions/ReplaceReadLineWithReadln.html
+++ b/plugins/kotlin/idea/resources-en/inspectionDescriptions/ReplaceReadLineWithReadln.html
@@ -1,0 +1,21 @@
+<html>
+<body>
+Reports calls to <code>readLine()</code> that can be replaced with <code>readln()</code> or <code>readlnOrNull()</code>.
+<p>
+    Using corresponding functions makes your code simpler.
+</p>
+<p>
+    The quick-fix replaces <code>readLine()!!</code> with <code>readln()</code> and <code>readLine()</code> with <code>readlnOrNull()</code>.
+</p>
+<p><b>Examples:</b></p>
+<pre><code>
+    val x = readLine()!!
+    val y = readLine()?.length
+</code></pre>
+<p>After the quick-fix is applied:</p>
+<pre><code>
+    val x = readln()
+    val y = readlnOrNull()?.length
+</code></pre>
+</body>
+</html>

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceReadLineWithReadlnInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceReadLineWithReadlnInspection.kt
@@ -1,0 +1,54 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.config.ApiVersion
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.base.projectStructure.languageVersionSettings
+import org.jetbrains.kotlin.idea.inspections.collections.isCalling
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelectorOrThis
+
+class ReplaceReadLineWithReadlnInspection : AbstractKotlinInspection() {
+    companion object {
+        private val readLineFqName = FqName("kotlin.io.readLine")
+        private val readlnFqName = FqName("kotlin.io.readln")
+        private val readlnOrNullFqName = FqName("kotlin.io.readlnOrNull")
+    }
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = callExpressionVisitor(fun(callExpression) {
+        if (callExpression.languageVersionSettings.apiVersion < ApiVersion.KOTLIN_1_6) return
+        if (!callExpression.isCalling(readLineFqName)) return
+
+        val qualifiedOrCall = callExpression.getQualifiedExpressionForSelectorOrThis()
+        val parent = qualifiedOrCall.parent
+        val (targetExpression, newFunction) = if (parent is KtPostfixExpression && parent.operationToken == KtTokens.EXCLEXCL) {
+            parent to readlnFqName
+        } else {
+            qualifiedOrCall to readlnOrNullFqName
+        }
+        val newFunctionName = newFunction.shortName().asString()
+
+        holder.registerProblem(
+            targetExpression,
+            KotlinBundle.message("replace.0.with.1", readLineFqName.shortName().asString(), newFunctionName),
+            ReplaceFix(newFunctionName)
+        )
+    })
+
+    private class ReplaceFix(private val functionName: String) : LocalQuickFix {
+        override fun getName() = KotlinBundle.message("replace.with.0", functionName)
+
+        override fun getFamilyName() = name
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            descriptor.psiElement.replace(KtPsiFactory(project).createExpression("$functionName()"))
+        }
+    }
+}

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceReadLineWithReadlnInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceReadLineWithReadlnInspection.kt
@@ -8,9 +8,11 @@ import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.base.projectStructure.languageVersionSettings
+import org.jetbrains.kotlin.idea.core.ShortenReferences
 import org.jetbrains.kotlin.idea.inspections.collections.isCalling
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtPostfixExpression
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.callExpressionVisitor
@@ -48,7 +50,8 @@ class ReplaceReadLineWithReadlnInspection : AbstractKotlinInspection() {
         override fun getFamilyName() = name
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            descriptor.psiElement.replace(KtPsiFactory(project).createExpression("$functionName()"))
+            val replaced = descriptor.psiElement.replace(KtPsiFactory(project).createExpression("kotlin.io.$functionName()"))
+            ShortenReferences.DEFAULT.process(replaced as KtElement)
         }
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -13043,6 +13043,69 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("testData/inspectionsLocal/ReplaceReadLineWithReadln")
+    public abstract static class ReplaceReadLineWithReadln extends AbstractLocalInspectionTest {
+        @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/inspectionsLocal/ReplaceReadLineWithReadln/readln")
+        public static class Readln extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("qualified.kt")
+            public void testQualified() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/qualified.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/simple.kt");
+            }
+
+            @TestMetadata("withSelector.kt")
+            public void testWithSelector() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/withSelector.kt");
+            }
+        }
+
+        @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull")
+        public static class ReadlnOrNull extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("qualified.kt")
+            public void testQualified() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/qualified.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/simple.kt");
+            }
+
+            @TestMetadata("withSelector.kt")
+            public void testWithSelector() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/withSelector.kt");
+            }
+        }
+
+        @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/inspectionsLocal/ReplaceReadLineWithReadln")
+        public static class Uncategorized extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("version1_5.kt")
+            public void testVersion1_5() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/version1_5.kt");
+            }
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("testData/inspectionsLocal/replaceStringFormatWithLiteral")
     public static class ReplaceStringFormatWithLiteral extends AbstractLocalInspectionTest {
         private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -13057,6 +13057,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                 runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/qualified.kt");
             }
 
+            @TestMetadata("sameName.kt")
+            public void testSameName() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/sameName.kt");
+            }
+
             @TestMetadata("simple.kt")
             public void testSimple() throws Exception {
                 runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/simple.kt");
@@ -13078,6 +13083,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             @TestMetadata("qualified.kt")
             public void testQualified() throws Exception {
                 runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/qualified.kt");
+            }
+
+            @TestMetadata("sameName.kt")
+            public void testSameName() throws Exception {
+                runTest("testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/sameName.kt");
             }
 
             @TestMetadata("simple.kt")

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/.inspection
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ReplaceReadLineWithReadlnInspection

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/qualified.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/qualified.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    <caret>kotlin.io.readLine()!!
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/qualified.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/qualified.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    readln()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/sameName.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/sameName.kt
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun main() {
+    <caret>readLine()!!
+}
+
+fun readln() {}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/sameName.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/sameName.kt.after
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun main() {
+    kotlin.io.readln()
+}
+
+fun readln() {}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/simple.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/simple.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    <caret>readLine()!!
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/simple.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/simple.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    readln()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/withSelector.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/withSelector.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    <caret>readLine()!!.length
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/withSelector.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readln/withSelector.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    readln().length
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/qualified.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/qualified.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    <caret>kotlin.io.readLine()?.length
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/qualified.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/qualified.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    readlnOrNull()?.length
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/sameName.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/sameName.kt
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun main() {
+    <caret>readLine()
+}
+
+fun readlnOrNull() {}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/sameName.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/sameName.kt.after
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun main() {
+    kotlin.io.readlnOrNull()
+}
+
+fun readlnOrNull() {}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/simple.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/simple.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    <caret>readLine()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/simple.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/simple.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    readlnOrNull()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/withSelector.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/withSelector.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    <caret>readLine()?.length
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/withSelector.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/readlnOrNull/withSelector.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun main() {
+    readlnOrNull()?.length
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/version1_5.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/ReplaceReadLineWithReadln/version1_5.kt
@@ -1,0 +1,6 @@
+// API_VERSION: 1.5
+// PROBLEM: none
+// WITH_STDLIB
+fun main() {
+    <caret>readLine()
+}

--- a/plugins/kotlin/plugin/resources/META-INF/inspections-fe10.xml
+++ b/plugins/kotlin/plugin/resources/META-INF/inspections-fe10.xml
@@ -2976,6 +2976,14 @@
                      level="WEAK WARNING"
                      language="kotlin"
                      key="inspection.verbose.nullability.and.emptiness.display.name" bundle="messages.KotlinBundle"/>
+
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceReadLineWithReadlnInspection"
+                     groupPath="Kotlin"
+                     groupBundle="messages.KotlinBundle" groupKey="group.names.style.issues"
+                     enabledByDefault="true"
+                     level="WEAK WARNING"
+                     language="kotlin"
+                     key="inspection.replace.readline.with.readln.display.name" bundle="messages.KotlinBundle"/>
   </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19509