### PR TITLE
IDEA-265238 - added support time conversions for `format` methods

### DIFF
--- a/platform/core-api/src/com/intellij/psi/CommonClassNames.java
+++ b/platform/core-api/src/com/intellij/psi/CommonClassNames.java
@@ -115,6 +115,7 @@ public interface CommonClassNames {
   String JAVA_TIME_LOCAL_TIME = "java.time.LocalTime";
   String JAVA_TIME_LOCAL_DATE_TIME = "java.time.LocalDateTime";
   String JAVA_TIME_OFFSET_DATE_TIME = "java.time.OffsetDateTime";
+  String JAVA_TIME_OFFSET_TIME = "java.time.OffsetTime";
   String JAVA_TIME_ZONED_DATE_TIME = "java.time.ZonedDateTime";
 
   String JAVA_UTIL_CONCURRENT_FUTURE = "java.util.concurrent.Future";

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/malformed_format_string/MalformedFormatString.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/malformed_format_string/MalformedFormatString.java
@@ -101,11 +101,24 @@ public class MalformedFormatString {
         String.format(<warning descr="Illegal format string specifier: precision ('.4') not allowed in '%.4tT'">"%.4tT"</warning>, new Date());
         String.format(<warning descr="Illegal format string specifier: precision ('.5') not allowed in '%.5c'">"%.5c"</warning>, '\u00A9');
         String.format(<warning descr="Illegal format string specifier: precision ('.6') not allowed in '%.6x'">"%.6x"</warning>, 15);
+        String.format(<warning descr="Illegal format string specifier: precision ('.1') not allowed in '%.1d'">"%.1d"</warning>, 1);
+
+        //date-time conversions not allowed
+        String.format(<warning descr="Illegal format string specifier: unknown conversion in 'tX'">"%tX"</warning>, java.time.LocalDateTime.now());
+        String.format("%tz", <warning descr="Argument type 'LocalDateTime' does not match the type of the format specifier '%tz'">java.time.LocalDateTime.now()</warning>);
+        String.format("%ts", <warning descr="Argument type 'LocalDateTime' does not match the type of the format specifier '%ts'">java.time.LocalDateTime.now()</warning>);
+        String.format("%tH", <warning descr="Argument type 'LocalDate' does not match the type of the format specifier '%tH'">java.time.LocalDate.now()</warning>);
+        String.format("%th", <warning descr="Argument type 'LocalTime' does not match the type of the format specifier '%th'">java.time.LocalTime.now()</warning>);
+        String.format("%ta", <warning descr="Argument type 'OffsetTime' does not match the type of the format specifier '%ta'">java.time.OffsetTime.now()</warning>);
     }
 
     void goodStrings() {
         String.format("%,d", 34567890);
         System.out.printf("%tF %n", java.time.ZonedDateTime.now()); // java.time.temporal.TemporalAccessor, new in Java 8
+        System.out.printf("%tI", java.time.LocalDateTime.now());
+        System.out.printf("%tB", java.time.LocalDate.now());
+        System.out.printf("%tR", java.time.LocalTime.now());
+        System.out.printf("%tZ", java.time.OffsetDateTime.now());
     }
 
     void previousFlag() {

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/MalformedFormatStringInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/MalformedFormatStringInspectionTest.java
@@ -89,6 +89,51 @@ public abstract class ZonedDateTime implements Temporal {
     public static ZonedDateTime now() {
         return null;
     }
+}""",
+
+      """
+package java.time;
+import java.time.temporal.Temporal;
+public abstract class LocalDateTime implements Temporal {
+    public static LocalDateTime now() {
+        return null;
+    }
+}""",
+
+      """
+package java.time;
+import java.time.temporal.Temporal;
+public abstract class LocalDate implements Temporal {
+    public static LocalDate now() {
+        return null;
+    }
+}""",
+
+      """
+package java.time;
+import java.time.temporal.Temporal;
+public abstract class LocalTime implements Temporal {
+    public static LocalTime now() {
+        return null;
+    }
+}""",
+
+      """
+package java.time;
+import java.time.temporal.Temporal;
+public abstract class OffsetDateTime implements Temporal {
+    public static OffsetDateTime now() {
+        return null;
+    }
+}""",
+
+      """
+package java.time;
+import java.time.temporal.Temporal;
+public abstract class OffsetTime implements Temporal {
+    public static OffsetTime now() {
+        return null;
+    }
 }"""
     };
   }


### PR DESCRIPTION
IDEA-265238 
https://youtrack.jetbrains.com/issue/IDEA-265238/Report-illegal-time-conversions-in-format-strings

Additionally, I added that `d` is not used with precision (`"%.1d`) , according to https://docs.oracle.com/en/java/javase/18/docs/api/java.base/java/util/Formatter.html
for Byte, Short, Integer, and Long the precision is not applicable.

Also,  checks for the most popular java.time classes about appropriate conversions are added.

