### PR TITLE
KTIJ-22470 False positive 'Redundant qualifier name' caused by property and object' property with the same name

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/expressionExt.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/expressionExt.kt
@@ -8,7 +8,6 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiMethod
-import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
@@ -55,8 +54,9 @@ fun KtNamedDeclaration.nameIdentifierTextRangeInThis(): TextRange? = nameIdentif
 fun PsiElement.hasComments(): Boolean = anyDescendantOfType<PsiComment>()
 
 fun KtDotQualifiedExpression.hasNotReceiver(): Boolean {
-    val element = getQualifiedElementSelector()?.mainReference?.resolve() ?: return false
-    return element is KtClassOrObject ||
+    val selector = getQualifiedElementSelector() ?: return false
+    val element = selector.mainReference?.resolve() ?: return false
+    return element is KtClassOrObject && selector.text !in listOf("copy", "toString", "hashCode", "equals") ||
             element is KtConstructor<*> ||
             element is KtCallableDeclaration && element.receiverTypeReference == null && (element.containingClassOrObject is KtObjectDeclaration?) ||
             element is PsiMember && element.hasModifier(JvmModifier.STATIC) ||

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10653,6 +10653,26 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariable2.kt");
         }
 
+        @TestMetadata("notApplicableSameNameVariableWithCopy.kt")
+        public void testNotApplicableSameNameVariableWithCopy() throws Exception {
+            runTest("testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithCopy.kt");
+        }
+
+        @TestMetadata("notApplicableSameNameVariableWithEquals.kt")
+        public void testNotApplicableSameNameVariableWithEquals() throws Exception {
+            runTest("testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithEquals.kt");
+        }
+
+        @TestMetadata("notApplicableSameNameVariableWithHashCode.kt")
+        public void testNotApplicableSameNameVariableWithHashCode() throws Exception {
+            runTest("testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithHashCode.kt");
+        }
+
+        @TestMetadata("notApplicableSameNameVariableWithToString.kt")
+        public void testNotApplicableSameNameVariableWithToString() throws Exception {
+            runTest("testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithToString.kt");
+        }
+
         @TestMetadata("notApplicableThis.kt")
         public void testNotApplicableThis() throws Exception {
             runTest("testData/inspectionsLocal/removeRedundantQualifierName/notApplicableThis.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithCopy.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithCopy.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+data class Foo(val name: String)
+
+object Bar {
+    val foo = Foo("foo")
+}
+
+object Test {
+    val foo = <caret>Bar.foo.copy(name = "foo2")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithEquals.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithEquals.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+data class Foo(val name: String)
+
+object Bar {
+    val foo = Foo("foo")
+}
+
+object Test {
+    val foo = <caret>Bar.foo.equals("")
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithHashCode.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithHashCode.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+data class Foo(val name: String)
+
+object Bar {
+    val foo = Foo("foo")
+}
+
+object Test {
+    val foo = <caret>Bar.foo.hashCode()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithToString.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/removeRedundantQualifierName/notApplicableSameNameVariableWithToString.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+data class Foo(val name: String)
+
+object Bar {
+    val foo = Foo("foo")
+}
+
+object Test {
+    val foo = <caret>Bar.foo.toString()
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-22470