### PR TITLE
[PY-56210] Add id for PyModuleNameCompletionContributor

### DIFF
--- a/python/python-psi-impl/resources/META-INF/PythonPsiImpl.xml
+++ b/python/python-psi-impl/resources/META-INF/PythonPsiImpl.xml
@@ -120,7 +120,7 @@
                             implementationClass="com.jetbrains.python.codeInsight.completion.PyClassNameCompletionContributor"/>
     <completion.contributor language="Python"
                             implementationClass="com.jetbrains.python.codeInsight.completion.PyModulePackageCompletionContributor"/>
-    <completion.contributor language="Python" order="first"
+    <completion.contributor language="Python" order="first" id="pyModuleNameCompletionContributor"
                             implementationClass="com.jetbrains.python.codeInsight.completion.PyModuleNameCompletionContributor"/>
     <completion.contributor language="Python"
                             implementationClass="com.jetbrains.python.codeInsight.completion.PyUnresolvedModuleAttributeCompletionContributor"/>


### PR DESCRIPTION
Allow other contributors to take priority over it if needed.

https://youtrack.jetbrains.com/issue/PY-56210/PyModuleNameCompletionContributor-should-be-disabled-in-injected-code