### PR TITLE
Fix inline return rendering

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
@@ -1947,6 +1947,18 @@ public class JavaDocInfoGenerator {
     buffer.append(".");
   }
 
+  private PsiElement[] getNestedChildren(PsiElement[] children) {
+    List<PsiElement> elements = new ArrayList<>();
+    boolean isIn
+    for (int i = 0; i < children.length; i++) {
+      PsiElement child = children[i];
+      if (child instanceof PsiDocToken token && token.getTokenType() == JavaDocTokenType.DOC_INLINE_TAG_START) {
+
+      }
+    }
+    return elements.toArray(PsiElement[]::new);
+  }
+
   @Contract(pure = true)
   private static String getWhitespacesBeforeLFWhenLeadingAsterisk(PsiElement element) {
     final PsiElement sibling = element.getNextSibling();

--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
@@ -1942,22 +1942,10 @@ public class JavaDocInfoGenerator {
   private void generateInlineReturnValue(@NotNull StringBuilder buffer, @NotNull PsiInlineDocTag tag, InheritDocProvider<PsiElement[]> provider) {
     // According to the spec (https://docs.oracle.com/en/java/javase/16/docs/specs/javadoc/doc-comment-spec.html#return), the format is "Returns<description>."
     buffer.append("Returns");
-    final PsiElement[] children = tag.getChildren();
-    generateValue(buffer, Arrays.copyOfRange(children, 2, children.length - 1), 0, provider);
+    generateValue(buffer, tag.getDataElements(), 0, provider);
     buffer.append(".");
   }
 
-  private PsiElement[] getNestedChildren(PsiElement[] children) {
-    List<PsiElement> elements = new ArrayList<>();
-    boolean isIn
-    for (int i = 0; i < children.length; i++) {
-      PsiElement child = children[i];
-      if (child instanceof PsiDocToken token && token.getTokenType() == JavaDocTokenType.DOC_INLINE_TAG_START) {
-
-      }
-    }
-    return elements.toArray(PsiElement[]::new);
-  }
 
   @Contract(pure = true)
   private static String getWhitespacesBeforeLFWhenLeadingAsterisk(PsiElement element) {

--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
@@ -1940,7 +1940,8 @@ public class JavaDocInfoGenerator {
 
   @Contract(mutates = "param1")
   private void generateInlineReturnValue(@NotNull StringBuilder buffer, @NotNull PsiInlineDocTag tag, InheritDocProvider<PsiElement[]> provider) {
-    buffer.append("Returns ");
+    // According to the spec (https://docs.oracle.com/en/java/javase/16/docs/specs/javadoc/doc-comment-spec.html#return), the format is "Returns<description>."
+    buffer.append("Returns");
     final PsiElement[] children = tag.getChildren();
     generateValue(buffer, Arrays.copyOfRange(children, 2, children.length - 1), 0, provider);
     buffer.append(".");

--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
@@ -1946,7 +1946,6 @@ public class JavaDocInfoGenerator {
     buffer.append(".");
   }
 
-
   @Contract(pure = true)
   private static String getWhitespacesBeforeLFWhenLeadingAsterisk(PsiElement element) {
     final PsiElement sibling = element.getNextSibling();

--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocInfoGenerator.java
@@ -101,6 +101,7 @@ public class JavaDocInfoGenerator {
   private static final String INDEX_TAG = "index";
   private static final String SUMMARY_TAG = "summary";
   private static final String SNIPPET_TAG = "snippet";
+  private static final String RETURN_TAG = "return";
   private static final String LT = "&lt;";
   private static final String GT = "&gt;";
   private static final String NBSP = "&nbsp;";
@@ -1783,6 +1784,9 @@ public class JavaDocInfoGenerator {
         }
         else if (tagName.equals(SNIPPET_TAG)) {
           generateSnippetValue(buffer, tag);
+        }
+        else if (tagName.equals(RETURN_TAG)) {
+          generateInlineReturnValue(buffer, tag, provider);
         } else {
           generateUnknownInlineTagValue(buffer, tag);
         }
@@ -1932,6 +1936,14 @@ public class JavaDocInfoGenerator {
         }
         buffer.append(attributes != null ? getStyledSpan(true, attributes, text) : text);
       });
+  }
+
+  @Contract(mutates = "param1")
+  private void generateInlineReturnValue(@NotNull StringBuilder buffer, @NotNull PsiInlineDocTag tag, InheritDocProvider<PsiElement[]> provider) {
+    buffer.append("Returns ");
+    final PsiElement[] children = tag.getChildren();
+    generateValue(buffer, Arrays.copyOfRange(children, 2, children.length - 1), 0, provider);
+    buffer.append(".");
   }
 
   @Contract(pure = true)
@@ -3075,13 +3087,13 @@ public class JavaDocInfoGenerator {
     @Override
     public PsiDocTag find(PsiDocCommentOwner owner, PsiDocComment comment) {
       if (comment != null) {
-        PsiDocTag returnTag = comment.findTagByName("return");
+        PsiDocTag returnTag = comment.findTagByName(RETURN_TAG);
         if (returnTag != null) {
           return returnTag;
         }
         if (PsiUtil.isLanguageLevel16OrHigher(comment)) {
           for (PsiElement child : comment.getChildren()) {
-            if (child instanceof PsiDocTag && "return".equals(((PsiDocTag)child).getName())) {
+            if (child instanceof PsiDocTag && RETURN_TAG.equals(((PsiDocTag)child).getName())) {
               return (PsiDocTag)child;
             }
           }

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/JavaDocumentationTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/JavaDocumentationTest.kt
@@ -242,7 +242,7 @@ class JavaDocumentationTest : LightJavaCodeInsightFixtureTestCase() {
     """.trimIndent())
       val method = PsiTreeUtil.getParentOfType(myFixture.file.findElementAt(myFixture.editor.caretModel.offset), PsiMethod::class.java)
       val doc = JavaDocumentationProvider().generateRenderedDoc(method!!.docComment!!)
-      val expected = "<div class='content'> @return smth </div><table class='sections'><tr><td valign='top' class='section'><p>Returns:</td><td valign='top'><p> smth</td></table>"
+      val expected = "<div class='content'> Returns smth. </div><table class='sections'><tr><td valign='top' class='section'><p>Returns:</td><td valign='top'><p> smth</td></table>"
       TestCase.assertEquals(expected, doc)
     }
   }


### PR DESCRIPTION
This PR fixes the Javadoc renderer in order to properly render the description, according to the [spec](https://docs.oracle.com/en/java/javase/16/docs/specs/javadoc/doc-comment-spec.html#return):
> As an inline tag, provides content for the first sentence of a method's description, and a "Returns" section, as if `@return` description were also present. In the default English locale, the first sentence is _Returns description ._

Before:
![image](https://user-images.githubusercontent.com/65940752/205453365-a99d9c06-434c-44a4-a339-23e3900c0f12.png)
After:
![image](https://user-images.githubusercontent.com/65940752/205453368-967243c1-776e-4436-9157-8d2851011760.png)

Note: in order for [IDEA-300185](https://youtrack.jetbrains.com/issue/IDEA-300185) to be properly fixed, nested inline tags would need to be properly parsed