### PR TITLE
[java-decompiler] DeadCodeHelper mergeBasicBlocks method (avoid dead loop )

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/code/DeadCodeHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/code/DeadCodeHelper.java
@@ -529,7 +529,7 @@ public final class DeadCodeHelper {
     while (true) {
 
       boolean merged = false;
-
+      int originBlocksCount = graph.getBlocks().size();
       for (BasicBlock block : graph.getBlocks()) {
 
         InstructionSequence seq = block.getSeq();
@@ -565,7 +565,9 @@ public final class DeadCodeHelper {
           }
         }
       }
-
+      if(graph.getBlocks().size() == originBlocksCount && merged){
+        break;
+      }
       if (!merged) {
         break;
       }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/code/DeadCodeHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/code/DeadCodeHelper.java
@@ -565,10 +565,7 @@ public final class DeadCodeHelper {
           }
         }
       }
-      if(graph.getBlocks().size() == originBlocksCount && merged){
-        break;
-      }
-      if (!merged) {
+      if (!merged || graph.getBlocks().size() == originBlocksCount) {
         break;
       }
     }


### PR DESCRIPTION
avoid dead loop when handle a special class file
[e.class.zip](https://github.com/JetBrains/intellij-community/files/9426605/e.class.zip)
.