### PR TITLE
[IDEA-301271] Make it possible to ignore KDoc for override elements.

### DIFF
--- a/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
@@ -1264,6 +1264,7 @@ replace.with.kotlin.analog.function.text=Replace with ''{0}'' function
 add.documentation.fix.text=Add documentation
 missing.documentation=Missing documentation
 0.is.missing.documentation={0} is missing documentation
+ignore.override.elements=Ignore override elements
 it.s.prohibited.to.call.0.with.min.value.step.since.1.3=It''s prohibited to call {0} with MIN_VALUE step since 1.3
 obsolete.coroutine.usage.in.whole.fix.family.name=Fix experimental coroutines usages in the project
 obsolete.kotlin.js.packages.usage.in.whole.fix.family.name=Fix 'kotlin.dom' and 'kotlin.browser' packages usages in the project


### PR DESCRIPTION
Override elements usually have KDoc defined by their parent declarations. Therefore they don't need to re-declare KDoc. However, KDocMissingDocumentationInspection doesn't always work as intended when we are overriding a method from an interface defined in some library and sources are not available. This typically happens in Bazel plugin and monorepo for example. Therefore we should allow an option to explicitly disable the KDocMissingDocumentationInspection for override elements with a checkbox.

This would give users more customizations over their IDE and make Kotlin easier to use.

You Track: https://youtrack.jetbrains.com/issue/IDEA-301271/Make-it-possible-to-ignore-KDoc-for-override-elements