### PR TITLE
IDEA-304621: Allow multiple ItemPresentations for each type

### DIFF
--- a/platform/core-api/src/com/intellij/navigation/ItemPresentationProviders.java
+++ b/platform/core-api/src/com/intellij/navigation/ItemPresentationProviders.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.util.ClassExtension;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-
 public final class ItemPresentationProviders extends ClassExtension<ItemPresentationProvider> {
   public static final ItemPresentationProviders INSTANCE = new ItemPresentationProviders();
 
@@ -15,13 +14,14 @@ public final class ItemPresentationProviders extends ClassExtension<ItemPresenta
 
   @Nullable
   @SuppressWarnings({"unchecked"})
-  public static <T extends NavigationItem> ItemPresentationProvider<T> getItemPresentationProvider(@NotNull T element) {
-    return (ItemPresentationProvider<T>)INSTANCE.forClass(element.getClass());
-  }
-
-  @Nullable
   public static ItemPresentation getItemPresentation(@NotNull NavigationItem element) {
-    final ItemPresentationProvider<NavigationItem> provider = getItemPresentationProvider(element);
-    return provider == null ? null : provider.getPresentation(element);
+    for (ItemPresentationProvider<NavigationItem> provider : INSTANCE.forKey(element.getClass())) {
+      ItemPresentation presentation = provider.getPresentation(element);
+      if (presentation != null) {
+        return presentation;
+      }
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/IDEA-304621

ItemPresentationProviders currently assumes that there is only a single ItemPresentationProvider present for a given type; if that provider returns null, it does not fall back on any further providers.

This means that plugins are not able to override any built-in behavior for item presentation without duplicating all the logic for a given type. (For example, changing presentation for specific Kotlin functions, but not all Kotlin functions.) Worse, if two pluging try to override the same type, only one of them will take effect.

This change iterates through all the providers for a given type and returns the first non-null result. This allows multiple plugins to augment the same type as need be, and prevents the necessity of those plugins mimicking the built-in platform behavior for that same type.