### PR TITLE
Fix MessageBus listener leak in WelcomeFrame

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/WelcomeFrame.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/WelcomeFrame.kt
@@ -51,6 +51,7 @@ import javax.swing.KeyStroke
 class WelcomeFrame : JFrame(), IdeFrame, AccessibleContextAccessor {
   private val myScreen: WelcomeScreen
   private val myBalloonLayout: BalloonLayout
+  private val listenerDisposable = Disposer.newDisposable()
 
   init {
     SplashManager.hideBeforeShow(this)
@@ -62,12 +63,10 @@ class WelcomeFrame : JFrame(), IdeFrame, AccessibleContextAccessor {
     contentPane = screen.welcomePanel
     title = ApplicationNamesInfo.getInstance().fullProductName
     AppUIUtil.updateWindowIcon(this)
-    val listenerDisposable = Disposer.newDisposable()
     ApplicationManager.getApplication().messageBus.connect(listenerDisposable).subscribe(ProjectManager.TOPIC,
                                                                                          object : ProjectManagerListener {
                                                                                            @Suppress("removal", "OVERRIDE_DEPRECATION")
                                                                                            override fun projectOpened(project: Project) {
-                                                                                             Disposer.dispose(listenerDisposable)
                                                                                              dispose()
                                                                                            }
                                                                                          })
@@ -213,6 +212,7 @@ class WelcomeFrame : JFrame(), IdeFrame, AccessibleContextAccessor {
     saveLocation(bounds)
     super.dispose()
     Disposer.dispose(myScreen)
+    Disposer.dispose(listenerDisposable)
     resetInstance()
   }
 


### PR DESCRIPTION
The current code assumes that the frame is only disposed by receiving a projectOpened event. However, it is possible to call dispose() directly; this is done by Android Studio, which uses two WelcomeFrames sequentially on a fresh install.

When dispose() is called directly, the MessageBus listener is not removed; this is a memory leak. It also causes a NullPointerException when the projectOpened event occurs later: the dangling listener calls resetInstance(), which causes FlatWelcomeFrame's cleanup method to fail.