### PR TITLE
[Java. Inspections] IDEA-277232 - improved processing comments for switch expressions

### DIFF
--- a/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitch/ExpressionsWithComments.java
+++ b/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitch/ExpressionsWithComments.java
@@ -1,0 +1,53 @@
+class ExpressionsWithComments {
+  String foo1(int n) {
+    return switch (n) {
+      //comment1
+      //comment2
+      //comment3
+      case 1 -> "A"; //comment4
+      case 2 -> "B";
+      //comment1
+      //comment2
+      //comment3
+      case 3 -> <weak_warning descr="Duplicate branch in 'switch'">"A";</weak_warning> //comment4
+      default -> "";
+    };
+  }
+
+  String foo2(int n) {
+    return switch (n) {
+      //comment1
+      case 1 -> "A";
+      case 2 -> "B";
+      //comment1
+      case 3 ->"A";//comment2
+      default -> "";
+    };
+  }
+
+  String foo3(int n) {
+    return switch (n) {
+      //comment1
+      case 1 -> <weak_warning descr="Branch in 'switch' is a duplicate of the default branch">"A";</weak_warning> //comment2
+      case 2 -> "B";
+      case 3 -> "C";
+      //comment1
+      default -> "A"; //comment2
+    };
+  }
+
+  String foo4(int n) {
+    return switch (n) {
+      //comment1
+      case 1 -> {
+        yield "A";//comment2
+      }
+      case 2 -> "B";
+      //comment1
+      case 3 -> <weak_warning descr="Duplicate branch in 'switch'">{
+        yield "A";//comment2
+      }</weak_warning>
+      default -> "";
+    };
+  }
+}

--- a/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/afterDefaultExpressionsWithComments.java
+++ b/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/afterDefaultExpressionsWithComments.java
@@ -1,0 +1,11 @@
+// "Delete redundant 'switch' branch" "GENERIC_ERROR_OR_WARNING"
+class C {
+    void foo(int n) {
+        switch (n) {
+            case 2 -> bar("B");
+            //comment1
+            default ->bar("A");//comment2
+        }
+    }
+    void bar(String s){}
+}

--- a/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/afterSimpleExpressionsWithComments.java
+++ b/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/afterSimpleExpressionsWithComments.java
@@ -1,0 +1,12 @@
+// "Merge with 'case 1'" "GENERIC_ERROR_OR_WARNING"
+class SimpleExpressionsWithComments {
+  String foo(int n) {
+    return switch (n) {
+      //comment1
+      //comment2
+      //comment3
+      case 1, 3 -> "A"; //comment4
+      case 2 -> "B";
+    };
+  }
+}

--- a/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/beforeDefaultExpressionsWithComments.java
+++ b/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/beforeDefaultExpressionsWithComments.java
@@ -1,0 +1,13 @@
+// "Delete redundant 'switch' branch" "GENERIC_ERROR_OR_WARNING"
+class C {
+    void foo(int n) {
+        switch (n) {
+            //comment1
+            case 1 -> bar("A");<caret>//comment2
+            case 2 -> bar("B");
+            //comment1
+            default ->bar("A");//comment2
+        }
+    }
+    void bar(String s){}
+}

--- a/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/beforeSimpleExpressionsWithComments.java
+++ b/java/java-tests/testData/inspection/duplicateBranchesInEnhancedSwitchFix/beforeSimpleExpressionsWithComments.java
@@ -1,0 +1,16 @@
+// "Merge with 'case 1'" "GENERIC_ERROR_OR_WARNING"
+class SimpleExpressionsWithComments {
+  String foo(int n) {
+    return switch (n) {
+      //comment1
+      //comment2
+      //comment3
+      case 1 -> "A"; //comment4
+      case 2 -> "B";
+      //comment1
+      //comment2
+      //comment3
+      case 3 -> <caret>"A"; //comment4
+    };
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/DuplicateBranchesInEnhancedSwitchTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/DuplicateBranchesInEnhancedSwitchTest.kt
@@ -36,6 +36,7 @@ class DuplicateBranchesInEnhancedSwitchTest : LightJavaCodeInsightFixtureTestCas
   fun testTwoPatterns() = doTest()
   fun testWhenClause1() = IdeaTestUtil.withLevel(module, LanguageLevel.JDK_19_PREVIEW) { doTest() }
   fun testWhenClause2() = IdeaTestUtil.withLevel(module, LanguageLevel.JDK_19_PREVIEW) { doTest() }
+  fun testExpressionsWithComments() = doTest()
 
   private fun doTest() {
     myFixture.enableInspections(DuplicateBranchesInSwitchInspection())


### PR DESCRIPTION
I tried to implement https://youtrack.jetbrains.com/issue/IDEA-277232

About realization:

It seems to me, that it is usual, that comments are connected to their  `case` in the next way:

```java
    return switch (n) {
      //first comment about case 1 because it is upper and on a new line
      case 1 -> {
        yield "A";//second comment about case 1 too until a new line delimiter
      }
      case 2 -> "B";
      //third comment about case 3
      case 3 ->"A";//forth about case 3 too
      default -> "";
```

I tried to implement this way:
- `first comment` is connected to `case 1` because it is upper `case 1` and on a new line
-  `second comment` is connected to `case 2` because it is on the same line and after this comment, there is a new line delimiter.

If something is wrong, I am ready to change it.
Thank you in advance