### PR TITLE
[Java. Inspections] IDEA-297385 - added options to ignore overloaded methods whose parameters are definitely incompatible

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
@@ -1353,6 +1353,7 @@ string.indexof.replaceable.by.contains.display.name='String.indexOf()' expressio
 overloaded.methods.with.same.number.parameters.problem.descriptor=Multiple methods named <code>#ref</code> with the same number of parameters #loc
 overloaded.vararg.method.problem.descriptor=Overloaded varargs method <code>#ref()</code> #loc
 overloaded.vararg.constructor.problem.descriptor=Overloaded varargs constructor <code>#ref()</code> #loc
+overloaded.vararg.method.problem.option=<html>Ignore overloaded methods whose parameter types are definitely incompatible</html>
 cached.number.constructor.call.display.name=Number constructor call with primitive argument
 cached.number.constructor.call.problem.descriptor=Number constructor call with primitive argument #loc
 cached.number.constructor.call.ignore.string.arguments.option=Ignore new number expressions with a String argument

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/OverloadedVarargsMethod.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/OverloadedVarargsMethod.html
@@ -9,5 +9,8 @@ because it is often unclear which overload gets called.
     public void execute(Runnable r1, Runnable r2) {}
 </code></pre>
 <!-- tooltip end -->
+<p>
+  Use the option to ignore overloaded methods whose parameter types are definitely incompatible.
+</p>
 </body>
 </html>

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/naming/OverloadedVarargsMethodInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/naming/OverloadedVarargsMethodInspectionTest.java
@@ -64,4 +64,29 @@ public class OverloadedVarargsMethodInspectionTest extends LightJavaInspectionTe
            "        }" +
            "    }");
   }
+
+  public void testNoWarningBecauseOfTypes() {
+    doTest("class Overload {" +
+           "  public void method() {}" +
+           "  public void method(int p1) {}" +
+           "  public void method(int p1, int p2) {}" +
+           "  public void method(int p1, String p2, int p3) {}" +
+           "  public void method(int p1, String p2, String p3, int p4) {}" +
+           "  public void method(int p1, String p2, String... p3) {}" +
+           "}");
+  }
+
+  public void testWarningForConvertibleArgumentTypes() {
+    doTest("class Overload {" +
+           "  public void method(Number p1, String p2) {}" +
+           "  public void /*Overloaded varargs method 'method()'*/method/**/(Integer p1, String p2, String... p3) {}" +
+           "}");
+  }
+
+  public void testWarningWithOneArgument() {
+    doTest("class Overload {" +
+           "  public void method() {}" +
+           "  public void /*Overloaded varargs method 'method()'*/method/**/(String... p1) {}" +
+           "}");
+  }
 }


### PR DESCRIPTION
I tried to fix https://youtrack.jetbrains.com/issue/IDEA-297385/Overloaded-varargs-method-triggers-when-not-needed

About realization.
1. I tried to follow the way from ` OverloadedMethodsWithSameNumberOfParametersInspection`, which has the additional parameter, and it seems to me, that it could be useful in OverloadedVarargsMethodInspection inspection too.

2. It seems to me, that cases like 
```java
public void method(Integer i1, Integer i2, String... strings){}
public void method(Integer i1){}
```
are obvious and there is no reason to highlight them because we have a certain indicator for these methods: Integer i2

3. I am not sure, but cases  like:
```java
public void method(Integer i1, Integer i2, String... strings){}
public void method(Integer i1, Integer i2, Integer i3){}
```
are also obvious to me and,  probably,  IDEA could skip it.

4. In this inspection, I prefer to use `isConvertibleFrom` instead of  usual `isAssignableFrom`, because I want to catch cases like

```java
public class Test<E> {
    public void test(E e) {}
    public void test(String... strings) {}
}
```

If something is wrong, I am ready to change it.
Thank you in advance