### PR TITLE
Fix use of `executor.id` instead of `executor.toolWindowId` in `RunContentManagerImpl`

### DIFF
--- a/platform/execution-impl/src/com/intellij/execution/ui/RunContentManagerImpl.kt
+++ b/platform/execution-impl/src/com/intellij/execution/ui/RunContentManagerImpl.kt
@@ -459,7 +459,7 @@ class RunContentManagerImpl(private val project: Project) : RunContentManager {
   private inline fun processToolWindowContentManagers(processor: (ToolWindow, ContentManager) -> Unit) {
     val toolWindowManager = getToolWindowManager()
     for (executor in Executor.EXECUTOR_EXTENSION_NAME.extensionList) {
-      val toolWindow = toolWindowManager.getToolWindow(executor.id) ?: continue
+      val toolWindow = toolWindowManager.getToolWindow(executor.toolWindowId) ?: continue
       processor(toolWindow, toolWindow.contentManagerIfCreated ?: continue)
     }
 


### PR DESCRIPTION
Fixes [IDEA-305375](https://youtrack.jetbrains.com/issue/IDEA-305375/processToolWindowContentManagers-in-RunContentManagerImpl-class-uses-executorid-instead-of-executortoolWindowId).