### PR TITLE
[kotlin] Setter backing field should be assigned: fix highlighting range

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SetterBackingFieldAssignmentInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SetterBackingFieldAssignmentInspection.kt
@@ -4,6 +4,7 @@ package org.jetbrains.kotlin.idea.inspections
 
 import com.intellij.codeInspection.*
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
@@ -18,6 +19,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 
 import org.jetbrains.kotlin.idea.codeinsight.api.classic.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 class SetterBackingFieldAssignmentInspection : AbstractKotlinInspection(), CleanupLocalInspectionTool {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession): PsiElementVisitor =
@@ -52,10 +55,13 @@ class SetterBackingFieldAssignmentInspection : AbstractKotlinInspection(), Clean
                     }
                 }) return
 
+            val name = accessor.namePlaceholder
+            val highlightRange = TextRange(name.startOffset, (accessor.rightParenthesis ?: name).endOffset).shiftLeft(accessor.startOffset)
             holder.registerProblem(
                 accessor,
                 KotlinBundle.message("existing.backing.field.is.not.assigned.by.the.setter"),
                 ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                highlightRange,
                 AssignBackingFieldFix()
             )
         })

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -14133,6 +14133,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/setterBackingFieldAssignment/noBackingField.kt");
         }
 
+        @TestMetadata("onLeftBrace.kt")
+        public void testOnLeftBrace() throws Exception {
+            runTest("testData/inspectionsLocal/setterBackingFieldAssignment/onLeftBrace.kt");
+        }
+
         @TestMetadata("plusAssign.kt")
         public void testPlusAssign() throws Exception {
             runTest("testData/inspectionsLocal/setterBackingFieldAssignment/plusAssign.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/noAssignment2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/noAssignment2.kt
@@ -1,6 +1,6 @@
 class Test {
     var foo: Int = 1
-        <caret>set(value) {
+        set(value)<caret> {
             bar(field)
         }
 

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/noAssignment5.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/noAssignment5.kt
@@ -1,5 +1,5 @@
 class Test {
     private var str1: String? = null
     private var str2: String? = null
-        set(value) { str1 = value }<caret>
+        <caret>set(value) { str1 = value }
 }

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/onLeftBrace.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/setterBackingFieldAssignment/onLeftBrace.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+class Test {
+    var foo: Int = 1
+    set(value) <caret>{
+    }
+}


### PR DESCRIPTION
https://github.com/JetBrains/intellij-community/pull/2231#pullrequestreview-1182117148

<img width="222" alt="スクリーンショット 2022-11-17 17 15 32" src="https://user-images.githubusercontent.com/1121855/202395034-4dd3c297-114f-47a9-91ac-9097b842d884.png">
