### PR TITLE
IDEA-309689 & IDEA-240111 - Configurable disabling of up-to-date checks for all test tasks

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionHelper.java
@@ -909,7 +909,7 @@ public class GradleExecutionHelper {
 
   @Nullable
   public static String renderInitScript(@NotNull Set<String> testTasksPatterns) {
-    InputStream stream = Init.class.getResourceAsStream("/org/jetbrains/plugins/gradle/tooling/internal/init/testFilterInit.gradle");
+    InputStream stream = Init.class.getResourceAsStream("/org/jetbrains/plugins/gradle/tooling/internal/init/testFilter.init.gradle");
     if (stream == null) {
       LOG.error("Can't find test filter init script template");
       return null;

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilter.init.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/testFilter.init.gradle
@@ -9,11 +9,19 @@ try {
  // ignore, class not available
 }
 
+def forceTestTasksToReRun =
+  providers.gradleProperty("org.jetbrains.plugins.gradle.force_test_tasks_to_re_run")
+    .orElse("true")
+    .map({it.toBoolean()})
+
 gradle.taskGraph.whenReady { taskGraph ->
   taskGraph.allTasks.each { Task task ->
     if (task instanceof Test || (abstractTestTaskClass != null && abstractTestTaskClass.isAssignableFrom(task.class))) {
       try {
-        task.outputs.upToDateWhen { false }
+        task.inputs.property("forceTestTasksToReRun", forceTestTasksToReRun)
+        task.outputs.upToDateWhen {
+          !forceTestTasksToReRun.getOrElse(true)
+        }
         String[] strings = ['*']
         if(ijTestIncludes.size() > 0 && ijTestIncludes != strings) {
           def filter = task.getFilter()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-309689

Partial fix for https://youtrack.jetbrains.com/issue/IDEA-240111

This will allow users to disable the current IntelliJ behaviour which breaks Gradle incremental task support.

This would be helpful in testing a more complete solution: https://github.com/aSemy/intellij-gradle-init-plugin/

Also rename testFilterInit.gradle to testFilter.init.gradle (better IDE support)