### PR TITLE
IDEA-240111 use Gradle incremental task inputs/outputs to avoid re-running test tasks

### DIFF
--- a/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
+++ b/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
@@ -1,8 +1,3 @@
-import org.gradle.api.Task
-import org.gradle.api.tasks.Sync
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.testing.Test
-
 //file:noinspection GrPackage
 
 gradle.allprojects { project ->

--- a/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
+++ b/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
@@ -5,7 +5,7 @@ gradle.allprojects { project ->
     loggerTask.outputs.upToDateWhen { false }
 
     from(project.tasks.withType(Test)) {
-      include("**/*.xml")
+      include("**/ijLog*.xml")
     }
     into(loggerTask.temporaryDir)
 

--- a/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
+++ b/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
@@ -21,7 +21,7 @@ gradle.allprojects { project ->
         .sort { it.name }
         .eachWithIndex { file, i ->
           String msg = file.newReader().readLines().join("")
-          logger.lifecycle("[ijTestEventLogger] " + i + "/" + eventLogFiles.size() + ": " + msg)
+          logger.lifecycle("[ijTestEventLogger] " + (i + 1) + "/" + eventLogFiles.size() + " " + file.name + ": " + msg)
           println msg
         }
     }

--- a/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
+++ b/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
@@ -24,16 +24,9 @@ gradle.allprojects { project ->
           file.withReader { reader ->
             reader
               .readLines()
-              //.sort() // don't need to sort, because the log-writer is synchronized
+            //.sort() // don't need to sort, because the log-writer is synchronized
               .forEach { line ->
-                int index = line.indexOf('\t')
-                if (index > 0) {
-                  String msg = line.substring(index).trim()
-                  System.out.println(msg)
-                }
-                else {
-                  logger.warn("[ijTestEventLogger] invalid line $index - $line")
-                }
+                System.out.println(line)
               }
           }
         }

--- a/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
+++ b/plugins/gradle/java/resources/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle
@@ -5,24 +5,37 @@ gradle.allprojects { project ->
     loggerTask.outputs.upToDateWhen { false }
 
     from(project.tasks.withType(Test)) {
-      include("**/ijLog*.xml")
+      include("**/*.ij.log")
     }
     into(loggerTask.temporaryDir)
 
     doLast {
       List<File> eventLogFiles = new ArrayList<File>()
       loggerTask.destinationDir.eachFileRecurse(groovy.io.FileType.FILES) { File file ->
-        if (file.name.endsWith(".xml")) {
-          eventLogFiles.add(file)
-        }
+        eventLogFiles.add(file)
       }
 
       eventLogFiles
         .sort { it.name }
         .eachWithIndex { file, i ->
-          String msg = file.newReader().readLines().join("")
-          logger.lifecycle("[ijTestEventLogger] " + (i + 1) + "/" + eventLogFiles.size() + " " + file.name + ": " + msg)
-          println msg
+
+          logger.lifecycle("[ijTestEventLogger] $i " + file.name)
+
+          file.withReader { reader ->
+            reader
+              .readLines()
+              //.sort() // don't need to sort, because the log-writer is synchronized
+              .forEach { line ->
+                int index = line.indexOf('\t')
+                if (index > 0) {
+                  String msg = line.substring(index).trim()
+                  System.out.println(msg)
+                }
+                else {
+                  logger.warn("[ijTestEventLogger] invalid line $index - $line")
+                }
+              }
+          }
         }
     }
   }

--- a/plugins/gradle/java/src/service/project/JavaGradleProjectResolver.java
+++ b/plugins/gradle/java/src/service/project/JavaGradleProjectResolver.java
@@ -177,7 +177,7 @@ public class JavaGradleProjectResolver extends AbstractProjectResolverExtension 
     boolean testsWillBeExecuted = Boolean.parseBoolean(parameters.get(TEST_EXECUTION_EXPECTED_KEY));
     boolean testLauncherWillBeUsed = Boolean.parseBoolean(parameters.get(TEST_LAUNCHER_WILL_BE_USED_KEY));
     if (testsWillBeExecuted && !testLauncherWillBeUsed) {
-      String name = "/org/jetbrains/plugins/gradle/java/addTestListener.groovy";
+      String name = "/org/jetbrains/plugins/gradle/java/addTestListener.init.gradle";
       try (Reader reader = new InputStreamReader(getClass().getResourceAsStream(name), StandardCharsets.UTF_8)) {
         initScriptConsumer.consume(StreamUtil.readText(reader));
       }

--- a/plugins/gradle/java/testSources/execution/test/runner/GradleTestRunnerViewTest.kt
+++ b/plugins/gradle/java/testSources/execution/test/runner/GradleTestRunnerViewTest.kt
@@ -183,7 +183,10 @@ class GradleTestRunnerViewTest : GradleImportingTestCase() {
     } else {
       consoleTextWithoutFirstTestingGreetingsLine = consoleText
     }
-    assertThat(consoleTextWithoutFirstTestingGreetingsLine).contains(testOutputText)
+    assertThat(consoleTextWithoutFirstTestingGreetingsLine)
+      .describedAs("console text\n${consoleText.prependIndent("  > ")}\n")
+      .contains(testOutputText)
+
     val expectedText = if (SystemInfo.isWindows) {
       scriptOutputText + scriptOutputTextWOEol + "\n"
     } else {
@@ -192,18 +195,20 @@ class GradleTestRunnerViewTest : GradleImportingTestCase() {
       "text\n" +
       "text w/o eol\n"
     }
-    assertEquals(expectedText, consoleTextWithoutFirstTestingGreetingsLine.substringBefore(testOutputText))
+    assertEquals("console text\n${consoleText.prependIndent("  > ")}\n", expectedText, consoleTextWithoutFirstTestingGreetingsLine.substringBefore(testOutputText))
   }
 
   @Test
   fun `test build tw output for Gradle test runner execution`() {
     createProjectSubFile("src/test/java/my/pack/AppTest.java",
-                         "package my.pack;\n" +
-                         "import org.junit.Test;\n" +
-                         "public class AppTest {\n" +
-                         "    @Test\n" +
-                         "    public void test() {}\n" +
-                         "}\n")
+                         """
+package my.pack;
+import org.junit.Test;
+public class AppTest {
+    @Test
+    public void test() {}
+}
+""")
 
     importProject(createBuildScriptBuilder()
                     .withJavaPlugin()
@@ -229,6 +234,7 @@ class GradleTestRunnerViewTest : GradleImportingTestCase() {
         :processTestResources
         :testClasses
         :test
+        :ijTestEventLogger
       """.trimIndent()
     )
   }

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
@@ -4,11 +4,7 @@
 import groovy.xml.MarkupBuilder
 import org.gradle.api.Task
 import org.gradle.api.logging.Logging
-import org.gradle.api.tasks.testing.TestDescriptor
-import org.gradle.api.tasks.testing.TestListener
-import org.gradle.api.tasks.testing.TestOutputEvent
-import org.gradle.api.tasks.testing.TestOutputListener
-import org.gradle.api.tasks.testing.TestResult
+import org.gradle.api.tasks.testing.*
 
 class IJTestEventLogger {
 
@@ -22,6 +18,7 @@ class IJTestEventLogger {
       .optional(true)
 
     task.doFirst {
+      // delete previous test results
       testReportDir.deleteDir()
       testReportDir.mkdirs()
     }
@@ -136,19 +133,19 @@ class IJTestEventLogger {
   }
 
   static def wrap(String s) {
-    if(!s) return s;
-    s.replaceAll("\r\n|\n\r|\n|\r","<ijLogEol/>")
+    if (!s) return s;
+    s.replaceAll("\r\n|\n\r|\n|\r", "<ijLogEol/>")
   }
 
   static String writeLog(s) {
-    logger.lifecycle("[IJTestEventLogger] " + s)
+    //logger.lifecycle("[IJTestEventLogger] " + s)
     def msg = String.format("<ijLog>%s</ijLog>", wrap(s))
     //println msg
     return msg
   }
 
   static def logTestReportLocation(def report) {
-    if(!report) return
+    if (!report) return
     def writer = new StringWriter()
     def xml = new MarkupBuilder(writer)
     xml.event(type: 'reportLocation', testReport: report)
@@ -166,7 +163,7 @@ class IJTestEventLogger {
   }
 
   static def getStackTrace(Throwable t) {
-    if(!t) return ''
+    if (!t) return ''
     StringWriter sw = new StringWriter()
     t.printStackTrace(new PrintWriter(sw))
     sw.toString()
@@ -175,7 +172,8 @@ class IJTestEventLogger {
   static def getName(TestDescriptor descriptor) {
     try {
       return descriptor.getDisplayName() // available starting from ver. 4.10.3
-    } catch (Throwable ignore) {
+    }
+    catch (Throwable ignore) {
       return descriptor.getName()
     }
   }

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
@@ -143,7 +143,7 @@ class IJTestEventLogger {
   static String writeLog(s) {
     logger.lifecycle("[IJTestEventLogger] " + s)
     def msg = String.format("<ijLog>%s</ijLog>", wrap(s))
-    println msg
+    //println msg
     return msg
   }
 

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
@@ -11,7 +11,7 @@ class IJTestEventLogger {
   static def logger = Logging.getLogger("IJTestEventLogger")
 
   static def configureTestEventLogging(Task task) {
-    def testReportDir = task.temporaryDir.toPath().resolve("ijTestEvents/").toFile()
+    File testReportDir = task.temporaryDir.toPath().resolve("ijTestEvents/").toFile()
 
     task.outputs.dir(testReportDir)
       .withPropertyName("ijTestEvents")
@@ -123,27 +123,11 @@ class IJTestEventLogger {
       }
     }
 
-    // make sure that the logs are ordered by when they 'should' happen, because the test data doesn't always
-    // contain a start/end time, and currentTimeMillis might return the same timestamp for multiple events per test.
-    int order = 999
-    switch (testEventType) {
-      case "beforeSuite": order = 100
-        break;
-      case "beforeTest": order = 300
-        break;
-      case "afterTest": order = 600
-        break;
-      case "afterSuite": order = 800
-        break;
-      case "onOutput": order = 900
-        break;
-    }
-
     String log = writeLog(writer.toString())
-    appendTestLogFile(testReportDir, order, log)
+    appendTestLogFile(testReportDir, log)
   }
 
-  private static synchronized void appendTestLogFile(File testReportDir, int order, String msg) {
+  private static synchronized void appendTestLogFile(File testReportDir, String msg) {
 
     // group log files together by time so Gradle doesn't get flooded with tiny files,
     // and large files are too big to work with.
@@ -151,8 +135,6 @@ class IJTestEventLogger {
 
     File testXmlFile = testReportDir.toPath().resolve("${filename}.ij.log").toFile()
     if (!testXmlFile.isFile()) testXmlFile.createNewFile()
-
-    msg = System.currentTimeMillis() + "_" + order + " \t " + msg
 
     testXmlFile.withWriterAppend {
       it.writeLine(msg)

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
@@ -123,8 +123,24 @@ class IJTestEventLogger {
       }
     }
 
+    // make sure that the logs are ordered by when they 'should' happen, because the test data doesn't always
+    // contain a start/end time, and currentTimeMillis might return the same timestamp for multiple events per test.
+    int order = 999
+    switch (testEventType) {
+      case "beforeSuite": order = 100
+        break;
+      case "beforeTest": order = 300
+        break;
+      case "afterTest": order = 600
+        break;
+      case "afterSuite": order = 800
+        break;
+      case "onOutput": order = 900
+        break;
+    }
+
     String log = writeLog(writer.toString())
-    File xmlFile = testReportDir.toPath().resolve(System.currentTimeMillis() + "-" + log.md5() + ".xml").toFile()
+    File xmlFile = testReportDir.toPath().resolve("ijLog_" + System.currentTimeMillis() + "_" + order + "_" + log.md5() + ".xml").toFile()
     xmlFile.write(log)
   }
 

--- a/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
+++ b/plugins/gradle/resources/org/jetbrains/plugins/gradle/IJTestLogger.groovy
@@ -140,8 +140,23 @@ class IJTestEventLogger {
     }
 
     String log = writeLog(writer.toString())
-    File xmlFile = testReportDir.toPath().resolve("ijLog_" + System.currentTimeMillis() + "_" + order + "_" + log.md5() + ".xml").toFile()
-    xmlFile.write(log)
+    appendTestLogFile(testReportDir, order, log)
+  }
+
+  private static synchronized void appendTestLogFile(File testReportDir, int order, String msg) {
+
+    // group log files together by time so Gradle doesn't get flooded with tiny files,
+    // and large files are too big to work with.
+    String filename = System.currentTimeSeconds().toString().dropRight(2)
+
+    File testXmlFile = testReportDir.toPath().resolve("${filename}.ij.log").toFile()
+    if (!testXmlFile.isFile()) testXmlFile.createNewFile()
+
+    msg = System.currentTimeMillis() + "_" + order + " \t " + msg
+
+    testXmlFile.withWriterAppend {
+      it.writeLine(msg)
+    }
   }
 
   static String escapeCdata(String s) {

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilterInit.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilterInit.gradle
@@ -1,21 +1,34 @@
 //file:noinspection GrPackage
-
+//@formatter:off
 String[] ijTestIncludes = ${TEST_NAME_INCLUDES}
+//@formatter:on
+
+logger.lifecycle("[testFilterInit.gradle] ijTestIncludes = " + ijTestIncludes.join(", "))
 
 Class abstractTestTaskClass = null
 try {
   abstractTestTaskClass = Class.forName("org.gradle.api.tasks.testing.AbstractTestTask")
 } catch (ClassNotFoundException ex) {
- // ignore, class not available
+  // ignore, class not available
 }
 
 gradle.taskGraph.whenReady { taskGraph ->
   taskGraph.allTasks.each { Task task ->
     if (task instanceof Test || (abstractTestTaskClass != null && abstractTestTaskClass.isAssignableFrom(task.class))) {
+
+      logger.lifecycle("[testFilterInit.gradle] configuring " + task.name + " to have input: " + ijTestIncludes.join(", "))
+      task.inputs.property("ijTestIncludes", ijTestIncludes)
+
       try {
-        task.outputs.upToDateWhen { false }
+        if (task.extensions.extraProperties.has("disableIntellijForceTests")){
+          logger.warn("[testFilterInit.gradle] NOT forcing tests to run")
+        } else (!task.hasProperty("disableIntellijForceTests")) {
+          logger.warn("[testFilterInit.gradle] forcing tests to run")
+
+          task.outputs.upToDateWhen { false }
+        }
         String[] strings = ['*']
-        if(ijTestIncludes.size() > 0 && ijTestIncludes != strings) {
+        if (ijTestIncludes.size() > 0 && ijTestIncludes != strings) {
           def filter = task.getFilter()
           filter.setIncludePatterns(new String[0])
           ijTestIncludes.each() {

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilterInit.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilterInit.gradle
@@ -8,25 +8,15 @@ logger.lifecycle("[testFilterInit.gradle] ijTestIncludes = " + ijTestIncludes.jo
 Class abstractTestTaskClass = null
 try {
   abstractTestTaskClass = Class.forName("org.gradle.api.tasks.testing.AbstractTestTask")
-} catch (ClassNotFoundException ex) {
+}
+catch (ClassNotFoundException ex) {
   // ignore, class not available
 }
 
 gradle.taskGraph.whenReady { taskGraph ->
   taskGraph.allTasks.each { Task task ->
     if (task instanceof Test || (abstractTestTaskClass != null && abstractTestTaskClass.isAssignableFrom(task.class))) {
-
-      logger.lifecycle("[testFilterInit.gradle] configuring " + task.name + " to have input: " + ijTestIncludes.join(", "))
-      task.inputs.property("ijTestIncludes", ijTestIncludes)
-
       try {
-        if (task.extensions.extraProperties.has("disableIntellijForceTests")){
-          logger.warn("[testFilterInit.gradle] NOT forcing tests to run")
-        } else (!task.hasProperty("disableIntellijForceTests")) {
-          logger.warn("[testFilterInit.gradle] forcing tests to run")
-
-          task.outputs.upToDateWhen { false }
-        }
         String[] strings = ['*']
         if (ijTestIncludes.size() > 0 && ijTestIncludes != strings) {
           def filter = task.getFilter()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-240111

This PR demonstrates how IntelliJ can use [Gradle task inputs/outputs](https://docs.gradle.org/7.5.1/userguide/more_about_tasks.html#sec:up_to_date_checks) to avoid re-running tasks that have not changed.

I feel this change is really important, as Gradle incremental build is a really powerful tool. Implementing this change (once it is tidied up and has tests!) would have a huge impact on users, as their workflow would become faster. Additionally the power requirements of repeatedly re-running the same tests would be avoided, helping reduce energy usage worldwide.

### Summary

`IJTestEventLogger` now creates an output directory property, `ijTestEvents`. Instead of printing the XML task update to stdout, it logs it to the output directory. The files are named by timestamp and test-event type so they can be ordered. (I added an md5 checksum just in case there's a clash - but there's probably a better solution.)

The init script also registers a new task, `ijTestEventLogger`, which captures the XML output of all test tasks. It then prints the XML to stdout, which is picked up by IntelliJ.

`ijTestEventLogger` is set to always run (it is never up-to-date), and is a [finalizer task](https://docs.gradle.org/7.5.1/userguide/more_about_tasks.html#sec:finalizer_tasks) so it will always run, no matter if the test tasks pass or fail.

### Potential Improvements

* This update makes the visuals a little strange, because IntelliJ doesn't live update tests like it did before. It waits for all tests in a subproject to run before updating them all very quickly. Perhaps still continue printing lines from each test task, but in the new `ijTestEventLogger` task use incremental inputs to only print files when their status is 'MODIFIED', not 'ADDED'?
* Further performance improvements:  Perhaps use the Workers API to split the read/write load up? Find a better way to save/load files? Coroutines? AsynchronousFileChannel?

### Other changes 

* renamed `addTestListener.groovy` to `addTestListener.init.gradle` (better IDE integration)
 
### TODO

- [x] Improve performance. It's very bad at the moment when there is a lot of output logged, because this creates a large number of XML files. Gradle has to fingerprint them all Perhaps create one file per test-id+event type, and append each test event to that file? Then split the file later.
- [ ] Remove debug logging
- [ ] Add the same logic for `logTestReportLocation()`, `logConfigurationError()`
- [ ] Check if `KotlinMppTestLogger` and the Android version need to be updated too (although I think these should be done in separate PRs)
- [ ] Create a ticket to create an [init script plugin](https://docs.gradle.org/current/userguide/init_scripts.html#sec:init_script_plugins) (working with Groovy is pretty rough, and it's very difficult to test)
