### PR TITLE
KTIJ-23009 False positive "Constructor parameter is never used as a property" warning on actual property in constructor when passed to superclass

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/CanBeParameterInspection.kt
@@ -75,7 +75,7 @@ class CanBeParameterInspection : AbstractKotlinInspection() {
             // Applicable to val / var parameters of a class / object primary constructors
             val valOrVar = parameter.valOrVarKeyword ?: return
             val name = parameter.name ?: return
-            if (parameter.hasModifier(OVERRIDE_KEYWORD)) return
+            if (parameter.hasModifier(OVERRIDE_KEYWORD) || parameter.hasModifier(ACTUAL_KEYWORD)) return
             if (parameter.annotationEntries.isNotEmpty()) return
             val constructor = parameter.parent.parent as? KtPrimaryConstructor ?: return
             val klass = constructor.getContainingClassOrObject() as? KtClass ?: return

--- a/plugins/kotlin/idea/tests/testData/inspections/canBeParameter/actual.kt
+++ b/plugins/kotlin/idea/tests/testData/inspections/canBeParameter/actual.kt
@@ -1,0 +1,12 @@
+expect abstract class Bar
+
+expect class Foo : Bar {
+    val baz: Int
+}
+
+actual abstract class Bar(baz: String)
+
+actual class Foo(
+    // NO
+    actual val baz: Int
+) : Bar(baz.toString())


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23009