### PR TITLE
KTIJ-23266 Formatter: Extra spaces aren't deleted after `typealias` keyword

### DIFF
--- a/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
+++ b/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/kotlinSpacingRules.kt
@@ -328,6 +328,8 @@ fun createSpacingBuilder(settings: CodeStyleSettings, builderUtil: KotlinSpacing
             beforeInside(IDENTIFIER, CLASS).spaces(1)
             beforeInside(IDENTIFIER, OBJECT_DECLARATION).spaces(1)
 
+            after(TYPE_ALIAS_KEYWORD).spaces(1)
+
             after(VAL_KEYWORD).spaces(1)
             after(VAR_KEYWORD).spaces(1)
             betweenInside(TYPE_PARAMETER_LIST, IDENTIFIER, PROPERTY).spaces(1)

--- a/plugins/kotlin/idea/tests/testData/formatter/TypeAliasSpacing.after.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/TypeAliasSpacing.after.kt
@@ -36,3 +36,5 @@ object OO
 typealias L = Int
 
 internal typealias M = Int
+
+typealias N = String

--- a/plugins/kotlin/idea/tests/testData/formatter/TypeAliasSpacing.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/TypeAliasSpacing.kt
@@ -28,3 +28,5 @@ object OO
 typealias L = Int
 
 internal typealias M = Int
+
+typealias    N     =      String


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23266