### PR TITLE
IDEA-298773: Fix memory leak in GotoSymbolModel2

### DIFF
--- a/java/java-tests/testSrc/com/intellij/java/navigation/ModuleNavigationTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/navigation/ModuleNavigationTest.kt
@@ -32,7 +32,7 @@ class ModuleNavigationTest : LightJavaCodeInsightFixtureTestCase() {
 
   fun testGoToSymbol() {
     val file = myFixture.configureByText("module-info.java", "module my.mod.name { }")
-    val items = GotoSymbolModel2(myFixture.project).getElementsByName("my.mod.name", false, "my.mod")
+    val items = GotoSymbolModel2(myFixture.project, myFixture.testRootDisposable).getElementsByName("my.mod.name", false, "my.mod")
     assertThat(items).containsExactly((file as PsiJavaFile).moduleDeclaration!!)
   }
 }

--- a/platform/lang-impl/src/com/intellij/ide/actions/searcheverywhere/SymbolSearchEverywhereContributor.java
+++ b/platform/lang-impl/src/com/intellij/ide/actions/searcheverywhere/SymbolSearchEverywhereContributor.java
@@ -41,7 +41,7 @@ public class SymbolSearchEverywhereContributor extends AbstractGotoSEContributor
   @NotNull
   @Override
   protected FilteringGotoByModel<LanguageRef> createModel(@NotNull Project project) {
-    GotoSymbolModel2 model = new GotoSymbolModel2(project);
+    GotoSymbolModel2 model = new GotoSymbolModel2(project, this);
     if (myFilter != null) {
       model.setFilterItems(myFilter.getSelectedElements());
     }

--- a/platform/lang-impl/src/com/intellij/ide/util/gotoByName/GotoSymbolModel2.java
+++ b/platform/lang-impl/src/com/intellij/ide/util/gotoByName/GotoSymbolModel2.java
@@ -23,21 +23,21 @@ public class GotoSymbolModel2 extends FilteringGotoByModel<LanguageRef> {
   private String[] mySeparators;
   private final boolean myAllContributors;
 
-  public GotoSymbolModel2(@NotNull Project project, ChooseByNameContributor @NotNull [] contributors) {
+  public GotoSymbolModel2(@NotNull Project project, ChooseByNameContributor @NotNull [] contributors, @NotNull Disposable parentDisposable) {
     super(project, contributors);
     myAllContributors = false;
-    addEpListener(project);
+    addEpListener(parentDisposable);
   }
 
-  public GotoSymbolModel2(@NotNull Project project) {
+  public GotoSymbolModel2(@NotNull Project project, @NotNull Disposable parentDisposable) {
     super(project, new ChooseByNameContributor[0]);
     myAllContributors = true;
-    addEpListener(project);
+    addEpListener(parentDisposable);
   }
 
-  private void addEpListener(@NotNull Project project) {
+  private void addEpListener(@NotNull Disposable parentDisposable) {
     ChooseByNameContributor.CLASS_EP_NAME.addChangeListener(
-      () -> mySeparators = null, project);
+      () -> mySeparators = null, parentDisposable);
   }
 
   @Override

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/navigation/GotoWithMultipleLibrariesTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/navigation/GotoWithMultipleLibrariesTest.kt
@@ -54,7 +54,7 @@ class GotoWithMultipleLibrariesTest : AbstractMultiModuleTest() {
         }
 
         checkFiles({ project.allKotlinFiles() }) {
-            GotoCheck.checkGotoDirectives(GotoSymbolModel2(project), editor, nonProjectSymbols = true, checkNavigation = true)
+            GotoCheck.checkGotoDirectives(GotoSymbolModel2(project, testRootDisposable), editor, nonProjectSymbols = true, checkNavigation = true)
         }
     }
 


### PR DESCRIPTION
Use SymbolSearchEverywhereContributor instead of Project for the parent
disposable for the extension point listeners.