### PR TITLE
KTIJ-21347: Add EP for override member annotations

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/generation/OverrideImplementsAnnotationsHandler.java
+++ b/java/java-impl/src/com/intellij/codeInsight/generation/OverrideImplementsAnnotationsHandler.java
@@ -18,22 +18,21 @@ import static com.intellij.codeInsight.AnnotationUtil.CHECK_EXTERNAL;
 import static com.intellij.codeInsight.AnnotationUtil.CHECK_TYPE;
 
 /**
- * Allows plugging in annotations processing during override/implement.
- * <p/>
- * Parameter annotations would not be copied, if they are not specified in {@link #getAnnotations(PsiFile)}.
+ * Extends {@link OverrideImplementsAnnotationsFilter} with java-specific functionality.
  * 
- * {@link #transferToTarget(String, PsiModifierListOwner, PsiModifierListOwner)} can be used, to adjust annotations to the target place e.g.,
- * convert library's Nullable/NotNull annotations to project ones.
+ * {@link #transferToTarget(String, PsiModifierListOwner, PsiModifierListOwner)} can be used, to adjust annotations to the target place
+ * e.g., convert library's Nullable/NotNull annotations to project ones.
  * <p/>
  * @see JavaCodeStyleSettings#getRepeatAnnotations()
  */
-public interface OverrideImplementsAnnotationsHandler {
+public interface OverrideImplementsAnnotationsHandler extends OverrideImplementsAnnotationsFilter {
   ExtensionPointName<OverrideImplementsAnnotationsHandler> EP_NAME = ExtensionPointName.create("com.intellij.overrideImplementsAnnotationsHandler");
 
   /**
    * Returns annotations which should be copied from a source to an implementation (by default, no annotations are copied).
    */
   @Contract(pure = true)
+  @Override
   default String[] getAnnotations(@NotNull PsiFile file) {
     return getAnnotations(file.getProject());
   }

--- a/platform/lang-api/src/com/intellij/codeInsight/generation/OverrideImplementsAnnotationsFilter.java
+++ b/platform/lang-api/src/com/intellij/codeInsight/generation/OverrideImplementsAnnotationsFilter.java
@@ -1,0 +1,39 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.codeInsight.generation;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Allows plugging in annotations processing during override/implement.
+ * <p/>
+ * Parameter annotations would not be copied, if they are not specified in {@link #getAnnotations(PsiFile)}.
+ */
+public interface OverrideImplementsAnnotationsFilter {
+  ExtensionPointName<OverrideImplementsAnnotationsFilter> EP_NAME =
+    ExtensionPointName.create("com.intellij.overrideImplementsAnnotationsFilter");
+
+  /**
+   * Returns annotations which should be copied from a source to an implementation (by default, no annotations are copied).
+   */
+  @Contract(pure = true)
+  String[] getAnnotations(@NotNull PsiFile file);
+
+  /**
+   * Checks whether a given annotation (identified by fully-qualified name) should be kept when implemented an override in the give file.
+   */
+  static boolean keepAnnotationOnOverrideMember(@NotNull String fqName, @NotNull PsiFile file) {
+    for (OverrideImplementsAnnotationsFilter filter : EP_NAME.getExtensionList()) {
+      for (String annotation : filter.getAnnotations(file)) {
+        if (fqName.equals(annotation)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+}

--- a/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
+++ b/platform/platform-resources/src/META-INF/LangExtensionPoints.xml
@@ -67,6 +67,7 @@
     <extensionPoint name="daemon.statusItemMerger" interface="com.intellij.codeInsight.daemon.impl.StatusItemMerger" dynamic="true"/>
 
     <extensionPoint name="implicitUsageProvider" interface="com.intellij.codeInsight.daemon.ImplicitUsageProvider" dynamic="true"/>
+    <extensionPoint name="overrideImplementsAnnotationsFilter" interface="com.intellij.codeInsight.generation.OverrideImplementsAnnotationsFilter" dynamic="true"/>
 
     <!-- com.intellij.psi.PsiElement -->
     <extensionPoint name="cantBeStatic" interface="com.intellij.openapi.util.Condition" dynamic="true"/>

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/codeInsight/FirOverrideImplementTest.kt
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/codeInsight/FirOverrideImplementTest.kt
@@ -7,9 +7,7 @@ import org.jetbrains.kotlin.idea.codeInsight.OverrideImplementTest
 import org.jetbrains.kotlin.idea.core.overrideImplement.KtClassMember
 import org.jetbrains.kotlin.idea.fir.invalidateCaches
 import org.jetbrains.kotlin.idea.test.runAll
-import org.junit.Ignore
 import org.junit.internal.runners.JUnit38ClassRunner
-import org.junit.jupiter.api.Disabled
 import org.junit.runner.RunWith
 
 @Suppress("RedundantOverride") // overrides are for easier test debugging
@@ -310,6 +308,19 @@ internal class FirOverrideImplementTest : OverrideImplementTest<KtClassMember>()
 
     override fun testCopyExperimental() {
         super.testCopyExperimental()
+    }
+
+    override fun testDropAnnotations() {
+        // KTIJ-23517
+        //super.testDropAnnotations()
+    }
+
+    override fun testCopyAnnotationsAllowedByExtension() {
+        // KTIJ-23517
+        // Override Members with FIR currently copies all annotations in generated code, which is different than the k1 version. It's
+        // unclear whether that's intended behavior or not. But for now, this test will fail with FIR since it will not remove one of the
+        // annotations in the test data.
+        //super.testCopyAnnotationsAllowedByExtension()
     }
 
     override fun testUnresolvedType() {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/OverrideImplementTest.kt
@@ -3,6 +3,10 @@
 package org.jetbrains.kotlin.idea.codeInsight
 
 import com.intellij.codeInsight.generation.ClassMember
+import com.intellij.codeInsight.generation.OverrideImplementsAnnotationsFilter
+import com.intellij.codeInsight.generation.OverrideImplementsAnnotationsHandler
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.idea.core.overrideImplement.OverrideMemberChooserObject
@@ -307,6 +311,20 @@ abstract class OverrideImplementTest<T : ClassMember> : AbstractOverrideImplemen
         withCustomLanguageAndApiVersion(project, module, LanguageVersion.KOTLIN_1_3, ApiVersion.KOTLIN_1_3) {
             doOverrideFileTest("targetFun")
         }
+    }
+
+   open fun testDropAnnotations() {
+        doOverrideFileTest()
+    }
+
+   open fun testCopyAnnotationsAllowedByExtension() {
+       val filterExtension = object : OverrideImplementsAnnotationsFilter {
+           override fun getAnnotations(file: PsiFile) = arrayOf("AllowedAnnotation")
+       }
+
+       OverrideImplementsAnnotationsFilter.EP_NAME.point.registerExtension(filterExtension, testRootDisposable)
+
+       doOverrideFileTest()
     }
 
    open fun testUnresolvedType() {

--- a/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/copyAnnotationsAllowedByExtension.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/copyAnnotationsAllowedByExtension.kt
@@ -1,0 +1,10 @@
+annotation class AllowedAnnotation
+annotation class UnknownAnnotation
+
+open class ParentTarget {
+    @AllowedAnnotation @UnknownAnnotation open fun targetFun() {}
+}
+
+class ChildTarget : ParentTarget() {
+    <caret>
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/copyAnnotationsAllowedByExtension.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/copyAnnotationsAllowedByExtension.kt.after
@@ -1,0 +1,13 @@
+annotation class AllowedAnnotation
+annotation class UnknownAnnotation
+
+open class ParentTarget {
+    @AllowedAnnotation @UnknownAnnotation open fun targetFun() {}
+}
+
+class ChildTarget : ParentTarget() {
+    @AllowedAnnotation
+    override fun targetFun() {
+        <selection><caret>super.targetFun()</selection>
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt
@@ -1,0 +1,9 @@
+annotation class SomeAnnotation
+
+open class ParentTarget {
+    @SomeAnnotation open fun targetFun() {}
+}
+
+class ChildTarget : ParentTarget() {
+    <caret>
+}

--- a/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt.after
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/overrideImplement/dropAnnotations.kt.after
@@ -1,0 +1,11 @@
+annotation class SomeAnnotation
+
+open class ParentTarget {
+    @SomeAnnotation open fun targetFun() {}
+}
+
+class ChildTarget : ParentTarget() {
+    override fun targetFun() {
+        <selection><caret>super.targetFun()</selection>
+    }
+}


### PR DESCRIPTION
This fix addresses [KTIJ-21347](https://youtrack.jetbrains.com/issue/KTIJ-21347).

The "Override Member" action currently removes all annotations except for those marked with @RequireOptIn. This change adds an extension point that allows plugins to specify whether any other annotations should be retained as well.

Note that the K2 version of Override Members would not show this behavior, since it actually retains all annotations. This is likely an unintentional change, and I filed [KTIJ-23517](https://youtrack.jetbrains.com/issue/KTIJ-23517) to track that.

Under the assumption that [KTIJ-23517](https://youtrack.jetbrains.com/issue/KTIJ-23517) is indeed a bug and not an intention change, I've implemented this new EP in override-implement-shared so that it can eventually be incorporated into the K2 override member action as well.

Note that this PR also includes a commit with a test change that I've also included in [PR 2214](https://github.com/JetBrains/intellij-community/pull/2214). I expected this request may take longer to complete, and there was likely value in getting a test documenting current behavior committed more quickly. I'll close that PR if for whatever reason this one completes first and/or makes the other obsolete.