### PR TITLE
KTIJ-23384 "Generate secondary constructor" fails with parameter names that are keywords

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateSecondaryConstructorAction.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/generate/KotlinGenerateSecondaryConstructorAction.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.idea.util.getTypeSubstitution
 import org.jetbrains.kotlin.idea.util.orEmpty
 import org.jetbrains.kotlin.idea.util.toSubstitutor
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.quoteIfNeeded
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
@@ -163,7 +164,7 @@ class KotlinGenerateSecondaryConstructorAction : KotlinGenerateMemberActionBase<
             for (parameter in superConstructor.valueParameters) {
                 val isVararg = parameter.varargElementType != null
 
-                val paramName = Fe10KotlinNameSuggester.suggestNameByName(parameter.name.asString(), validator)
+                val paramName = Fe10KotlinNameSuggester.suggestNameByName(parameter.name.asString(), validator).quoteIfNeeded()
 
                 val typeToUse = parameter.varargElementType ?: parameter.type
                 val paramType = IdeDescriptorRenderers.SOURCE_CODE.renderType(

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/generate/CodeInsightActionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/generate/CodeInsightActionTestGenerated.java
@@ -43,6 +43,11 @@ public class CodeInsightActionTestGenerated extends AbstractCodeInsightActionTes
         runTest("testData/codeInsight/generate/secondaryConstructors/javaSupersWithGenerics.kt");
     }
 
+    @TestMetadata("javaSupersWithKeywords.kt")
+    public void testJavaSupersWithKeywords() throws Exception {
+        runTest("testData/codeInsight/generate/secondaryConstructors/javaSupersWithKeywords.kt");
+    }
+
     @TestMetadata("primaryExists.kt")
     public void testPrimaryExists() throws Exception {
         runTest("testData/codeInsight/generate/secondaryConstructors/primaryExists.kt");

--- a/plugins/kotlin/idea/tests/testData/codeInsight/generate/secondaryConstructors/javaSupersWithKeywords.java
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/generate/secondaryConstructors/javaSupersWithKeywords.java
@@ -1,0 +1,9 @@
+public class Base {
+    public Base(int in) {
+
+    }
+
+    public Base(int in, int i, int when) {
+
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/generate/secondaryConstructors/javaSupersWithKeywords.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/generate/secondaryConstructors/javaSupersWithKeywords.kt
@@ -1,0 +1,3 @@
+// ACTION_CLASS: org.jetbrains.kotlin.idea.actions.generate.KotlinGenerateSecondaryConstructorAction
+class Foo : Base {<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/generate/secondaryConstructors/javaSupersWithKeywords.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/generate/secondaryConstructors/javaSupersWithKeywords.kt.after
@@ -1,0 +1,5 @@
+// ACTION_CLASS: org.jetbrains.kotlin.idea.actions.generate.KotlinGenerateSecondaryConstructorAction
+class Foo : Base {
+    <caret>constructor(`in`: Int) : super(`in`)
+    constructor(`in`: Int, i: Int, `when`: Int) : super(`in`, i, `when`)
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23384