### PR TITLE
KTIJ-18099 Naming conventions inspection: factory functions named as a base class and producing object of a named child class are flagged

### DIFF
--- a/plugins/kotlin/idea/tests/testData/inspections/naming/function/test.kt
+++ b/plugins/kotlin/idea/tests/testData/inspections/naming/function/test.kt
@@ -36,3 +36,7 @@ fun Generic2() = Generic2(0)
 
 class Generic3<ID>(val id: ID)
 fun Generic3(b: Boolean): Generic3<Int>? = if (b) Generic3(0) else null
+
+interface Baz
+class BazImpl : Baz
+fun Baz() = BazImpl()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-18099