### PR TITLE
Coverage suite type alignment

### DIFF
--- a/plugins/coverage/src/com/intellij/coverage/JavaCoverageSuite.java
+++ b/plugins/coverage/src/com/intellij/coverage/JavaCoverageSuite.java
@@ -57,7 +57,7 @@ public final class JavaCoverageSuite extends BaseCoverageSuite {
                            final boolean tracingEnabled,
                            final boolean trackTestFolders,
                            final CoverageRunner coverageRunner,
-                           @NotNull final JavaCoverageEngine coverageSupportProvider,
+                           @NotNull final CoverageEngine coverageEngine,
                            final Project project) {
     super(name, coverageDataFileProvider, lastCoverageTimeStamp, coverageByTestEnabled,
           tracingEnabled, trackTestFolders,
@@ -65,7 +65,7 @@ public final class JavaCoverageSuite extends BaseCoverageSuite {
 
     myFilters = filters;
     myExcludePatterns = excludePatterns;
-    myCoverageEngine = coverageSupportProvider;
+    myCoverageEngine = coverageEngine;
   }
 
   public String @NotNull [] getFilteredPackageNames() {


### PR DESCRIPTION
Working on adding a custom coverage impl for java and found this to be an issue. All the usages of this parameter and callers of the get method do use CoverageEngine and I found no casting. 