### PR TITLE
Do Not Use KotlinLambdaAsyncMethodFilter if SAM has a Suspend Method

### DIFF
--- a/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinLambdaInfo.kt
+++ b/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinLambdaInfo.kt
@@ -16,7 +16,8 @@ data class KotlinLambdaInfo(
     val isNoinline: Boolean,
     val isNameMangledInBytecode: Boolean,
     val methodName: String,
-    val callerMethodInfo: CallableMemberInfo
+    val callerMethodInfo: CallableMemberInfo,
+    val isSamSuspendMethod: Boolean
 ) {
     val isInline = callerMethodInfo.isInline && !isNoinline && !isSam
 
@@ -25,19 +26,38 @@ data class KotlinLambdaInfo(
         parameterDescriptor: ValueParameterDescriptor,
         callerMethodOrdinal: Int,
         isNameMangledInBytecode: Boolean,
-        isSam: Boolean = false,
-        methodName: String = OperatorNameConventions.INVOKE.asString()
     ) : this(
-            parameterDescriptor.name.asString(),
-            callerMethodOrdinal,
-            countParameterIndex(callerMethodDescriptor, parameterDescriptor),
-            parameterDescriptor.hasSuspendFunctionType,
-            isSam,
-            parameterDescriptor.isNoinline,
-            isNameMangledInBytecode,
-            methodName,
-            CallableMemberInfo(callerMethodDescriptor)
+        parameterName = parameterDescriptor.name.asString(),
+        callerMethodOrdinal = callerMethodOrdinal,
+        parameterIndex = countParameterIndex(callerMethodDescriptor, parameterDescriptor),
+        isSuspend = parameterDescriptor.hasSuspendFunctionType,
+        isSam = false,
+        isNoinline = parameterDescriptor.isNoinline,
+        isNameMangledInBytecode = isNameMangledInBytecode,
+        methodName = OperatorNameConventions.INVOKE.asString(),
+        callerMethodInfo = CallableMemberInfo(callerMethodDescriptor),
+        isSamSuspendMethod = false
         )
+
+    constructor(
+        callerMethodDescriptor: CallableMemberDescriptor,
+        parameterDescriptor: ValueParameterDescriptor,
+        callerMethodOrdinal: Int,
+        isNameMangledInBytecode: Boolean,
+        methodName: String,
+        isSamSuspendMethod: Boolean,
+    ) : this(
+        parameterName = parameterDescriptor.name.asString(),
+        callerMethodOrdinal = callerMethodOrdinal,
+        parameterIndex = countParameterIndex(callerMethodDescriptor, parameterDescriptor),
+        isSuspend = parameterDescriptor.hasSuspendFunctionType,
+        isSam = true,
+        isNoinline = parameterDescriptor.isNoinline,
+        isNameMangledInBytecode = isNameMangledInBytecode,
+        methodName = methodName,
+        callerMethodInfo = CallableMemberInfo(callerMethodDescriptor),
+        isSamSuspendMethod = isSamSuspendMethod
+    )
 
     fun getLabel() =
         "${callerMethodInfo.name}: $parameterName.$methodName()"

--- a/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinLambdaSmartStepTarget.kt
+++ b/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinLambdaSmartStepTarget.kt
@@ -26,7 +26,11 @@ class KotlinLambdaSmartStepTarget(
             lambdaInfo
         )
 
-        if (!lambdaInfo.isSuspend && !lambdaInfo.callerMethodInfo.isInline && Registry.get("debugger.async.smart.step.into").asBoolean()) {
+        if (!lambdaInfo.isSuspend
+            && !lambdaInfo.callerMethodInfo.isInline
+            && !lambdaInfo.isSamSuspendMethod
+            && Registry.get("debugger.async.smart.step.into").asBoolean()
+        ) {
             val declaration = declarationPtr.getElementInReadAction()
             return KotlinLambdaAsyncMethodFilter(
                 declaration,

--- a/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/SmartStepTargetVisitor.kt
+++ b/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/SmartStepTargetVisitor.kt
@@ -179,8 +179,8 @@ class SmartStepTargetVisitor(
                     parameter,
                     callerMethodOrdinal,
                     methodDescriptor.containsInlineClassInValueArguments(),
-                    true,
-                    methodDescriptor.getMethodName()
+                    methodDescriptor.name.asString(),
+                    (methodDescriptor as? FunctionDescriptor)?.isSuspend ?: false
                 )
             )
         }

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
@@ -1420,6 +1420,11 @@ public abstract class K2IrKotlinSteppingTestGenerated extends AbstractK2IrKotlin
             runTest("../testData/stepping/custom/smartStepIntoSubClass.kt");
         }
 
+        @TestMetadata("smartStepIntoSuspendFunInterface.kt")
+        public void testSmartStepIntoSuspendFunInterface() throws Exception {
+            runTest("../testData/stepping/custom/smartStepIntoSuspendFunInterface.kt");
+        }
+
         @TestMetadata("smartStepIntoSuspendLambda.kt")
         public void testSmartStepIntoSuspendLambda() throws Exception {
             runTest("../testData/stepping/custom/smartStepIntoSuspendLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -1420,6 +1420,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/custom/smartStepIntoSubClass.kt");
         }
 
+        @TestMetadata("smartStepIntoSuspendFunInterface.kt")
+        public void testSmartStepIntoSuspendFunInterface() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoSuspendFunInterface.kt");
+        }
+
         @TestMetadata("smartStepIntoSuspendLambda.kt")
         public void testSmartStepIntoSuspendLambda() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoSuspendLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -1420,6 +1420,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/custom/smartStepIntoSubClass.kt");
         }
 
+        @TestMetadata("smartStepIntoSuspendFunInterface.kt")
+        public void testSmartStepIntoSuspendFunInterface() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoSuspendFunInterface.kt");
+        }
+
         @TestMetadata("smartStepIntoSuspendLambda.kt")
         public void testSmartStepIntoSuspendLambda() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoSuspendLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoSuspendFunInterface.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoSuspendFunInterface.kt
@@ -1,0 +1,33 @@
+// ATTACH_LIBRARY: maven(org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4)
+// KTIJ-23430
+package smartStepIntoSuspendFunInterface
+
+import kotlinx.coroutines.flow.asFlow
+
+suspend fun main() {
+    // Flow.collect() uses a FlowCollector which is a functional interface witha  suspend method.
+
+    // SMART_STEP_INTO_BY_INDEX: 4
+    // RESUME: 1
+    //Breakpoint!
+    listOf(1).asFlow().collect {
+        println(it)
+    }
+
+    // The following behavior seems to be identical to the Flow.collect() example but prior to fixing KTIJ-23430, it behaves differently.
+    // With Flow.collect(), stepping into the lambda steps over it, but with this example, the debugger hangs.
+
+    // SMART_STEP_INTO_BY_INDEX: 3
+    //Breakpoint!
+    listOf(1).collect {
+        println(it)
+    }
+}
+
+private suspend fun <T> Iterable<T>.collect(visitor: FlowCollector<T>) = forEach { visitor.emit(it) }
+
+private fun interface FlowCollector<in T> {
+    suspend fun emit(value: T)
+}
+
+// IGNORE_K2

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoSuspendFunInterface.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoSuspendFunInterface.out
@@ -1,0 +1,11 @@
+LineBreakpoint created at smartStepIntoSuspendFunInterface.kt:13
+LineBreakpoint created at smartStepIntoSuspendFunInterface.kt:22
+Run Java
+Connected to the target VM
+smartStepIntoSuspendFunInterface.kt:13
+smartStepIntoSuspendFunInterface.kt:14
+smartStepIntoSuspendFunInterface.kt:22
+smartStepIntoSuspendFunInterface.kt:23
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
For example:

```
public fun interface FlowCollector<in T> {
    public suspend fun emit(value: T)
}
```

https://youtrack.jetbrains.com/issue/KTIJ-23430/Step-Into-A-Flow-Lambda-Steps-Over