### PR TITLE
[IDEA-300969] Identical branches inspection: handle continue

### DIFF
--- a/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseBasicContinue.java
+++ b/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseBasicContinue.java
@@ -1,0 +1,14 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i) {
+    while (0 < i) {
+      i--;
+        System.out.println("Next iteration");
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueInDoWhile.java
+++ b/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueInDoWhile.java
@@ -1,0 +1,14 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i) {
+    do {
+      i--;
+        System.out.println("Next iteration");
+    } while(0 < i);
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueInFor.java
+++ b/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueInFor.java
@@ -1,0 +1,14 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work() {
+    for (int i = 0; i < 100; i++) {
+      System.out.println("Another statement");
+        System.out.println("Next iteration");
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueInForeach.java
+++ b/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueInForeach.java
@@ -1,0 +1,14 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i, List<String> texts) {
+    for (String text : texts) {
+      i--;
+        System.out.println("Next iteration");
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueLabel.java
+++ b/java/java-tests/testData/inspection/commonIfParts/afterImplicitElseContinueLabel.java
@@ -1,0 +1,14 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i) {
+    loop:while(0 < i) {
+      i--;
+        continue loop;
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseBadContinue.java
+++ b/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseBadContinue.java
@@ -1,0 +1,21 @@
+// "Collapse 'if' statement" "false"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i) {
+    outer:while(0 < i) {
+      i--;
+      while(i % 2 == 0)  {
+        i--;
+        if<caret>(i == 10)  {
+          System.out.println("Next iteration");
+          continue outer;
+        }
+        System.out.println("Next iteration");
+      }
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseBasicContinue.java
+++ b/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseBasicContinue.java
@@ -1,0 +1,18 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i) {
+    while (0 < i) {
+      i--;
+      if<caret>(i == 10)  {
+        System.out.println("Next iteration");
+        continue;
+      }
+      System.out.println("Next iteration");
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueInDoWhile.java
+++ b/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueInDoWhile.java
@@ -1,0 +1,18 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i) {
+    do {
+      i--;
+      if<caret>(i == 10)  {
+        System.out.println("Next iteration");
+        continue;
+      }
+      System.out.println("Next iteration");
+    } while(0 < i);
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueInFor.java
+++ b/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueInFor.java
@@ -1,0 +1,18 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work() {
+    for (int i = 0; i < 100; i++) {
+      System.out.println("Another statement");
+      if<caret>(i == 10) {
+        System.out.println("Next iteration");
+        continue;
+      }
+      System.out.println("Next iteration");
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueInForeach.java
+++ b/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueInForeach.java
@@ -1,0 +1,18 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i, List<String> texts) {
+    for (String text : texts) {
+      i--;
+      if<caret>(i == 10) {
+        System.out.println("Next iteration");
+        continue;
+      }
+      System.out.println("Next iteration");
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueLabel.java
+++ b/java/java-tests/testData/inspection/commonIfParts/beforeImplicitElseContinueLabel.java
@@ -1,0 +1,17 @@
+// "Collapse 'if' statement" "true"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work(int i) {
+    loop:while(0 < i) {
+      i--;
+      if<caret>(i == 10)  {
+        continue loop;
+      }
+      continue loop;
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/commonIfParts/beforeTooManyStatementAtTheEndOfLoop.java
+++ b/java/java-tests/testData/inspection/commonIfParts/beforeTooManyStatementAtTheEndOfLoop.java
@@ -1,0 +1,18 @@
+// "Collapse 'if' statement" "false"
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class IfStatementWithIdenticalBranches {
+  void work() {
+    for (int i = 0; i < 100; i++) {
+      if<caret>(i == 10) {
+        System.out.println("Next iteration");
+        continue;
+      }
+      System.out.println("Next iteration");
+      System.out.println("Another statement");
+    }
+  }
+}

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/IfStatementWithIdenticalBranchesInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/controlflow/IfStatementWithIdenticalBranchesInspection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2018 Dave Griffith, Bas Leijdekkers
+ * Copyright 2003-2022 Dave Griffith, Bas Leijdekkers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import static com.intellij.util.ObjectUtils.tryCast;
 public class IfStatementWithIdenticalBranchesInspection extends AbstractBaseJavaLocalInspectionTool {
   public boolean myHighlightWhenLastStatementIsCall = false;
 
-  private static final List<IfStatementInspector> ourInspectors = new ArrayList<>(Arrays.asList(
+  private static final List<IfStatementInspector> ourInspectors = Collections.unmodifiableList(Arrays.asList(
     ImplicitElse::inspect,
     ThenElse::inspect,
     ElseIf::inspect
@@ -613,7 +613,8 @@ public class IfStatementWithIdenticalBranchesInspection extends AbstractBaseJava
   @Nullable
   private static ImplicitElseData getIfWithImplicitElse(@NotNull PsiIfStatement ifStatement,
                                                         PsiStatement @NotNull [] thenStatements,
-                                                        boolean returnsNothing) {
+                                                        String jumpKeyword, boolean basicJumpStatement) {
+    if (!PsiKeyword.RETURN.equals(jumpKeyword) && !PsiKeyword.CONTINUE.equals(jumpKeyword)) return null;
     int statementsLength = thenStatements.length;
     if (statementsLength == 0) return null;
     PsiIfStatement currentIf = ifStatement;
@@ -641,21 +642,22 @@ public class IfStatementWithIdenticalBranchesInspection extends AbstractBaseJava
       if (enclosingIf == null) break;
       currentIf = enclosingIf;
     }
-    if(conditionHasSideEffects && ifStatement != currentIf) return null;
+    if (conditionHasSideEffects && ifStatement != currentIf) return null;
     // ensure it is last statements in method
     PsiElement parent = currentIf.getParent();
     if (!(parent instanceof PsiCodeBlock)) return null;
-    if (!(parent.getParent() instanceof PsiMethod)) return null;
-    if (!statements.isEmpty()) {
-      if (PsiTreeUtil.getNextSiblingOfType(statements.get(statements.size() - 1), PsiStatement.class) != null) return null;
+    if (PsiKeyword.RETURN.equals(jumpKeyword)) {
+      if (!(parent.getParent() instanceof PsiMethod)) return null;
+      if (!statements.isEmpty()) {
+        if (PsiTreeUtil.getNextSiblingOfType(statements.get(statements.size() - 1), PsiStatement.class) != null) return null;
+      }
     }
-    if (returnsNothing) {
-      // skip possible return;
+    if (PsiKeyword.CONTINUE.equals(jumpKeyword) && !(parent.getParent() instanceof PsiBlockStatement) && !(parent.getParent().getParent() instanceof PsiLoopStatement)) return null;
+    if (basicJumpStatement) {
+      // skip possible jump statement
       if (count == statementsLength || count == statementsLength - 1) return new ImplicitElseData(statements, currentIf);
     }
-    else {
-      if (count == statementsLength) return new ImplicitElseData(statements, currentIf);
-    }
+    else if (count == statementsLength) return new ImplicitElseData(statements, currentIf);
     return null;
   }
 
@@ -697,9 +699,17 @@ public class IfStatementWithIdenticalBranchesInspection extends AbstractBaseJava
                              @NotNull PsiIfStatement ifStatement) {
       if (elseBranch.length != 0 || thenBranch.length == 0) return null;
       PsiStatement lastThenStatement = thenBranch[thenBranch.length - 1];
-      if (!(lastThenStatement instanceof PsiReturnStatement)) return null;
-      boolean returnsNothing = ((PsiReturnStatement)lastThenStatement).getReturnValue() == null;
-      ImplicitElseData implicitElse = getIfWithImplicitElse(ifStatement, thenBranch, returnsNothing);
+      String jumpKeyword = null;
+      boolean basicJumpStatement = false;
+      if (lastThenStatement instanceof PsiReturnStatement) {
+        jumpKeyword = PsiKeyword.RETURN;
+        basicJumpStatement = ((PsiReturnStatement)lastThenStatement).getReturnValue() == null;
+      } else if (lastThenStatement instanceof PsiContinueStatement) {
+        jumpKeyword = PsiKeyword.CONTINUE;
+        basicJumpStatement = ((PsiContinueStatement)lastThenStatement).getLabelIdentifier() == null;
+      }
+      if (jumpKeyword == null) return null;
+      ImplicitElseData implicitElse = getIfWithImplicitElse(ifStatement, thenBranch, jumpKeyword, basicJumpStatement);
       if (implicitElse == null) return null;
       if (implicitElse.myImplicitElseStatements.isEmpty()) return null;
       if (implicitElse.myImplicitElseStatements.size() == 1) {
@@ -738,6 +748,14 @@ public class IfStatementWithIdenticalBranchesInspection extends AbstractBaseJava
       ExtractCommonIfPartsFix fix = new ExtractCommonIfPartsFix(type, false, isOnTheFly);
       return new IfInspectionResult(ifStatement.getFirstChild(), true, fix, type.getDescriptionMessage(false));
     }
+  }
+
+  @NotNull
+  private static LocalEquivalenceChecker getChecker(PsiStatement[] thenBranch, PsiStatement[] elseBranch) {
+    Set<PsiLocalVariable> localVariables = new HashSet<>();
+    addLocalVariables(localVariables, Arrays.asList(thenBranch));
+    addLocalVariables(localVariables, Arrays.asList(elseBranch));
+    return new LocalEquivalenceChecker(localVariables);
   }
 
   private static final class ThenElse {
@@ -785,14 +803,6 @@ public class IfStatementWithIdenticalBranchesInspection extends AbstractBaseJava
       }
       return ContainerUtil
         .or(headCommonParts, unit -> unit.haveSideEffects() && !(unit.getThenStatement() instanceof PsiDeclarationStatement));
-    }
-
-    @NotNull
-    private static LocalEquivalenceChecker getChecker(PsiStatement[] thenBranch, PsiStatement[] elseBranch) {
-      Set<PsiLocalVariable> localVariables = new HashSet<>();
-      addLocalVariables(localVariables, Arrays.asList(thenBranch));
-      addLocalVariables(localVariables, Arrays.asList(elseBranch));
-      return new LocalEquivalenceChecker(localVariables);
     }
 
     @NotNull
@@ -1171,10 +1181,7 @@ public class IfStatementWithIdenticalBranchesInspection extends AbstractBaseJava
       PsiStatement elseIfElseBranch = elseIf.getElseBranch();
       if (elseIfElseBranch == null) return null;
       if (elseIfThen.length != thenStatements.length) return null;
-      Set<PsiLocalVariable> variables = new HashSet<>();
-      addLocalVariables(variables, Arrays.asList(thenStatements));
-      addLocalVariables(variables, Arrays.asList(elseIfThen));
-      LocalEquivalenceChecker equivalence = new LocalEquivalenceChecker(variables);
+      LocalEquivalenceChecker equivalence = getChecker(thenStatements, elseIfThen);
       if (!branchesAreEquivalent(thenStatements, Arrays.asList(elseIfThen), equivalence)) return null;
       return new ElseIf(elseBranch, elseIfElseBranch, elseIfThenBranch, elseIfCondition, equivalence.mySubstitutionTable);
     }

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/controlflow/if_statement_with_identical_branches/IfStatementWithIdenticalBranches.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/controlflow/if_statement_with_identical_branches/IfStatementWithIdenticalBranches.java
@@ -6,21 +6,31 @@ import java.util.Set;
 
 public class IfStatementWithIdenticalBranches {
 
-    void one() {
-        <warning descr="'if' statement with identical branches">if</warning> (true) {
+    void simpleCases(boolean isValid) {
+        if (isValid) {
 
         } else {
 
         }
-        <warning descr="'if' statement with identical branches">if</warning> (false) {
+        <weak_warning descr="'if' statement can be collapsed">if</weak_warning> (isValid) {
             System.out.println();
             return;
         }
         System.out.println();
     }
 
-    int two() {
-        <warning descr="'if' statement with identical branches">if</warning> (true) {
+  void implicitElseInAForLoop() {
+    for (int i = 0; i < 100; i++) {
+      <weak_warning descr="'if' statement can be collapsed">if</weak_warning> (i == 10) {
+        System.out.println("Next iteration");
+        continue;
+      }
+      System.out.println("Next iteration");
+    }
+  }
+
+    int sameCodeWithDifferentIdentifierNames(boolean isValid) {
+        <weak_warning descr="'if' statement can be collapsed">if</weak_warning> (isValid) {
             int i = 2;
             return i;
         } else {
@@ -29,8 +39,8 @@ public class IfStatementWithIdenticalBranches {
         }
     }
 
-    int three() {
-        if (true) {
+    int differentCode(boolean isValid) {
+        if (isValid) {
             int i = 3;
             return i;
         } else {
@@ -39,9 +49,9 @@ public class IfStatementWithIdenticalBranches {
         }
     }
 
-    void four() {
-        if (true) {
-            <warning descr="'if' statement with identical branches">if</warning> (false) {
+    void impliciteJumpStatement(boolean isValid, boolean isActive) {
+        if (isValid) {
+            <weak_warning descr="'if' statement can be collapsed">if</weak_warning> (isActive) {
                 System.out.println();
                 return;
             }
@@ -49,19 +59,19 @@ public class IfStatementWithIdenticalBranches {
         System.out.println();
     }
 
-    void five() {
+    void nonLinearControlflow(boolean isValid) {
         boolean b = true;
         while (b) {
-            if (true) {
+            if (isValid) {
                 System.out.println();
             }
         }
         System.out.println();
     }
 
-    void six() {
-        if (true) {
-            <warning descr="'if' statement with identical branches">if</warning> (false) {
+    void identicalCodeInSeveralBlocks(boolean isValid, boolean isActive) {
+        if (isActive) {
+            if (isValid) {
                 System.out.println();
                 System.out.println();
                 return;
@@ -71,41 +81,41 @@ public class IfStatementWithIdenticalBranches {
         System.out.println();
     }
 
-    void seven() {
-        if (true) {
+    void notIdenticalJumpedCode(boolean isValid, boolean isActive) {
+        if (isValid) {
             System.out.println();
             return;
-        } else if (true) {
+        } else if (isActive) {
             System.out.println("different");
             return;
         }
         System.out.println();
     }
 
-    void eight() {
-        if (true) {
+    void notIdenticalCode(boolean isValid, boolean isActive) {
+        if (isValid) {
             System.out.println();
-        } else if (true) {
+        } else if (isActive) {
             System.out.println("different");
         } else {
             System.out.println();
         }
     }
 
-    void nine() {
-        <warning descr="'if' statement with identical branches">if</warning> (true) {
+    void longIdenticalCode(boolean isValid, boolean isActive) {
+        if (isValid) {
 
-        } else <warning descr="'if' statement with identical branches">if</warning> (true) {
+        } else if (isActive) {
 
-        } else <warning descr="'if' statement with identical branches">if</warning> (true) {
+        } else if (true) {
 
         } else {
 
         }
     }
 
-  void blocks() {
-    <warning descr="'if' statement with identical branches">if</warning> (true) {
+  void blocks(boolean isValid) {
+    <weak_warning descr="'if' statement can be collapsed">if</weak_warning> (isValid) {
       System.out.println();
       return;
     }
@@ -165,7 +175,7 @@ class NotADup {
 
   void m() {
     int j;
-    <warning descr="'if' statement with identical branches">if</warning> (true) {
+    <weak_warning descr="'if' statement can be collapsed">if</weak_warning> (true) {
       j = 2;
     }
     else {
@@ -175,7 +185,7 @@ class NotADup {
   }
 
   void n(int i) {
-    <warning descr="'if' statement with identical branches">if</warning> (i == 0) {
+    if (i == 0) {
       System.out.println(((i)));
       ;
       ;

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/controlflow/IfStatementWithIdenticalBranchesFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/controlflow/IfStatementWithIdenticalBranchesFixTest.java
@@ -1,0 +1,20 @@
+package com.siyeh.ig.controlflow;
+
+import com.intellij.codeInsight.daemon.quickFix.LightQuickFixParameterizedTestCase;
+import com.intellij.codeInspection.LocalInspectionTool;
+import org.jetbrains.annotations.NotNull;
+
+public class IfStatementWithIdenticalBranchesFixTest extends LightQuickFixParameterizedTestCase {
+
+  @Override
+  protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
+    IfStatementWithIdenticalBranchesInspection inspection = new IfStatementWithIdenticalBranchesInspection();
+    inspection.myHighlightWhenLastStatementIsCall = !getTestName(false).equals("LastStatementIsCallInfo.java");
+    return new LocalInspectionTool[]{inspection};
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/inspection/commonIfParts";
+  }
+}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/controlflow/IfStatementWithIdenticalBranchesInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/controlflow/IfStatementWithIdenticalBranchesInspectionTest.java
@@ -1,20 +1,21 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.controlflow;
 
-import com.intellij.codeInsight.daemon.quickFix.LightQuickFixParameterizedTestCase;
-import com.intellij.codeInspection.LocalInspectionTool;
-import org.jetbrains.annotations.NotNull;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import com.siyeh.ig.LightJavaInspectionTestCase;
 
-public class IfStatementWithIdenticalBranchesInspectionTest extends LightQuickFixParameterizedTestCase {
-
-  @Override
-  protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
-    IfStatementWithIdenticalBranchesInspection inspection = new IfStatementWithIdenticalBranchesInspection();
-    inspection.myHighlightWhenLastStatementIsCall = !getTestName(false).equals("LastStatementIsCallInfo.java");
-    return new LocalInspectionTool[]{inspection};
-  }
-
+public class IfStatementWithIdenticalBranchesInspectionTest extends LightJavaCodeInsightFixtureTestCase {
   @Override
   protected String getBasePath() {
-    return "/inspection/commonIfParts";
+    return LightJavaInspectionTestCase.INSPECTION_GADGETS_TEST_DATA_PATH + "com/siyeh/igtest/controlflow/if_statement_with_identical_branches";
+  }
+
+  private void doTest() {
+    myFixture.enableInspections(new IfStatementWithIdenticalBranchesInspection());
+    myFixture.testHighlighting(getTestName(false) + ".java");
+  }
+
+  public void testIfStatementWithIdenticalBranches() {
+    doTest();
   }
 }


### PR DESCRIPTION
Hi @amaembo,

***What steps will reproduce the issue?***

1. Go to *File* → *Settings..*. → *Editor* → *Inspections*
2. Enable *'if' statements with identical branches*
3. Enable Severity: *Warning*
4. Add this method in a Java class:

```Java
  void work(int i) {
    while (0 < i) {
      i--;
      if (i == 10) {
        System.out.println("Next iteration");
        continue;
      }
      System.out.println("Next iteration");
    }
  }
```

***What is the expected result?***
The inspection *'if' statements with identical branches* is suggested.
***What happens instead?***
Nothing appears.

The same way the inspection searches implicit `else` with method `return`, it should handle loop `continue`. If a label is present, the `continue` statement must be explicit. It should work for `while`, `do`/`while`, `for` and foreach loops.

I have added some successful unit tests.