### PR TITLE
[IDEA-301618] Indicate if an escaped character is in a class

### DIFF
--- a/RegExpSupport/src/org/intellij/lang/regexp/RegExpLanguageHost.java
+++ b/RegExpSupport/src/org/intellij/lang/regexp/RegExpLanguageHost.java
@@ -14,7 +14,21 @@ public interface RegExpLanguageHost {
   EnumSet<RegExpGroup.Type> EMPTY_NAMED_GROUP_TYPES = EnumSet.noneOf(RegExpGroup.Type.class);
   String[][] EMPTY_COMPLETION_ITEMS_ARRAY = new String[0][];
 
+  /**
+   * @deprecated Use {@link #characterNeedsEscaping(char, boolean)} instead.
+   */
+  @Deprecated
   boolean characterNeedsEscaping(char c);
+
+  /**
+   * Returns whether the given character needs to be escaped to be treated as a literal.
+   * @param c a character to be considered.
+   * @param isInClass whether the character is within a RegExpClass (ie, within "[...]").
+   */
+  default boolean characterNeedsEscaping(char c, boolean isInClass) {
+    return characterNeedsEscaping(c);
+  }
+
   boolean supportsPerl5EmbeddedComments();
   boolean supportsPossessiveQuantifiers();
   default boolean isDuplicateGroupNamesAllowed(@NotNull RegExpGroup group) {

--- a/RegExpSupport/src/org/intellij/lang/regexp/RegExpLanguageHosts.java
+++ b/RegExpSupport/src/org/intellij/lang/regexp/RegExpLanguageHosts.java
@@ -51,7 +51,7 @@ public final class RegExpLanguageHosts extends ClassExtension<RegExpLanguageHost
     final RegExpLanguageHost host = findRegExpHost(ch);
     if (host != null) {
       final char c = text.charAt(1);
-      return !host.characterNeedsEscaping(c);
+      return !host.characterNeedsEscaping(c, ch.getParent() instanceof RegExpClass);
     }
     else {
       return !("\\]".equals(text) || "\\}".equals(text));


### PR DESCRIPTION
Minor fix addressing [IDEA-301618](https://youtrack.jetbrains.com/issue/IDEA-301618).

A new method overload has been added for RegExpLanguageHost.characterNeedsEscaping(), allowing the implementation to know whether the given character is occurring within a class or not. I've added the overload with a default implementation and marked the existing method as deprecated, so that this will not be a breaking change and existing logic will continue to operate as it currently does.