### PR TITLE
KTIJ-22736 "'StringBuilder.append(CharArray, offset, len)' call on the JVM": remove redundant zero

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceWithStringBuilderAppendRangeInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceWithStringBuilderAppendRangeInspection.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.platform.jvm.isJvm
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.typeUtil.isInt
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 class ReplaceWithStringBuilderAppendRangeInspection : AbstractKotlinInspection() {
     companion object {
@@ -64,14 +65,19 @@ class ReplaceWithStringBuilderAppendRangeInspection : AbstractKotlinInspection()
 
             val psiFactory = KtPsiFactory(callExpression)
             calleeExpression.replace(psiFactory.createCalleeExpression(functionName))
-            if (secondArg is KtConstantExpression && thirdArg is KtConstantExpression) {
-                thirdArg.replace(psiFactory.createExpression(secondArg.text.toInt().plus(thirdArg.text.toInt()).toString()))
-            } else {
+
+            val secondArgAsInt = secondArg.toIntOrNull()
+            val thirdArgAsInt = thirdArg.toIntOrNull()
+            if (secondArgAsInt != null && thirdArgAsInt != null) {
+                thirdArg.replace(psiFactory.createExpression(secondArgAsInt.plus(thirdArgAsInt).toString()))
+            } else if (secondArgAsInt != 0) {
                 thirdArg.replace(psiFactory.createExpressionByPattern("$0 + $1", secondArg, thirdArg))
             }
         }
 
         private fun KtPsiFactory.createCalleeExpression(functionName: String): KtExpression =
             (createExpression("$functionName()") as KtCallExpression).calleeExpression!!
+
+        private fun KtExpression.toIntOrNull(): Int? = safeAs<KtConstantExpression>()?.text?.toIntOrNull()
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -13303,6 +13303,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         public void testSimple() throws Exception {
             runTest("testData/inspectionsLocal/replaceWithStringBuilderAppendRange/simple.kt");
         }
+
+        @TestMetadata("zeroOffset.kt")
+        public void testZeroOffset() throws Exception {
+            runTest("testData/inspectionsLocal/replaceWithStringBuilderAppendRange/zeroOffset.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceWithStringBuilderAppendRange/zeroOffset.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceWithStringBuilderAppendRange/zeroOffset.kt
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun test(charArray: CharArray, len: Int): String {
+    return buildString {
+        <caret>append(charArray, 0, len)
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceWithStringBuilderAppendRange/zeroOffset.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceWithStringBuilderAppendRange/zeroOffset.kt.after
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun test(charArray: CharArray, len: Int): String {
+    return buildString {
+        appendRange(charArray, 0, len)
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-22736