### PR TITLE
[Java. Inspections] IDEA-265253 - supported equals methods of test frameworks

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
@@ -2007,6 +2007,7 @@ class.with.only.private.constructors.problem.descriptor=Class <code>#ref</code> 
 property.value.set.to.itself.display.name=Property value set to itself
 equals.with.itself.display.name='equals()' called on itself
 equals.with.itself.problem.descriptor=<code>#ref()</code> called on itself
+equals.with.itself.option=Only warn on final library class types or primitives
 junit4.method.naming.convention.element.description=JUnit 4+ test method
 junit3.method.naming.convention.element.description=JUnit 3 test method
 introduce.holder.class.quickfix=Introduce holder class

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/EqualsWithItselfInspection.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/bugs/EqualsWithItselfInspection.java
@@ -1,16 +1,22 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.siyeh.ig.bugs;
 
+import com.intellij.codeInspection.ui.SingleCheckboxOptionsPanel;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiUtil;
+import com.intellij.psi.util.TypeConversionUtil;
 import com.siyeh.InspectionGadgetsBundle;
 import com.siyeh.ig.BaseInspection;
 import com.siyeh.ig.BaseInspectionVisitor;
 import com.siyeh.ig.callMatcher.CallMatcher;
 import com.siyeh.ig.psiutils.EquivalenceChecker;
 import com.siyeh.ig.psiutils.ExpressionUtils;
+import com.siyeh.ig.psiutils.LibraryUtil;
 import com.siyeh.ig.psiutils.SideEffectChecker;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
 
 /**
  * @author Bas Leijdekkers
@@ -31,11 +37,45 @@ public class EqualsWithItselfInspection extends BaseInspection {
     CallMatcher.staticCall(CommonClassNames.JAVA_LANG_DOUBLE, "compare")
   );
 
+  private static final CallMatcher ASSERT_ARGUMENT_COMPARISON = CallMatcher.anyOf(
+    CallMatcher.staticCall("org.junit.Assert", "assertEquals", "assertArrayEquals", "assertIterableEquals",
+                           "assertLinesMatch", "assertNotEquals"),
+    CallMatcher.staticCall("org.junit.jupiter.api.Assertions", "assertEquals", "assertArrayEquals", "assertIterableEquals",
+                           "assertLinesMatch", "assertNotEquals")
+  );
+
+  private static final CallMatcher ASSERT_ARGUMENTS_THE_SAME = CallMatcher.anyOf(
+    CallMatcher.staticCall("org.junit.Assert", "assertSame", "assertNotSame"),
+    CallMatcher.staticCall("org.junit.jupiter.api.Assertions", "assertSame", "assertNotSame")
+  );
+
+
   private static final CallMatcher ONE_ARGUMENT_COMPARISON = CallMatcher.anyOf(
     CallMatcher.instanceCall(CommonClassNames.JAVA_LANG_OBJECT, "equals"),
     CallMatcher.instanceCall(CommonClassNames.JAVA_LANG_STRING, "equalsIgnoreCase", "compareToIgnoreCase"),
     CallMatcher.instanceCall(CommonClassNames.JAVA_LANG_COMPARABLE, "compareTo")
   );
+
+  private static final CallMatcher ASSERTJ_COMPARISON =
+    CallMatcher.instanceCall("org.assertj.core.api.AbstractAssert", "isEqualTo", "isNotEqualTo").parameterCount(1);
+
+
+  private static final CallMatcher ASSERTJ_THE_SAME =
+    CallMatcher.instanceCall("org.assertj.core.api.AbstractAssert", "isSameAs", "isNotSameAs").parameterCount(1);
+
+
+  private static final CallMatcher ASSERTJ_ASSERT_THAT =
+    CallMatcher.staticCall("org.assertj.core.api.Assertions", "assertThat").parameterCount(1);
+
+
+  @SuppressWarnings("PublicField")
+  public boolean ignoreNonFinalClasses = false;
+
+  @Override
+  public JComponent createOptionsPanel() {
+    return new SingleCheckboxOptionsPanel(InspectionGadgetsBundle.message("equals.with.itself.option"),
+                                          this, "ignoreNonFinalClasses");
+  }
 
   @NotNull
   @Override
@@ -48,14 +88,28 @@ public class EqualsWithItselfInspection extends BaseInspection {
     return new EqualsWithItselfVisitor();
   }
 
-  private static class EqualsWithItselfVisitor extends BaseInspectionVisitor {
+  private class EqualsWithItselfVisitor extends BaseInspectionVisitor {
 
     @Override
     public void visitMethodCallExpression(@NotNull PsiMethodCallExpression expression) {
       super.visitMethodCallExpression(expression);
-      if (isEqualsWithItself(expression)) {
+      if (checkArgumentFinalLibraryClassOrPrimitives(expression) && isEqualsWithItself(expression)) {
         registerMethodCallError(expression);
       }
+    }
+
+    private boolean checkArgumentFinalLibraryClassOrPrimitives(PsiMethodCallExpression expression) {
+      if (!ignoreNonFinalClasses) return true;
+      final PsiExpressionList argumentList = expression.getArgumentList();
+      if (argumentList.getExpressionCount() < 1) return false;
+      PsiType type = argumentList.getExpressions()[0].getType();
+      if (type == null) return false;
+
+      if (TypeConversionUtil.isPrimitiveAndNotNull(type)) return true;
+
+      PsiClass aClass = PsiUtil.resolveClassInClassTypeOnly(type);
+      if (!LibraryUtil.classIsInLibrary(aClass)) return false;
+      return aClass.hasModifierProperty(PsiModifier.FINAL);
     }
   }
 
@@ -64,26 +118,58 @@ public class EqualsWithItselfInspection extends BaseInspection {
     final PsiExpressionList argumentList = expression.getArgumentList();
     final int count = argumentList.getExpressionCount();
     if (count == 1) {
+      final PsiExpression qualifier = ExpressionUtils.getEffectiveQualifier(methodExpression);
+      final PsiExpression[] arguments = argumentList.getExpressions();
+      final PsiExpression argument = PsiUtil.skipParenthesizedExprDown(arguments[0]);
       if (ONE_ARGUMENT_COMPARISON.test(expression)) {
-        final PsiExpression qualifier = ExpressionUtils.getEffectiveQualifier(methodExpression);
-        final PsiExpression[] arguments = argumentList.getExpressions();
-        final PsiExpression argument = PsiUtil.skipParenthesizedExprDown(arguments[0]);
         return isItself(qualifier, argument);
       }
+      else if (ASSERTJ_COMPARISON.test(expression)) {
+        return isItself(getAssertThatArgument(expression), argument);
+      }
+      else if (ASSERTJ_THE_SAME.test(expression)) {
+        return isTheSame(getAssertThatArgument(expression), argument);
+      }
     }
-    else if (count == 2) {
-      if (TWO_ARGUMENT_COMPARISON.test(expression)) {
-        final PsiExpression[] arguments = argumentList.getExpressions();
-        final PsiExpression firstArgument = PsiUtil.skipParenthesizedExprDown(arguments[0]);
-        final PsiExpression secondArgument = PsiUtil.skipParenthesizedExprDown(arguments[1]);
+    else if (count == 2 || count == 3) {
+      final PsiExpression[] arguments = argumentList.getExpressions();
+      final PsiExpression firstArgument = PsiUtil.skipParenthesizedExprDown(arguments[0]);
+      final PsiExpression secondArgument = PsiUtil.skipParenthesizedExprDown(arguments[1]);
+
+      if (TWO_ARGUMENT_COMPARISON.test(expression) || ASSERT_ARGUMENT_COMPARISON.test(expression)) {
         return isItself(firstArgument, secondArgument);
+      }
+      else if (ASSERT_ARGUMENTS_THE_SAME.test(expression)) {
+        return isTheSame(firstArgument, secondArgument);
       }
     }
     return false;
   }
 
-  private static boolean isItself(PsiExpression left, PsiExpression right) {
-    return left != null &&
+  @Nullable
+  private static PsiExpression getAssertThatArgument(@Nullable PsiExpression expression) {
+    while (expression instanceof PsiMethodCallExpression callExpression) {
+      if (ASSERTJ_ASSERT_THAT.test(callExpression)) return callExpression.getArgumentList().getExpressions()[0];
+      PsiReferenceExpression reference = callExpression.getMethodExpression();
+      expression = reference.getQualifierExpression();
+      expression = PsiUtil.skipParenthesizedExprDown(expression);
+    }
+    return null;
+  }
+
+  private static boolean isTheSame(@Nullable PsiExpression left, @Nullable PsiExpression right) {
+    left = PsiUtil.skipParenthesizedExprDown(left);
+    right = PsiUtil.skipParenthesizedExprDown(right);
+    if (!(left instanceof PsiReferenceExpression leftReference && right instanceof PsiReferenceExpression rightReference)) {
+      return false;
+    }
+    PsiElement resolvedFromLeft = leftReference.resolve();
+    PsiElement resolvedFromRight = rightReference.resolve();
+    return resolvedFromLeft!=null && resolvedFromLeft == resolvedFromRight;
+  }
+
+  private static boolean isItself(@Nullable PsiExpression left, @Nullable PsiExpression right) {
+    return left != null && right != null &&
            EquivalenceChecker.getCanonicalPsiEquivalence().expressionsAreEquivalent(left, right) &&
            !SideEffectChecker.mayHaveSideEffects(left);
   }

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/EqualsWithItself.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/EqualsWithItself.html
@@ -20,5 +20,7 @@ with itself.
 </code></pre>
 <!-- tooltip end -->
 <p>
+  Use the option to report only on final library class types or primitives.
+</p>
 </body>
 </html>

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/equals_with_itself/EqualsWithItself.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/equals_with_itself/EqualsWithItself.java
@@ -67,6 +67,17 @@ class EqualsWithItself {
     c.<warning descr="'compare()' called on itself">compare</warning>(ss, ss);
   }
 
+  void test(String arg) {
+    org.junit.jupiter.api.Assertions.<warning descr="'assertEquals()' called on itself">assertEquals</warning>(arg, arg);
+    org.junit.jupiter.api.Assertions.<warning descr="'assertNotEquals()' called on itself">assertNotEquals</warning>(arg, arg);
+    org.junit.Assert.<warning descr="'assertSame()' called on itself">assertSame</warning>(arg, arg);
+    org.assertj.core.api.Assertions.assertThat(arg).<warning descr="'isEqualTo()' called on itself">isEqualTo</warning>(arg);
+    org.assertj.core.api.Assertions.assertThat(arg).anotherTest(arg).<warning descr="'isEqualTo()' called on itself">isEqualTo</warning>(arg);
+    Object o1 = new Object();
+    Object o2 = new Object();
+    org.junit.Assert.assertSame(o1, o2);
+  }
+
   static class Outer {
     class Inner extends Outer {
       void test() {

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/equals_with_itself/EqualsWithItself_ignoreNonFinalClasses.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/bugs/equals_with_itself/EqualsWithItself_ignoreNonFinalClasses.java
@@ -1,0 +1,23 @@
+import java.util.*;
+
+class EqualsWithItself_ignoreNonFinalClasses {
+
+  boolean foo(Object o) {
+    return o.equals(o);
+  }
+
+  boolean string(String s) {
+    return s.<warning descr="'equalsIgnoreCase()' called on itself">equalsIgnoreCase</warning>(s);
+  }
+
+  boolean integer(Integer i) {
+    return i.<warning descr="'equals()' called on itself">equals</warning>(i);
+  }
+
+  boolean customClass(FinalClass finalClass) {
+    return finalClass.equals(finalClass);
+  }
+
+  private static final class FinalClass{
+  }
+}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/EqualsWithItselfInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/bugs/EqualsWithItselfInspectionTest.java
@@ -2,28 +2,78 @@
 package com.siyeh.ig.bugs;
 
 import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.codeInspection.ui.OptionAccessor;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.siyeh.ig.LightJavaInspectionTestCase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Comparator;
 
 /**
  * @author Bas Leijdekkers
  */
 public class EqualsWithItselfInspectionTest extends LightJavaInspectionTestCase {
 
-  public void testEqualsWithItself() { doTest(); }
+  public void testEqualsWithItself() {
+    doTest();
+  }
+
+  public void testEqualsWithItself_ignoreNonFinalClasses() {
+    doTest();
+  }
 
   @Nullable
   @Override
   protected InspectionProfileEntry getInspection() {
-    return new EqualsWithItselfInspection();
+    EqualsWithItselfInspection inspection = new EqualsWithItselfInspection();
+    String option = StringUtil.substringAfter(getName(), "_");
+    if(option != null) {
+      new OptionAccessor.Default(inspection).setOption(option, true);
+    }
+    return inspection;
   }
 
   @Override
   protected @NotNull LightProjectDescriptor getProjectDescriptor() {
     return JAVA_11;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Override
+  protected String[] getEnvironmentClasses() {
+    return new String[] {"""
+     package org.junit.jupiter.api;
+     public class Assertions{
+     	public static void assertEquals(Object expected, Object actual) {}
+     	public static void assertNotEquals(Object expected, Object actual) {}
+     }
+     """,
+     """
+     package org.junit;
+     public class Assert{
+     	public static void assertSame(Object expected, Object actual) {}
+     }
+     """,
+     """
+     package org.assertj.core.api;
+     import org.assertj.core.api.AbstractAssert;
+     public class Assertions{
+      public static AbstractAssert assertThat(Object actual) {
+        return new AbstractAssert();
+      }
+     }
+     """,
+     """
+     package org.assertj.core.api;
+     public class AbstractAssert{
+      public AbstractAssert isEqualTo(Object expected) {
+       return this;
+      }
+      public AbstractAssert anotherTest(Object expected) {
+       return this;
+      }
+     }
+     """,
+    };
   }
 }


### PR DESCRIPTION
I tried to implement https://youtrack.jetbrains.com/issue/IDEA-265253

About realization:

- I added a new option `Only warn on final library class types or primitives`, but disabled it by default, because it seems to me, that it is not a really popular case.

- Added support for methods `org.junit.Assert` like "assertEquals", "assertArrayEquals", "assertIterableEquals", "assertLinesMatch", "assertNotEquals
- Added support for `org.junit.jupiter.api.Assertions`, but in this case it is possible to have a chain, like  `org.assertj.core.api.Assertions.assertThat(arg).anotherTest(arg).isEqualTo(arg);`,  and it is needed to find a correct qualifier
- Additionally, I added cases like `assertSame` to catch:
`org.junit.Assert.assertSame(o1, o2);`


If something is wrong, I am ready to change it.
Thank you in advance