### PR TITLE
platform: interprate 'os.name' property as case insensitive

### DIFF
--- a/platform/util-rt/src/com/intellij/openapi/util/SystemInfoRt.java
+++ b/platform/util-rt/src/com/intellij/openapi/util/SystemInfoRt.java
@@ -10,7 +10,7 @@ import java.util.Locale;
  * Intended to use by external (out-of-IDE-process) runners and helpers, so it should not contain any library dependencies.
  */
 public final class SystemInfoRt {
-  public static final String OS_NAME = System.getProperty("os.name");
+  public static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
   public static final String OS_VERSION = System.getProperty("os.version").toLowerCase(Locale.ENGLISH);
 
   private static final String _OS_NAME = OS_NAME.toLowerCase(Locale.ENGLISH);


### PR DESCRIPTION
Given:

```java
public class Test {
    public static void main(String... args) {
        System.out.println(String.format("os.name=%s", System.getProperty("os.name")));
    }
}
```

Output:

```
os.name=Linux
```

Notice the mixed case.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>