### PR TITLE
Kotlin Parcelize: Fix type of `CREATOR` field in `ParcelizeUltraLightClassModifierExtension`

### DIFF
--- a/plugins/kotlin/compiler-plugins/parcelize/common/src/org/jetbrains/kotlin/idea/compilerPlugin/parcelize/ParcelizeUltraLightClassModifierExtension.kt
+++ b/plugins/kotlin/compiler-plugins/parcelize/common/src/org/jetbrains/kotlin/idea/compilerPlugin/parcelize/ParcelizeUltraLightClassModifierExtension.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.idea.base.util.module
 import org.jetbrains.kotlin.parcelize.ParcelizeSyntheticComponent
 import org.jetbrains.kotlin.parcelize.serializers.ParcelizeExtensionBase
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.util.isAnnotated
 import org.jetbrains.kotlin.util.isOrdinaryClass
 
@@ -50,12 +51,12 @@ class ParcelizeUltraLightClassModifierExtension : ParcelizeExtensionBase, UltraL
         val parcelizeClass = tryGetParcelizeClass(declaration, descriptor) ?: return
         if (parcelizeClass.hasCreatorField()) return
 
-        val field = object: LightFieldBuilder("CREATOR", "android.os.Parcelable.Creator", containingDeclaration), KtLightField {
+        val creatorType = "android.os.Parcelable.Creator<${parcelizeClass.fqNameSafe.asString()}>"
+        val field = object: LightFieldBuilder("CREATOR", creatorType, containingDeclaration), KtLightField {
             override val kotlinOrigin: KtDeclaration? get() = null
             override val lightMemberOrigin: LightMemberOrigin? get() = null
             override fun computeConstantValue(visitedVars: MutableSet<PsiVariable>?): Any? = null
             override fun getContainingClass(): KtLightClass = containingDeclaration
-
         }.also {
             it.setModifiers("public", "static", "final")
         }


### PR DESCRIPTION
See https://issuetracker.google.com/110131003

Currently, the `CREATOR` field added by the `ParcelizeUltraLightClassModifierExtension` has a raw type of [`Parcelable.Creator`](https://developer.android.com/reference/android/os/Parcelable.Creator). The type parameter should instead be instantiated with the current class, to yield correct types when using `createFromParcel` or `newArray` from Java code.