### PR TITLE
[IDEA-297272] Handle cleanup conflict: System.out.println("a" + "b");

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/LengthOneStringsInConcatenationInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/performance/LengthOneStringsInConcatenationInspection.java
@@ -25,7 +25,7 @@ import com.siyeh.InspectionGadgetsBundle;
 import com.siyeh.ig.BaseInspection;
 import com.siyeh.ig.BaseInspectionVisitor;
 import com.siyeh.ig.InspectionGadgetsFix;
-import com.siyeh.ig.PsiReplacementUtil;
+import com.siyeh.ig.psiutils.CommentTracker;
 import com.siyeh.ig.psiutils.ExpressionUtils;
 import com.siyeh.ig.psiutils.TypeUtils;
 import org.jetbrains.annotations.NotNull;
@@ -71,7 +71,7 @@ public class LengthOneStringsInConcatenationInspection extends BaseInspection im
       }
       final String text = expression.getText();
       final String charLiteral = PsiLiteralUtil.charLiteralForCharString(text);
-      PsiReplacementUtil.replaceExpression(expression, charLiteral);
+      new CommentTracker().replaceAndRestoreComments(expression, charLiteral);
     }
   }
 

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/LengthOneStringsInConcatenation.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/LengthOneStringsInConcatenation.html
@@ -6,7 +6,7 @@ Reports concatenation with string literals that consist of one character.
 <pre><code>
   String hello = hell + "o";
 </code></pre>
-<p>After the quick-fix is applied:</p>
+<p>After the fix is applied:</p>
 <pre><code>
   String hello = hell + 'o';
 </code></pre>


### PR DESCRIPTION
Hi @sirgl,

***What steps will reproduce the issue?***
1\. Write the following statement in a Java class:

```Java
System.out.println("a" + "b"); // ab
```

2\. Right-click
3\. Go to *Analyze...* → *Code cleanup*
4\. Go to *...* → *Java* → *Performance* → *Single character concatenation*
5\. Enable *Single character concatenation*
6\. Click on *OK*

***What is the expected result?***

```Java
System.out.println("a" + 'b'); // ab
```

***What happens instead?***

```Java
System.out.println('a' + 'b'); // 195
```

The problem is that the inspection has identified two expressions to fix but each case is relied on the other. If one case is fixed, the other should not be fixed anymore. In other words, the context needs to be re-evaluated before applying a second fix. That's what this PR does.

The PR also adds a unit test class. All the tests successfully pass.