### PR TITLE
[Java. Inspections] IDEA-266603 - support assignment from StringBuilder

### DIFF
--- a/plugins/InspectionGadgets/src/com/siyeh/ig/style/StringBufferReplaceableByStringInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/style/StringBufferReplaceableByStringInspection.java
@@ -567,9 +567,21 @@ public class StringBufferReplaceableByStringInspection extends BaseInspection im
     @Override
     public void visitAssignmentExpression(@NotNull PsiAssignmentExpression expression) {
       super.visitAssignmentExpression(expression);
-      if (expression.getTextOffset() > myVariable.getTextOffset() && !myToStringFound && !isArgumentOfStringBuilderMethod(expression)) {
+      if (expression.getTextOffset() > myVariable.getTextOffset() && !myToStringFound && !isArgumentOfStringBuilderMethod(expression)
+          && !isToStringCallForCurrentBuilder(expression.getRExpression())) {
         myPossibleSideEffect = expression;
       }
+    }
+
+    private boolean isToStringCallForCurrentBuilder(@Nullable PsiExpression expression) {
+      if (expression == null) {
+        return false;
+      }
+      PsiExpression downExpression = PsiUtil.skipParenthesizedExprDown(expression);
+      if (!(downExpression instanceof PsiMethodCallExpression psiMethodCallExpression)) {
+        return false;
+      }
+      return isToStringCall(psiMethodCallExpression) && isCallToStringBuilderMethod(psiMethodCallExpression);
     }
 
     @Override

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/replace_with_string/SideEffect3.after.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/replace_with_string/SideEffect3.after.java
@@ -1,0 +1,11 @@
+class SideEffect {
+
+  public String checkForAssignment(String name) throws IOException {
+    int len = name.length() * 2 + 1;
+      <caret>StringBuilder sb3 = new StringBuilder(len);
+      String sb = "1" +
+              '/';
+    name = sb;
+    return name;
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/replace_with_string/SideEffect3.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igfixes/style/replace_with_string/SideEffect3.java
@@ -1,0 +1,13 @@
+class SideEffect {
+
+  public String checkForAssignment(String name) throws IOException {
+    int len = name.length() * 2 + 1;
+    StringBuilder s<caret>b = new StringBuilder(len);
+    StringBuilder sb3 = new StringBuilder(len);
+    sb.append(1);
+    name = sb
+      .append('/')
+      .toString();
+    return name;
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/string_buffer_replaceable_by_string/StringBufferReplaceableByString.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/string_buffer_replaceable_by_string/StringBufferReplaceableByString.java
@@ -159,4 +159,34 @@ public class StringBufferReplaceableByString {
       .add(str2)
       .toString();
   }
+
+  void test3(String name) {
+    StringBuilder <warning descr="'StringBuilder sb' can be replaced with 'String'">sb</warning> = new StringBuilder(name.length());
+    name = sb.append(name.replace('.', '/'))
+      .append('/')
+      .append(name)
+      .toString();
+
+    StringBuilder sb2 = new StringBuilder(name.length());
+    name = "";
+    name = sb2.append(name.replace('.', '/'))
+      .append('/')
+      .append(name)
+      .toString();
+
+    StringBuilder sb3 = new StringBuilder(name.length());
+    name = sb3.append(name.replace('.', '/'))
+      .append('/')
+      .append(name)
+      .toString();
+
+    String name2 = sb3.toString();
+
+    StringBuilder sb4 = new StringBuilder(name.length());
+    name = sb4.append(name.replace('.', '/'))
+      .insert(0,1)
+      .append('/')
+      .append(name)
+      .toString();
+  }
 }

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/StringBufferReplaceableByStringFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/fixes/style/StringBufferReplaceableByStringFixTest.java
@@ -78,6 +78,7 @@ public class StringBufferReplaceableByStringFixTest extends IGQuickFixesTestCase
   public void testCharacterPlusAppend() { doTestFor("StringBuilder"); }
   public void testSideEffect() { doTestFor("StringBuilder"); }
   public void testSideEffect2() { doTestFor("StringBuilder"); }
+  public void testSideEffect3() { doTestFor("StringBuilder"); }
 
   public void testComplexSignOnNextLine() {
     final CommonCodeStyleSettings settings = CodeStyle.getSettings(getProject()).getCommonSettings(JavaLanguage.INSTANCE);


### PR DESCRIPTION
I tried to fix https://youtrack.jetbrains.com/issue/IDEA-266603/Inspection-StringBuilder-can-be-replaced-with-String-fails-to-issue-a-warning-in-trivial-case

About realization.

Before this fix, the inspection usually marks almost all assignment expressions as said-effect and doesn't offer a quick fix. 
It seems  to me that it is possible to change this behavior and there is no reason to mark the assignment
- if this assignment is a terminal operation (`toString`) and
- if this assignment is a chain of operations for `StringBuilder`

Cases like
```java
        StringBuilder sb4 = new StringBuilder(name.length());
        name = sb4.append(name.replace('.', '/'))
                .insert(0,1)
                .append('/')
                .append(name)
                .toString();
```
are processed correctly during further checks.

If something is wrong, I am ready to change it.
Thank you in advance