### PR TITLE
Update argument name to match CoverageEngine method argument name

### DIFF
--- a/plugins/coverage-common/src/com/intellij/coverage/CoverageDataManager.java
+++ b/plugins/coverage-common/src/com/intellij/coverage/CoverageDataManager.java
@@ -37,7 +37,7 @@ public abstract class CoverageDataManager {
                                                  String[] filters,
                                                  long lastCoverageTimeStamp,
                                                  @Nullable String suiteToMergeWith, final CoverageRunner coverageRunner,
-                                                 final boolean collectLineInfo, final boolean tracingEnabled);
+                                                 final boolean coverageByTestEnabled, final boolean tracingEnabled);
 
   public abstract CoverageSuite addExternalCoverageSuite(String selectedFileName,
                                                          long timeStamp,

--- a/plugins/coverage-common/src/com/intellij/coverage/CoverageDataManagerImpl.java
+++ b/plugins/coverage-common/src/com/intellij/coverage/CoverageDataManagerImpl.java
@@ -228,9 +228,9 @@ public class CoverageDataManagerImpl extends CoverageDataManager implements Disp
   public CoverageSuite addCoverageSuite(final String name, final CoverageFileProvider fileProvider, final String[] filters, final long lastCoverageTimeStamp,
                                         @Nullable final String suiteToMergeWith,
                                         final CoverageRunner coverageRunner,
-                                        final boolean collectLineInfo,
+                                        final boolean coverageByTestEnabled,
                                         final boolean tracingEnabled) {
-    final CoverageSuite suite = createCoverageSuite(coverageRunner, name, fileProvider, filters, lastCoverageTimeStamp, suiteToMergeWith, collectLineInfo, tracingEnabled);
+    final CoverageSuite suite = createCoverageSuite(coverageRunner, name, fileProvider, filters, lastCoverageTimeStamp, suiteToMergeWith, coverageByTestEnabled, tracingEnabled);
     if (suiteToMergeWith == null || !name.equals(suiteToMergeWith)) {
       removeCoverageSuite(suite);
     }
@@ -648,14 +648,14 @@ public class CoverageDataManagerImpl extends CoverageDataManager implements Disp
                                             final String[] filters,
                                             final long lastCoverageTimeStamp,
                                             final String suiteToMergeWith,
-                                            final boolean collectLineInfo,
+                                            final boolean coverageByTestEnabled,
                                             final boolean tracingEnabled) {
 
     CoverageSuite suite = null;
     for (CoverageEngine engine : CoverageEngine.EP_NAME.getExtensions()) {
       if (coverageRunner.acceptsCoverageEngine(engine)) {
         suite = engine.createCoverageSuite(coverageRunner, name, fileProvider, filters, lastCoverageTimeStamp,
-                                           suiteToMergeWith, collectLineInfo, tracingEnabled, false, myProject);
+                                           suiteToMergeWith, coverageByTestEnabled, tracingEnabled, false, myProject);
         if (suite != null) {
           break;
         }


### PR DESCRIPTION
Noticed these variables do not match their function when calling `engine.createCoverageSuite`