### PR TITLE
KTIJ-22046: Fix J2K import resolve scope

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/PlainTextPasteImportResolver.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/conversion/copy/PlainTextPasteImportResolver.kt
@@ -45,7 +45,7 @@ class PlainTextPasteImportResolver(private val dataForConversion: DataForConvers
     private val resolutionFacade = targetFile.getResolutionFacade()
 
     private val shortNameCache = PsiShortNamesCache.getInstance(project)
-    private val scope = file.resolveScope
+    private val scope = targetFile.resolveScope
 
     private val failedToResolveReferenceNames = HashSet<String>()
     private var ambiguityInResolution = false


### PR DESCRIPTION
Issue link: https://youtrack.jetbrains.com/issue/KTIJ-22046

Previously, PlainTextPasteImportResolver computed a resolve scope using the temporary file that holds pasted text. Instead it should compute a resolve scope using the target file, since that is where import statements will be inserted.

After this change, both 'scope' and 'resolutionFacade' are constructed from the same target file. Thus we should no longer see issues like KTIJ-22046 [in which the resolution facade was being queried for descriptors outside its domain].

Side note: I'm not sure how to add a test for this, and the repro cases are not so simple. However, I verified locally that this change fixes the case I saw.