### PR TITLE
[KTIJ-19314] Debugger: Account for synthetic names of captured locals

### DIFF
--- a/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/variables/VariableFinder.kt
+++ b/plugins/kotlin/jvm-debugger/evaluation/src/org/jetbrains/kotlin/idea/debugger/evaluate/variables/VariableFinder.kt
@@ -7,6 +7,7 @@ import com.intellij.debugger.engine.evaluation.EvaluationContextImpl
 import com.intellij.debugger.jdi.LocalVariableProxyImpl
 import com.intellij.debugger.jdi.StackFrameProxyImpl
 import com.sun.jdi.*
+import org.jetbrains.kotlin.backend.common.descriptors.synthesizedString
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.AsmUtil.getCapturedFieldName
 import org.jetbrains.kotlin.codegen.AsmUtil.getLabeledThisName
@@ -137,6 +138,9 @@ class VariableFinder(val context: ExecutionContext) {
 
         // Local variables – direct search
         findLocalVariable(variables, kind, kind.name)?.let { return it }
+
+        // Local variables - synthetic captured local variable (IR Backend)
+        findLocalVariable(variables, kind, kind.name.synthesizedString)?.let { return it }
 
         // Recursive search in local receiver variables
         findCapturedVariableInReceiver(variables, kind)?.let { return it }

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
@@ -846,9 +846,39 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedLocalVar.kt");
             }
 
+            @TestMetadata("localFunctionWithCapturedOuterParameter.kt")
+            public void testLocalFunctionWithCapturedOuterParameter() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.kt");
+            }
+
             @TestMetadata("twoLocals.kt")
             public void testTwoLocals() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/twoLocals.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping2.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping3.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping3() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping4.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping4() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping5.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping5() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.kt");
             }
         }
 

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -846,9 +846,39 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedLocalVar.kt");
             }
 
+            @TestMetadata("localFunctionWithCapturedOuterParameter.kt")
+            public void testLocalFunctionWithCapturedOuterParameter() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.kt");
+            }
+
             @TestMetadata("twoLocals.kt")
             public void testTwoLocals() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/twoLocals.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping2.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping3.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping3() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping4.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping4() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping5.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping5() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.kt");
             }
         }
 

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
@@ -846,9 +846,39 @@ public abstract class KotlinEvaluateExpressionInMppTestGenerated extends Abstrac
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedLocalVar.kt");
             }
 
+            @TestMetadata("localFunctionWithCapturedOuterParameter.kt")
+            public void testLocalFunctionWithCapturedOuterParameter() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.kt");
+            }
+
             @TestMetadata("twoLocals.kt")
             public void testTwoLocals() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/twoLocals.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping2.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping3.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping3() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping4.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping4() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping5.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping5() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.kt");
             }
         }
 

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
@@ -846,9 +846,39 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedLocalVar.kt");
             }
 
+            @TestMetadata("localFunctionWithCapturedOuterParameter.kt")
+            public void testLocalFunctionWithCapturedOuterParameter() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.kt");
+            }
+
             @TestMetadata("twoLocals.kt")
             public void testTwoLocals() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/simpleLocals/twoLocals.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping2.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping3.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping3() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping4.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping4() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.kt");
+            }
+
+            @TestMetadata("variableFinderShouldNotImplementDynamicScoping5.kt")
+            public void testVariableFinderShouldNotImplementDynamicScoping5() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.kt");
             }
         }
 

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.kt
@@ -1,0 +1,13 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package localFunction
+
+fun main(args: Array<String>) {
+    fun inner() {
+        //Breakpoint!
+        val x = args
+    }
+    inner()
+}
+
+// EXPRESSION: args.size
+// RESULT: 0: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/localFunctionWithCapturedOuterParameter.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at localFunctionWithCapturedOuterParameter.kt:7
+Run Java
+Connected to the target VM
+localFunctionWithCapturedOuterParameter.kt:7
+Compile bytecode for args.size
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.kt
@@ -1,0 +1,21 @@
+package variableFinderShouldNotImplementDynamicScoping
+
+fun outer(x: Int): () -> Int {
+    fun inner(): Int {
+        return x
+    }
+    fun returned(): Int {
+        //Breakpoint!
+        return 0
+    }
+    return ::returned
+}
+
+fun main() {
+    val x = 45
+    val f = outer(54)
+    f()
+}
+
+// EXPRESSION: x
+// RESULT: Cannot find local variable 'x' with type int

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at variableFinderShouldNotImplementDynamicScoping.kt:9
+Run Java
+Connected to the target VM
+variableFinderShouldNotImplementDynamicScoping.kt:9
+Compile bytecode for x
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.kt
@@ -1,0 +1,27 @@
+package variableFinderShouldNotImplementDynamicScoping2
+
+fun outer(x: Int): () -> Int {
+    fun inner(): Int {
+        return x
+    }
+    fun returned(): Int {
+        //Breakpoint!
+        return 0
+    }
+    return ::returned
+}
+
+fun test(x: Int) {
+    fun inner() {
+        val f = outer(54)
+        f()
+    }
+    inner()
+}
+
+fun main() {
+   test(45)
+}
+
+// EXPRESSION: x
+// RESULT: Cannot find local variable 'x' with type int

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping2.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at variableFinderShouldNotImplementDynamicScoping2.kt:9
+Run Java
+Connected to the target VM
+variableFinderShouldNotImplementDynamicScoping2.kt:9
+Compile bytecode for x
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.kt
@@ -1,0 +1,28 @@
+package variableFinderShouldNotImplementDynamicScoping2
+
+fun outer(x: Int): () -> Int {
+    fun inner(): Int {
+        return x
+    }
+    fun returned(): Int {
+        //Breakpoint!
+        return 0
+    }
+    return ::returned
+}
+
+fun test(x: Int) {
+    fun inner(x: Int) {
+        val y = x
+        val f = outer(54)
+        f()
+    }
+    inner(x)
+}
+
+fun main() {
+   test(45)
+}
+
+// EXPRESSION: x
+// RESULT: Cannot find local variable 'x' with type int

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping3.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at variableFinderShouldNotImplementDynamicScoping3.kt:9
+Run Java
+Connected to the target VM
+variableFinderShouldNotImplementDynamicScoping3.kt:9
+Compile bytecode for x
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.kt
@@ -1,0 +1,28 @@
+package variableFinderShouldNotImplementDynamicScoping2
+
+fun outer(x: Int): () -> Int {
+    fun inner(): Int {
+        return x
+    }
+    fun returned(): Int {
+        //Breakpoint!
+        return 0
+    }
+    return ::returned
+}
+
+fun test(x: Int) {
+    fun inner() {
+        val y = x
+        val f = outer(54)
+        f()
+    }
+    inner()
+}
+
+fun main() {
+   test(45)
+}
+
+// EXPRESSION: x
+// RESULT: Cannot find local variable 'x' with type int

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping4.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at variableFinderShouldNotImplementDynamicScoping4.kt:9
+Run Java
+Connected to the target VM
+variableFinderShouldNotImplementDynamicScoping4.kt:9
+Compile bytecode for x
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.kt
@@ -1,0 +1,19 @@
+package variableFinderShouldNotImplementDynamicScoping2
+
+fun outer(x: Int): () -> Int {
+    fun inner(): Int {
+        val y = x
+        val x = 57
+        //Breakpoint!
+        return x
+    }
+    return ::inner
+}
+
+
+fun main() {
+    outer(75)()
+}
+
+// EXPRESSION: x
+// RESULT: 57: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/simpleLocals/variableFinderShouldNotImplementDynamicScoping5.out
@@ -1,0 +1,8 @@
+LineBreakpoint created at variableFinderShouldNotImplementDynamicScoping5.kt:8
+Run Java
+Connected to the target VM
+variableFinderShouldNotImplementDynamicScoping5.kt:8
+Compile bytecode for x
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Small fix to a long-standing issue in the debugger caused by the move to compile local functions to static functions instead of lambdas by the IR compiler.

Resolved by simply also looking for the equivalently named synthetic variable in the local scope.