### PR TITLE
KTIJ-23953 Quickfix for "Java methods should be replaced with Kotlin analog" doesn't add parentheses

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/jdk2k/Transformation.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/jdk2k/Transformation.kt
@@ -2,15 +2,13 @@
 
 package org.jetbrains.kotlin.idea.inspections.jdk2k
 
+import org.jetbrains.kotlin.idea.base.psi.replaced
 import org.jetbrains.kotlin.idea.caches.resolve.resolveImportReference
 import org.jetbrains.kotlin.idea.core.ShortenReferences
-import org.jetbrains.kotlin.idea.base.psi.replaced
 import org.jetbrains.kotlin.idea.util.CommentSaver
 import org.jetbrains.kotlin.idea.util.ImportInsertHelper
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtOperationExpression
-import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelectorOrThis
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getType
@@ -39,17 +37,19 @@ object ToExtensionFunctionWithNonNullableReceiver : Transformation {
         val psiFactory = KtPsiFactory(callExpression.project)
         val valueArguments = callExpression.valueArguments
         val typeArguments = callExpression.typeArgumentList?.text ?: ""
-        val receiverText = valueArguments.first().getArgumentExpression()
-            ?.run { if (this is KtOperationExpression) "($text)" else text }
-            ?: valueArguments.first().text
+        val receiverText = valueArguments.first().let { it.getArgumentExpression()?.text ?: it.text }
         val argumentsText = valueArguments.drop(1).joinToString(separator = ", ") { it.text }
 
         val oldExpression = callExpression.getQualifiedExpressionForSelectorOrThis()
         val commentSaver = CommentSaver(oldExpression)
 
         val replaced = oldExpression.replaced(
-            psiFactory.createExpression("$receiverText.${replacement.kotlinFunctionShortName}$typeArguments($argumentsText)")
-        )
+            psiFactory.createExpression("($receiverText).${replacement.kotlinFunctionShortName}$typeArguments($argumentsText)")
+        ) as KtDotQualifiedExpression
+        val receiver = replaced.receiverExpression as KtParenthesizedExpression
+        if (KtPsiUtil.areParenthesesUseless(receiver)) {
+            receiver.expression?.let { receiver.replace(it) }
+        }
         commentSaver.restore(replaced)
 
         file.resolveImportReference(FqName(replacement.kotlinFunctionFqName)).firstOrNull()?.let {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -12312,6 +12312,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                 KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
             }
 
+            @TestMetadata("addParentheses.kt")
+            public void testAddParentheses() throws Exception {
+                runTest("testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/compare/addParentheses.kt");
+            }
+
             @TestMetadata("byte.kt")
             public void testByte() throws Exception {
                 runTest("testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/compare/byte.kt");
@@ -12627,6 +12632,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         public static class ToString extends AbstractLocalInspectionTest {
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("addParentheses.kt")
+            public void testAddParentheses() throws Exception {
+                runTest("testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/toString/addParentheses.kt");
             }
 
             @TestMetadata("byteToString.kt")

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/compare/addParentheses.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/compare/addParentheses.kt
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+fun foo(b: Boolean) {
+    val t = Integer.<caret>compare(if (b) 1 else 10, 6)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/compare/addParentheses.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/compare/addParentheses.kt.after
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+fun foo(b: Boolean) {
+    val t = (if (b) 1 else 10).compareTo(6)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/toString/addParentheses.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/toString/addParentheses.kt
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+fun test(b: Boolean) {
+    Integer.toString<caret>(if (b) 1 else 0)
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/toString/addParentheses.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/replaceJavaStaticMethodWithKotlinAnalog/toString/addParentheses.kt.after
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+fun test(b: Boolean) {
+    (if (b) 1 else 0).toString()
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23953