### PR TITLE
Step into lambdas with parameters destructuring

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/KotlinPositionManager.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/KotlinPositionManager.kt
@@ -578,9 +578,6 @@ private fun decorateSourcePosition(location: Location, sourcePosition: SourcePos
     return sourcePosition
 }
 
-private fun Location.getZeroBasedLineNumber(): Int =
-    DebuggerUtilsEx.getLineNumber(this, true)
-
 private fun Location.hasVisibleInlineLambdasOnLines(lines: IntRange): Boolean {
     val method = safeMethod() ?: return false
     return method.getInlineFunctionAndArgumentVariablesToBordersMap()

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/debuggerUtil.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/debuggerUtil.kt
@@ -9,6 +9,7 @@ import com.intellij.debugger.engine.DebuggerManagerThreadImpl
 import com.intellij.debugger.engine.events.DebuggerCommandImpl
 import com.intellij.debugger.impl.DebuggerContextImpl
 import com.intellij.debugger.impl.DebuggerUtilsAsync
+import com.intellij.debugger.impl.DebuggerUtilsEx
 import com.intellij.debugger.jdi.StackFrameProxyImpl
 import com.intellij.openapi.application.runReadAction
 import com.intellij.psi.PsiElement
@@ -282,3 +283,9 @@ fun Method.getInlineFunctionOrArgumentVariables(): Sequence<LocalVariable> {
 
 val DebugProcessImpl.canRunEvaluation: Boolean
     get() = suspendManager.pausedContext != null
+
+val KtFunction.isLambdaOrAnonymous: Boolean
+    get() = this is KtFunctionLiteral || name == null
+
+fun Location.getZeroBasedLineNumber(): Int =
+    DebuggerUtilsEx.getLineNumber(this, true)

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
@@ -1480,6 +1480,11 @@ public abstract class K2IrKotlinSteppingTestGenerated extends AbstractK2IrKotlin
             runTest("../testData/stepping/custom/smartStepWithInlineClass.kt");
         }
 
+        @TestMetadata("stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt")
+        public void testStepIntoAnonymousObjectInsideLambdaWithDestructuring() throws Exception {
+            runTest("../testData/stepping/custom/stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt");
+        }
+
         @TestMetadata("stepIntoLibWithSources.kt")
         public void testStepIntoLibWithSources() throws Exception {
             runTest("../testData/stepping/custom/stepIntoLibWithSources.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
@@ -767,6 +767,16 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
             }
 
+            @TestMetadata("stepIntoNestedInlineLambdasWithDestructuring.kt")
+            public void testStepIntoNestedInlineLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoOneLineLambdaWithDestructuring.kt")
+            public void testStepIntoOneLineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
             public void testStepIntoSamLambdaWithDestructuring() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionTestGenerated.java
@@ -757,6 +757,21 @@ public abstract class IrKotlinEvaluateExpressionTestGenerated extends AbstractIr
                 runTest("testData/evaluation/singleBreakpoint/lambdas/oneLineLambda.kt");
             }
 
+            @TestMetadata("stepIntoInlineLambdaWithDestructuring.kt")
+            public void testStepIntoInlineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithDestructuring.kt")
+            public void testStepIntoLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
+            public void testStepIntoSamLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("twoLambdasOnOneLineFirst.kt")
             public void testTwoLambdasOnOneLineFirst() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/twoLambdasOnOneLineFirst.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -767,6 +767,16 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
             }
 
+            @TestMetadata("stepIntoNestedInlineLambdasWithDestructuring.kt")
+            public void testStepIntoNestedInlineLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoOneLineLambdaWithDestructuring.kt")
+            public void testStepIntoOneLineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
             public void testStepIntoSamLambdaWithDestructuring() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -757,6 +757,21 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
                 runTest("testData/evaluation/singleBreakpoint/lambdas/oneLineLambda.kt");
             }
 
+            @TestMetadata("stepIntoInlineLambdaWithDestructuring.kt")
+            public void testStepIntoInlineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithDestructuring.kt")
+            public void testStepIntoLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
+            public void testStepIntoSamLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("twoLambdasOnOneLineFirst.kt")
             public void testTwoLambdasOnOneLineFirst() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/twoLambdasOnOneLineFirst.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -1480,6 +1480,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/custom/smartStepWithInlineClass.kt");
         }
 
+        @TestMetadata("stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt")
+        public void testStepIntoAnonymousObjectInsideLambdaWithDestructuring() throws Exception {
+            runTest("testData/stepping/custom/stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt");
+        }
+
         @TestMetadata("stepIntoLibWithSources.kt")
         public void testStepIntoLibWithSources() throws Exception {
             runTest("testData/stepping/custom/stepIntoLibWithSources.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
@@ -767,6 +767,16 @@ public abstract class KotlinEvaluateExpressionInMppTestGenerated extends Abstrac
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
             }
 
+            @TestMetadata("stepIntoNestedInlineLambdasWithDestructuring.kt")
+            public void testStepIntoNestedInlineLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoOneLineLambdaWithDestructuring.kt")
+            public void testStepIntoOneLineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
             public void testStepIntoSamLambdaWithDestructuring() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionInMppTestGenerated.java
@@ -757,6 +757,21 @@ public abstract class KotlinEvaluateExpressionInMppTestGenerated extends Abstrac
                 runTest("testData/evaluation/singleBreakpoint/lambdas/oneLineLambda.kt");
             }
 
+            @TestMetadata("stepIntoInlineLambdaWithDestructuring.kt")
+            public void testStepIntoInlineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithDestructuring.kt")
+            public void testStepIntoLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
+            public void testStepIntoSamLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("twoLambdasOnOneLineFirst.kt")
             public void testTwoLambdasOnOneLineFirst() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/twoLambdasOnOneLineFirst.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
@@ -757,6 +757,21 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
                 runTest("testData/evaluation/singleBreakpoint/lambdas/oneLineLambda.kt");
             }
 
+            @TestMetadata("stepIntoInlineLambdaWithDestructuring.kt")
+            public void testStepIntoInlineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithDestructuring.kt")
+            public void testStepIntoLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
+            public void testStepIntoSamLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("twoLambdasOnOneLineFirst.kt")
             public void testTwoLambdasOnOneLineFirst() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/twoLambdasOnOneLineFirst.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinEvaluateExpressionTestGenerated.java
@@ -767,6 +767,16 @@ public abstract class KotlinEvaluateExpressionTestGenerated extends AbstractKotl
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt");
             }
 
+            @TestMetadata("stepIntoNestedInlineLambdasWithDestructuring.kt")
+            public void testStepIntoNestedInlineLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoOneLineLambdaWithDestructuring.kt")
+            public void testStepIntoOneLineLambdaWithDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.kt");
+            }
+
             @TestMetadata("stepIntoSamLambdaWithDestructuring.kt")
             public void testStepIntoSamLambdaWithDestructuring() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -1480,6 +1480,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/custom/smartStepWithInlineClass.kt");
         }
 
+        @TestMetadata("stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt")
+        public void testStepIntoAnonymousObjectInsideLambdaWithDestructuring() throws Exception {
+            runTest("testData/stepping/custom/stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt");
+        }
+
         @TestMetadata("stepIntoLibWithSources.kt")
         public void testStepIntoLibWithSources() throws Exception {
             runTest("testData/stepping/custom/stepIntoLibWithSources.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/util/FramePrinter.kt
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/util/FramePrinter.kt
@@ -189,16 +189,16 @@ class FramePrinter(private val suspendContext: SuspendContextImpl) {
     }
 }
 
-fun SourcePosition.render(): String {
+fun SourcePosition.render(): String = runReadAction {
     val virtualFile = file.originalFile.virtualFile ?: file.viewProvider.virtualFile
 
-    val libraryEntry = runReadAction {  LibraryUtil.findLibraryEntry(virtualFile, file.project) }
+    val libraryEntry = LibraryUtil.findLibraryEntry(virtualFile, file.project)
     if (libraryEntry != null && (libraryEntry is JdkOrderEntry || libraryEntry.presentableName == KOTLIN_LIBRARY_NAME)) {
         val suffix = if (isInCompiledFile()) "COMPILED" else "EXT"
-        return FileUtil.getNameWithoutExtension(virtualFile.name) + ".!$suffix!"
+        return@runReadAction FileUtil.getNameWithoutExtension(virtualFile.name) + ".!$suffix!"
     }
 
-    return virtualFile.name + ":" + (line + 1)
+    return@runReadAction virtualFile.name + ":" + (line + 1)
 }
 
 private fun SourcePosition.isInCompiledFile(): Boolean {

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt
@@ -30,3 +30,4 @@ fun main() {
 }
 
 // PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.kt
@@ -1,0 +1,32 @@
+// ATTACH_LIBRARY: utils
+package stepIntoInlineLambdaWithDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+inline fun inlineFoo(f: (A, Int, Int, B, Int, A, B) -> Unit) {
+    val a = A(1, 1)
+    val b = B()
+    // STEP_INTO: 1
+    // EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+    // RESULT: 15: I
+    //Breakpoint!
+    f(a, 1, 1, b, 1, a, b)
+}
+
+fun main() {
+    inlineFoo { (a, b),
+                c,
+                d, (e,
+                    f, g,
+                    h),
+                i,
+                (j, k),
+                (l,
+                    m,
+                    n, o) ->
+        println()
+    }
+}
+
+// PRINT_FRAME

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.out
@@ -6,16 +6,9 @@ stepIntoInlineLambdaWithDestructuring.kt:14
 stepIntoInlineLambdaWithDestructuring.kt:28
 Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
 InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoInlineLambdaWithDestructuring.kt:28)
-    JavaValue[local] $i$f$inlineFoo: int = undefined
-    JavaValue[local] a$iv: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithDestructuring.kt:18)
-        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
-        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
-    JavaValue[local] b$iv: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithDestructuring.kt:18)
-        DummyMessageValueNode = Class has no properties
-    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:23)
-    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
     JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:19)
-    JavaValue[local] $i$a$-inlineFoo-StepIntoInlineLambdaWithDestructuringKt$main$1: int = undefined
+    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
+    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:23)
     JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
     JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
     JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
@@ -29,51 +22,12 @@ InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoInlineLambdaWithDestructu
     JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
     JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
 InlineStackFrame inlineFoo (stepIntoInlineLambdaWithDestructuring.kt:14)
-    JavaValue[local] $i$f$inlineFoo: int = undefined
-    JavaValue[local] a$iv: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] a: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithDestructuring.kt:18)
         JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
         JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
-    JavaValue[local] b$iv: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithDestructuring.kt:18)
         DummyMessageValueNode = Class has no properties
-    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:23)
-    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
-    JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:19)
-    JavaValue[local] $i$a$-inlineFoo-StepIntoInlineLambdaWithDestructuringKt$main$1: int = undefined
-    JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
-    JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
-    JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
-    JavaValue[local] f: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
-    JavaValue[local] g: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
-    JavaValue[local] h: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:22)
-    JavaValue[local] j: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
-    JavaValue[local] k: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
-    JavaValue[local] l: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:25)
-    JavaValue[local] m: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:26)
-    JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
-    JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
 KotlinStackFrame (stepIntoInlineLambdaWithDestructuring.kt:18)
-    JavaValue[local] $i$f$inlineFoo: int = undefined
-    JavaValue[local] a$iv: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithDestructuring.kt:18)
-        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
-        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
-    JavaValue[local] b$iv: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithDestructuring.kt:18)
-        DummyMessageValueNode = Class has no properties
-    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:23)
-    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
-    JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:19)
-    JavaValue[local] $i$a$-inlineFoo-StepIntoInlineLambdaWithDestructuringKt$main$1: int = undefined
-    JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
-    JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
-    JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
-    JavaValue[local] f: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
-    JavaValue[local] g: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
-    JavaValue[local] h: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:22)
-    JavaValue[local] j: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
-    JavaValue[local] k: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
-    JavaValue[local] l: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:25)
-    JavaValue[local] m: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:26)
-    JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
-    JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
 Disconnected from the target VM
 
 Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoInlineLambdaWithDestructuring.out
@@ -1,0 +1,79 @@
+// IGNORE_BACKEND: JVM_WITH_OLD_EVALUATOR
+LineBreakpoint created at stepIntoInlineLambdaWithDestructuring.kt:14
+Run Java
+Connected to the target VM
+stepIntoInlineLambdaWithDestructuring.kt:14
+stepIntoInlineLambdaWithDestructuring.kt:28
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoInlineLambdaWithDestructuring.kt:28)
+    JavaValue[local] $i$f$inlineFoo: int = undefined
+    JavaValue[local] a$iv: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithDestructuring.kt:18)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+    JavaValue[local] b$iv: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithDestructuring.kt:18)
+        DummyMessageValueNode = Class has no properties
+    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:23)
+    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
+    JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:19)
+    JavaValue[local] $i$a$-inlineFoo-StepIntoInlineLambdaWithDestructuringKt$main$1: int = undefined
+    JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
+    JavaValue[local] f: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
+    JavaValue[local] g: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
+    JavaValue[local] h: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:22)
+    JavaValue[local] j: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
+    JavaValue[local] k: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
+    JavaValue[local] l: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:25)
+    JavaValue[local] m: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:26)
+    JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
+    JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
+InlineStackFrame inlineFoo (stepIntoInlineLambdaWithDestructuring.kt:14)
+    JavaValue[local] $i$f$inlineFoo: int = undefined
+    JavaValue[local] a$iv: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithDestructuring.kt:18)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+    JavaValue[local] b$iv: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithDestructuring.kt:18)
+        DummyMessageValueNode = Class has no properties
+    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:23)
+    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
+    JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:19)
+    JavaValue[local] $i$a$-inlineFoo-StepIntoInlineLambdaWithDestructuringKt$main$1: int = undefined
+    JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
+    JavaValue[local] f: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
+    JavaValue[local] g: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
+    JavaValue[local] h: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:22)
+    JavaValue[local] j: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
+    JavaValue[local] k: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
+    JavaValue[local] l: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:25)
+    JavaValue[local] m: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:26)
+    JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
+    JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
+KotlinStackFrame (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] $i$f$inlineFoo: int = undefined
+    JavaValue[local] a$iv: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithDestructuring.kt:18)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+    JavaValue[local] b$iv: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithDestructuring.kt:18)
+        DummyMessageValueNode = Class has no properties
+    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:23)
+    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
+    JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:19)
+    JavaValue[local] $i$a$-inlineFoo-StepIntoInlineLambdaWithDestructuringKt$main$1: int = undefined
+    JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:18)
+    JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:20)
+    JavaValue[local] f: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
+    JavaValue[local] g: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:21)
+    JavaValue[local] h: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:22)
+    JavaValue[local] j: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
+    JavaValue[local] k: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:24)
+    JavaValue[local] l: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:25)
+    JavaValue[local] m: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:26)
+    JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
+    JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithDestructuring.kt:27)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.kt
@@ -1,0 +1,32 @@
+// ATTACH_LIBRARY: utils
+package stepIntoLambdaWithDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun foo(f: (A, Int, Int, B, Int, A, B) -> Unit) {
+    val a = A(1, 1)
+    val b = B()
+    // STEP_INTO: 1
+    // EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+    // RESULT: 15: I
+    //Breakpoint!
+    f(a, 1, 1, b, 1, a, b)
+}
+
+fun main() {
+    foo { (a, b),
+          c,
+          d, (e,
+              f, g,
+              h),
+          i,
+          (j, k),
+          (l,
+              m,
+              n, o) ->
+        println()
+    }
+}
+
+// PRINT_FRAME

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoLambdaWithDestructuring.out
@@ -1,0 +1,28 @@
+// IGNORE_BACKEND: JVM_WITH_OLD_EVALUATOR
+LineBreakpoint created at stepIntoLambdaWithDestructuring.kt:14
+Run Java
+Connected to the target VM
+stepIntoLambdaWithDestructuring.kt:14
+stepIntoLambdaWithDestructuring.kt:28
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+KotlinStackFrame (stepIntoLambdaWithDestructuring.kt:28)
+    JavaValue[this] this: StepIntoLambdaWithDestructuringKt$main$1@uniqueID = Function7<destructurableClasses.A, java.lang.Integer, java.lang.Integer, destructurableClasses.B, java.lang.Integer, destructurableClasses.A, destructurableClasses.B, kotlin.Unit>
+        JavaValue[field] arity: int = 7 (Lambda.!EXT!)
+    JavaValue[local] c: int = 1 (stepIntoLambdaWithDestructuring.kt:19)
+    JavaValue[local] d: int = 1 (stepIntoLambdaWithDestructuring.kt:20)
+    JavaValue[local] i: int = 1 (stepIntoLambdaWithDestructuring.kt:23)
+    JavaValue[local] a: int = 1 (stepIntoLambdaWithDestructuring.kt:18)
+    JavaValue[local] b: int = 1 (stepIntoLambdaWithDestructuring.kt:18)
+    JavaValue[local] e: int = 1 (stepIntoLambdaWithDestructuring.kt:20)
+    JavaValue[local] f: int = 1 (stepIntoLambdaWithDestructuring.kt:21)
+    JavaValue[local] g: int = 1 (stepIntoLambdaWithDestructuring.kt:21)
+    JavaValue[local] h: int = 1 (stepIntoLambdaWithDestructuring.kt:22)
+    JavaValue[local] j: int = 1 (stepIntoLambdaWithDestructuring.kt:24)
+    JavaValue[local] k: int = 1 (stepIntoLambdaWithDestructuring.kt:24)
+    JavaValue[local] l: int = 1 (stepIntoLambdaWithDestructuring.kt:25)
+    JavaValue[local] m: int = 1 (stepIntoLambdaWithDestructuring.kt:26)
+    JavaValue[local] n: int = 1 (stepIntoLambdaWithDestructuring.kt:27)
+    JavaValue[local] o: int = 1 (stepIntoLambdaWithDestructuring.kt:27)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.kt
@@ -1,0 +1,39 @@
+// ATTACH_LIBRARY: utils
+package stepIntoNesterInlineLambdasWithDestructuring
+
+import destructurableClasses.B
+
+inline fun inlineFoo(f: (B) -> Unit) {
+    val b = B()
+    f(b)
+}
+
+inline fun inlineBar(f: (B) -> Unit) {
+    val b = B()
+    // STEP_INTO: 1
+    // EXPRESSION: x + y
+    // RESULT: 2: I
+    //Breakpoint!
+    f(b)
+}
+
+fun main() {
+    inlineFoo { (x, _, y, _) ->
+        inlineFoo { (x, _, y, _) ->
+            println()
+        }
+
+        inlineFoo { (x, _, y, _) ->
+            inlineFoo { (x, _, y, _) ->
+                inlineBar { (x, _, y, _) -> println() }
+            }
+        }
+
+        inlineFoo { (x, _, y, _) ->
+            println()
+        }
+    }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoNestedInlineLambdasWithDestructuring.out
@@ -1,0 +1,35 @@
+// IGNORE_BACKEND: JVM_WITH_OLD_EVALUATOR
+LineBreakpoint created at stepIntoNestedInlineLambdasWithDestructuring.kt:17
+Run Java
+Connected to the target VM
+stepIntoNestedInlineLambdasWithDestructuring.kt:17
+stepIntoNestedInlineLambdasWithDestructuring.kt:28
+Compile bytecode for x + y
+InlineStackFrame lambda 'inlineBar' in 'main' (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+    JavaValue[local] x: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+    JavaValue[local] y: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+InlineStackFrame inlineBar (stepIntoNestedInlineLambdasWithDestructuring.kt:17)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode
+        DummyMessageValueNode = Class has no properties
+InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+    JavaValue[local] x: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+    JavaValue[local] y: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+InlineStackFrame inlineFoo (stepIntoNestedInlineLambdasWithDestructuring.kt:8)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode
+        DummyMessageValueNode = Class has no properties
+InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoNestedInlineLambdasWithDestructuring.kt:27)
+    JavaValue[local] x: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+    JavaValue[local] y: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+InlineStackFrame inlineFoo (stepIntoNestedInlineLambdasWithDestructuring.kt:8)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode
+        DummyMessageValueNode = Class has no properties
+InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoNestedInlineLambdasWithDestructuring.kt:26)
+    JavaValue[local] x: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+    JavaValue[local] y: int = 1 (stepIntoNestedInlineLambdasWithDestructuring.kt:28)
+InlineStackFrame inlineFoo (stepIntoNestedInlineLambdasWithDestructuring.kt:8)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode
+        DummyMessageValueNode = Class has no properties
+KotlinStackFrame (stepIntoNestedInlineLambdasWithDestructuring.kt:21)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.kt
@@ -1,0 +1,19 @@
+// ATTACH_LIBRARY: utils
+package stepIntoOneLineLambdaWithDestructuring
+
+import destructurableClasses.B
+
+fun foo(f: (B) -> Unit) {
+    val b = B()
+    // STEP_INTO: 1
+    // EXPRESSION: x + y
+    // RESULT: 2: I
+    //Breakpoint!
+    f(b)
+}
+
+fun main() {
+    foo { (x, _, y, _) -> println() }
+}
+
+// PRINT_FRAME

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoOneLineLambdaWithDestructuring.out
@@ -1,0 +1,15 @@
+// IGNORE_BACKEND: JVM_WITH_OLD_EVALUATOR
+LineBreakpoint created at stepIntoOneLineLambdaWithDestructuring.kt:12
+Run Java
+Connected to the target VM
+stepIntoOneLineLambdaWithDestructuring.kt:12
+stepIntoOneLineLambdaWithDestructuring.kt:16
+Compile bytecode for x + y
+KotlinStackFrame (stepIntoOneLineLambdaWithDestructuring.kt:16)
+    JavaValue[this] this: StepIntoOneLineLambdaWithDestructuringKt$main$1@uniqueID = Function1<destructurableClasses.B, kotlin.Unit>
+        JavaValue[field] arity: int = 1 (Lambda.!EXT!)
+    JavaValue[local] x: int = 1 (stepIntoOneLineLambdaWithDestructuring.kt:16)
+    JavaValue[local] y: int = 1 (stepIntoOneLineLambdaWithDestructuring.kt:16)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.kt
@@ -1,0 +1,36 @@
+// ATTACH_LIBRARY: utils
+package stepIntoSamLambdaWithDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun interface Runnable {
+    fun run(a: A, b: Int, c: Int, d: B, e: Int, f: A, g: B)
+}
+
+fun run(runnable: Runnable) {
+    val a = A(1, 1)
+    val b = B()
+    // STEP_INTO: 1
+    // EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+    // RESULT: 15: I
+    //Breakpoint!
+    runnable.run(a, 1, 1, b, 1, a, b)
+}
+
+fun main() {
+    run { (a, b),
+          c,
+          d, (e,
+              f, g,
+              h),
+          i,
+          (j, k),
+          (l,
+              m,
+              n, o) ->
+        println()
+    }
+}
+
+// PRINT_FRAME

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/lambdas/stepIntoSamLambdaWithDestructuring.out
@@ -1,0 +1,26 @@
+// IGNORE_BACKEND: JVM_WITH_OLD_EVALUATOR
+LineBreakpoint created at stepIntoSamLambdaWithDestructuring.kt:18
+Run Java
+Connected to the target VM
+stepIntoSamLambdaWithDestructuring.kt:18
+stepIntoSamLambdaWithDestructuring.kt:32
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+KotlinStackFrame (stepIntoSamLambdaWithDestructuring.kt:32)
+    JavaValue[local] c: int = 1 (stepIntoSamLambdaWithDestructuring.kt:23)
+    JavaValue[local] d: int = 1 (stepIntoSamLambdaWithDestructuring.kt:24)
+    JavaValue[local] i: int = 1 (stepIntoSamLambdaWithDestructuring.kt:27)
+    JavaValue[local] a: int = 1 (stepIntoSamLambdaWithDestructuring.kt:22)
+    JavaValue[local] b: int = 1 (stepIntoSamLambdaWithDestructuring.kt:22)
+    JavaValue[local] e: int = 1 (stepIntoSamLambdaWithDestructuring.kt:24)
+    JavaValue[local] f: int = 1 (stepIntoSamLambdaWithDestructuring.kt:25)
+    JavaValue[local] g: int = 1 (stepIntoSamLambdaWithDestructuring.kt:25)
+    JavaValue[local] h: int = 1 (stepIntoSamLambdaWithDestructuring.kt:26)
+    JavaValue[local] j: int = 1 (stepIntoSamLambdaWithDestructuring.kt:28)
+    JavaValue[local] k: int = 1 (stepIntoSamLambdaWithDestructuring.kt:28)
+    JavaValue[local] l: int = 1 (stepIntoSamLambdaWithDestructuring.kt:29)
+    JavaValue[local] m: int = 1 (stepIntoSamLambdaWithDestructuring.kt:30)
+    JavaValue[local] n: int = 1 (stepIntoSamLambdaWithDestructuring.kt:31)
+    JavaValue[local] o: int = 1 (stepIntoSamLambdaWithDestructuring.kt:31)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/lib/utils/destructurableClasses.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/lib/utils/destructurableClasses.kt
@@ -1,0 +1,11 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package destructurableClasses
+
+data class A(val x: Int, val y: Int)
+
+class B {
+    operator fun component1() = 1
+    operator fun component2() = 1
+    operator fun component3() = 1
+    operator fun component4() = 1
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt
@@ -1,0 +1,47 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package stepIntoAnonymousObjectInsideLambdaWithDestructuring
+
+import destructurableClasses.B
+
+fun foo(f: (B) -> Unit) {
+    val b = B()
+    f(b)
+}
+
+fun main() {
+    foo { (x, _, y, _) ->
+        val task = object : Runnable {
+            override fun run() {
+                println()
+            }
+        }
+        // STEP_INTO: 1
+        // RESUME: 1
+        //Breakpoint!
+        task.run()
+
+        val lambda = {
+            println()
+        }
+        // STEP_INTO: 1
+        // RESUME: 1
+        //Breakpoint!
+        lambda()
+
+        val anonymousFun = fun() {
+            println()
+        }
+        // STEP_INTO: 1
+        // RESUME: 1
+        //Breakpoint!
+        anonymousFun()
+
+        fun localFun() {
+            println()
+        }
+        // STEP_INTO: 1
+        //Breakpoint!
+        localFun()
+    }
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepIntoAnonymousObjectInsideLambdaWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepIntoAnonymousObjectInsideLambdaWithDestructuring.out
@@ -1,0 +1,17 @@
+LineBreakpoint created at stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:22
+LineBreakpoint created at stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:30
+LineBreakpoint created at stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:38
+LineBreakpoint created at stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:45
+Run Java
+Connected to the target VM
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:22
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:16
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:30
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:25
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:38
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:33
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:45
+stepIntoAnonymousObjectInsideLambdaWithDestructuring.kt:41
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
The corresponding issue: https://youtrack.jetbrains.com/issue/KTIJ-23778

When stepping into a lambda with parameter destructuring a user would stop inside the lambda's body, but the parameters would still be uninitialized and couldn't be observed in the debugger. This happened because the debugger stopped on an opcode that comes before `component*` function calls. Now after the 'step into' these `component*` calls will be skipped until all the variables are initialized.

@madsager 


