### PR TITLE
IDEA-302246 String.repeat() can replace more kinds of concatenation

### DIFF
--- a/java/java-impl-inspections/src/com/intellij/codeInspection/ExplicitArrayFillingInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/ExplicitArrayFillingInspection.java
@@ -82,16 +82,6 @@ public class ExplicitArrayFillingInspection extends AbstractBaseJavaLocalInspect
         registerProblem(statement, true);
       }
 
-      private boolean isChangedInLoop(@NotNull CountingLoop loop, @NotNull PsiExpression rValue) {
-        if (VariableAccessUtils.collectUsedVariables(rValue).contains(loop.getCounter()) ||
-            SideEffectChecker.mayHaveSideEffects(rValue)) {
-          return true;
-        }
-        return ExpressionUtils.nonStructuralChildren(rValue)
-          .filter(c -> c instanceof PsiCallExpression)
-          .anyMatch(call -> !ClassUtils.isImmutable(call.getType()) && !ConstructionUtils.isEmptyArrayInitializer(call));
-      }
-
       private boolean isDefaultValue(@NotNull PsiExpression expression, @Nullable Object defaultValue, @Nullable PsiType lType) {
         if (ExpressionUtils.isNullLiteral(expression) && defaultValue == null) return true;
         Object constantValue = ExpressionUtils.computeConstantExpression(expression);
@@ -235,6 +225,16 @@ public class ExplicitArrayFillingInspection extends AbstractBaseJavaLocalInspect
         return range;
       }
     };
+  }
+
+  public static boolean isChangedInLoop(@NotNull CountingLoop loop, @NotNull PsiExpression rValue) {
+    if (VariableAccessUtils.collectUsedVariables(rValue).contains(loop.getCounter()) ||
+        SideEffectChecker.mayHaveSideEffects(rValue)) {
+      return true;
+    }
+    return ExpressionUtils.nonStructuralChildren(rValue)
+      .filter(c -> c instanceof PsiCallExpression)
+      .anyMatch(call -> !ClassUtils.isImmutable(call.getType()) && !ConstructionUtils.isEmptyArrayInitializer(call));
   }
 
   private static final class ReplaceWithArraysCallFix implements LocalQuickFix {

--- a/java/java-impl-inspections/src/com/intellij/codeInspection/StringRepeatCanBeUsedInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/StringRepeatCanBeUsedInspection.java
@@ -22,10 +22,21 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.Writer;
+
 import static com.intellij.util.ObjectUtils.tryCast;
 
 public class StringRepeatCanBeUsedInspection extends AbstractBaseJavaLocalInspectionTool {
-  private static final CallMatcher APPEND = CallMatcher.instanceCall("java.lang.AbstractStringBuilder", "append").parameterCount(1);
+  private static final CallMatcher APPEND = CallMatcher.instanceCall(Appendable.class.getName(), "append").parameterCount(1);
+  private static final CallMatcher INSERT = CallMatcher.instanceCall("java.lang.AbstractStringBuilder", "insert").parameterCount(2);
+  private static final CallMatcher PRINT = CallMatcher.instanceCall(PrintStream.class.getName(), "print").parameterCount(1);
+  private static final CallMatcher
+    WRITE_OR_PRINT = CallMatcher.anyOf(CallMatcher.instanceCall(Writer.class.getName(), "write").parameterTypes(String.class.getName())
+    , CallMatcher.instanceCall(OutputStream.class.getName(), "write").parameterTypes("byte[]")
+    , PRINT);
+  private static final CallMatcher CONCAT = CallMatcher.instanceCall(String.class.getName(), "concat").parameterCount(1);
 
   public boolean ADD_MATH_MAX = true;
 
@@ -42,16 +53,13 @@ public class StringRepeatCanBeUsedInspection extends AbstractBaseJavaLocalInspec
     return new JavaElementVisitor() {
       @Override
       public void visitForStatement(@NotNull PsiForStatement statement) {
-        PsiMethodCallExpression call = findAppendCall(statement);
-        if (call == null) return;
-        PsiReferenceExpression qualifier = tryCast(PsiUtil.skipParenthesizedExprDown(call.getMethodExpression().getQualifierExpression()),
-                                                   PsiReferenceExpression.class);
-        if (qualifier == null || !ExpressionUtil.isEffectivelyUnqualified(qualifier)) return;
         CountingLoop loop = CountingLoop.from(statement);
         if (loop == null) return;
         PsiLocalVariable var = loop.getCounter();
-        if (var.getType().equals(PsiType.LONG) || VariableAccessUtils.variableIsUsed(var, call)) return;
-        PsiExpression arg = call.getArgumentList().getExpressions()[0];
+        if (PsiType.LONG.equals(var.getType()) || VariableAccessUtils.variableIsUsed(var, statement.getBody())) return;
+        PsiExpressionStatement appendingStatement = findAppendingStatement(statement);
+        PsiExpression arg = findAppendedContent(loop, appendingStatement);
+        if (arg == null) return;
         if (SideEffectChecker.mayHaveSideEffects(arg)) return;
         holder.registerProblem(statement.getFirstChild(), JavaBundle.message(
           "inspection.message.can.be.replaced.with.string.repeat"),
@@ -61,12 +69,105 @@ public class StringRepeatCanBeUsedInspection extends AbstractBaseJavaLocalInspec
   }
 
   @Nullable
-  private static PsiMethodCallExpression findAppendCall(PsiForStatement statement) {
-    PsiExpressionStatement body = tryCast(ControlFlowUtils.stripBraces(statement.getBody()), PsiExpressionStatement.class);
-    if (body == null) return null;
-    PsiMethodCallExpression call = tryCast(body.getExpression(), PsiMethodCallExpression.class);
-    if (!APPEND.test(call)) return null;
-    return call;
+  private static PsiExpressionStatement findAppendingStatement(PsiForStatement statement) {
+    PsiStatement @NotNull [] bodyStatements = ControlFlowUtils.unwrapBlock(statement.getBody());
+    if (bodyStatements.length != 1) return null;
+    return tryCast(bodyStatements[0], PsiExpressionStatement.class);
+  }
+
+  @Nullable
+  private static PsiExpression findAppendedContent(@Nullable CountingLoop loop, @Nullable PsiExpressionStatement appendingStatement) {
+    if (appendingStatement == null) return null;
+    PsiExpression appendingExpression = appendingStatement.getExpression();
+    PsiAssignmentExpression assignmentExpression = tryCast(appendingExpression, PsiAssignmentExpression.class);
+    PsiReferenceExpression destinationVariable = null;
+    if (assignmentExpression != null) {
+      destinationVariable = tryCast(assignmentExpression.getLExpression(), PsiReferenceExpression.class);
+      if (destinationVariable == null
+          || destinationVariable.getType() == null) return null;
+    }
+    if (destinationVariable != null && JavaTokenType.PLUSEQ.equals(assignmentExpression.getOperationTokenType())) {
+      // Case: textString += " ";
+      if (!TypeUtils.isJavaLangString(destinationVariable.getType())) return null;
+      return assignmentExpression.getRExpression();
+    }
+    if (destinationVariable != null && TypeUtils.isJavaLangString(destinationVariable.getType())) {
+      if (JavaTokenType.EQ.equals(assignmentExpression.getOperationTokenType())) {
+        PsiPolyadicExpression concatenation = tryCast(PsiUtil.skipParenthesizedExprDown(assignmentExpression.getRExpression()),
+                                                      PsiPolyadicExpression.class);
+        PsiMethodCallExpression concatCall = tryCast(assignmentExpression.getRExpression(), PsiMethodCallExpression.class);
+        PsiExpression leftString = null;
+        PsiExpression rightString = null;
+        if (concatenation != null && JavaTokenType.PLUS.equals(concatenation.getOperationTokenType()) && concatenation.getOperands().length == 2) {
+          // Case: textString = textString + " ";
+          leftString = PsiUtil.skipParenthesizedExprDown(concatenation.getOperands()[0]);
+          rightString = concatenation.getOperands()[1];
+        } else if (CONCAT.test(concatCall)) {
+          // Case: textString = textString.concat(" ");
+          leftString = PsiUtil.skipParenthesizedExprDown(concatCall.getMethodExpression().getQualifierExpression());
+          rightString = concatCall.getArgumentList().getExpressions()[0];
+        }
+        if (leftString == null || rightString == null) return null;
+        if (EquivalenceChecker.getCanonicalPsiEquivalence().expressionsAreEquivalent(destinationVariable, leftString)) {
+          // Case: textString = textString + " ";
+          return rightString;
+        } else if (EquivalenceChecker.getCanonicalPsiEquivalence().expressionsAreEquivalent(destinationVariable, rightString)) {
+          // Case: textString = " " + textString;
+          return leftString;
+        }
+        return null;
+      }
+    }
+    return findAppendedObject(loop, appendingExpression, assignmentExpression, destinationVariable);
+  }
+
+  @Nullable
+  private static PsiExpression findAppendedObject(@Nullable CountingLoop loop,
+                                             PsiExpression appendingExpression,
+                                             PsiAssignmentExpression assignmentExpression,
+                                             PsiReferenceExpression destinationVariable) {
+    if (destinationVariable != null) {
+      // Case: textBuilder = textBuilder.append(" ");
+      appendingExpression = assignmentExpression.getRExpression();
+    }
+    PsiMethodCallExpression call = tryCast(appendingExpression, PsiMethodCallExpression.class);
+    if (call != null) {
+      PsiReferenceExpression caller = tryCast(PsiUtil.skipParenthesizedExprDown(call.getMethodExpression().getQualifierExpression()),
+                                                 PsiReferenceExpression.class);
+      if (caller == null) return null;
+      if (PRINT.test(call)
+          && destinationVariable == null
+          && "out".equals(caller.getReferenceName())) {
+        // Case: System.out.print(" ");
+
+        PsiElement referent = caller.resolve();
+        if (referent instanceof PsiField) {
+          PsiField field = (PsiField)referent;
+          PsiClass containingClass = field.getContainingClass();
+          if (containingClass != null && "java.lang.System".equals(containingClass.getQualifiedName())) {
+            return call.getArgumentList().getExpressions()[0];
+          }
+        }
+      }
+      if (!ExpressionUtil.isEffectivelyUnqualified(caller)) return null;
+      if (ClassUtils.isKnownClassImplementation(caller)) {
+        if (APPEND.test(call)) {
+          // Case: textBuilder.append(" ");
+          return call.getArgumentList().getExpressions()[0];
+        }
+        if (INSERT.test(call)) {
+          // Case: textBuilder.insert(0, " ");
+          PsiExpression[] expressions = call.getArgumentList().getExpressions();
+          if (loop == null || ExplicitArrayFillingInspection.isChangedInLoop(loop, expressions[0])) return null;
+          return expressions[1];
+        }
+        if (destinationVariable != null) return null;
+        if (WRITE_OR_PRINT.test(call)) {
+          return call.getArgumentList().getExpressions()[0];
+        }
+      }
+    }
+    return null;
   }
 
   private static final class StringRepeatCanBeUsedFix implements LocalQuickFix {
@@ -89,11 +190,9 @@ public class StringRepeatCanBeUsedInspection extends AbstractBaseJavaLocalInspec
       if (statement == null) return;
       CountingLoop loop = CountingLoop.from(statement);
       if (loop == null) return;
-      PsiMethodCallExpression call = findAppendCall(statement);
-      if (call == null) return;
-      PsiExpression builder = call.getMethodExpression().getQualifierExpression();
-      if (builder == null) return;
-      PsiExpression arg = call.getArgumentList().getExpressions()[0];
+      PsiExpressionStatement appendingStatement = findAppendingStatement(statement);
+      PsiExpression arg = findAppendedContent(loop, appendingStatement);
+      if (arg == null) return;
       PsiExpression from, to;
       if (loop.isDescending()) {
         from = loop.getBound();
@@ -111,10 +210,10 @@ public class StringRepeatCanBeUsedInspection extends AbstractBaseJavaLocalInspec
       }
       String replacement = repeatQualifier + ".repeat(" + countText + ")";
       ct.replace(arg, replacement);
-      PsiExpressionStatement result = (PsiExpressionStatement)ct.replaceAndRestoreComments(statement, call.getParent());
+      PsiExpressionStatement result = (PsiExpressionStatement)ct.replaceAndRestoreComments(statement, appendingStatement);
       if (myAddMathMax) {
-        PsiMethodCallExpression appendCall = (PsiMethodCallExpression)result.getExpression();
-        PsiMethodCallExpression repeatCall = (PsiMethodCallExpression)appendCall.getArgumentList().getExpressions()[0];
+        PsiMethodCallExpression repeatCall = tryCast(findAppendedContent(loop, result), PsiMethodCallExpression.class);
+        if (repeatCall == null) return;
         PsiMethodCallExpression maxCall = (PsiMethodCallExpression)repeatCall.getArgumentList().getExpressions()[0];
         PsiExpression count = maxCall.getArgumentList().getExpressions()[1];
         LongRangeSet range = CommonDataflow.getExpressionRange(count);

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatDifferentAssignment.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatDifferentAssignment.java
@@ -1,0 +1,9 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String tenSpaces() {
+    StringBuilder sb = new StringBuilder();
+    StringBuilder anotherBuilder = new StringBuilder();
+      anotherBuilder = sb.append(" ".repeat(10));
+    return anotherBuilder.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatInsert.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatInsert.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    StringBuilder sb = new StringBuilder();
+      sb.insert(0, " ".repeat(100));
+    return sb.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatInsertAnywhere.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatInsertAnywhere.java
@@ -1,0 +1,7 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces(StringBuilder sb) {
+      sb.insert(123, " ".repeat(100));
+    return sb.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatOutputStream.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatOutputStream.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+import java.io.ByteArrayOutputStream;
+
+class Test {
+  String hundredSpaces() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      baos.write(String.valueOf(" ".getBytes()).repeat(Math.max(0, 100)));
+    return baos.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatPrintStream.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatPrintStream.java
@@ -1,0 +1,11 @@
+// "Replace with 'String.repeat()'" "true"
+import java.io.PrintStream;
+
+class Test {
+  void hundredSpaces() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(baos);
+      ps.print(" ".repeat(100));
+    ps.close();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatReassignment.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatReassignment.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    StringBuilder sb = new StringBuilder();
+      sb = sb.append(" ".repeat(100));
+    return sb.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringAdding.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringAdding.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+      text += " ".repeat(100);
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringConcatMethod.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringConcatMethod.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+      text = text.concat(" ".repeat(100));
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringConcatMethodPrefix.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringConcatMethodPrefix.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+      text = " ".repeat(100).concat(text);
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringPrefixing.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringPrefixing.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+      text = " ".repeat(100) + text;
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringReassignment.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatStringReassignment.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+      text = text + " ".repeat(100);
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatSystemOutPrint.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatSystemOutPrint.java
@@ -1,0 +1,6 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  void hundredSpaces() {
+      System.out.print(" ".repeat(100));
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/afterRepeatWriter.java
+++ b/java/java-tests/testData/inspection/stringRepeat/afterRepeatWriter.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+import java.io.StringWriter;
+
+class Test {
+  String hundredSpaces() {
+    StringWriter sw = new StringWriter();
+      sw.write(" ".repeat(100));
+    return sw.getBuffer().toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatAnonymousWriter.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatAnonymousWriter.java
@@ -1,0 +1,16 @@
+// "Replace with 'String.repeat()'" "false"
+import java.io.StringWriter;
+
+class Test {
+  String hundredSpaces() {
+    StringWriter sw = new StringWriter() {
+      public void write(String text) {
+        super.write(Math.random());
+      }
+    };
+    f<caret>or(int i=0; i<100; i++) {
+      sw.write(" ");
+    }
+    return sw.getBuffer().toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatBadMethod.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatBadMethod.java
@@ -1,0 +1,12 @@
+// "Replace with 'String.repeat()'" "false"
+import java.io.StringWriter;
+
+class Test {
+  String hundredSpaces() {
+    StringWriter sw = new StringWriter();
+    f<caret>or(int i=0; i<100; i++) {
+      sw.write(1);
+    }
+    return sw.getBuffer().toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatDifferentAssignment.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatDifferentAssignment.java
@@ -1,0 +1,11 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String tenSpaces() {
+    StringBuilder sb = new StringBuilder();
+    StringBuilder anotherBuilder = new StringBuilder();
+    f<caret>or(int i=0; i<10; i++) {
+      anotherBuilder = sb.append(" ");
+    }
+    return anotherBuilder.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatInsert.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatInsert.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    StringBuilder sb = new StringBuilder();
+    f<caret>or(int i=0; i<100; i++) {
+      sb.insert(0, " ");
+    }
+    return sb.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatInsertAnywhere.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatInsertAnywhere.java
@@ -1,0 +1,9 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces(StringBuilder sb) {
+    f<caret>or(int i=0; i<100; i++) {
+      sb.insert(123, " ");
+    }
+    return sb.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatOutputStream.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatOutputStream.java
@@ -1,0 +1,12 @@
+// "Replace with 'String.repeat()'" "true"
+import java.io.ByteArrayOutputStream;
+
+class Test {
+  String hundredSpaces() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    f<caret>or(int i=0; i<100; i++) {
+      baos.write(" ".getBytes());
+    }
+    return baos.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatPrintStream.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatPrintStream.java
@@ -1,0 +1,13 @@
+// "Replace with 'String.repeat()'" "true"
+import java.io.PrintStream;
+
+class Test {
+  void hundredSpaces() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(baos);
+    f<caret>or(int i=0; i<100; i++) {
+      ps.print(" ");
+    }
+    ps.close();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatReassignment.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatReassignment.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    StringBuilder sb = new StringBuilder();
+    f<caret>or(int i=0; i<100; i++) {
+      sb = sb.append(" ");
+    }
+    return sb.toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringAdding.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringAdding.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    f<caret>or(int i=0; i<100; i++) {
+      text += " ";
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringBadMethod.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringBadMethod.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "false"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    f<caret>or(int i=0; i<100; i++) {
+      text = text.formatted(" ");
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringBadOperator.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringBadOperator.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "false"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    f<caret>or(int i=0; i<100; i++) {
+      text = " ";
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringConcatMethod.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringConcatMethod.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    f<caret>or(int i=0; i<100; i++) {
+      text = text.concat(" ");
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringConcatMethodPrefix.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringConcatMethodPrefix.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    f<caret>or(int i=0; i<100; i++) {
+      text = " ".concat(text);
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringPrefixing.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringPrefixing.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    f<caret>or(int i=0; i<100; i++) {
+      text = " " + text;
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringReassignment.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringReassignment.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    f<caret>or(int i=0; i<100; i++) {
+      text = text + " ";
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringWrongAssignment.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatStringWrongAssignment.java
@@ -1,0 +1,11 @@
+// "Replace with 'String.repeat()'" "false"
+class Test {
+  String hundredSpaces() {
+    String text = "";
+    String anotherText = "";
+    f<caret>or(int i=0; i<100; i++) {
+      anotherText = text + " ";
+    }
+    return text;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatSystemOutPrint.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatSystemOutPrint.java
@@ -1,0 +1,8 @@
+// "Replace with 'String.repeat()'" "true"
+class Test {
+  void hundredSpaces() {
+    f<caret>or(int i=0; i<100; i++) {
+      System.out.print(" ");
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatUnknownWriter.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatUnknownWriter.java
@@ -1,0 +1,18 @@
+// "Replace with 'String.repeat()'" "false"
+import java.io.StringWriter;
+
+class Test {
+  private static class AnonymousWriter extends StringWriter() {
+    public void write(String text) {
+      super.write(Math.random());
+    }
+  }
+
+  String hundredSpaces() {
+    AnonymousWriter sw = new AnonymousWriter();
+    f<caret>or(int i=0; i<100; i++) {
+      sw.write(" ");
+    }
+    return sw.getBuffer().toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatUsingCounter.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatUsingCounter.java
@@ -1,0 +1,9 @@
+// "Replace with 'String.repeat()'" "false"
+class Test {
+  String[] hundredSpaces(String[] texts) {
+    f<caret>or(int i=0; i<100; i++) {
+      texts[i] = texts[i] + " ";
+    }
+    return texts;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatVariableWithSideEffect.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatVariableWithSideEffect.java
@@ -1,0 +1,10 @@
+// "Replace with 'String.repeat()'" "false"
+class Test {
+  String[] hundredSpaces(String[] texts) {
+    int j = 123;
+    f<caret>or(int i=0; i<100; i++) {
+      texts[j++] = texts[j++] + " ";
+    }
+    return texts;
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeat/beforeRepeatWriter.java
+++ b/java/java-tests/testData/inspection/stringRepeat/beforeRepeatWriter.java
@@ -1,0 +1,12 @@
+// "Replace with 'String.repeat()'" "true"
+import java.io.StringWriter;
+
+class Test {
+  String hundredSpaces() {
+    StringWriter sw = new StringWriter();
+    f<caret>or(int i=0; i<100; i++) {
+      sw.write(" ");
+    }
+    return sw.getBuffer().toString();
+  }
+}

--- a/java/java-tests/testData/inspection/stringRepeatCanBeUsed/StringRepeatCanBeUsed.java
+++ b/java/java-tests/testData/inspection/stringRepeatCanBeUsed/StringRepeatCanBeUsed.java
@@ -1,0 +1,10 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+class C {
+  public static void main(String[] args) {
+    StringBuilder sb = new StringBuilder();
+    <warning descr="Can be replaced with 'String.repeat()'">for</warning>(int i=0; i<100; i++) {
+      sb = sb.append(" ");
+    }
+    System.out.println("Result: " + sb);
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/StringRepeatCanBeUsedFixTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/StringRepeatCanBeUsedFixTest.java
@@ -1,0 +1,28 @@
+// Copyright 2000-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.java.codeInspection;
+
+import com.intellij.codeInsight.daemon.quickFix.LightQuickFixParameterizedTestCase;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.StringRepeatCanBeUsedInspection;
+import com.intellij.testFramework.LightProjectDescriptor;
+import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase.JAVA_11;
+
+public class StringRepeatCanBeUsedFixTest extends LightQuickFixParameterizedTestCase {
+  @Override
+  protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
+    return new LocalInspectionTool[]{new StringRepeatCanBeUsedInspection()};
+  }
+
+  @NotNull
+  @Override
+  protected LightProjectDescriptor getProjectDescriptor() {
+    return JAVA_11;
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/inspection/stringRepeat";
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/StringRepeatCanBeUsedInspectionTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/StringRepeatCanBeUsedInspectionTest.java
@@ -1,18 +1,24 @@
-// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.java.codeInspection;
 
-import com.intellij.codeInsight.daemon.quickFix.LightQuickFixParameterizedTestCase;
-import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.JavaTestUtil;
+import com.intellij.codeInspection.InspectionProfileEntry;
 import com.intellij.codeInspection.StringRepeatCanBeUsedInspection;
 import com.intellij.testFramework.LightProjectDescriptor;
+import com.siyeh.ig.LightJavaInspectionTestCase;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import static com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase.JAVA_11;
-
-public class StringRepeatCanBeUsedInspectionTest extends LightQuickFixParameterizedTestCase {
+public class StringRepeatCanBeUsedInspectionTest extends LightJavaInspectionTestCase {
   @Override
-  protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
-    return new LocalInspectionTool[]{new StringRepeatCanBeUsedInspection()};
+  protected String getTestDataPath() {
+    return JavaTestUtil.getJavaTestDataPath() + "/inspection/stringRepeatCanBeUsed/";
+  }
+
+  @Nullable
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new StringRepeatCanBeUsedInspection();
   }
 
   @NotNull
@@ -21,8 +27,5 @@ public class StringRepeatCanBeUsedInspectionTest extends LightQuickFixParameteri
     return JAVA_11;
   }
 
-  @Override
-  protected String getBasePath() {
-    return "/inspection/stringRepeat";
-  }
+  public void testStringRepeatCanBeUsed() { doTest(); }
 }


### PR DESCRIPTION
Hi @amaembo,

***What steps will reproduce the issue?***

1. Go to *File* → *Settings..*. → *Editor* → *Inspections*
2. Enable *String.repeat() can be used*
3. Enable Severity: *Warning*
4. Add this method in a Java class:

```Java
  void work() {
    for(int i=0; i<100; i++) {
      System.out.print(" ");
    }
  }
```

***What is the expected result?***
The inspection *String.repeat() can be used* is suggested.
***What happens instead?***
The inspection *String.repeat() can be used* is not suggested.

In addition to the already handled syntax of concatenation:

```Java
  myStringBuilder.append(" ");
```

..., this ticket also handles those syntax of concatenation:

```Java
  myStringBuilder = myStringBuilder.append(" ");

  myStringBuilder = myStringBuilder.insert(0, " ");

  myStringBuilder = myStringBuilder.insert(123, " ");

  anotherStringBuilder = myStringBuilder.insert(123, " ");

  myStringObject = myStringObject + " ";

  myStringObject += " ";

  myStringObject = myStringObject.concat(" ");

  myStringObject = " ".concat(myStringObject);

  myStringObject = " " + myStringObject;

  System.out.print(" ");

  myPrintStream.print(" ");

  myOutputStream.write(" ");

  myWriter.write(" ");
```

`System.out.println(" ")` is not handled as it adds a new line. Methods are refactored only if we know the implementation. A custom implementation may not follow the specifications so the result is unpredictable. When an insertion index is used, this index must not change during the original iteration. In string reassignment, we check that the string variable is the same. The concatenation order is always preserved.

I have added some unit tests that run successfully.