### PR TITLE
IDEA-302026 IDEA treats javac note messages as errors during build if message includes a path

### DIFF
--- a/platform/lang-impl/src/com/intellij/build/output/JavacOutputParser.java
+++ b/platform/lang-impl/src/com/intellij/build/output/JavacOutputParser.java
@@ -32,7 +32,7 @@ public class JavacOutputParser implements BuildOutputParser {
 
   private static final char COLON = ':';
   private static final @NonNls String WARNING_PREFIX = "warning:"; // default value
-  private static final @NonNls String NOTE_PREFIX = "note:";
+  private static final @NonNls String NOTE_PREFIX = "Note:";
   private static final @NonNls String ERROR_PREFIX = "error:";
   private final String[] myFileExtensions;
 


### PR DESCRIPTION
JavacOutputParser hardcodes prefixes from javac and there's an error in the prefix for the note.
As a result, `JavacOutputParser.parse` can't find the prefix and treats this message as an error by default.
In the JDK sources the prefix for the `DiagnosticType.NOTE` is (probably erroneously) "Note" with the capital N, while for `WARNING` and `ERROR` they start with the lowercase letter.
See [AbstractDiagnosticFormatter.java](https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractDiagnosticFormatter.java#L112) and [compiler.properties](https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties#L1612).
So this very simple change is to keep the text in sync with the JDK sources.