### PR TITLE
code stlye: remove maximum right margin

### DIFF
--- a/platform/code-style-api/src/com/intellij/psi/codeStyle/CodeStyleConstraints.java
+++ b/platform/code-style-api/src/com/intellij/psi/codeStyle/CodeStyleConstraints.java
@@ -16,7 +16,7 @@
 package com.intellij.psi.codeStyle;
 
 public interface CodeStyleConstraints {
-  int MAX_RIGHT_MARGIN = 1000;
+  int MAX_RIGHT_MARGIN = Integer.MAX_VALUE;
   int MIN_INDENT_SIZE = 0;
   int MAX_INDENT_SIZE = 32;
   int MIN_TAB_SIZE = 1;


### PR DESCRIPTION
This option is really annoying, I sometimes have lines that exceed that value (e.g. minified files). I never ever want them to be hard wrapped, this option allows this. If you do not need it, simply set the maximum hard wrap not that high, leave it at the default value (120)