### PR TITLE
ui: Use the correct constants when opening a split window

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/intention/impl/QuickEditHandler.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/intention/impl/QuickEditHandler.java
@@ -203,7 +203,7 @@ public class QuickEditHandler extends UserDataHolderBase implements Disposable, 
       final FileEditor[] editors = fileEditorManager.getEditors(myNewVirtualFile);
       if (editors.length == 0) {
         final EditorWindow curWindow = fileEditorManager.getCurrentWindow();
-        mySplittedWindow = curWindow.split(SwingConstants.HORIZONTAL, false, myNewVirtualFile, true);
+        mySplittedWindow = curWindow.split(JSplitPane.VERTICAL_SPLIT, false, myNewVirtualFile, true);
       }
       Editor editor = fileEditorManager.openTextEditor(new OpenFileDescriptor(myProject, myNewVirtualFile, injectedOffset), true);
       // fold missing values

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
@@ -807,7 +807,7 @@ open class EditorsSplitters internal constructor(val manager: FileEditorManagerI
         }
       }
     }
-    return window.split(SwingConstants.VERTICAL, true, file, requestFocus)
+    return window.split(JSplitPane.HORIZONTAL_SPLIT, true, file, requestFocus)
   }
 }
 


### PR DESCRIPTION
Judging by the implementation, `EditorWindow.split` seems to expect either `HORIZONTAL_SPLIT` or `VERTICAL_SPLIT` from `JSplitPane` for its first argument, not any of the constants in `SwingConstants`.

NB: I haven't tested this myself because I didn't set up the full build environment for IntelliJ but it should work since `JSplitPane` is already imported via `javax.swing.*`.