### PR TITLE
Add PYCHARM_DISPLAY_HOST env var for remote access

### DIFF
--- a/plugins/kotlin/docs/fir-ide/architecture/general-architecture.md
+++ b/plugins/kotlin/docs/fir-ide/architecture/general-architecture.md
@@ -6,8 +6,8 @@ The FIR IDE plugin has a layer architecture and consists of 4 layers, where laye
 
 1. **FIR Compiler** Frontend.  [Read more about FIR](https://github.com/JetBrains/kotlin/blob/master/docs/fir/fir-basics.md).
 
-2. **Low-level API Layer**. The interlayer between **Analysis API** & **FIR** Mostly responsible for **KtElement → FirElement** mapping, lazy resolving of FIR Declarations, and diagnostics collecting.[Read more about Low-Level API](https://github.com/JetBrains/kotlin/blob/master/docs/analysis-api/low-level-api-fir.md).
+2. **Low-level API Layer**. The interlayer between **Analysis API** & **FIR** Mostly responsible for **KtElement → FirElement** mapping, lazy resolving of FIR Declarations, and diagnostics collecting.[Read more about Low-Level API](https://github.com/JetBrains/kotlin/blob/master/docs/analysis/low-level-api-fir/low-level-api-fir.md).
 
-3. **Analysis API Layer**. The public API allows the Kotlin IDEA FIR plugin to interact with the compiler. The API surface is Kotlin frontend agnostic, and it can work via both Kotlin frontends FIR and FE1.0. [Read more about Analysis API](https://github.com/JetBrains/kotlin/blob/master/docs/analysis-api/analysis-api.md).
+3. **Analysis API Layer**. The public API allows the Kotlin IDEA FIR plugin to interact with the compiler. The API surface is Kotlin frontend agnostic, and it can work via both Kotlin frontends FIR and FE1.0. [Read more about Analysis API](https://github.com/JetBrains/kotlin/blob/master/docs/analysis/analysis-api/analysis-api.md).
 
 4. **Plugin Subsystems layer**. The layer where the actual plugin is. All subsystems (completion/highlighting/find usages) live here. It does not interact directly with the Kotlin compiler(and corresponding modules do not have dependencies on compiler modules). To get Kotlin resolve information, it uses **Analysis API**.

--- a/python/helpers/pycharm_display/datalore/display/display_.py
+++ b/python/helpers/pycharm_display/datalore/display/display_.py
@@ -18,7 +18,7 @@ else:
 
 __all__ = ['display']
 
-HOST = "http://127.0.0.1"
+HOST = os.getenv("PYCHARM_DISPLAY_HOST", "http://127.0.0.1")
 PORT_ENV = int(os.getenv("PYCHARM_DISPLAY_PORT", "-1"))
 PORT = PORT_ENV
 if PORT == -1:


### PR DESCRIPTION
Enables displaying matplotlib charts in SciView from Docker-based and remote interpreters.

See:
https://youtrack.jetbrains.com/issue/PY-32668/Cannot-view-plots-from-remote-python-interpreter-natively-in-PyCharm-SciView
https://youtrack.jetbrains.com/issue/PY-33558/Matplotlib-in-Docker-container-fails

Workaround described here:
https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000017759/comments/7654144737170