### PR TITLE
Fix SourceDirs HashSet ordering for consistent GradleOutputDir

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/CommonGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/CommonGradleProjectResolverExtension.java
@@ -661,6 +661,7 @@ public final class CommonGradleProjectResolverExtension extends AbstractProjectR
   private static File getGradleOutputDir(@Nullable ExternalSourceDirectorySet sourceDirectorySet) {
     if (sourceDirectorySet == null) return null;
     String firstExistingLang = sourceDirectorySet.getSrcDirs().stream()
+      .sorted()
       .filter(File::exists)
       .findFirst()
       .map(File::getName)

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleFoldersImportingTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleFoldersImportingTest.java
@@ -758,6 +758,24 @@ public class GradleFoldersImportingTest extends GradleImportingTestCase {
   }
 
   @Test
+  @TargetVersions("4.1+")
+  public void testMultipleSourcesConsistencyCompilerOutput() throws Exception {
+    createProjectSubFile("src/main/java/A.java", "class A {}");
+    createProjectSubFile("src/main/kotlin/A.kt", "class A {}");
+    GradleBuildScriptBuilder buildScript = createBuildScriptBuilder()
+      .withMavenCentral()
+      .withKotlinJvmPlugin()
+      .withJavaLibraryPlugin();
+    importPerSourceSet(false);
+    importProject(buildScript.generate());
+    assertModules("project");
+    assertContentEntryExists("project");
+    assertSourceExists("project",
+                       "src/main/java","src/main/kotlin");
+    assertModuleOutput("project", getProjectPath() + "/build/classes/java/main", getProjectPath() + "/build/classes/java/test");
+  }
+
+  @Test
   public void testSharedSourceFolders() throws Exception {
     createProjectSubFile("settings.gradle", "include 'app1', 'app2'");
     createProjectSubFile("shared/resources/resource.txt");


### PR DESCRIPTION
### Context
Due to the recent merge of the `intellij-community` into `studio` we figure out that one of our tests snapshot tests started to be flaky due to the following commit introduced recently: https://github.com/JetBrains/intellij-community/commit/dff59a2d1944e020dcb4e4d2c176c9b9a3b79721

### Issue
Given that Gradle model can contain multiple output directories (for each language: java, scala, kotlin, etc.) right now with the above changes the `firstExistingLang` isn't always consistent on the different runs when project have multiple source directories. This is strictly linked of `findFirst()` of an HashSet that doesn't maintains the order of the elements, having the following:

- srcDirs java first
<img width="1136" alt="srcDirs java first" src="https://user-images.githubusercontent.com/18151158/185627156-7d5ed9ec-15b7-4a8e-b3c0-7d715edc8c71.png">

- srcDirs kotlin first
<img width="1195" alt="srcDirs kotlin first" src="https://user-images.githubusercontent.com/18151158/185627118-4db11a70-46b1-43c1-b8cb-82fcc0981bc0.png">

### Test
I added a specific test where this behaviour is now validated, given a project with `java library` and `kotlin` plugin applied assert that `compilerOutputUrl` and `CompilerOutputUrlForTests` are always the expected `java classesOutputPath`

### Next
For sure this part should be reconsidered in the future where probably `getGradleOutputDir` should return a list of files but until that will be great to keep consistency on the results
