### PR TITLE
[Java. Inspections] IDEA-248328 - supported side effects before cycle

### DIFF
--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/psiutils/SideEffectChecker.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/psiutils/SideEffectChecker.java
@@ -68,7 +68,7 @@ public final class SideEffectChecker {
     return visitor.mayHaveSideEffects();
   }
 
-  public static boolean mayHaveSideEffects(@NotNull PsiElement element, Predicate<? super PsiElement> shouldIgnoreElement) {
+  public static boolean mayHaveSideEffects(@NotNull PsiElement element, @NotNull Predicate<? super PsiElement> shouldIgnoreElement) {
     final SideEffectsVisitor visitor = new SideEffectsVisitor(null, element, shouldIgnoreElement);
     element.accept(visitor);
     return visitor.mayHaveSideEffects();
@@ -83,6 +83,10 @@ public final class SideEffectChecker {
    */
   public static boolean mayHaveNonLocalSideEffects(@NotNull PsiElement element) {
     return mayHaveSideEffects(element, SideEffectChecker::isLocalSideEffect);
+  }
+
+  public static boolean mayHaveNonLocalSideEffects(@NotNull PsiElement element, @NotNull Predicate<PsiElement> shouldIgnoreElement) {
+    return mayHaveSideEffects(element, shouldIgnoreElement.or(e -> isLocalSideEffect(e)));
   }
 
   private static boolean isLocalSideEffect(PsiElement e) {

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/migration/foreach/ForCanBeForEach.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/migration/foreach/ForCanBeForEach.java
@@ -348,6 +348,84 @@ public class ForCanBeForEach {
           }
       }
   }
+
+  private static String[] staticArg = new String[]{};
+
+  public void testArrayShouldIgnore(String[] arr) {
+    int newLength = 1;
+    int oldLength = arr.length;
+    if (oldLength < newLength) {
+      arr = Arrays.copyOf(arr, newLength);
+    }
+
+    for (int i = 0; i < oldLength; i++) {
+      String s = arr[i];
+      System.out.println(s);
+    }
+  }
+
+  public void testArrayShouldIgnore2() {
+    int newLength = 1;
+    int oldLength = staticArg.length;
+    if (oldLength < newLength) {
+      staticArg = Arrays.copyOf(staticArg, newLength);
+    }
+
+    for (int i = 0; i < oldLength; i++) {
+      String s = staticArg[i];
+      System.out.println(s);
+    }
+  }
+
+  public void testArrayShouldIgnore3() {
+    int oldLength = staticArg.length;
+    notPureMethod1();
+
+    for (int i = 0; i < oldLength; i++) {
+      String s = staticArg[i];
+      System.out.println(s);
+    }
+  }
+
+  private void notPureMethod1() {
+    staticArg = new String[]{"11"};
+  }
+
+  public void testListShouldIgnore1(List<String> lists) {
+    int oldSize = lists.size();
+
+    lists = new ArrayList<>();
+
+    for (int i = 0; i < oldSize; i++) {
+      String s = lists.get(i);
+      System.out.println(s);
+    }
+  }
+
+  public void testListShouldIgnore2(List<String> lists) {
+    int oldSize = lists.size();
+
+    lists.add("1");
+
+    for (int i = 0; i < oldSize; i++) {
+      String s = lists.get(i);
+      System.out.println(s);
+    }
+  }
+
+  void sideEffectsWith2Methods(List<String> ls) {
+    int size = ls.size();
+    method1(ls);
+    method1(ls);
+    for (int i = (0); (i < (size)); (i)++) {
+      Object o = ls.get(i);
+      System.out.println("o = " + o);
+    }
+  }
+
+  private void method1(List<String> ls) {
+    ls.add("1");
+  }
 }
 class OuterClass
 {


### PR DESCRIPTION
I tried to implement https://youtrack.jetbrains.com/issue/IDEA-248328 

About realization:
The main idea is to add side effect checks for statements between an assignment for `.size()` or `length` and `for` statement.

If `for` statement is for a local array, it is impossible to change its size, so it is necessary to check the only assignment for the array variable
if `for` statement is for non-local array, it is necessary to check also non-local side effects.

if `for` statement is for a local collection, it seems to me that it is necessary to check assignments and non-local side effects.
if `for` statement is for a non-local collection, it seems to me that it will be better to check all side effects.

If something is wrong, I am ready to change it.
Thank you in advance