### PR TITLE
Groovy: Fix parenthesizing of ranges in ForToEachIntention

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/utils/ParenthesesUtils.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/utils/ParenthesesUtils.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.groovy.lang.lexer.GroovyTokenTypes;
 import org.jetbrains.plugins.groovy.lang.parser.GroovyElementTypes;
 import org.jetbrains.plugins.groovy.lang.psi.GroovyPsiElementFactory;
+import org.jetbrains.plugins.groovy.lang.psi.api.GrRangeExpression;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.arguments.GrArgumentList;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.*;
 
@@ -129,6 +130,7 @@ public final class ParenthesesUtils {
   public static int getPrecedence(GrExpression expr) {
     if (expr instanceof GrUnaryExpression) return ((GrUnaryExpression)expr).isPostfix() ? POSTFIX_PRECEDENCE : PREFIX_PRECEDENCE;
     if (expr instanceof GrTypeCastExpression) return TYPE_CAST_PRECEDENCE;
+    if (expr instanceof GrRangeExpression) return RANGE_PRECEDENCE;
     if (expr instanceof GrConditionalExpression) return CONDITIONAL_PRECEDENCE;
     if (expr instanceof GrSafeCastExpression) return SAFE_CAST_PRECEDENCE;
     if (expr instanceof GrAssignmentExpression) return ASSIGNMENT_PRECEDENCE;

--- a/plugins/groovy/test/org/jetbrains/plugins/groovy/intentions/closure/forToEach/ForToEachIntentionTest.groovy
+++ b/plugins/groovy/test/org/jetbrains/plugins/groovy/intentions/closure/forToEach/ForToEachIntentionTest.groovy
@@ -1,0 +1,26 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.groovy.intentions.closure.forToEach;
+
+import org.jetbrains.plugins.groovy.intentions.GrIntentionTestCase;
+import org.jetbrains.plugins.groovy.intentions.closure.ForToEachIntention;
+import org.jetbrains.plugins.groovy.util.TestUtils;
+
+class ForToEachIntentionTest extends GrIntentionTestCase {
+
+  ForToEachIntentionTest() {
+    super(ForToEachIntention.class)
+  }
+
+  @Override
+  protected String getBasePath() {
+    return TestUtils.testDataPath + "intentions/ForToEach/"
+  }
+
+  void testForToEachOnRangeWithoutParentheses() {
+    doTest(true)
+  }
+
+  void testForToEachOnRangeWithParentheses() {
+    doTest(true)
+  }
+}

--- a/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithParentheses.groovy
+++ b/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithParentheses.groovy
@@ -1,0 +1,3 @@
+f<caret>or (i in (0..<10)) {
+    println i
+}

--- a/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithParentheses_after.groovy
+++ b/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithParentheses_after.groovy
@@ -1,0 +1,3 @@
+(0..<10).each { i ->
+    println i
+}

--- a/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithoutParentheses.groovy
+++ b/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithoutParentheses.groovy
@@ -1,0 +1,3 @@
+f<caret>or (i in 0..<10) {
+    println i
+}

--- a/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithoutParentheses_after.groovy
+++ b/plugins/groovy/testdata/intentions/ForToEach/ForToEachOnRangeWithoutParentheses_after.groovy
@@ -1,0 +1,3 @@
+(0..<10).each { i ->
+    println i
+}


### PR DESCRIPTION
Previously,
```groovy
for (i in (0..<10)) {
    println i
}
```
was transformed into
```groovy
0..<10.each { i ->
    println i
}
```

However, this calls the `each` method on `10` instead of the range. To fix the transformation, the range needs parentheses. It seems like returning the range precedence fixes the issue.

I didn't find any existing test for the intention, so I created a new file, similar to the `EachToForIntentionTest` one.