### PR TITLE
Added ability to open file in active tab group regardless of the presence of the file in other tab groups

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.java
@@ -141,7 +141,8 @@ public abstract class FileEditorManagerImpl extends FileEditorManagerEx implemen
   public enum OpenMode {
     NEW_WINDOW,
     RIGHT_SPLIT,
-    DEFAULT
+    DEFAULT,
+    CURRENT_EDITOR
   }
 
   private volatile @Nullable EditorsSplitters mySplitters;
@@ -797,6 +798,12 @@ public abstract class FileEditorManagerImpl extends FileEditorManagerEx implemen
         Pair<FileEditor[], FileEditorProvider[]> pair = openInRightSplit(file);
         if (pair != null) return pair;
       }
+      if(mode == OpenMode.CURRENT_EDITOR) {
+        EditorWindow activeCurrentWindow = getActiveSplittersSync().getCurrentWindow();
+        if(activeCurrentWindow != null) {
+          return openFileImpl2(activeCurrentWindow, file, options);
+        }
+      }
     }
 
     EditorWindow windowToOpenIn = window;
@@ -904,6 +911,7 @@ public abstract class FileEditorManagerImpl extends FileEditorManagerEx implemen
         if (strings.contains(ACTION_OPEN_IN_NEW_WINDOW)) return OpenMode.NEW_WINDOW;
         if (strings.contains(ACTION_OPEN_IN_RIGHT_SPLIT)) return OpenMode.RIGHT_SPLIT;
       }
+      if (ke.isAltDown()) return OpenMode.CURRENT_EDITOR;
     }
 
     return OpenMode.DEFAULT;


### PR DESCRIPTION
This attempts to add back functionality that was present in intellij some time ago.
Previously on OpenFile/Project/* Modal you used be able to open file in active pane using Alt+Shift+Enter
It's very annoying when instead of opening file in current tab group it's changing the file in the other tab group that was used specifically for context if target file happens to be in that tab group.
In case there are no other open file modifiers and alt is pressed it opens file in selected tab group.

This is my first public pr, I don't know much about the project.
There may be significant issues with this approach. 
Please point me in the right direction if there are issues.