### PR TITLE
KTIJ-21661 `Convert property initializer to getter` intention generates incorrect getter for a property initialized via constructor parameter

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -7183,6 +7183,16 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertPropertyInitializerToGetter/errorType.kt");
         }
 
+        @TestMetadata("hasReferenceToPrimaryCtorParameter.kt")
+        public void testHasReferenceToPrimaryCtorParameter() throws Exception {
+            runTest("testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorParameter.kt");
+        }
+
+        @TestMetadata("hasReferenceToPrimaryCtorProperty.kt")
+        public void testHasReferenceToPrimaryCtorProperty() throws Exception {
+            runTest("testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorProperty.kt");
+        }
+
         @TestMetadata("inapplicableIfExtensionProperty.kt")
         public void testInapplicableIfExtensionProperty() throws Exception {
             runTest("testData/intentions/convertPropertyInitializerToGetter/inapplicableIfExtensionProperty.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorParameter.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorParameter.kt
@@ -1,0 +1,4 @@
+// IS_APPLICABLE: false
+class C(val i: Int, j: Int) {
+    val x = i + j<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorProperty.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorProperty.kt
@@ -1,0 +1,3 @@
+class C(val i: Int, val j: Int) {
+    val x = i + j<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorProperty.kt.after
+++ b/plugins/kotlin/idea/tests/testData/intentions/convertPropertyInitializerToGetter/hasReferenceToPrimaryCtorProperty.kt.after
@@ -1,0 +1,4 @@
+class C(val i: Int, val j: Int) {
+    val x: Int
+        get() = i + j
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-21661