### PR TITLE
[KTIJ-21854] Reorder composite analysis results in fragment compiler

### DIFF
--- a/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluatorBuilder.kt
+++ b/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/KotlinEvaluatorBuilder.kt
@@ -236,10 +236,38 @@ class KotlinEvaluator(val codeFragment: KtCodeFragment, private val sourcePositi
                         analysisResult.bindingContext
                     ).second
                 } else {
+                    // The IR Evaluator is sensitive to the analysis order of files in fragment compilation:
+                    // The codeFragment must be passed _last_ to analysis such that the result is stacked at
+                    // the _bottom_ of the composite analysis result.
+                    //
+                    // The situation as seen from here is as follows:
+                    //   1) `analyzeWithAllCompilerChecks` analyze each individual file passed to it separately.
+                    //   2) The individual results are "stacked" on top of each other.
+                    //   3) With distinct files, "stacking on top" is equivalent to "side by side" - there is
+                    //      no overlap in what is analyzed, so the order doesn't matter: the composite analysis
+                    //      result is just a look-up mechanism for convenience.
+                    //   4) Code Fragments perform partial analysis of the context of the fragment, e.g. a
+                    //      breakpoint in a function causes partial analysis of the surrounding function.
+                    //   5) If the surrounding function is _also_ included in the `filesToCompile`, that
+                    //      function will be analyzed more than once: in particular, fresh symbols will be
+                    //      allocated anew upon repeated analysis.
+                    //   6) Now the order of composition is significant: layering the fragment at the bottom
+                    //      ensures code that needs a consistent view of the entire function (i.e. psi2ir)
+                    //      does not mix the fresh, partial view of the function in the fragment analysis with
+                    //      the complete analysis from the separate analysis of the entire file included in the
+                    //      compilation.
+                    //
+                    fun <T> MutableList<T>.moveToLast(element: T) {
+                        removeAll(listOf(element))
+                        add(element)
+                    }
+
                     gatherProjectFilesDependedOnByFragment(
                         codeFragment,
                         analysisResult.bindingContext
-                    ).toList()
+                    ).toMutableList().apply {
+                        moveToLast(codeFragment)
+                    }
                 }
                 val analysis = resolutionFacade.analyzeWithAllCompilerChecks(filesToCompile)
                 Pair(analysis.bindingContext, filesToCompile)

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
@@ -1656,6 +1656,11 @@ public abstract class KotlinEvaluateExpressionInMppTestGenerated extends Abstrac
             runTest("testData/evaluation/multiplatform/functionBreakpointInCommonCode.kt");
         }
 
+        @TestMetadata("ktij21854.kt")
+        public void testKtij21854() throws Exception {
+            runTest("testData/evaluation/multiplatform/ktij21854.kt");
+        }
+
         @TestMetadata("typealiasFromCommonCode.kt")
         public void testTypealiasFromCommonCode() throws Exception {
             runTest("testData/evaluation/multiplatform/typealiasFromCommonCode.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multiplatform/ktij21854.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multiplatform/ktij21854.kt
@@ -1,0 +1,33 @@
+
+// MODULE: common
+// PLATFORM: common
+
+// FILE: common.kt
+
+fun test() {
+    val x = 1
+    fun bar(): Int {
+        val y = x
+        return y
+    }
+    val s = "OK"
+
+    //Breakpoint1
+    return
+}
+
+// ADDITIONAL_BREAKPOINT: common.kt / Breakpoint1 / line / 1
+
+// EXPRESSION: s
+// RESULT: "OK": Ljava/lang/String;
+
+
+// MODULE: jvm
+// PLATFORM: jvm
+// DEPENDS_ON: common
+
+// FILE: jvm.kt
+
+fun main() {
+    test()
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multiplatform/ktij21854.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multiplatform/ktij21854.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at common.kt:16 lambdaOrdinal = 1
+Run Java
+Connected to the target VM
+common.kt:16
+Compile bytecode for s
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Compiler side changes in https://github.com/JetBrains/kotlin/pull/4880

---

The IR Fragment Compiler reuses the batch IR compiler infrastructure for compilation.This requires full analysis of the fragment dependencies included for compilation. 

See the comment in KotlinEvaluatorBuilder for a detailed breakdown, but, in short, the order of analysis result composition is significant for purpose of psi2ir: code fragments trigger partial analysis of the function containing the fragment, and layering this _on top_ of the complete analysis of the dependent files causes the Composite binding context to present an inconsistent view _of the dependent file_ where, in this specific case, a fresh descriptor was created for the local variable `x` and included in the symbol table while generating IR for `test`, but the reference to `x` in `bar` was pointing to a different local variable descriptor for `x`, since the local function was not reanalyzed by the analysis for the fragment context.

(Incidentally, this also explains why upgrading to `FULL` analysis for the fragment context resolves the issues: now we again have a complete and consistent view of the function `test`, including the body of the local `bar`, and all descriptors agree.)

Resolves [KTIJ-21854](https://youtrack.jetbrains.com/issue/KTIJ-21854/MPP-DebuggerIR-Evaluate-expression-fails-for-local-variable-on-first-run) and [KTIJ-21877](https://youtrack.jetbrains.com/issue/KTIJ-21877/IR-debugger-Errors-on-attempt-to-evaluate-expression)