### PR TITLE
[IDEA-304611] "Cast can be replaced with variable" inspection fails when the cast is in a loop

### DIFF
--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterAllInLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterAllInLoop.java
@@ -1,0 +1,13 @@
+// "Replace '(FooBar)foo' with 'foobar'" "true"
+
+class FooBar {
+  public int baz;
+
+  void method(Object foo, List<String> texts) {
+    for (String text : texts) {
+      FooBar foobar = (FooBar)foo;
+      baz = foobar.baz;
+      foobar = null;
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterChangedAfterCastingVar.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterChangedAfterCastingVar.java
@@ -9,5 +9,6 @@ class FooBar {
     FooBar foobar = (FooBar)foo;
     Object o = foobar.baz;
     foo = null;
+    return 0;
   }
 }

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterChangedAfterVar.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterChangedAfterVar.java
@@ -9,5 +9,6 @@ class FooBar {
     FooBar foobar = (FooBar)foo;
     Object o = foobar.baz;
     foobar = null;
+    return 0;
   }
 }

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterControlFlow.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterControlFlow.java
@@ -1,0 +1,13 @@
+// "Replace '(FooBar)foo' with 'foobar'" "true"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo) {
+    FooBar foobar = (FooBar)foo;
+    if (baz == 0) {
+      return foobar.baz;
+    }
+    return -1;
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterForLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/afterForLoop.java
@@ -1,0 +1,14 @@
+// "Replace '(FooBar)foo' with 'foobar'" "true"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo) {
+    FooBar foobar = (FooBar)foo;
+    for (int i = 0; i < 10; i++) {
+      baz = foobar.baz;
+    }
+    foobar = null;
+    return -1;
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeAllInLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeAllInLoop.java
@@ -1,0 +1,13 @@
+// "Replace '(FooBar)foo' with 'foobar'" "true"
+
+class FooBar {
+  public int baz;
+
+  void method(Object foo, List<String> texts) {
+    for (String text : texts) {
+      FooBar foobar = (FooBar)foo;
+      baz = ((FooBar<caret>)foo).baz;
+      foobar = null;
+    }
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeAssignmentInForLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeAssignmentInForLoop.java
@@ -1,0 +1,14 @@
+// "Replace '(FooBar)foo' with 'foobar'" "false"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo) {
+    FooBar foobar = (FooBar)foo;
+    for (int i = 0; i < 10; i++) {
+      baz = ((FooBar<caret>)foo).baz;
+      foobar = null;
+    }
+    return -1;
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeChangedAfterCastingVar.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeChangedAfterCastingVar.java
@@ -9,5 +9,6 @@ class FooBar {
     FooBar foobar = (FooBar)foo;
     Object o = ((FooBar<caret>)foo).baz;
     foo = null;
+    return 0;
   }
 }

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeChangedAfterVar.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeChangedAfterVar.java
@@ -9,5 +9,6 @@ class FooBar {
     FooBar foobar = (FooBar)foo;
     Object o = ((FooBar<caret>)foo).baz;
     foobar = null;
+    return 0;
   }
 }

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeControlFlow.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeControlFlow.java
@@ -1,0 +1,13 @@
+// "Replace '(FooBar)foo' with 'foobar'" "true"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo) {
+    FooBar foobar = (FooBar)foo;
+    if (baz == 0) {
+      return ((FooBar<caret>)foo).baz;
+    }
+    return -1;
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeDoWhileLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeDoWhileLoop.java
@@ -1,0 +1,14 @@
+// "Replace '(FooBar)foo' with 'foobar'" "false"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo) {
+    FooBar foobar = (FooBar)foo;
+    do {
+      baz = ((FooBar<caret>)foo).baz + baz;
+      foobar = null;
+    } while (baz < 10);
+    return -1;
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeForLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeForLoop.java
@@ -1,0 +1,14 @@
+// "Replace '(FooBar)foo' with 'foobar'" "true"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo) {
+    FooBar foobar = (FooBar)foo;
+    for (int i = 0; i < 10; i++) {
+      baz = ((FooBar<caret>)foo).baz;
+    }
+    foobar = null;
+    return -1;
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeForeachLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeForeachLoop.java
@@ -1,0 +1,14 @@
+// "Replace '(FooBar)foo' with 'foobar'" "false"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo, List<String> texts) {
+    FooBar foobar = (FooBar)foo;
+    for (String text : texts) {
+      baz = ((FooBar<caret>)foo).baz;
+      foobar = null;
+    }
+    return -1;
+  }
+}

--- a/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeWhileLoop.java
+++ b/java/java-tests/testData/inspection/castCanBeReplacedWithVariable/beforeWhileLoop.java
@@ -1,0 +1,14 @@
+// "Replace '(FooBar)foo' with 'foobar'" "false"
+
+class FooBar {
+  public int baz;
+
+  int method(Object foo) {
+    FooBar foobar = (FooBar)foo;
+    while (baz < 10) {
+      baz = ((FooBar<caret>)foo).baz + baz;
+      foobar = null;
+    }
+    return -1;
+  }
+}


### PR DESCRIPTION
Hi @amaembo,

***What steps will reproduce the issue?***

1. Go to *File* → *Settings..*. → *Editor* → *Inspections* (this feature is not released in an official version yet)
2. Enable *Cast can be replaced with variable*
3. Enable Severity: *Warning*
4. Add this method in a Java class:

```Java
  void method(Object foo) {
    String foobar = (String)foo;
    for (int i = 0; i < 10; i++) {
      System.out.println(((String)foo).trim());
      foobar = null;
    }
  }
```

***What is the expected result?***
The inspection *Cast can be replaced with variable* is suggested.
***What happens instead?***
The inspection *Cast can be replaced with variable* is not suggested.

`CastCanBeReplacedWithVariableInspection` should not suggest nor directly fix the cast when the variable is reassigned in the same loop as the cast.

I have successfully run the Unit tests.