### PR TITLE
IDEA-306827: Make Emoji search in the Emoji Picker case-insensitive

### DIFF
--- a/plugins/emojipicker/src/org/jetbrains/plugins/emojipicker/service/EmojiService.java
+++ b/plugins/emojipicker/src/org/jetbrains/plugins/emojipicker/service/EmojiService.java
@@ -227,7 +227,7 @@ public final class EmojiService implements PersistentStateComponent<EmojiService
     }
 
     synchronized List<Emoji> lookupEmoji(@NonNls String prefix) {
-      if (myIndex.lookupIds(myIdMap, prefix)) {
+      if (myIndex.lookupIds(myIdMap, prefix.toLowerCase())) {
         List<Emoji> result = new ArrayList<>(100);
         for (int i = 0; i < myIdMap.length; i++) {
           if (myIdMap[i]) result.add(myEmoji.get(i));
@@ -324,7 +324,7 @@ public final class EmojiService implements PersistentStateComponent<EmojiService
             @NonNls String value = node.getTextContent();
             if (node.getAttributes().getNamedItem("type") == null) {
               for (String keyword : value.split("\\|")) {
-                myIndexTree.add(keyword.strip(), index);
+                myIndexTree.add(keyword.strip().toLowerCase(), index);
               }
             }
             else if (names != null) {


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/IDEA-306827

Well, maybe it's not the most effective option (although I see the index is cached), but at least it demonstrates the idea: Emoji search should be case-insensitive.