### PR TITLE
[IDEA-301967] Unified diff viewer - cannot click Revert icon immediately after reverting a previous change

### DIFF
--- a/platform/diff-impl/src/com/intellij/diff/tools/fragmented/UnifiedDiffViewer.java
+++ b/platform/diff-impl/src/com/intellij/diff/tools/fragmented/UnifiedDiffViewer.java
@@ -44,6 +44,7 @@ import com.intellij.openapi.editor.ex.MarkupModelEx;
 import com.intellij.openapi.editor.ex.RangeHighlighterEx;
 import com.intellij.openapi.editor.highlighter.EditorHighlighter;
 import com.intellij.openapi.editor.impl.DocumentMarkupModel;
+import com.intellij.openapi.editor.impl.EditorImpl;
 import com.intellij.openapi.editor.impl.LineNumberConverterAdapter;
 import com.intellij.openapi.editor.impl.event.MarkupModelListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -1430,6 +1431,10 @@ public class UnifiedDiffViewer extends ListenerDiffViewerBase implements Differe
       }
       else {
         editor.setHighlighter(DiffUtil.createEmptyEditorHighlighter());
+      }
+      
+      if (editor instanceof EditorImpl editorImpl) {
+        editorImpl.doNotIgnoreNextConsecutiveMouseEvent();
       }
 
       UnifiedEditorRangeHighlighter.erase(project, editor.getDocument());

--- a/platform/diff-impl/src/com/intellij/diff/util/DiffGutterRenderer.java
+++ b/platform/diff-impl/src/com/intellij/diff/util/DiffGutterRenderer.java
@@ -84,8 +84,7 @@ public abstract class DiffGutterRenderer extends GutterIconRenderer implements N
 
   protected void performAction(@NotNull AnActionEvent e) {
     MouseEvent mouseEvent = ObjectUtils.tryCast(e.getInputEvent(), MouseEvent.class);
-    if (mouseEvent == null ||
-        mouseEvent.getButton() == MouseEvent.BUTTON1 && mouseEvent.getClickCount() == 1) {
+    if (mouseEvent == null || mouseEvent.getButton() == MouseEvent.BUTTON1) {
       handleMouseClick();
     }
   }

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
@@ -1000,6 +1000,10 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
 
     myFractionalMetricsHintValue = UISettings.getEditorFractionalMetricsHint();
   }
+  
+  public void doNotIgnoreNextConsecutiveMouseEvent() {
+    myIgnoreMouseEventsConsecutiveToInitial = false;
+  }
 
   @Contract("_->fail")
   public void throwDisposalError(@NonNls @NotNull String msg) {


### PR DESCRIPTION
Please see https://youtrack.jetbrains.com/issue/IDEA-301967 for a video of the problem. The comments then explain why this issue happens, and from them it should be clear why I made these changes in the PR.

The `clickCount` condition was introduced in c3e755b7699eeb61272c0a6666e92b27c052c255 which is about right-clicking, not about the number of clicks, so it seems it was added reduntantly and should be safe to remove.

I would not say that the way I reset the consecutive mouse event flag is the best solution here, so if you let me know how you'd like to code that better, I'll be happy to edit the PR.