### PR TITLE
KTIJ-23517: Add test for implement members annotation behavior

### DIFF
--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/codeInsight/FirOverrideImplementTest.kt
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/codeInsight/FirOverrideImplementTest.kt
@@ -7,9 +7,7 @@ import org.jetbrains.kotlin.idea.codeInsight.OverrideImplementTest
 import org.jetbrains.kotlin.idea.core.overrideImplement.KtClassMember
 import org.jetbrains.kotlin.idea.fir.invalidateCaches
 import org.jetbrains.kotlin.idea.test.runAll
-import org.junit.Ignore
 import org.junit.internal.runners.JUnit38ClassRunner
-import org.junit.jupiter.api.Disabled
 import org.junit.runner.RunWith
 
 @Suppress("RedundantOverride") // overrides are for easier test debugging
@@ -310,6 +308,11 @@ internal class FirOverrideImplementTest : OverrideImplementTest<KtClassMember>()
 
     override fun testCopyExperimental() {
         super.testCopyExperimental()
+    }
+
+    override fun testDropAnnotations() {
+        // KTIJ-23517
+        //super.testDropAnnotations()
     }
 
     override fun testUnresolvedType() {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.kt
@@ -309,6 +309,10 @@ abstract class OverrideImplementTest<T : ClassMember> : AbstractOverrideImplemen
         }
     }
 
+   open fun testDropAnnotations() {
+        doOverrideFileTest()
+    }
+
    open fun testUnresolvedType() {
         doOverrideFileTest()
     }

--- a/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt
@@ -1,0 +1,9 @@
+annotation class SomeAnnotation
+
+open class ParentTarget {
+    @SomeAnnotation open fun targetFun() {}
+}
+
+class ChildTarget : ParentTarget() {
+    <caret>
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt.after
@@ -1,0 +1,11 @@
+annotation class SomeAnnotation
+
+open class ParentTarget {
+    @SomeAnnotation open fun targetFun() {}
+}
+
+class ChildTarget : ParentTarget() {
+    override fun targetFun() {
+        <selection><caret>super.targetFun()</selection>
+    }
+}


### PR DESCRIPTION
Implementing an override in K1 explicitly contains a filter to remove annotations, with the exception of any annotations marked with @RequiresOptIn.

K2 does not implement this behavior, instead retaining all annotations.

This change adds a test documenting the current behavior. [KTIJ-23517](https://youtrack.jetbrains.com/issue/KTIJ-23517) tracks the difference in behavior between K1 and K2.