### PR TITLE
Fix handling of not updated VFS in coverage plugin

### DIFF
--- a/plugins/coverage/src/com/intellij/coverage/JavaCoverageClassesEnumerator.java
+++ b/plugins/coverage/src/com/intellij/coverage/JavaCoverageClassesEnumerator.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressIndicatorProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.OrderEnumerator;
+import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
@@ -112,7 +113,7 @@ public abstract class JavaCoverageClassesEnumerator {
       else if (productionRootsSet.contains(output)) {
         continue;
       }
-      final File outputRoot = PackageAnnotator.findRelativeFile(rootPackageVMName, output);
+      final File outputRoot = PackageAnnotator.findRelativeFile(rootPackageVMName, VfsUtilCore.virtualToIoFile(output));
       if (outputRoot.exists()) {
         visitRoot(outputRoot, rootPackageVMName, scope);
       }

--- a/plugins/coverage/src/com/intellij/coverage/PackageAnnotator.java
+++ b/plugins/coverage/src/com/intellij/coverage/PackageAnnotator.java
@@ -183,8 +183,7 @@ public final class PackageAnnotator {
     myRunner = runner;
   }
 
-  public static @NotNull File findRelativeFile(@NotNull String rootPackageVMName, VirtualFile output) {
-    File outputRoot = VfsUtilCore.virtualToIoFile(output);
+  public static @NotNull File findRelativeFile(@NotNull String rootPackageVMName, File outputRoot) {
     outputRoot = rootPackageVMName.length() > 0 ? new File(outputRoot, FileUtil.toSystemDependentName(rootPackageVMName)) : outputRoot;
     return outputRoot;
   }
@@ -196,7 +195,8 @@ public final class PackageAnnotator {
         .isInTestSourceContent(psiClass.getContainingFile().getVirtualFile());
       final CompilerModuleExtension moduleExtension = CompilerModuleExtension.getInstance(module);
       if (moduleExtension == null) return null;
-      final VirtualFile outputPath = isInTests ? moduleExtension.getCompilerOutputPathForTests() : moduleExtension.getCompilerOutputPath();
+      final String outputPathUrl = isInTests ? moduleExtension.getCompilerOutputUrlForTests() : moduleExtension.getCompilerOutputUrl();
+      final File outputPath = outputPathUrl != null ? new File(VfsUtilCore.urlToPath(outputPathUrl)) : null;
 
       if (outputPath != null) {
         final String qualifiedName = psiClass.getQualifiedName();


### PR DESCRIPTION
The Coverage plugin used to expect build output directories to be present in the virtual file system as a result of building a project. However, even making sure that build output roots are present in the VFS is an expensive operation on large projects. This is despite the coverage plugin using Java IO to deal with .class files.

Use `getCompilerOutputUrl()` instead of `getCompilerOutput()` and make sure the virtual file system is refreshed when it is really needed. This avoids refreshing on build completion.