### PR TITLE
[IDEA-300159] Redundant close(): Search closing statements in ending if statements

### DIFF
--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/afterLoneIf.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/afterLoneIf.java
@@ -1,0 +1,18 @@
+// "Remove redundant 'close()'" "true-preview"
+
+class MyAutoCloseable implements AutoCloseable {
+  @Override
+  public void close() {
+
+  }
+}
+
+class RemoveTry {
+  public static void main(String[] args) {
+    try(MyAutoCloseable ac = new MyAutoCloseable()) {
+      System.out.println("Number of parameters?");
+      if (args.length == 0) {
+      }
+    }
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/afterSubStatement.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/afterSubStatement.java
@@ -1,0 +1,21 @@
+// "Remove redundant 'close()'" "true-preview"
+
+class MyAutoCloseable implements AutoCloseable {
+  @Override
+  public void close() {
+
+  }
+}
+
+class RemoveTry {
+  public static void main(String[] args) {
+    try(MyAutoCloseable ac = new MyAutoCloseable()) {
+      if (args.length == 0) {
+        System.out.println("No parameters");
+      } else if (args.length == 1) {
+        System.out.println("One parameter: " + args[0]);
+      } else if (args.length > 1) {
+      }
+    }
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/beforeLoneIf.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/beforeLoneIf.java
@@ -1,0 +1,17 @@
+// "Remove redundant 'close()'" "true-preview"
+
+class MyAutoCloseable implements AutoCloseable {
+  @Override
+  public void close() {
+
+  }
+}
+
+class RemoveTry {
+  public static void main(String[] args) {
+    try(MyAutoCloseable ac = new MyAutoCloseable()) {
+      System.out.println("Number of parameters?");
+      if (args.length == 0) ac.close<caret>();
+    }
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/beforeSubStatement.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantExplicitClose/beforeSubStatement.java
@@ -1,0 +1,22 @@
+// "Remove redundant 'close()'" "true-preview"
+
+class MyAutoCloseable implements AutoCloseable {
+  @Override
+  public void close() {
+
+  }
+}
+
+class RemoveTry {
+  public static void main(String[] args) {
+    try(MyAutoCloseable ac = new MyAutoCloseable()) {
+      if (args.length == 0) {
+        System.out.println("No parameters");
+        ac.close<caret>();
+      } else if (args.length == 1) {
+        System.out.println("One parameter: " + args[0]);
+      } else if (args.length > 1) {
+      }
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/redundantExplicitClose/RedundantExplicitClose.java
+++ b/java/java-tests/testData/inspection/redundantExplicitClose/RedundantExplicitClose.java
@@ -1,0 +1,21 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+class MyAutoCloseable implements AutoCloseable {
+  @Override
+  public void close() {
+
+  }
+}
+
+class C {
+  public static void main(String[] args) {
+    try(MyAutoCloseable ac = new MyAutoCloseable()) {
+      if (args.length == 0) {
+        System.out.println("No parameters");
+        <warning descr="Redundant 'close()'">ac.close();</warning>
+      } else if (args.length == 1) {
+        System.out.println("One parameter: " + args[0]);
+      } else if (args.length > 1) {
+      }
+    }
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/codeInsight/daemon/impl/quickfix/RedundantExplicitCloseFixTest.java
+++ b/java/java-tests/testSrc/com/intellij/codeInsight/daemon/impl/quickfix/RedundantExplicitCloseFixTest.java
@@ -6,8 +6,7 @@ import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.RedundantExplicitCloseInspection;
 import org.jetbrains.annotations.NotNull;
 
-
-public class RedundantExplicitCloseInspectionTest extends LightQuickFixParameterizedTestCase {
+public class RedundantExplicitCloseFixTest extends LightQuickFixParameterizedTestCase {
   @Override
   protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
     return new LocalInspectionTool[]{

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantExplicitCloseInspectionTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantExplicitCloseInspectionTest.java
@@ -1,0 +1,23 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.java.codeInspection;
+
+import com.intellij.JavaTestUtil;
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.codeInspection.RedundantExplicitCloseInspection;
+import com.siyeh.ig.LightJavaInspectionTestCase;
+import org.jetbrains.annotations.Nullable;
+
+public class RedundantExplicitCloseInspectionTest extends LightJavaInspectionTestCase {
+  @Override
+  protected String getTestDataPath() {
+    return JavaTestUtil.getJavaTestDataPath() + "/inspection/redundantExplicitClose/";
+  }
+
+  @Nullable
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new RedundantExplicitCloseInspection();
+  }
+
+  public void testRedundantExplicitClose() { doTest(); }
+}


### PR DESCRIPTION
Hi @amaembo,

***What steps will reproduce the issue?***

1. Go to *File* → *Settings..*. → *Editor* → *Inspections*
2. Enable *Redundant close() usage*
3. Enable Severity: *Warning*
4. Add this method in a Java 7 class:

```Java
  try(AutoCloseable ac = new AutoCloseable() {
      @Override
      public void close() {
      }
    }) {
    foo();
    if (isValid) {
      bar();
      ac.close();
    }
  }
```

***What is the expected result?***
The inspection *Redundant 'close()'* is suggested.
***What happens instead?***
Nothing appears.

The inspection searches closing statements at the end of the `try` block, but in this ticket, we also parse if statements.

I have also added some unit tests that passed successfully.