### PR TITLE
IDEA-306900 Support plugins that want to profile Gradle run configurations

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
@@ -1021,6 +1021,14 @@ public final class ExternalSystemUtil {
     return RUNNER_IDS.get(executorId);
   }
 
+  public static void registerRunnerId(@NotNull String executorId, @NotNull String externalSystemRunnerId)  {
+    if (!RUNNER_IDS.containsKey(executorId)) {
+      RUNNER_IDS.put(executorId, externalSystemRunnerId);
+    } else {
+      throw new ExternalSystemException("Executor with ID " + executorId + " is already registered");
+    }
+  }
+
   /**
    * Tries to obtain external project info implied by the given settings and link that external project to the given ide project.
    *


### PR DESCRIPTION
External build systems map the selected executor to their own implementation. Currently, only "Run" and "Debug" executors are registered in the `ExternalSystemUtil.RUNNER_IDS` map. A profiler plugin that wants to handle Gradle run configurations somehow has to provide a runner for this purpose. Currently, this requires the use of reflection. For example, the JProfiler plugin currently does this:

    val runnerIds = ExternalSystemUtil::class.java.getDeclaredField("RUNNER_IDS")
        .apply { isAccessible = true }
        .get(null) as MutableMap<String, String>
    runnerIds[RUNNER_ID] = RUNNER_ID

to ask the external build system to actually use its profiling executor (RUNNER_ID).

To avoid this, a method should be added to allow registering a runner ID mapping for external build systems.
