### PR TITLE
[KTIJ-1742] Readd intentions to convert between trimIndent and trimMargin

### DIFF
--- a/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
@@ -1695,6 +1695,7 @@ convert.to.0.unsafecast.1=Convert to ''{0}.unsafeCast<{1}>()''
 convert.to.unsafecast.call=Convert to unsafeCast() call
 convert.to.array.parameter=Convert to array parameter
 convert.to.assignment.expression=Converts the assignment statement to an expression
+convert.to.trim.margin=Convert to trimMargin() call
 create.kotlin.subclass=Create Kotlin subclass
 use.destructuring.declaration=Use destructuring declaration
 implement.as.constructor.parameter=Implement as constructor parameter

--- a/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
@@ -1695,6 +1695,7 @@ convert.to.0.unsafecast.1=Convert to ''{0}.unsafeCast<{1}>()''
 convert.to.unsafecast.call=Convert to unsafeCast() call
 convert.to.array.parameter=Convert to array parameter
 convert.to.assignment.expression=Converts the assignment statement to an expression
+convert.to.trim.indent=Convert to trimIndent() call
 convert.to.trim.margin=Convert to trimMargin() call
 create.kotlin.subclass=Create Kotlin subclass
 use.destructuring.declaration=Use destructuring declaration

--- a/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimIndentToTrimMarginIntention/after.kt.template
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimIndentToTrimMarginIntention/after.kt.template
@@ -1,0 +1,7 @@
+fun foo() {
+    <spot>val x =
+        """
+            a
+            b
+        """.trimIndent()</spot>
+}

--- a/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimIndentToTrimMarginIntention/before.kt.template
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimIndentToTrimMarginIntention/before.kt.template
@@ -1,0 +1,7 @@
+fun foo() {
+    <spot>val x =
+        """
+            |a
+            |b
+        """.trimMargin()</spot>
+}

--- a/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimIndentToTrimMarginIntention/description.html
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimIndentToTrimMarginIntention/description.html
@@ -1,0 +1,6 @@
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<html>
+<body>
+Converts an <code>trimIndent()</code> call to an <code>trimMargin()</code> call.
+</body>
+</html>

--- a/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimMarginToTrimIndentIntention/after.kt.template
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimMarginToTrimIndentIntention/after.kt.template
@@ -1,0 +1,7 @@
+fun foo() {
+    <spot>val x =
+        """
+            |a
+            |b
+        """.trimMargin()</spot>
+}

--- a/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimMarginToTrimIndentIntention/before.kt.template
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimMarginToTrimIndentIntention/before.kt.template
@@ -1,0 +1,7 @@
+fun foo() {
+    <spot>val x =
+        """
+            a
+            b
+        """.trimIndent()</spot>
+}

--- a/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimMarginToTrimIndentIntention/description.html
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/intentionDescriptions/ConvertTrimMarginToTrimIndentIntention/description.html
@@ -1,0 +1,6 @@
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<html>
+<body>
+Converts a <code>trimMargin()</code> call to a <code>trimIndent()</code> call.
+</body>
+</html>

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTrimIndentToTrimMarginIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTrimIndentToTrimMarginIntention.kt
@@ -1,0 +1,53 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.intentions
+
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
+import org.jetbrains.kotlin.idea.codeinsight.api.classic.intentions.SelfTargetingIntention
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+class ConvertTrimIndentToTrimMarginIntention : SelfTargetingIntention<KtCallExpression>(
+    KtCallExpression::class.java, KotlinBundle.lazyMessage("convert.to.trim.margin")
+) {
+    override fun isApplicableTo(element: KtCallExpression, caretOffset: Int): Boolean {
+        val template = (element.getQualifiedExpressionForSelector()?.receiverExpression as? KtStringTemplateExpression) ?: return false
+        if (!template.text.startsWith("\"\"\"")) return false
+
+        val callee = element.calleeExpression ?: return false
+        if (callee.text != "trimIndent" || callee.getCallableDescriptor()?.fqNameSafe != FqName("kotlin.text.trimIndent")) return false
+
+        val entries = template.entries
+        return listOfNotNull(entries.firstOrNull(), entries.lastOrNull()).all { it.text.isLineBreakOrBlank() }
+    }
+
+    override fun applyTo(element: KtCallExpression, editor: Editor?) {
+        val qualifiedExpression = element.getQualifiedExpressionForSelector()
+        val template = (qualifiedExpression?.receiverExpression as? KtStringTemplateExpression) ?: return
+
+        val indent = template.entries.asSequence().mapNotNull { stringTemplateEntry ->
+            val text = stringTemplateEntry.text
+            if (text.isLineBreakOrBlank()) null else text.takeWhile { it.isWhitespace() }
+        }.minByOrNull { it.length } ?: ""
+
+        val newTemplate = buildString {
+            template.entries.forEach { entry ->
+                val text = entry.text
+                if (text.isLineBreakOrBlank()) {
+                    append(text)
+                } else {
+                    append(indent)
+                    append("|")
+                    append(text.drop(indent.length))
+                }
+            }
+        }
+        qualifiedExpression.replace(KtPsiFactory(element).createExpression("\"\"\"$newTemplate\"\"\".trimMargin()"))
+    }
+}
+
+private fun String.isLineBreakOrBlank() = this == "\n" || this.isBlank()

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTrimMarginToTrimIndentIntention.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertTrimMarginToTrimIndentIntention.kt
@@ -1,0 +1,73 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.intentions
+
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
+import org.jetbrains.kotlin.idea.codeinsight.api.classic.intentions.SelfTargetingIntention
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+class ConvertTrimMarginToTrimIndentIntention : SelfTargetingIntention<KtCallExpression>(
+    KtCallExpression::class.java, KotlinBundle.lazyMessage("convert.to.trim.indent")
+) {
+    override fun isApplicableTo(element: KtCallExpression, caretOffset: Int): Boolean {
+        val template = (element.getQualifiedExpressionForSelector()?.receiverExpression as? KtStringTemplateExpression) ?: return false
+        if (!template.text.startsWith("\"\"\"")) return false
+
+        val callee = element.calleeExpression ?: return false
+        if (callee.text != "trimMargin" || callee.getCallableDescriptor()?.fqNameSafe != FqName("kotlin.text.trimMargin")) return false
+
+        val marginPrefix = element.marginPrefix() ?: return false
+
+        val entries = template.entries
+        if (!listOfNotNull(entries.firstOrNull(), entries.lastOrNull()).all { it.text.isLineBreakOrBlank() }) {
+            return false
+        }
+
+        return entries.drop(1).dropLast(1).all { stringTemplateEntry ->
+            val text = stringTemplateEntry.text
+            text.isLineBreakOrBlank() || text.dropWhile { it.isWhitespace() }.startsWith(marginPrefix)
+        }
+    }
+
+    override fun applyTo(element: KtCallExpression, editor: Editor?) {
+        val qualifiedExpression = element.getQualifiedExpressionForSelector()
+        val template = (qualifiedExpression?.receiverExpression as? KtStringTemplateExpression) ?: return
+        val marginPrefix = element.marginPrefix() ?: return
+
+        val indent = template.entries.asSequence().mapNotNull { stringTemplateEntry ->
+            val text = stringTemplateEntry.text
+            if (text.isLineBreakOrBlank()) null else text.takeWhile { it.isWhitespace() }
+        }.minBy { it.length } ?: ""
+
+        val newTemplate = buildString {
+            template.entries.forEach { entry ->
+                val text = entry.text
+                if (text.isLineBreakOrBlank()) {
+                    append(text)
+                } else {
+                    append(indent)
+                    append(entry.text.dropWhile { it.isWhitespace() }.replaceFirst(marginPrefix, ""))
+                }
+            }
+        }
+        qualifiedExpression.replace(KtPsiFactory(element).createExpression("\"\"\"$newTemplate\"\"\".trimIndent()"))
+    }
+}
+
+private fun KtCallExpression.marginPrefix(): String? {
+    val argument = valueArguments.firstOrNull()?.getArgumentExpression()
+    if (argument != null) {
+        if (argument !is KtStringTemplateExpression) return null
+        val entry = argument.entries.toList().singleOrNull() as? KtLiteralStringTemplateEntry ?: return null
+        return entry.text.replace("\"", "")
+    }
+    return "|"
+}
+
+private fun String.isLineBreakOrBlank() = this == "\n" || this.isBlank()

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -9405,6 +9405,39 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("testData/intentions/convertTrimIndentToTrimMargin")
+    public static class ConvertTrimIndentToTrimMargin extends AbstractIntentionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        @TestMetadata("differentIndent.kt")
+        public void testDifferentIndent() throws Exception {
+            runTest("testData/intentions/convertTrimIndentToTrimMargin/differentIndent.kt");
+        }
+
+        @TestMetadata("notBlankFirst.kt")
+        public void testNotBlankFirst() throws Exception {
+            runTest("testData/intentions/convertTrimIndentToTrimMargin/notBlankFirst.kt");
+        }
+
+        @TestMetadata("notBlankLast.kt")
+        public void testNotBlankLast() throws Exception {
+            runTest("testData/intentions/convertTrimIndentToTrimMargin/notBlankLast.kt");
+        }
+
+        @TestMetadata("notRawString.kt")
+        public void testNotRawString() throws Exception {
+            runTest("testData/intentions/convertTrimIndentToTrimMargin/notRawString.kt");
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            runTest("testData/intentions/convertTrimIndentToTrimMargin/simple.kt");
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("testData/intentions/convertTryFinallyToUseCall")
     public static class ConvertTryFinallyToUseCall extends AbstractIntentionTest {
         private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -9438,6 +9438,59 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("testData/intentions/convertTrimMarginToTrimIndent")
+    public static class ConvertTrimMarginToTrimIndent extends AbstractIntentionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        @TestMetadata("differentIndent.kt")
+        public void testDifferentIndent() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/differentIndent.kt");
+        }
+
+        @TestMetadata("escapedMarginPrefixArgument.kt")
+        public void testEscapedMarginPrefixArgument() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/escapedMarginPrefixArgument.kt");
+        }
+
+        @TestMetadata("noMarginPrefix.kt")
+        public void testNoMarginPrefix() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/noMarginPrefix.kt");
+        }
+
+        @TestMetadata("notBlankFirst.kt")
+        public void testNotBlankFirst() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/notBlankFirst.kt");
+        }
+
+        @TestMetadata("notBlankLast.kt")
+        public void testNotBlankLast() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/notBlankLast.kt");
+        }
+
+        @TestMetadata("notRawString.kt")
+        public void testNotRawString() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/notRawString.kt");
+        }
+
+        @TestMetadata("referenceMarginPrefixArgument.kt")
+        public void testReferenceMarginPrefixArgument() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/referenceMarginPrefixArgument.kt");
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/simple.kt");
+        }
+
+        @TestMetadata("simple2.kt")
+        public void testSimple2() throws Exception {
+            runTest("testData/intentions/convertTrimMarginToTrimIndent/simple2.kt");
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("testData/intentions/convertTryFinallyToUseCall")
     public static class ConvertTryFinallyToUseCall extends AbstractIntentionTest {
         private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/.intention
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/.intention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.intentions.ConvertTrimIndentToTrimMarginIntention

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/differentIndent.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/differentIndent.kt
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                a
+                    b
+                        c
+            """.<caret>trimIndent()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/differentIndent.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/differentIndent.kt.after
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                |a
+                |    b
+                |        c
+            """.trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/notBlankFirst.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/notBlankFirst.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x =
+        """1
+                a
+                b
+            """.<caret>trimIndent()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/notBlankLast.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/notBlankLast.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                a
+                b
+            1""".<caret>trimIndent()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/notRawString.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/notRawString.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x = "   a".<caret>trimIndent()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/simple.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/simple.kt
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// INTENTION_TEXT: "Convert to trimMargin() call"
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                a
+                b
+            """.<caret>trimIndent()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/simple.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimIndentToTrimMargin/simple.kt.after
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// INTENTION_TEXT: "Convert to trimMargin() call"
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                |a
+                |b
+            """.trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/.intention
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/.intention
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.intentions.ConvertTrimMarginToTrimIndentIntention

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/differentIndent.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/differentIndent.kt
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                |a
+                    |    b
+                        |c
+            """.<caret>trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/differentIndent.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/differentIndent.kt.after
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                a
+                    b
+                c
+            """.trimIndent()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/escapedMarginPrefixArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/escapedMarginPrefixArgument.kt
@@ -1,0 +1,10 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                \a
+                \b
+            """.<caret>trimMargin("\\")
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/noMarginPrefix.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/noMarginPrefix.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                |a
+                b
+            """.<caret>trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/notBlankFirst.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/notBlankFirst.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x =
+        """1
+                |a
+                |b
+            """.<caret>trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/notBlankLast.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/notBlankLast.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                |a
+                |b
+            1"""<caret>.trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/notRawString.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/notRawString.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test() {
+    val x = "   |a".<caret>trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/referenceMarginPrefixArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/referenceMarginPrefixArgument.kt
@@ -1,0 +1,9 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun test(marginPrefix: String) {
+    val x =
+        """
+                |a
+                |b
+            """.<caret>trimMargin(marginPrefix)
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple.kt
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// INTENTION_TEXT: "Convert to trimIndent() call"
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                |a
+                |b
+            """.<caret>trimMargin()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple.kt.after
@@ -1,0 +1,10 @@
+// AFTER-WARNING: Variable 'x' is never used
+// INTENTION_TEXT: "Convert to trimIndent() call"
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                a
+                b
+            """.trimIndent()
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple2.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple2.kt
@@ -1,0 +1,9 @@
+// AFTER-WARNING: Variable 'x' is never used
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                #a
+                #b
+            """.<caret>trimMargin("#")
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple2.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertTrimMarginToTrimIndent/simple2.kt.after
@@ -1,0 +1,9 @@
+// AFTER-WARNING: Variable 'x' is never used
+// WITH_STDLIB
+fun test() {
+    val x =
+        """
+                a
+                b
+            """.trimIndent()
+}

--- a/plugins/kotlin/plugin/k1/resources/META-INF/inspections-fe10.xml
+++ b/plugins/kotlin/plugin/k1/resources/META-INF/inspections-fe10.xml
@@ -925,6 +925,13 @@
     </intentionAction>
 
     <intentionAction>
+      <className>org.jetbrains.kotlin.idea.intentions.ConvertTrimIndentToTrimMarginIntention</className>
+      <category>Kotlin</category>
+      <bundleName>messages.KotlinBundle</bundleName>
+      <categoryKey>group.names.kotlin</categoryKey>
+    </intentionAction>
+
+    <intentionAction>
       <language>kotlin</language>
       <className>org.jetbrains.kotlin.idea.intentions.ConvertPropertyGetterToInitializerIntention</className>
       <bundleName>messages.KotlinBundle</bundleName>

--- a/plugins/kotlin/plugin/k1/resources/META-INF/inspections-fe10.xml
+++ b/plugins/kotlin/plugin/k1/resources/META-INF/inspections-fe10.xml
@@ -925,6 +925,13 @@
     </intentionAction>
 
     <intentionAction>
+      <className>org.jetbrains.kotlin.idea.intentions.ConvertTrimMarginToTrimIndentIntention</className>
+      <category>Kotlin</category>
+      <bundleName>messages.KotlinBundle</bundleName>
+      <categoryKey>group.names.kotlin</categoryKey>
+    </intentionAction>
+
+    <intentionAction>
       <className>org.jetbrains.kotlin.idea.intentions.ConvertTrimIndentToTrimMarginIntention</className>
       <category>Kotlin</category>
       <bundleName>messages.KotlinBundle</bundleName>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-1742/Intention-which-converts-trimIndent-to-trimMargin-isnt-shown

All tests fail with `// ERROR: Unresolved reference: trimIndent` or `trimMargin` and I don't know what could be the reason for that.
Any help with that would be appreciated.