### PR TITLE
KTIJ-19935 False positive "Unused symbol" for enum entry with imported `values` synthetic function

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
@@ -508,8 +508,11 @@ class UnusedSymbolInspection : AbstractKotlinInspection() {
             true,
             KtTypeReference::class.java,
             KtQualifiedExpression::class.java,
-            KtCallableReferenceExpression::class.java
-        ) ?: return false
+            KtCallableReferenceExpression::class.java,
+            KtImportDirective::class.java,
+        )?.let {
+            it.getStrictParentOfType<KtImportDirective>() ?: it
+        } ?: return false
         return parent.isReferenceToBuiltInEnumFunction()
     }
 

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/Utils.kt
@@ -257,6 +257,14 @@ fun KtElement.isReferenceToBuiltInEnumFunction(): Boolean {
 
         is KtCallExpression -> this.calleeExpression?.text in ENUM_STATIC_METHODS
         is KtCallableReferenceExpression -> this.callableReference.text in ENUM_STATIC_METHODS
+        is KtImportDirective -> {
+            val importedFqName = this.importedFqName
+            val enumStaticMethods = when {
+                importedFqName != null && importPath?.isAllUnder == true -> ENUM_STATIC_METHODS.map { FqName("$importedFqName.$it") }
+                else -> listOfNotNull(importedFqName)
+            }
+            enumStaticMethods.isNotEmpty() && containingFile.anyDescendantOfType<KtCallExpression> { it.isCalling(enumStaticMethods) }
+        }
         else -> false
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -16461,6 +16461,21 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunction9.kt");
         }
 
+        @TestMetadata("usedEnumFunctionWithImport.kt")
+        public void testUsedEnumFunctionWithImport() throws Exception {
+            runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport.kt");
+        }
+
+        @TestMetadata("usedEnumFunctionWithImport2.kt")
+        public void testUsedEnumFunctionWithImport2() throws Exception {
+            runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport2.kt");
+        }
+
+        @TestMetadata("usedEnumFunctionWithImport3.kt")
+        public void testUsedEnumFunctionWithImport3() throws Exception {
+            runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport3.kt");
+        }
+
         @TestMetadata("usedEnumFunctionWithNestedEnum.kt")
         public void testUsedEnumFunctionWithNestedEnum() throws Exception {
             runTest("testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithNestedEnum.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+import E.*
+
+enum class E {
+    <caret>X
+}
+
+fun test() {
+    values()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport2.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+package foo.bar.baz
+
+import foo.bar.baz.E.*
+
+enum class E {
+    <caret>X
+}
+
+fun test() {
+    values()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/unusedSymbol/usedEnumFunctionWithImport3.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+package foo.bar.baz
+
+import foo.bar.baz.E.valueOf
+
+enum class E {
+    <caret>X
+}
+
+fun test() {
+    valueOf("")
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-19935