### PR TITLE
[KTIJ-11416] Pasting multiline text to KDoc like in JavaDoc

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessor.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessor.kt
@@ -1,0 +1,36 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.editor
+
+import com.intellij.codeInsight.editorActions.CopyPastePreProcessor
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.RawText
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.parentOfType
+import com.intellij.util.DocumentUtil
+import com.intellij.util.text.CharArrayUtil
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.KtFile
+
+class KDocCopyPastePreProcessor : CopyPastePreProcessor {
+    override fun preprocessOnCopy(file: PsiFile, startOffsets: IntArray, endOffsets: IntArray, text: String) = null
+
+    override fun preprocessOnPaste(project: Project, file: PsiFile, editor: Editor, text: String, rawText: RawText?): String {
+        if (file !is KtFile) return text
+
+        val offset = editor.selectionModel.selectionStart
+        if (DocumentUtil.isAtLineEnd(offset, editor.document) && text.startsWith("\n")) return text
+
+        val element = file.findElementAt(offset)
+        element?.parentOfType<KDoc>() ?: return text
+
+        val document = editor.document
+        val lineStartOffset = DocumentUtil.getLineStartOffset(offset, document)
+        val chars = document.immutableCharSequence
+        val firstNonWsLineOffset = CharArrayUtil.shiftForward(chars, lineStartOffset, " \t")
+        if (firstNonWsLineOffset >= offset || chars[firstNonWsLineOffset] != '*') return text
+
+        val lineStartReplacement = "\n" + chars.subSequence(lineStartOffset, firstNonWsLineOffset + 1) + " "
+        return text.trimEnd('\n').replace("\n", lineStartReplacement)
+    }
+}

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessor.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessor.kt
@@ -19,8 +19,6 @@ class KDocCopyPastePreProcessor : CopyPastePreProcessor {
         if (file !is KtFile) return text
 
         val offset = editor.selectionModel.selectionStart
-        if (DocumentUtil.isAtLineEnd(offset, editor.document) && text.startsWith("\n")) return text
-
         val element = file.findElementAt(offset)
         element?.parentOfType<KDoc>() ?: return text
 
@@ -31,6 +29,6 @@ class KDocCopyPastePreProcessor : CopyPastePreProcessor {
         if (firstNonWsLineOffset >= offset || chars[firstNonWsLineOffset] != '*') return text
 
         val lineStartReplacement = "\n" + chars.subSequence(lineStartOffset, firstNonWsLineOffset + 1) + " "
-        return text.trimEnd('\n').replace("\n", lineStartReplacement)
+        return text.trim('\n').replace("\n", lineStartReplacement)
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessorTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessorTest.kt
@@ -1,0 +1,233 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.kotlin.idea.editor
+
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.testFramework.EditorTestUtil
+import org.jetbrains.kotlin.idea.test.KotlinLightCodeInsightFixtureTestCase
+import java.awt.datatransfer.StringSelection
+
+class KDocCopyPastePreProcessorTest : KotlinLightCodeInsightFixtureTestCase() {
+    fun testDefaultPaste() = doTypeTest(
+        """
+            Hello
+            World
+        """.trimIndent(),
+        """
+            /**
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             * Hello
+             * World
+             */
+        """.trimIndent()
+    )
+
+    fun testPasteRightAfterAsterisks() = doTypeTest(
+        """
+            Hello
+            World
+        """.trimIndent(),
+        """
+            /**
+             *<caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             *Hello
+             * World
+             */
+        """.trimIndent()
+    )
+
+    fun testPasteNotAlignedText() = doTypeTest(
+        """
+            Hello
+                 World
+        """.trimIndent(),
+        """
+            /**
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             * Hello
+             *      World
+             */
+        """.trimIndent()
+    )
+
+    fun testPasteFirstLineNotAlignedText() = doTypeTest(
+        """
+                  Hello
+            World
+        """.trimIndent(),
+        """
+            /**
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             *       Hello
+             * World
+             */
+        """.trimIndent()
+    )
+
+    fun testPasteTextWithTrailingEmptyLines() = doTypeTest(
+        """
+            Hello
+            World
+            
+            
+            
+        """.trimIndent(),
+        """
+            /**
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             * Hello
+             * World
+             */
+        """.trimIndent()
+    )
+
+    // Works like in Java.
+    fun testPasteTextWithLeadingEmptyLines() = doTypeTest(
+        """
+            
+            
+            Hello
+            World
+        """.trimIndent(),
+        """
+            /**
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             *
+            
+            Hello
+            World
+             */
+        """.trimIndent()
+    )
+
+    fun testPasteKotlinCode() = doTypeTest(
+        """
+            fun main(args: Array<String>) {
+                println("Hello, world")
+            }
+        """.trimIndent(),
+        """
+            /**
+             * Example usage:
+             * 
+             * ```
+             * <caret>
+             * ```
+             */
+        """.trimIndent(),
+        """
+            /**
+             * Example usage:
+             * 
+             * ```
+             * fun main(args: Array<String>) {
+             *     println("Hello, world")
+             * }
+             * ```
+             */
+        """.trimIndent()
+    )
+
+    fun testPasteComplexMarkdownCode() = doTypeTest(
+        """
+            # Heading
+            
+            Some long
+            text.
+            
+            1. Item 1
+            2. Item 2
+            
+            ```kotlin
+            fun main(args: Array<String>) {
+                println("Hello, world")
+            }
+            ```
+            
+            > Quote
+            
+            | id | name |
+            |----|------|
+            | 1  | John |
+            | 2  | Jack |
+        """.trimIndent(),
+        """
+            /**
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             * # Heading
+             *
+             * Some long
+             * text.
+             *
+             * 1. Item 1
+             * 2. Item 2
+             *
+             * ```kotlin
+             * fun main(args: Array<String>) {
+             *     println("Hello, world")
+             * }
+             * ```
+             *
+             * > Quote
+             *
+             * | id | name |
+             * |----|------|
+             * | 1  | John |
+             * | 2  | Jack |
+             */
+        """.trimIndent()
+    )
+
+    fun testNonDocComment() = doTypeTest(
+        """
+            Hello
+            World
+        """.trimIndent(),
+        """
+            /*
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /*
+             * Hello
+            World
+             */
+        """.trimIndent()
+    )
+
+    private fun doTypeTest(text: String, beforeText: String, afterText: String) {
+        myFixture.configureByText("a.kt", beforeText.trimMargin())
+        CopyPasteManager.getInstance().setContents(StringSelection(text))
+        EditorTestUtil.performPaste(myFixture.editor)
+        myFixture.checkResult(afterText.trimMargin())
+    }
+}

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessorTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/KDocCopyPastePreProcessorTest.kt
@@ -101,7 +101,6 @@ class KDocCopyPastePreProcessorTest : KotlinLightCodeInsightFixtureTestCase() {
         """.trimIndent()
     )
 
-    // Works like in Java.
     fun testPasteTextWithLeadingEmptyLines() = doTypeTest(
         """
             
@@ -116,10 +115,30 @@ class KDocCopyPastePreProcessorTest : KotlinLightCodeInsightFixtureTestCase() {
         """.trimIndent(),
         """
             /**
-             *
+             * Hello
+             * World
+             */
+        """.trimIndent()
+    )
+
+    fun testPasteTextWithLeadingAndTrailingEmptyLines() = doTypeTest(
+        """
+            
             
             Hello
             World
+            
+            
+        """.trimIndent(),
+        """
+            /**
+             * <caret>
+             */
+        """.trimIndent(),
+        """
+            /**
+             * Hello
+             * World
              */
         """.trimIndent()
     )

--- a/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
+++ b/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
@@ -331,6 +331,8 @@
     <backspaceHandlerDelegate implementation="org.jetbrains.kotlin.idea.editor.KotlinStringTemplateBackspaceHandler"/>
     <backspaceHandlerDelegate implementation="org.jetbrains.kotlin.idea.editor.KotlinRawStringBackspaceHandler"/>
 
+    <copyPastePreProcessor implementation="org.jetbrains.kotlin.idea.editor.KDocCopyPastePreProcessor"/>
+
     <registryKey key="kotlin.lazy.import.suggestions"
                  description="Calculate import quick fix suggestion lazy."
                  defaultValue="false"

--- a/plugins/kotlin/plugin/k1/resources/META-INF/kotlin-core-fe10.xml
+++ b/plugins/kotlin/plugin/k1/resources/META-INF/kotlin-core-fe10.xml
@@ -193,6 +193,7 @@
     <copyPastePostProcessor implementation="org.jetbrains.kotlin.idea.conversion.copy.ConvertTextJavaCopyPasteProcessor"/>
     <copyPastePostProcessor implementation="org.jetbrains.kotlin.idea.codeInsight.KotlinCopyPasteReferenceProcessor"/>
     <copyPastePreProcessor implementation="org.jetbrains.kotlin.idea.editor.KotlinLiteralCopyPasteProcessor"/>
+    <copyPastePreProcessor implementation="org.jetbrains.kotlin.idea.editor.KDocCopyPastePreProcessor"/>
     <copyPastePostProcessor implementation="org.jetbrains.kotlin.idea.refactoring.cutPaste.MoveDeclarationsCopyPasteProcessor"/>
 
     <filePasteProvider implementation="org.jetbrains.kotlin.idea.conversion.copy.KotlinFilePasteProvider" order="first"/>

--- a/plugins/kotlin/plugin/k1/resources/META-INF/kotlin-core-fe10.xml
+++ b/plugins/kotlin/plugin/k1/resources/META-INF/kotlin-core-fe10.xml
@@ -193,7 +193,6 @@
     <copyPastePostProcessor implementation="org.jetbrains.kotlin.idea.conversion.copy.ConvertTextJavaCopyPasteProcessor"/>
     <copyPastePostProcessor implementation="org.jetbrains.kotlin.idea.codeInsight.KotlinCopyPasteReferenceProcessor"/>
     <copyPastePreProcessor implementation="org.jetbrains.kotlin.idea.editor.KotlinLiteralCopyPasteProcessor"/>
-    <copyPastePreProcessor implementation="org.jetbrains.kotlin.idea.editor.KDocCopyPastePreProcessor"/>
     <copyPastePostProcessor implementation="org.jetbrains.kotlin.idea.refactoring.cutPaste.MoveDeclarationsCopyPasteProcessor"/>
 
     <filePasteProvider implementation="org.jetbrains.kotlin.idea.conversion.copy.KotlinFilePasteProvider" order="first"/>


### PR DESCRIPTION
# Pasting multiline text to KDoc like in JavaDoc

Code:

```kotlin
/**
 * <caret>
 */
fun main() {}
```

Paste text:

```text
Some
multiline
text
```

## Before

```kotlin
/**
 * Some
multiline
text
 */
fun main() {}
```

## After (like for JavaDoc)

```kotlin
/**
 * Some
 * multiline
 * text
 */
fun main() {}
```

Fixes [KTIJ-22293](https://youtrack.jetbrains.com/issue/KTIJ-22293) [marked as duplicate]
Fixes [KTIJ-11416](https://youtrack.jetbrains.com/issue/KTIJ-11416)