### PR TITLE
Groovy: Fix erroneous remove parentheses from method call suggestion

### DIFF
--- a/plugins/groovy/src/org/jetbrains/plugins/groovy/intentions/conversions/RemoveParenthesesFromMethodCallIntention.kt
+++ b/plugins/groovy/src/org/jetbrains/plugins/groovy/intentions/conversions/RemoveParenthesesFromMethodCallIntention.kt
@@ -24,6 +24,7 @@ import com.intellij.util.IncorrectOperationException
 import org.jetbrains.plugins.groovy.intentions.base.Intention
 import org.jetbrains.plugins.groovy.intentions.base.PsiElementPredicate
 import org.jetbrains.plugins.groovy.lang.psi.GroovyPsiElementFactory
+import org.jetbrains.plugins.groovy.lang.psi.api.auxiliary.GrListOrMap
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.GrVariable
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.blocks.GrClosableBlock
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrAssignmentExpression
@@ -80,6 +81,12 @@ class RemoveParenthesesFromMethodCallIntention : Intention() {
       if (arguments.first() is GrClosableBlock) {
         // foo({}) -> foo {}, but not foo({}, a, b, c)
         return arguments.size == 1
+      }
+      if (arguments.first() is GrListOrMap) {
+        // foo([])
+        // foo([1])
+        // foo([a: 1])
+        return false
       }
       return true
     }

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/intentions/removeParenthesis/RemoveUnnecessaryParenthesesTest.groovy
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/intentions/removeParenthesis/RemoveUnnecessaryParenthesesTest.groovy
@@ -74,6 +74,18 @@ class RemoveUnnecessaryParenthesesTest extends LightJavaCodeInsightFixtureTestCa
     doTest 'a = <caret>foo(1)', 'a = foo 1'
   }
 
+  void 'test list literal argument'() {
+    doTest '<caret>foo([])'
+  }
+
+  void 'test list literal with content argument'() {
+    doTest '<caret>foo([1])'
+  }
+
+  void 'test map literal with content argument'() {
+    doTest '<caret>foo([a: 1])'
+  }
+
   private void doTest(String before, String after = null) {
     myFixture.configureByText "_.groovy", before
     def actions = myFixture.filterAvailableIntentions(getINTENTION_NAME())


### PR DESCRIPTION
Consider following code:
```groovy
class Experiment {
    static void main(String[] args) {
        def v = a([0]) // relevant
        println v
    }
    static def a = [1, 2, 3]
    static def a(o) { -1 }
}
```
IntelliJ currently provides the option to remove the parentheses of the method call in the commented line. The resulting code snippet is `a[0]`, which is valid, even compiles and runs, but yields a different result.

The suggestion is also present in cases where `a[0]` doesn't make sense, e.g., if no variable `a` exists in the current scope.

This fix checks whether the first argument is a list or map literal, in which case the intention shouldn't be suggested.

I don't know if this PR needs a bug report on YouTrack, if it needs one, I'll happily open one. Please let me know.