### PR TITLE
build-scripts: fix NPE when building dmg without bundled jre

### DIFF
--- a/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/MacDmgBuilder.groovy
+++ b/platform/build-scripts/groovy/org/jetbrains/intellij/build/impl/MacDmgBuilder.groovy
@@ -128,7 +128,7 @@ final class MacDmgBuilder {
     Path tempDir = context.paths.tempDir.resolve(sitFile.fileName.toString().replace(".sit", ""))
     if (jreArchivePath != null || sign) {
       BuildHelperKt.span(TraceManager.spanBuilder("bundle JBR and sign sit locally")
-                         .setAttribute("jreArchive", jreArchivePath.toString())
+                         .setAttribute("jreArchive", jreArchivePath?.toString() ?: "no-jdk")
                          .setAttribute("sitFile", sitFile.toString()), new Runnable() {
         @Override
         void run() {


### PR DESCRIPTION
When building with `-Dintellij.build.dmg.without.bundled.jre=true` on macOS, `jreArchivePath` is null.