### PR TITLE
IDEA-306601 Call PsiFile.isValid() under Read Action

### DIFF
--- a/plugins/groovy/src/org/jetbrains/plugins/groovy/refactoring/GroovyImportOptimizerRefactoringHelper.java
+++ b/plugins/groovy/src/org/jetbrains/plugins/groovy/refactoring/GroovyImportOptimizerRefactoringHelper.java
@@ -52,7 +52,7 @@ public class GroovyImportOptimizerRefactoringHelper implements RefactoringHelper
       final int total = files.size();
       int i = 0;
       for (final GroovyFile file : files) {
-        if (!file.isValid()) continue;
+        if (!ReadAction.compute(() -> file.isValid())) continue;
         final VirtualFile virtualFile = file.getVirtualFile();
         if (progressIndicator != null) {
           progressIndicator.setText2(virtualFile.getPresentableUrl());


### PR DESCRIPTION
If a refactoring causes any psi file to be marked potentially invalid, the isValid call requires a read action.