### PR TITLE
[IDEA-176363] Shell integration for fish breaks universal variables

### DIFF
--- a/plugins/terminal/resources/fish/config.fish
+++ b/plugins/terminal/resources/fish/config.fish
@@ -1,32 +1,5 @@
-if test -n "$OLD_XDG_CONFIG_HOME"
-  set XDG_CONFIG_HOME "$OLD_XDG_CONFIG_HOME"
-else
-  set -e XDG_CONFIG_HOME
-end
-
-if test -d ~/.config/fish/functions
-  for f in ~/.config/fish/functions/*.fish
-    source $f
-  end
-end
-
-if test -d ~/.config/fish/conf.d
-  for f in ~/.config/fish/conf.d/*.fish
-    source $f
-  end
-end
-
-if test -f ~/.config/fish/config.fish
-  . ~/.config/fish/config.fish
-end
-
-if test -n "$JEDITERM_USER_RCFILE"
-  . "$JEDITERM_USER_RCFILE"
-  set -e JEDITERM_USER_RCFILE
-end
-
 if test -n "$JEDITERM_SOURCE"
-  . "$JEDITERM_SOURCE"
+  source "$JEDITERM_SOURCE"
   set -e JEDITERM_SOURCE
 end
 


### PR DESCRIPTION
Should fix https://youtrack.jetbrains.com/issue/IDEA-176363/

The problem with the previous implementation was that it would completely ignore `~/.config/fish/fish_variables`, where all the universal variables are stored. (Sadly, that file isn't an actual fish script, so you can't really `source` it.)

The approach used by the previous implementation (overriding `$XDG_CONFIG_HOME`) was too brutal (one had to manually re-`source` all the user configs, functions, etc. after that) and an overkill anyways: despite effectively changing the entire `$__fish_config_dir`, there was only one file there, and even it (outside of trying to revert the consequences of overriding `$XDG_CONFIG_HOME`) would only really define and run one function.

The new implementation that I suggest simply tells fish to source the custom config file before executing other commands or running in interactive mode.