### PR TITLE
Support creation of CoverageSuite externally from DataManager

### DIFF
--- a/plugins/coverage-common/src/com/intellij/coverage/CoverageDataManagerImpl.java
+++ b/plugins/coverage-common/src/com/intellij/coverage/CoverageDataManagerImpl.java
@@ -231,12 +231,16 @@ public class CoverageDataManagerImpl extends CoverageDataManager implements Disp
                                         final boolean collectLineInfo,
                                         final boolean tracingEnabled) {
     final CoverageSuite suite = createCoverageSuite(coverageRunner, name, fileProvider, filters, lastCoverageTimeStamp, suiteToMergeWith, collectLineInfo, tracingEnabled);
-    if (suiteToMergeWith == null || !name.equals(suiteToMergeWith)) {
+    addCoverageSuite(suite, suiteToMergeWith);
+    return suite;
+  }
+
+  public void addCoverageSuite(final CoverageSuite suite, @Nullable final String suiteToMergeWith) {
+    if (suiteToMergeWith == null || !suite.getPresentableName().equals(suiteToMergeWith)) {
       removeCoverageSuite(suite);
     }
     myCoverageSuites.remove(suite); // remove previous instance
     myCoverageSuites.add(suite); // add new instance
-    return suite;
   }
 
   @Override


### PR DESCRIPTION
Using the method https://github.com/brian-mcnamara/intellij-community/blob/9496c964262ff590a163fc27c57c2f61fdeb89e5/plugins/coverage-common/src/com/intellij/coverage/CoverageDataManagerImpl.java#L228 limits the CoverageSuite creation, ultimatly passing the coverage configuration through would give me what I need, but I don't see why constructing and adding a suite is not supported. 