### PR TITLE
IDEA-308603 Order binary expressions

### DIFF
--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantStringOperation/beforeStripLengthEqualsOne.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantStringOperation/beforeStripLengthEqualsOne.java
@@ -1,0 +1,7 @@
+// "Use 'isBlank()' and remove redundant 'strip()' call" "false"
+
+class Test {
+  boolean validCase(String text) {
+    return text.<caret>strip().length() == 1;
+  }
+}

--- a/java/java-tests/testData/inspection/redundantStringOperation/ShouldReplaceStripByIsBlank.java
+++ b/java/java-tests/testData/inspection/redundantStringOperation/ShouldReplaceStripByIsBlank.java
@@ -1,0 +1,13 @@
+class ShouldReplaceStripByIsBlank {
+  boolean useIsEmpty(String text) {
+    return text.<warning descr="'strip()' call can be replaced with 'isBlank()'">strip</warning>().isEmpty();
+  }
+
+  boolean useLength(String text) {
+    return text.strip().length() == 0;
+  }
+
+  boolean useEquals(String text) {
+    return text.strip().equals("");
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/codeInsight/daemon/impl/quickfix/RedundantStringOperationInspectionTest.java
+++ b/java/java-tests/testSrc/com/intellij/codeInsight/daemon/impl/quickfix/RedundantStringOperationInspectionTest.java
@@ -19,9 +19,10 @@ public class RedundantStringOperationInspectionTest extends LightJavaInspectionT
 
   @Override
   protected @NotNull LightProjectDescriptor getProjectDescriptor() {
-    return LightJavaCodeInsightFixtureTestCase.JAVA_9;
+    return LightJavaCodeInsightFixtureTestCase.JAVA_11;
   }
 
+  public void testShouldReplaceStripByIsBlank() {doTest();}
   public void testEmptyStringArgument() {doTest();}
   public void testStringLengthArgument() {doTest();}
   public void testZeroArgument() {doTest();}

--- a/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/psiutils/OrderedBinaryExpression.java
+++ b/plugins/InspectionGadgets/InspectionGadgetsAnalysis/src/com/siyeh/ig/psiutils/OrderedBinaryExpression.java
@@ -1,0 +1,131 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.siyeh.ig.psiutils;
+
+import com.intellij.psi.JavaTokenType;
+import com.intellij.psi.PsiBinaryExpression;
+import com.intellij.psi.PsiExpression;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiUtil;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import static com.intellij.util.ObjectUtils.tryCast;
+
+/**
+ * Ordered binary expression for commutative operations.
+ *
+ * @param <F> First operand
+ * @param <S> Second operand
+ */
+public class OrderedBinaryExpression<F extends PsiExpression, S extends PsiExpression> {
+  private static final List<IElementType> COMMUTATIVE_OPERATORS = ContainerUtil.immutableList(JavaTokenType.AND,
+                                                                                              JavaTokenType.ANDAND,
+                                                                                              JavaTokenType.OROR,
+                                                                                              JavaTokenType.EQEQ,
+                                                                                              JavaTokenType.NE,
+                                                                                              JavaTokenType.OR,
+                                                                                              JavaTokenType.PLUS,
+                                                                                              JavaTokenType.ASTERISK,
+                                                                                              JavaTokenType.XOR);
+  private final @NotNull F firstOperand;
+  private final @NotNull IElementType tokenType;
+  private final @NotNull S secondOperand;
+
+  private OrderedBinaryExpression(@NotNull F firstOperand, @NotNull IElementType tokenType, @NotNull S secondOperand) {
+    this.firstOperand = firstOperand;
+    this.tokenType = tokenType;
+    this.secondOperand = secondOperand;
+  }
+
+  public @NotNull F getFirstOperand() {
+    return firstOperand;
+  }
+
+  public @NotNull IElementType getTokenType() {
+    return tokenType;
+  }
+
+  public @NotNull S getSecondOperand() {
+    return secondOperand;
+  }
+
+  /**
+   * Return the items of a binary expression in the order it is specified. It reverses the operator if needed.
+   *
+   * @param <O>          the required expression type
+   * @param node         the supposed binary expression
+   * @param firstClass   the class representing the required expression type
+   * @return the items of a binary expression in the order it is specified. It reverses the operator if needed.
+   */
+  public static @Nullable <O extends PsiExpression> OrderedBinaryExpression<O, PsiExpression> from(@Nullable final PsiExpression node, @Nullable final Class<O> firstClass) {
+    PsiBinaryExpression expression = as(node, PsiBinaryExpression.class);
+    if (expression == null || firstClass == null) return null;
+    O leftOperand = as(expression.getLOperand(), firstClass);
+    O rightOperand = as(expression.getROperand(), firstClass);
+    PsiExpression unparenthesizedRightOperand = PsiUtil.skipParenthesizedExprDown(expression.getROperand());
+    if (leftOperand != null && rightOperand == null && unparenthesizedRightOperand != null) {
+      return new OrderedBinaryExpression<>(leftOperand, expression.getOperationTokenType(), unparenthesizedRightOperand);
+    }
+    if (leftOperand == null && rightOperand != null) {
+      IElementType mirroredOperator = mirrorOperator(expression);
+      PsiExpression unparenthesizedLeftOperand = PsiUtil.skipParenthesizedExprDown(expression.getLOperand());
+      if (mirroredOperator != null && unparenthesizedLeftOperand != null) {
+        return new OrderedBinaryExpression<>(rightOperand, mirroredOperator, unparenthesizedLeftOperand);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Return the items of a binary expression in the order it is specified. It reverses the operator if needed.
+   *
+   * @param <F>          the required expression type
+   * @param <S>          the required expression type
+   * @param node         the supposed binary expression
+   * @param firstClass   the class representing the required expression type
+   * @param secondClass  the class representing the required expression type
+   * @return the items of a binary expression in the order it is specified. It reverses the operator if needed.
+   */
+  public static @Nullable <F extends PsiExpression, S extends PsiExpression> OrderedBinaryExpression<F, S> from(@Nullable final PsiExpression node, @Nullable final Class<F> firstClass, @Nullable final Class<S> secondClass) {
+    PsiBinaryExpression expression = as(node, PsiBinaryExpression.class);
+    if (expression == null || firstClass == null || secondClass == null) return null;
+    F leftFirst = as(expression.getLOperand(), firstClass);
+    S rightSecond = as(expression.getROperand(), secondClass);
+    if (leftFirst != null && rightSecond != null) {
+      return new OrderedBinaryExpression<>(leftFirst, expression.getOperationTokenType(), rightSecond);
+    }
+    IElementType mirroredOperator = mirrorOperator(expression);
+    if (mirroredOperator != null) {
+      F rightFirst = as(expression.getROperand(), firstClass);
+      S leftSecond = as(expression.getLOperand(), secondClass);
+
+      if (rightFirst != null && leftSecond != null) {
+        return new OrderedBinaryExpression<>(rightFirst, mirroredOperator, leftSecond);
+      }
+    }
+    return null;
+  }
+
+  private static <T extends PsiExpression> T as(PsiExpression input, Class<T> aClass) {
+    return tryCast(PsiUtil.skipParenthesizedExprDown(input), aClass);
+  }
+
+  private static IElementType mirrorOperator(final PsiBinaryExpression binaryExpression) {
+    IElementType operationTokenType = binaryExpression.getOperationTokenType();
+    if (COMMUTATIVE_OPERATORS.contains(operationTokenType)) {
+      return operationTokenType;
+    } else if (JavaTokenType.GT.equals(operationTokenType)) {
+      return JavaTokenType.LT;
+    } else if (JavaTokenType.GE.equals(operationTokenType)) {
+      return JavaTokenType.LE;
+    } else if (JavaTokenType.LT.equals(operationTokenType)) {
+      return JavaTokenType.GT;
+    } else if (JavaTokenType.LE.equals(operationTokenType)) {
+      return JavaTokenType.GE;
+    }
+    return null;
+  }
+}

--- a/plugins/InspectionGadgets/src/com/siyeh/ig/redundancy/RedundantStringOperationInspection.java
+++ b/plugins/InspectionGadgets/src/com/siyeh/ig/redundancy/RedundantStringOperationInspection.java
@@ -17,6 +17,7 @@ import com.intellij.psi.*;
 import com.intellij.psi.util.PsiLiteralUtil;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
+import com.siyeh.HardcodedMethodConstants;
 import com.siyeh.InspectionGadgetsBundle;
 import com.siyeh.ig.InspectionGadgetsFix;
 import com.siyeh.ig.PsiReplacementUtil;
@@ -50,15 +51,15 @@ public class RedundantStringOperationInspection extends AbstractBaseJavaLocalIns
 
   private static final CallMatcher BYTE_ARRAY_OUTPUT_STREAM_INTO_BYTE_ARRAY =
     exactInstanceCall(JAVA_IO_BYTE_ARRAY_OUTPUT_STREAM, "toByteArray").parameterCount(0);
-  private static final CallMatcher STRING_TO_STRING = exactInstanceCall(JAVA_LANG_STRING, "toString").parameterCount(0);
+  private static final CallMatcher STRING_TO_STRING = exactInstanceCall(JAVA_LANG_STRING, TO_STRING).parameterCount(0);
   private static final CallMatcher STRING_INTERN = exactInstanceCall(JAVA_LANG_STRING, "intern").parameterCount(0);
-  private static final CallMatcher STRING_LENGTH = exactInstanceCall(JAVA_LANG_STRING, "length").parameterCount(0);
+  private static final CallMatcher STRING_LENGTH = exactInstanceCall(JAVA_LANG_STRING, HardcodedMethodConstants.LENGTH).parameterCount(0);
   private static final CallMatcher STRING_SUBSTRING_ONE_ARG = exactInstanceCall(JAVA_LANG_STRING, "substring").parameterTypes("int");
   private static final CallMatcher STRING_SUBSTRING_TWO_ARG = exactInstanceCall(JAVA_LANG_STRING, "substring").parameterTypes("int", "int");
   private static final CallMatcher STRING_SUBSTRING = anyOf(STRING_SUBSTRING_ONE_ARG, STRING_SUBSTRING_TWO_ARG);
   private static final CallMatcher STRING_BUILDER_APPEND =
     instanceCall(JAVA_LANG_ABSTRACT_STRING_BUILDER, "append").parameterTypes(JAVA_LANG_STRING);
-  private static final CallMatcher STRING_BUILDER_TO_STRING = instanceCall(JAVA_LANG_ABSTRACT_STRING_BUILDER, "toString").parameterCount(0);
+  private static final CallMatcher STRING_BUILDER_TO_STRING = instanceCall(JAVA_LANG_ABSTRACT_STRING_BUILDER, TO_STRING).parameterCount(0);
   private static final CallMatcher PRINTSTREAM_PRINTLN = instanceCall("java.io.PrintStream", "println")
     .parameterTypes(JAVA_LANG_STRING);
   private static final CallMatcher METHOD_WITH_REDUNDANT_ZERO_AS_SECOND_PARAMETER =
@@ -66,7 +67,7 @@ public class RedundantStringOperationInspection extends AbstractBaseJavaLocalIns
   private static final CallMatcher STRING_LAST_INDEX_OF = exactInstanceCall(JAVA_LANG_STRING, "lastIndexOf").parameterCount(2);
   private static final CallMatcher STRING_IS_EMPTY = exactInstanceCall(JAVA_LANG_STRING, "isEmpty").parameterCount(0);
   private static final CallMatcher CASE_CHANGE = exactInstanceCall(JAVA_LANG_STRING, "toUpperCase", "toLowerCase");
-  private static final CallMatcher STRING_EQUALS = exactInstanceCall(JAVA_LANG_STRING, "equals").parameterTypes(JAVA_LANG_OBJECT);
+  private static final CallMatcher STRING_EQUALS = exactInstanceCall(JAVA_LANG_STRING, HardcodedMethodConstants.EQUALS).parameterTypes(JAVA_LANG_OBJECT);
   private static final CallMatcher STRING_EQUALS_IGNORE_CASE =
     exactInstanceCall(JAVA_LANG_STRING, "equalsIgnoreCase").parameterTypes(JAVA_LANG_STRING);
   private static final CallMatcher CHANGE_CASE = anyOf(exactInstanceCall(JAVA_LANG_STRING, "toLowerCase").parameterCount(0),
@@ -251,10 +252,10 @@ public class RedundantStringOperationInspection extends AbstractBaseJavaLocalIns
       return false;
     }
 
+    @Nullable
     private ProblemDescriptor getRedundantCaseEqualsProblem(PsiMethodCallExpression call) {
-
       PsiExpression equalTo = PsiUtil.skipParenthesizedExprDown(call.getArgumentList().getExpressions()[0]);
-
+      if (equalTo == null) return null;
       //case: "foo".equals(s.toLowerCase())
       if (equalTo instanceof PsiMethodCallExpression equalsToCallExpression &&
           isChangeCaseCall(equalsToCallExpression, call.getMethodExpression().getQualifierExpression())) {

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/SizeReplaceableByIsEmpty.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/SizeReplaceableByIsEmpty.java
@@ -5,16 +5,24 @@ import java.util.ArrayList;
 
 public class SizeReplaceableByIsEmpty {
 
-  boolean foo(String s) {
+  boolean equalsToZero(String s) {
     return <warning descr="'s.length() == 0' can be replaced with 's.isEmpty()'">s.length() == 0</warning>;
+  }
+
+  boolean minusThanOne(String s) {
+    return <warning descr="'s.length() < 1' can be replaced with 's.isEmpty()'">s.length() < 1</warning>;
   }
 
   boolean bas(StringBuilder b) {
     return b.length() == 0;
   }
 
-  boolean bar(Collection c) {
+  boolean collectionEqualsToZero(Collection c) {
     return <warning descr="'c.size() == 0' can be replaced with 'c.isEmpty()'">c.size() == 0</warning>;
+  }
+
+  boolean collectionMinusThanOne(Collection c) {
+    return <warning descr="'c.size() < 1' can be replaced with 'c.isEmpty()'">c.size() < 1</warning>;
   }
 
   boolean parens(Collection c) {

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/afterListComparedToOne.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/afterListComparedToOne.java
@@ -1,0 +1,10 @@
+// "Replace with 'isEmpty()'" "true"
+package com.siyeh.igtest.style.size_replaceable_by_is_empty;
+
+import java.util.LinkedList;
+
+public class SizeReplaceableByIsEmpty {
+  boolean equalsToZero(LinkedList l) {
+    return l.isEmpty();
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/afterListComparedToZero.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/afterListComparedToZero.java
@@ -1,0 +1,10 @@
+// "Replace with 'isEmpty()'" "true"
+package com.siyeh.igtest.style.size_replaceable_by_is_empty;
+
+import java.util.LinkedList;
+
+public class SizeReplaceableByIsEmpty {
+  boolean equalsToZero(LinkedList l) {
+    return l.isEmpty();
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/afterStringComparedToZero.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/afterStringComparedToZero.java
@@ -1,0 +1,8 @@
+// "Replace with 'isEmpty()'" "true"
+package com.siyeh.igtest.style.size_replaceable_by_is_empty;
+
+public class SizeReplaceableByIsEmpty {
+  boolean equalsToZero(String s) {
+    return s.isEmpty();
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/beforeListComparedToOne.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/beforeListComparedToOne.java
@@ -1,0 +1,10 @@
+// "Replace with 'isEmpty()'" "true"
+package com.siyeh.igtest.style.size_replaceable_by_is_empty;
+
+import java.util.LinkedList;
+
+public class SizeReplaceableByIsEmpty {
+  boolean equalsToZero(LinkedList l) {
+    return l.<caret>size() < 1;
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/beforeListComparedToZero.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/beforeListComparedToZero.java
@@ -1,0 +1,10 @@
+// "Replace with 'isEmpty()'" "true"
+package com.siyeh.igtest.style.size_replaceable_by_is_empty;
+
+import java.util.LinkedList;
+
+public class SizeReplaceableByIsEmpty {
+  boolean equalsToZero(LinkedList l) {
+    return l.<caret>size() == 0;
+  }
+}

--- a/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/beforeStringComparedToZero.java
+++ b/plugins/InspectionGadgets/test/com/siyeh/igtest/style/size_replaceable_by_is_empty/beforeStringComparedToZero.java
@@ -1,0 +1,8 @@
+// "Replace with 'isEmpty()'" "true"
+package com.siyeh.igtest.style.size_replaceable_by_is_empty;
+
+public class SizeReplaceableByIsEmpty {
+  boolean equalsToZero(String s) {
+    return s.<caret>length() == 0;
+  }
+}

--- a/plugins/InspectionGadgets/testsrc/com/siyeh/ig/style/SizeReplaceableByIsEmptyFixTest.java
+++ b/plugins/InspectionGadgets/testsrc/com/siyeh/ig/style/SizeReplaceableByIsEmptyFixTest.java
@@ -1,0 +1,27 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.siyeh.ig.style;
+
+import com.intellij.codeInsight.daemon.quickFix.LightQuickFixParameterizedTestCase;
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.openapi.application.PluginPathManager;
+import com.siyeh.ig.LightJavaInspectionTestCase;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SizeReplaceableByIsEmptyFixTest extends LightQuickFixParameterizedTestCase {
+  @Override
+  protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
+    return new LocalInspectionTool[]{new SizeReplaceableByIsEmptyInspection()};
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/com/siyeh/igtest/style/size_replaceable_by_is_empty";
+  }
+
+  @Override
+  protected @NotNull String getTestDataPath() {
+    return PluginPathManager.getPluginHomePath("InspectionGadgets") + "/test";
+  }
+}


### PR DESCRIPTION
Hi @amaembo,

This PR introduces the `OrderedBinaryExpression` class. I have already written this when I contributed to Eclipse IDE. It reads a PSI binary expression and then you can read it in the order you want, no matter what was the original order. It is very useful. Tell me if there is a better package than `com.intellij.psi.util`.

This PR changes the *Redundant String operation* and *String.equals() can be replaced by String.isEmpty()* inspections. Tell me if you agree the new labels.

***What steps will reproduce the issue?***

1. Go to *File* → *Settings...* → *Editor* → *Inspections*
2. Enable *Redundant String operation*
3. Enable Severity: *Warning*
4. Add this method in a Java 11 class:

```Java
  boolean isBlank(String text) {
    return "".equals(text.strip());
  }
```

***What is the expected result?***
The inspection *Redundant String operation* is suggested.
***What happens instead?***
The inspection *Redundant String operation* is not suggested.

`RedundantStringOperationInspection` should write:

```Java
text.isBlank()
```

...for the following inputs:

```Java
"".equals(text.strip())
text.strip().equals("")
text.strip().length() == 0
0 == text.strip().length()
text.strip().length() < 1
```

It should also handle negative forms.

I have added and successfully run unit tests.