### PR TITLE
KTIJ-22656 Introduce parameter fails when the last parameter without comma ends with a comment

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinCallableDefinitionUsage.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/usages/KotlinCallableDefinitionUsage.kt
@@ -2,8 +2,12 @@
 
 package org.jetbrains.kotlin.idea.refactoring.changeSignature.usages
 
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.siblings
 import com.intellij.usageView.UsageInfo
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
@@ -24,9 +28,11 @@ import org.jetbrains.kotlin.idea.refactoring.dropOverrideKeywordIfNecessary
 import org.jetbrains.kotlin.idea.refactoring.replaceListPsiAndKeepDelimiters
 import org.jetbrains.kotlin.idea.util.getTypeSubstitution
 import org.jetbrains.kotlin.idea.util.toSubstitutor
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getElementTextWithContext
+import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.getValueParameterList
 import org.jetbrains.kotlin.psi.typeRefHelpers.setReceiverTypeReference
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -35,6 +41,7 @@ import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeSubstitutor
 import org.jetbrains.kotlin.types.typeUtil.isUnit
+import org.jetbrains.kotlin.utils.ifEmpty
 import org.jetbrains.kotlin.utils.sure
 
 class KotlinCallableDefinitionUsage<T : PsiElement>(
@@ -182,6 +189,7 @@ class KotlinCallableDefinitionUsage<T : PsiElement>(
             newParameterList = if (canReplaceEntireList) {
                 parameterList.replace(newParameterList) as KtParameterList
             } else {
+                adjustTrailingComments(parameterList, newParameterList, psiFactory)
                 replaceListPsiAndKeepDelimiters(changeInfo, parameterList, newParameterList) { parameters }
             }
         } else {
@@ -227,5 +235,29 @@ class KotlinCallableDefinitionUsage<T : PsiElement>(
             val newIdentifier = psiFactory.createIdentifier(inheritedName)
             parameter.nameIdentifier?.replace(newIdentifier)
         }
+    }
+
+    private fun adjustTrailingComments(oldParameterList: KtParameterList, newParameterList: KtParameterList, psiFactory: KtPsiFactory) {
+        val oldLastParameter = oldParameterList.parameters.lastOrNull() ?: return
+        val oldLastParameterName = oldLastParameter.name ?: return
+        val trailingComments = oldLastParameter.nextComma().nextCommentsOnSameLine().ifEmpty { return }
+
+        val newParameter = newParameterList.parameters.firstOrNull { it.name == oldLastParameterName } ?: return
+        val newParameterComma = newParameter.nextComma() ?: return
+        trailingComments.reversed().forEach { newParameterList.addAfter(it, newParameterComma) }
+        newParameterList.addAfter(psiFactory.createWhiteSpace(), newParameterComma)
+
+        trailingComments.forEach { it.delete() }
+    }
+
+    private fun KtParameter.nextComma(): PsiElement? =
+        getNextSiblingIgnoringWhitespaceAndComments()?.takeIf { it.elementType == KtTokens.COMMA }
+
+    private fun PsiElement?.nextCommentsOnSameLine(): List<PsiElement> {
+        if (this == null) return emptyList()
+        val siblings = siblings(withSelf = false)
+            .takeWhile { it is PsiComment || (it is PsiWhiteSpace && !it.textContains('\n')) }
+            .dropWhile { it is PsiWhiteSpace }
+        return if (siblings.any { it is PsiComment }) siblings.toList() else emptyList()
     }
 }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinInplaceParameterIntroducer.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/introduce/introduceParameter/KotlinInplaceParameterIntroducer.kt
@@ -13,20 +13,19 @@ import com.intellij.openapi.editor.markup.MarkupModel
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.ui.JBColor
 import com.intellij.ui.NonFocusableCheckBox
-import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
 import org.jetbrains.kotlin.idea.base.psi.unifier.toRange
+import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
 import org.jetbrains.kotlin.idea.refactoring.changeSignature.KotlinValVar
 import org.jetbrains.kotlin.idea.refactoring.introduce.AbstractKotlinInplaceIntroducer
 import org.jetbrains.kotlin.idea.refactoring.introduce.introduceVariable.KotlinInplaceVariableIntroducer
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
 import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.psi.psiUtil.getElementTextWithContext
-import org.jetbrains.kotlin.psi.psiUtil.getValueParameterList
-import org.jetbrains.kotlin.psi.psiUtil.getValueParameters
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.psi.psiUtil.*
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 import java.awt.Color
@@ -124,7 +123,11 @@ class KotlinInplaceParameterIntroducer(
                         } else ""
 
                         "$modifier$parameterName: $parameterType$defaultValue"
-                    } else parameter.text
+                    } else {
+                        parameter.allChildren.toList()
+                            .dropLastWhile { it is PsiComment || it is PsiWhiteSpace }
+                            .joinToString(separator = "") { it.text }
+                    }
 
                     builder.append(parameterText)
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/refactoring/introduce/ExtractionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/refactoring/introduce/ExtractionTestGenerated.java
@@ -3238,9 +3238,19 @@ public abstract class ExtractionTestGenerated extends AbstractExtractionTest {
                 runTest("testData/refactoring/introduceParameter/lambdaArgument.kt");
             }
 
+            @TestMetadata("lastParameterHasBlockComment.kt")
+            public void testLastParameterHasBlockComment() throws Exception {
+                runTest("testData/refactoring/introduceParameter/lastParameterHasBlockComment.kt");
+            }
+
             @TestMetadata("lastParameterHasEolComment.kt")
             public void testLastParameterHasEolComment() throws Exception {
                 runTest("testData/refactoring/introduceParameter/lastParameterHasEolComment.kt");
+            }
+
+            @TestMetadata("lastParameterHasEolCommentAndTrailingComma.kt")
+            public void testLastParameterHasEolCommentAndTrailingComma() throws Exception {
+                runTest("testData/refactoring/introduceParameter/lastParameterHasEolCommentAndTrailingComma.kt");
             }
 
             @TestMetadata("partialSubstitution.kt")

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/refactoring/introduce/ExtractionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/refactoring/introduce/ExtractionTestGenerated.java
@@ -3238,6 +3238,11 @@ public abstract class ExtractionTestGenerated extends AbstractExtractionTest {
                 runTest("testData/refactoring/introduceParameter/lambdaArgument.kt");
             }
 
+            @TestMetadata("lastParameterHasEolComment.kt")
+            public void testLastParameterHasEolComment() throws Exception {
+                runTest("testData/refactoring/introduceParameter/lastParameterHasEolComment.kt");
+            }
+
             @TestMetadata("partialSubstitution.kt")
             public void testPartialSubstitution() throws Exception {
                 runTest("testData/refactoring/introduceParameter/partialSubstitution.kt");

--- a/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasBlockComment.kt
+++ b/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasBlockComment.kt
@@ -1,0 +1,5 @@
+class C(
+    val a: String /* comment1 */ /* comment2 */
+) {
+    val b = <selection>1</selection>
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasBlockComment.kt.after
+++ b/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasBlockComment.kt.after
@@ -1,0 +1,6 @@
+class C(
+    val a: String, /* comment1 */ /* comment2 */
+    i: Int = 1
+) {
+    val b = i
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolComment.kt
+++ b/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolComment.kt
@@ -1,0 +1,5 @@
+class C(
+    val a: String // parameter comment
+) {
+    val b = <selection>1</selection>
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolComment.kt.after
+++ b/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolComment.kt.after
@@ -1,0 +1,6 @@
+class C(
+    val a: String, // parameter comment
+    i: Int = 1
+) {
+    val b = i
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolCommentAndTrailingComma.kt
+++ b/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolCommentAndTrailingComma.kt
@@ -1,0 +1,5 @@
+class C(
+    val a: String, // parameter comment
+) {
+    val b = <selection>1</selection>
+}

--- a/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolCommentAndTrailingComma.kt.after
+++ b/plugins/kotlin/idea/tests/testData/refactoring/introduceParameter/lastParameterHasEolCommentAndTrailingComma.kt.after
@@ -1,0 +1,6 @@
+class C(
+    val a: String, // parameter comment
+    i: Int = 1,
+) {
+    val b = i
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-22656

```kotlin
class A(
    val a: String // test
    ) {
    fun main() {
        "".length
    }
}
```

<img width="604" alt="スクリーンショット 2022-09-04 20 40 08" src="https://user-images.githubusercontent.com/1121855/188311802-d3cc61cf-fdb8-4673-8d22-a609d2418a92.png">

↓

<img width="376" alt="スクリーンショット 2022-09-04 20 40 16" src="https://user-images.githubusercontent.com/1121855/188311816-1e9b561f-5f52-4c0b-a0b8-0d8398bb0e5c.png">

