### PR TITLE
KTIJ-22306 `Change type arguments to <*>` quickfix is not suggested for type checks in when expressions

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeToStarProjectionFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ChangeToStarProjectionFix.kt
@@ -95,7 +95,9 @@ class ChangeToStarProjectionFix(element: KtTypeElement) : KotlinQuickFixAction<K
         }
 
         private fun Diagnostic.isArrayInstanceCheck(): Boolean =
-            factory == Errors.CANNOT_CHECK_FOR_ERASED && Errors.CANNOT_CHECK_FOR_ERASED.cast(this).a.isArrayOrNullableArray()
+            factory == Errors.CANNOT_CHECK_FOR_ERASED
+                    && Errors.CANNOT_CHECK_FOR_ERASED.cast(this).a.isArrayOrNullableArray()
+                    && psiElement.parent is KtIsExpression
 
         private fun PsiElement.isOnJvm(): Boolean = safeAs<KtElement>()?.platform.isJvm()
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -1591,6 +1591,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
                 runTest("testData/quickfix/addStarProjections/checkType/array.kt");
             }
 
+            @TestMetadata("arrayInWhen.kt")
+            public void testArrayInWhen() throws Exception {
+                runTest("testData/quickfix/addStarProjections/checkType/arrayInWhen.kt");
+            }
+
             @TestMetadata("changeToStarProjectionMultipleParameters.kt")
             public void testChangeToStarProjectionMultipleParameters() throws Exception {
                 runTest("testData/quickfix/addStarProjections/checkType/changeToStarProjectionMultipleParameters.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/addStarProjections/checkType/arrayInWhen.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addStarProjections/checkType/arrayInWhen.kt
@@ -1,0 +1,5 @@
+// "Change type arguments to <*>" "true"
+fun test(a: Any) = when (a) {
+    is <caret>Array<String> -> 1
+    else -> 2
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/addStarProjections/checkType/arrayInWhen.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/addStarProjections/checkType/arrayInWhen.kt.after
@@ -1,0 +1,5 @@
+// "Change type arguments to <*>" "true"
+fun test(a: Any) = when (a) {
+    is Array<*> -> 1
+    else -> 2
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-22306