### PR TITLE
KTIJ-103: Trailing comma breaks formatting of 'when' expression

### DIFF
--- a/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/formatter/lineIndent/KotlinLangLineIndentProvider.kt
+++ b/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/formatter/lineIndent/KotlinLangLineIndentProvider.kt
@@ -54,6 +54,13 @@ abstract class KotlinLangLineIndentProvider : JavaLikeLangLineIndentProvider() {
                 return factory.createIndentCalculatorForArrow(before, after)
             }
 
+            after.isAt(Arrow) -> {
+                val arrowCalculator = factory.maybeCreateIndentCalculatorForArrowInsideWhenEntry(after)
+                if (arrowCalculator != null) {
+                    return arrowCalculator
+                }
+            }
+
             after.isAt(ArrayClosingBracket) && !currentPosition.hasLineBreaksAfter(offset) ->
                 return factory.createIndentCalculatorForBrace(
                     before,
@@ -268,6 +275,22 @@ abstract class KotlinLangLineIndentProvider : JavaLikeLangLineIndentProvider() {
                 createIndentCalculator(normalIndent, arrowPosition.startOffset)
             } else {
                 createIndentCalculatorForBrace(leftBrace, after, BlockOpeningBrace, BlockClosingBrace, normalIndent)
+            }
+        }
+
+        private fun IndentCalculatorFactory.maybeCreateIndentCalculatorForArrowInsideWhenEntry(
+            arrowPosition: SemanticEditorPosition,
+        ): IndentCalculator? {
+            val leftBrace = arrowPosition.copyAnd {
+                it.moveToLeftParenthesisBackwardsSkippingNested(BlockOpeningBrace, BlockClosingBrace)
+            }
+
+            val normalIndent = Indent.getNormalIndent()
+            val controlFlowStatementBefore = leftBrace.controlFlowStatementBefore()
+            return if (controlFlowStatementBefore != null && controlFlowStatementBefore.isAt(WhenKeyword)) {
+                createIndentCalculator(normalIndent, arrowPosition.startOffset)
+            } else {
+                null
             }
         }
 

--- a/plugins/kotlin/formatter/minimal/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt
+++ b/plugins/kotlin/formatter/minimal/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt
@@ -1067,7 +1067,7 @@ private val INDENT_RULES = arrayOf(
 
     strategy("Block in when entry")
         .within(WHEN_ENTRY)
-        .notForType(BLOCK, WHEN_CONDITION_EXPRESSION, WHEN_CONDITION_IN_RANGE, WHEN_CONDITION_IS_PATTERN, ELSE_KEYWORD, ARROW)
+        .notForType(BLOCK, WHEN_CONDITION_EXPRESSION, WHEN_CONDITION_IN_RANGE, WHEN_CONDITION_IS_PATTERN, ELSE_KEYWORD)
         .set(Indent.getNormalIndent()),
 
     strategy("Parameter list")

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/EnterHandlerTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/EnterHandlerTestGenerated.java
@@ -653,6 +653,11 @@ public abstract class EnterHandlerTestGenerated extends AbstractEnterHandlerTest
                 runTest("testData/editor/enterHandler/controlFlowConstructions/Try2.after.kt");
             }
 
+            @TestMetadata("WhenEntryArrow.after.kt")
+            public void testWhenEntryArrow() throws Exception {
+                runTest("testData/editor/enterHandler/controlFlowConstructions/WhenEntryArrow.after.kt");
+            }
+
             @TestMetadata("WhenWithCondition.after.kt")
             public void testWhenWithCondition() throws Exception {
                 runTest("testData/editor/enterHandler/controlFlowConstructions/WhenWithCondition.after.kt");

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/ElseInWhenWithOption.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/ElseInWhenWithOption.after.kt
@@ -2,7 +2,7 @@ fun some() {
     when {
         true && true ->
         else
-        <caret>-> Unit
+            <caret>-> Unit
     }
 }
 

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/ElseInWhenWithoutOption.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/ElseInWhenWithoutOption.after.kt
@@ -2,7 +2,7 @@ fun some() {
     when {
         true && false ->
         else
-        <caret>-> Unit
+            <caret>-> Unit
     }
 }
 

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/WhenEntryArrow.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/WhenEntryArrow.after.kt
@@ -1,0 +1,7 @@
+fun a() {
+    when (true) {
+        false -> Unit
+        true
+            <caret>-> Unit
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/WhenEntryArrow.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/controlFlowConstructions/WhenEntryArrow.kt
@@ -1,0 +1,6 @@
+fun a() {
+    when (true) {
+        false -> Unit
+        true <caret>-> Unit
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/formatter/WhenEntryExpr.after.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/WhenEntryExpr.after.kt
@@ -49,24 +49,51 @@ fun some(x: Any) {
     when (x) {
         is
         Int,
-        -> {
+            -> {
             0
         }
 
         3,
-        -> {
+            -> {
             2
         }
 
         in
         0..3,
-        -> {
+            -> {
             2
         }
 
         else
-        -> {
+            -> {
             1
+        }
+    }
+    when (x) {
+        is
+        Int,
+            -> listOf(
+            0
+        )
+
+        3,
+            -> if (true)
+            listOf(4)
+        else
+            listOf(
+                5
+            )
+
+        in
+        0..3,
+            -> run {
+            listOf(2)
+        }
+
+        else
+            -> when {
+            true -> listOf(1)
+            false -> listOf(2)
         }
     }
 }

--- a/plugins/kotlin/idea/tests/testData/formatter/WhenEntryExpr.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/WhenEntryExpr.kt
@@ -65,5 +65,29 @@ else
 1
 }
 }
+when (x) {
+is
+Int
+-> listOf(
+0
+)
+3
+-> if (true)
+listOf(4)
+else
+listOf(
+5
+)
+in
+0..3
+-> run {
+listOf(2)
+}
+else
+-> when {
+true -> listOf(1)
+false -> listOf(2)
+}
+}
 }
 // SET_TRUE: ALLOW_TRAILING_COMMA

--- a/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.inv.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.inv.kt
@@ -1,6 +1,6 @@
 fun foo(x: Any) = when (x) {
     Comparable::class, Iterable::class, String::class, // trailing comma
-    -> println(1)
+        -> println(1)
 
     else -> println(3)
 }
@@ -49,7 +49,7 @@ fun foo(x: Any) {
 
     when (x) {
         1
-        -> {
+            -> {
 
         }
 
@@ -76,7 +76,7 @@ fun foo(x: Any) {
 
     when {
         x in coll
-        -> {
+            -> {
 
         }
 

--- a/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.inv.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.inv.kt
@@ -21,7 +21,7 @@ fun foo(x: Any) {
     when (x) {
         Comparable::class, Iterable::class,
         String::class, /*// trailing comma*/
-        -> println(1)
+            -> println(1)
 
         else -> println(3)
     }

--- a/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.kt
@@ -1,6 +1,6 @@
 fun foo(x: Any) = when (x) {
     Comparable::class, Iterable::class, String::class, // trailing comma
-    -> println(1)
+        -> println(1)
 
     else -> println(3)
 }
@@ -50,7 +50,7 @@ fun foo(x: Any) {
 
     when (x) {
         1,
-        -> {
+            -> {
 
         }
 
@@ -79,7 +79,7 @@ fun foo(x: Any) {
 
     when {
         x in coll
-        -> {
+            -> {
 
         }
 

--- a/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/trailingComma/whenEntry/WhenEntry.after.kt
@@ -14,7 +14,7 @@ fun foo(x: Any) {
     when (x) {
         Comparable::class, Iterable::class,
         String::class, /*// trailing comma*/
-        -> println(1)
+            -> println(1)
 
         else -> println(3)
     }
@@ -22,7 +22,7 @@ fun foo(x: Any) {
     when (x) {
         Comparable::class, Iterable::class,
         String::class, /*// trailing comma*/
-        -> println(1)
+            -> println(1)
 
         else -> println(3)
     }
@@ -60,7 +60,7 @@ fun foo(x: Any) {
     when (x) {
         1, 2,
         3, /**/
-        -> {
+            -> {
 
         }
 
@@ -70,7 +70,7 @@ fun foo(x: Any) {
     when (val c = x) {
         1, 2,
         3, /**/
-        -> {
+            -> {
 
         }
 

--- a/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceTypingIndentationTestGenerated.java
+++ b/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceTypingIndentationTestGenerated.java
@@ -653,6 +653,11 @@ public abstract class PerformanceTypingIndentationTestGenerated extends Abstract
                 runTest("../idea/tests/testData/editor/enterHandler/controlFlowConstructions/Try2.after.kt");
             }
 
+            @TestMetadata("WhenEntryArrow.after.kt")
+            public void testWhenEntryArrow() throws Exception {
+                runTest("../idea/tests/testData/editor/enterHandler/controlFlowConstructions/WhenEntryArrow.after.kt");
+            }
+
             @TestMetadata("WhenWithCondition.after.kt")
             public void testWhenWithCondition() throws Exception {
                 runTest("../idea/tests/testData/editor/enterHandler/controlFlowConstructions/WhenWithCondition.after.kt");


### PR DESCRIPTION
Issue on YouTrack: [KTIJ-103](https://youtrack.jetbrains.com/issue/KTIJ-103/Trailing-comma-breaks-formatting-of-when-expression)