### PR TITLE
KTIJ-23794 "Suspicious callable reference as the only lambda element" quickfix: increase applicability range to whole lambda body

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SuspiciousCallableReferenceInLambdaInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/SuspiciousCallableReferenceInLambdaInspection.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInspection.IntentionWrapper
 import com.intellij.codeInspection.LocalInspectionToolSession
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.jetbrains.kotlin.builtins.getReturnTypeFromFunctionType
 import org.jetbrains.kotlin.builtins.isBuiltinFunctionalType
@@ -112,6 +113,8 @@ class SuspiciousCallableReferenceInLambdaInspection : AbstractKotlinInspection()
         }
 
         override fun isApplicableTo(element: KtLambdaExpression) = true
+
+        override fun skipProcessingFurtherElementsAfter(element: PsiElement)= false
     }
 }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -15142,6 +15142,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/normal.kt");
         }
 
+        @TestMetadata("onCallableReference.kt")
+        public void testOnCallableReference() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/onCallableReference.kt");
+        }
+
         @TestMetadata("parameter.kt")
         public void testParameter() throws Exception {
             runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/parameter.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/onCallableReference.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/onCallableReference.kt
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+fun test() {
+    listOf(1,2,3).map { it::toS<caret>tring }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/onCallableReference.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/onCallableReference.kt.after
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+fun test() {
+    listOf(1,2,3).map(Int::toString)
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23794