### PR TITLE
KTIJ-23412 False positive quickfix "Convert expression to 'Array' by inserting '.toTypedArray()'" with varargs

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertCollectionFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/ConvertCollectionFix.kt
@@ -63,6 +63,7 @@ class ConvertCollectionFix(element: KtExpression, val type: CollectionType) : Ko
         fun getConversionTypeOrNull(expressionType: KotlinType, expectedType: KotlinType): CollectionType? {
             val expressionCollectionType = expressionType.getCollectionType() ?: return null
             val expectedCollectionType = expectedType.getCollectionType() ?: return null
+            if (expressionCollectionType == expectedCollectionType) return null
 
             val expressionTypeArg = expressionType.arguments.singleOrNull()?.type ?: return null
             val expectedTypeArg = expectedType.arguments.singleOrNull()?.type ?: return null

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -14787,6 +14787,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
                 KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
             }
 
+            @TestMetadata("arrayToArray.kt")
+            public void testArrayToArray() throws Exception {
+                runTest("testData/quickfix/typeMismatch/convertCollection/arrayToArray.kt");
+            }
+
             @TestMetadata("arrayToCollection.kt")
             public void testArrayToCollection() throws Exception {
                 runTest("testData/quickfix/typeMismatch/convertCollection/arrayToCollection.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/typeMismatch/convertCollection/arrayToArray.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/typeMismatch/convertCollection/arrayToArray.kt
@@ -1,0 +1,12 @@
+// "Convert expression to 'Array' by inserting '.toTypedArray()'" "false"
+// ERROR: Type mismatch: inferred type is Array<out String> but Array<String> was expected
+// ACTION: Cast expression 'strings' to 'Array<String>'
+// ACTION: Change parameter 'strings' type of function 'bar' to 'Array<out String>'
+// ACTION: Create function 'bar'
+
+fun foo(vararg strings: String) {
+    bar(strings<caret>)
+}
+
+fun bar(strings: Array<String>) {
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23412