### PR TITLE
[Java. Inspections]  IDEA-288910 - option to avoid warning if two classes with the same simple name are used

### DIFF
--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/fixAll/afterFullyQualifiedName.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/fixAll/afterFullyQualifiedName.java
@@ -4,6 +4,6 @@ import java.util.Date;
 class FullyQualifiedName {
 
   void m(Object value) {
-    value = new java.sql.Date(((Date) value).getTime());
+    value = ((Date) value).getTime();
   }
 }

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/fixAll/beforeFullyQualifiedName.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/fixAll/beforeFullyQualifiedName.java
@@ -2,6 +2,6 @@
 class FullyQualifiedName {
 
   void m(Object value) {
-    value = new java.sql.Date(((java.<caret>util.Date) value).getTime());
+    value = ((java.<caret>util.Date) value).getTime();
   }
 }

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/resources/messages/InspectionGadgetsBundle.properties
@@ -523,6 +523,7 @@ string.buffer.replaceable.by.string.builder.display.name='StringBuffer' may be '
 comparison.of.short.and.char.display.name=Comparison of 'short' and 'char' values
 unnecessary.fully.qualified.name.display.name=Unnecessary fully qualified name
 ignore.in.module.statements.option=Ignore in Java 9 module statements
+ignore.the.same.name.option=Ignore if several classes with the same simple name are used
 unnecessary.label.on.break.statement.display.name=Unnecessary label on 'break' statement
 exception.name.doesnt.end.with.exception.display.name=Exception class name does not end with 'Exception'
 bad.exception.declared.display.name=Prohibited exception declared

--- a/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryFullyQualifiedName.html
+++ b/plugins/InspectionGadgets/src/inspectionDescriptions/UnnecessaryFullyQualifiedName.html
@@ -22,6 +22,8 @@ Reports fully qualified class names that can be shortened.
   Use the <b>Ignore in Java 9 module statements</b> option to ignore fully qualified names inside the Java 9
   <code>provides</code> and <code>uses</code> module statements.
 <p>
+  Use the <b>Ignore if several classes with the same simple name are used</b> option to ignore fully qualified names of classes with the same simple name.
+<p>
   In <a href="settings://preferences.sourceCode.Java?JavaDoc%20Inner">Settings | Editor | Code Style | Java | Imports</a>,
   use the following options to configure the inspection:</p>
 <ul>

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/unnecessary_fully_qualified_name_skip_warn_if_confusing/Test.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/unnecessary_fully_qualified_name_skip_warn_if_confusing/Test.java
@@ -1,0 +1,6 @@
+class Test {
+
+  void m(Object value) {
+    value = new java.sql.Date(((java.<caret>util.Date) value).getTime());
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/unnecessary_fully_qualified_name_skip_warn_if_confusing/expected.xml
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/unnecessary_fully_qualified_name_skip_warn_if_confusing/expected.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<problems>
+</problems>

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/style/UnnecessaryFullyQualifiedNameInspectionTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/style/UnnecessaryFullyQualifiedNameInspectionTest.java
@@ -30,6 +30,9 @@ public class UnnecessaryFullyQualifiedNameInspectionTest extends IGInspectionTes
   public void testConflictWithTypeParameter() {
     doTest(BASE_DIR + "unnecessary_fqn_type_parameter_conflict", new UnnecessaryFullyQualifiedNameInspection());
   }
+  public void testSkipWarningIfThereIsSameNames() {
+    doTest(BASE_DIR + "unnecessary_fully_qualified_name_skip_warn_if_confusing", new UnnecessaryFullyQualifiedNameInspection());
+  }
 
   private void doTestWithFqnInJavadocSetting(String dirPath, int classNamesInJavadoc) {
     JavaCodeStyleSettings javaSettings = JavaCodeStyleSettings.getInstance(getProject());


### PR DESCRIPTION
I tried to implement https://youtrack.jetbrains.com/issue/IDEA-288910 

About realization:
I added a new option and a new visitor, which looks for other fully-qualified names and if there are more references with the same name, such cases are skipped.

I added one more cache. I don't know if it is possible or not, but it seems to me, that it could be useful here not to go over classes many times. 

If something is wrong, I am ready to change it.
Thank you in advance