### PR TITLE
KTIJ-21895 "Inconsistent comment for Java parameter" inspection should ignore whitespace

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/InconsistentCommentForJavaParameterInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/InconsistentCommentForJavaParameterInspection.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
 import org.jetbrains.kotlin.idea.codeinsight.api.classic.inspections.AbstractKotlinInspection
 import org.jetbrains.kotlin.idea.intentions.AddNamesInCommentToJavaCallArgumentsIntention
 import org.jetbrains.kotlin.idea.intentions.AddNamesInCommentToJavaCallArgumentsIntention.Companion.blockCommentWithName
+import org.jetbrains.kotlin.idea.intentions.AddNamesInCommentToJavaCallArgumentsIntention.Companion.isParameterComment
 import org.jetbrains.kotlin.idea.intentions.AddNamesInCommentToJavaCallArgumentsIntention.Companion.toCommentedParameterName
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
@@ -33,12 +34,11 @@ class InconsistentCommentForJavaParameterInspection: AbstractKotlinInspection() 
 
             for ((argument, descriptor)  in valueDescriptorByValueArgument) {
                 val comment = argument.blockCommentWithName() ?: continue
-                val commentedParameterName = descriptor.toCommentedParameterName()
-                if (commentedParameterName == comment.text) continue
+                if (comment.isParameterComment(descriptor)) continue
                 holder.registerProblem(
                     comment,
                     KotlinBundle.message("inspection.message.inconsistent.parameter.name.for.0", descriptor.name.asString()),
-                    CorrectNamesInCommentsToJavaCallArgumentsFix(commentedParameterName)
+                    CorrectNamesInCommentsToJavaCallArgumentsFix(descriptor.toCommentedParameterName())
                 )
             }
         }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/ArgumentNameHints.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/parameterInfo/ArgumentNameHints.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.caches.resolve.safeAnalyzeNonSourceRootCode
 import org.jetbrains.kotlin.idea.core.resolveCandidates
+import org.jetbrains.kotlin.idea.intentions.AddNamesInCommentToJavaCallArgumentsIntention.Companion.isParameterComment
 import org.jetbrains.kotlin.idea.intentions.AddNamesInCommentToJavaCallArgumentsIntention.Companion.toCommentedParameterName
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassConstructorDescriptor
@@ -105,4 +106,4 @@ private fun KtExpression.isAnnotatedWithComment(valueParameter: ValueParameterDe
     (descriptor is JavaMethodDescriptor || descriptor is JavaClassConstructorDescriptor) &&
             prevLeafs
                 .takeWhile { it is PsiWhiteSpace || it is PsiComment }
-                .any { it is PsiComment && it.text == valueParameter.toCommentedParameterName() }
+                .any { it is PsiComment && it.isParameterComment(valueParameter) }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -5676,39 +5676,101 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
 
     @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("testData/inspectionsLocal/inconsistentCommentForJavaParameter")
-    public static class InconsistentCommentForJavaParameter extends AbstractLocalInspectionTest {
-        private void runTest(String testDataFilePath) throws Exception {
-            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+    public abstract static class InconsistentCommentForJavaParameter extends AbstractLocalInspectionTest {
+        @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/inspectionsLocal/inconsistentCommentForJavaParameter")
+        public static class Uncategorized extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("annotation.kt")
+            public void testAnnotation() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/annotation.kt");
+            }
+
+            @TestMetadata("comment.kt")
+            public void testComment() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/comment.kt");
+            }
+
+            @TestMetadata("na.kt")
+            public void testNa() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/na.kt");
+            }
+
+            @TestMetadata("simple.kt")
+            public void testSimple() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/simple.kt");
+            }
+
+            @TestMetadata("superSecondaryCtorCall.kt")
+            public void testSuperSecondaryCtorCall() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/superSecondaryCtorCall.kt");
+            }
+
+            @TestMetadata("superTypeCall.kt")
+            public void testSuperTypeCall() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/superTypeCall.kt");
+            }
         }
 
-        @TestMetadata("annotation.kt")
-        public void testAnnotation() throws Exception {
-            runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/annotation.kt");
-        }
+        @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace")
+        public static class Whitespace extends AbstractLocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
 
-        @TestMetadata("comment.kt")
-        public void testComment() throws Exception {
-            runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/comment.kt");
-        }
+            @TestMetadata("notSameName1.kt")
+            public void testNotSameName1() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName1.kt");
+            }
 
-        @TestMetadata("na.kt")
-        public void testNa() throws Exception {
-            runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/na.kt");
-        }
+            @TestMetadata("notSameName2.kt")
+            public void testNotSameName2() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName2.kt");
+            }
 
-        @TestMetadata("simple.kt")
-        public void testSimple() throws Exception {
-            runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/simple.kt");
-        }
+            @TestMetadata("notSameName3.kt")
+            public void testNotSameName3() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName3.kt");
+            }
 
-        @TestMetadata("superSecondaryCtorCall.kt")
-        public void testSuperSecondaryCtorCall() throws Exception {
-            runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/superSecondaryCtorCall.kt");
-        }
+            @TestMetadata("notSameName4.kt")
+            public void testNotSameName4() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName4.kt");
+            }
 
-        @TestMetadata("superTypeCall.kt")
-        public void testSuperTypeCall() throws Exception {
-            runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/superTypeCall.kt");
+            @TestMetadata("notSameName5.kt")
+            public void testNotSameName5() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName5.kt");
+            }
+
+            @TestMetadata("sameName1.kt")
+            public void testSameName1() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName1.kt");
+            }
+
+            @TestMetadata("sameName2.kt")
+            public void testSameName2() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName2.kt");
+            }
+
+            @TestMetadata("sameName3.kt")
+            public void testSameName3() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName3.kt");
+            }
+
+            @TestMetadata("sameName4.kt")
+            public void testSameName4() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName4.kt");
+            }
+
+            @TestMetadata("sameName5.kt")
+            public void testSameName5() throws Exception {
+                runTest("testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName5.kt");
+            }
         }
     }
 

--- a/plugins/kotlin/idea/tests/testData/codeInsight/hints/arguments/javaParameters.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/hints/arguments/javaParameters.kt
@@ -5,6 +5,12 @@ fun javaParameters() {
     some.invokeMe(<hint text="index:"/>0, <hint text="name:"/>"me")
     some.invokeMe(/* index = */ 0, /* name = */ "me")
 
+    some.invokeMe(/*index = */ 0, /* name = */ "me")
+    some.invokeMe(/* index= */ 0, /* name = */ "me")
+    some.invokeMe(/* index=*/ 0, /* name = */ "me")
+    some.invokeMe(/* index =*/ 0, /* name = */ "me")
+    some.invokeMe(/*   index   =   */ 0, /* name = */ "me")
+
     some.doNotInvokeMe(/* index = */ 0, /* ...args = */ "a", "b")
     some.doNotInvokeMe(/* index = */ 0, /* ...names = */ <hint text="...args:"/>"a", "b")
 

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName1.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName1.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName1.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName1.kt
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(<caret>/*s = */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName1.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName1.kt.after
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(/* string = */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName2.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName2.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName2.kt
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(<caret>/* s= */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName2.kt.after
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(/* string = */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName3.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName3.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName3.kt
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(<caret>/* s=*/"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName3.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName3.kt.after
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(/* string = */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName4.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName4.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName4.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName4.kt
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(<caret>/* s =*/"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName4.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName4.kt.after
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(/* string = */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName5.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName5.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName5.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName5.kt
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(<caret>/*  s  =  */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName5.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/notSameName5.kt.after
@@ -1,0 +1,3 @@
+fun test(j: J) {
+    j.foo(/* string = */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName1.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName1.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName1.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName1.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test(j: J) {
+    j.foo(<caret>/*string = */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName2.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName2.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName2.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test(j: J) {
+    j.foo(<caret>/* string= */"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName3.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName3.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName3.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test(j: J) {
+    j.foo(<caret>/* string=*/"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName4.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName4.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName4.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName4.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test(j: J) {
+    j.foo(<caret>/* string =*/"hello")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName5.1.java
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName5.1.java
@@ -1,0 +1,3 @@
+public class J {
+    void foo(String string) {}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName5.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/inconsistentCommentForJavaParameter/whitespace/sameName5.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+fun test(j: J) {
+    j.foo(<caret>/*  string  =  */"hello")
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21895