### PR TITLE
Startup param parsing: do not break on first param

### DIFF
--- a/platform/platform-impl/src/com/intellij/idea/CommandLineArgs.java
+++ b/platform/platform-impl/src/com/intellij/idea/CommandLineArgs.java
@@ -16,11 +16,9 @@ public final class CommandLineArgs {
     for (String arg : args) {
       if (arg.equalsIgnoreCase(DISABLE_NON_BUNDLED_PLUGINS)) {
         IdeaPluginDescriptorImpl.disableNonBundledPlugins = true;
-        break;
       }
       else if (arg.equalsIgnoreCase(DONT_REOPEN_PROJECTS)) {
         RecentProjectsManagerBase.dontReopenProjects = true;
-        break;
       }
     }
   }


### PR DESCRIPTION
Startup param parsing is erroneously returning early on the first
recognized paramter. This limits the number of startup parameters
to just one.

The fix is to remove the "break" statements, which presumably is
a left over from an optimization when there was only one parameter.