### PR TITLE
KTIJ-23106 "Remove single parameter declaration" in a lambda declared in function calls removes the parameter

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveSingleLambdaParameterFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/RemoveSingleLambdaParameterFix.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
 import org.jetbrains.kotlin.idea.codeinsight.api.classic.quickfixes.KotlinQuickFixAction
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 class RemoveSingleLambdaParameterFix(element: KtParameter) : KotlinQuickFixAction<KtParameter>(element) {
@@ -37,6 +38,8 @@ class RemoveSingleLambdaParameterFix(element: KtParameter) : KotlinQuickFixActio
 
             val lambdaParent = lambda.parent
             if (lambdaParent is KtWhenEntry || lambdaParent is KtContainerNodeForControlStructureBody) return null
+
+            if (lambda.getQualifiedExpressionForReceiver() != null) return null
 
             val property = lambda.getStrictParentOfType<KtProperty>()
             if (property != null && property.typeReference == null) return null

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -11970,6 +11970,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/removeSingleLambdaParameter/propertyWithImplicitType.kt");
         }
 
+        @TestMetadata("receiver.kt")
+        public void testReceiver() throws Exception {
+            runTest("testData/quickfix/removeSingleLambdaParameter/receiver.kt");
+        }
+
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("testData/quickfix/removeSingleLambdaParameter/simple.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/removeSingleLambdaParameter/receiver.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/removeSingleLambdaParameter/receiver.kt
@@ -1,0 +1,11 @@
+// "Remove single lambda parameter declaration" "false"
+// ACTION: Convert to anonymous function
+// ACTION: Convert to multi-line lambda
+// ACTION: Enable a trailing comma by default in the formatter
+// ACTION: Remove explicit lambda parameter types (may break code)
+// ACTION: Rename to _
+fun ((Boolean) -> Unit).foo() {}
+
+fun test() {
+    { <caret>b: Boolean -> }.foo()
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23106