### PR TITLE
IDEA-303699: Add a ContentManagerListener.contentRemoveQuery call

### DIFF
--- a/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowHeadlessManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowHeadlessManagerImpl.java
@@ -553,6 +553,9 @@ public class ToolWindowHeadlessManagerImpl extends ToolWindowManagerEx {
     public boolean removeContent(final @NotNull Content content, final boolean dispose) {
       boolean wasSelected = mySelected == content;
       int oldIndex = myContents.indexOf(content);
+      if (!fireContentRemoveQuery(content, oldIndex) || !content.isValid()) {
+        return false;
+      }
       if (wasSelected) {
         removeFromSelection(content);
       }
@@ -664,4 +667,16 @@ public class ToolWindowHeadlessManagerImpl extends ToolWindowManagerEx {
     public @NotNull ContentFactory getFactory() {
       return ApplicationManager.getApplication().getService(ContentFactory.class);
     }
-  }}
+
+    private boolean fireContentRemoveQuery(@NotNull Content content, int oldIndex) {
+      ContentManagerEvent event = new ContentManagerEvent(this, content, oldIndex, ContentManagerEvent.ContentOperation.undefined);
+      for (ContentManagerListener listener : myDispatcher.getListeners()) {
+        listener.contentRemoveQuery(event);
+        if (event.isConsumed()) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
This change removes a discrepancy between ToolWindowHeadlessManagerImpl and ContentManagerImpl.