### PR TITLE
Do not copy stream if all bindings are constructor args

### DIFF
--- a/platform/object-serializer/src/BeanBinding.kt
+++ b/platform/object-serializer/src/BeanBinding.kt
@@ -5,6 +5,7 @@ import com.amazon.ion.IonReader
 import com.amazon.ion.IonType
 import com.amazon.ion.system.IonReaderBuilder
 import it.unimi.dsi.fastutil.objects.Object2IntMap
+import com.intellij.openapi.util.io.BufferExposingByteArrayOutputStream
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import java.lang.reflect.Type
 import kotlin.reflect.full.primaryConstructor
@@ -99,15 +100,31 @@ internal class BeanBinding(beanClass: Class<*>) : BaseBeanBinding(beanClass), Bi
     val names = constructorInfo.names
     val initArgs = arrayOfNulls<Any?>(names.size)
 
-    val out = context.allocateByteArrayOutputStream()
-    // ionType is already checked - so, struct is expected
-    binaryWriterBuilder.newWriter(out).use { it.writeValue(context.reader) }
+    /**
+     * Applies [body] to `context.reader` and makes a copy of the structure being read if the second pass will be required
+     * to handle properties which are not deserialized by invoking the constructor.
+     */
+    fun doReadAndMakeCopyIfSecondPassIsNeeded(body: (reader: IonReader) -> Unit): BufferExposingByteArrayOutputStream? {
+      return if (bindings.size > names.size) {
+        val out = context.allocateByteArrayOutputStream()
+        // ionType is already checked - so, struct is expected
+        binaryWriterBuilder.newWriter(out).use { it.writeValue(context.reader) }
+        structReaderBuilder.build(out.internalBuffer, 0, out.size()).use { reader ->
+          reader.next()
+          body(reader)
+        }
+        out
+      }
+      else {
+        body(context.reader)
+        null
+      }
+    }
 
     // we cannot read all field values before creating instance because some field value can reference to parent - our instance,
     // so, first, create instance, and only then read rest of fields
     var id = -1
-    structReaderBuilder.build(out.internalBuffer, 0, out.size()).use { reader ->
-      reader.next()
+    val out = doReadAndMakeCopyIfSecondPassIsNeeded { reader ->
       val subReadContext = context.createSubContext(reader)
       readStruct(reader) { fieldName, type ->
         if (type == IonType.NULL) {
@@ -156,7 +173,7 @@ internal class BeanBinding(beanClass: Class<*>) : BaseBeanBinding(beanClass), Bi
       context.objectIdReader.registerObject(instance, id)
     }
 
-    if (bindings.size > names.size) {
+    if (out != null) {
       structReaderBuilder.build(out.internalBuffer, 0, out.size()).use { reader ->
         reader.next()
         readIntoObject(instance, context.createSubContext(reader), checkId = false /* already registered */) { !names.contains(it) }


### PR DESCRIPTION
When deserializing an entity which is instantiated via a constructor with parameters in the general case we need to make a copy of the input stream so that the constructor arguments can eb deserialized first. However, when all the serialized values are constructor arguments we do not need to make a copy as it is slow and inefficient.

This changes saves more than a minute of data node deserialisation time on https://github.com/gavra0/android-extra-large-benchmark