### PR TITLE
KTIJ-23789 "Change signature" refactoring shows preview which mismatches with the final result when used on Definitely not-null types

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/KotlinChangeInfo.kt
@@ -15,7 +15,6 @@ import com.intellij.util.VisibilityUtil
 import org.jetbrains.kotlin.asJava.getRepresentativeLightMethod
 import org.jetbrains.kotlin.asJava.toLightMethods
 import org.jetbrains.kotlin.asJava.unwrapped
-import org.jetbrains.kotlin.builtins.isNonExtensionFunctionType
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.DescriptorVisibility
@@ -39,7 +38,6 @@ import org.jetbrains.kotlin.psi.psiUtil.quoteIfNeeded
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.jvm.annotations.findJvmOverloadsAnnotation
 import org.jetbrains.kotlin.resolve.source.getPsi
-import org.jetbrains.kotlin.types.DefinitelyNotNullType
 import org.jetbrains.kotlin.types.isError
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 import org.jetbrains.kotlin.utils.keysToMap
@@ -272,13 +270,7 @@ open class KotlinChangeInfo(
 
             if (kind == Kind.FUNCTION) {
                 receiverParameterInfo?.let {
-                    val typeInfo = it.currentTypeInfo
-                    if (typeInfo.type != null && typeInfo.type.isNonExtensionFunctionType) {
-                        buffer.append("(${typeInfo.render()})")
-                    } else {
-                        buffer.append(typeInfo.render())
-                    }
-                    buffer.append('.')
+                    buffer.append(it.currentTypeInfo.getReceiverTypeText()).append('.')
                 }
                 buffer.append(newName)
             }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/changeSignatureUtils.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/refactoring/changeSignature/changeSignatureUtils.kt
@@ -8,6 +8,7 @@ import com.intellij.refactoring.changeSignature.CallerUsageInfo
 import com.intellij.refactoring.changeSignature.ChangeInfo
 import com.intellij.refactoring.changeSignature.OverriderUsageInfo
 import com.intellij.usageView.UsageInfo
+import org.jetbrains.kotlin.builtins.isFunctionType
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
@@ -141,7 +142,10 @@ internal val ChangeInfo.asKotlinChangeInfo: KotlinChangeInfo?
     }
 
 fun KotlinTypeInfo.getReceiverTypeText(): String {
-    // For a DNN type `KotlinTypeInfo.render()` can return it both parenthesized and not,
-    // depending on the case: from text or from type. We make sure not to parenthesize it twice.
-    return if (type is DefinitelyNotNullType) "(${render().removeSurrounding("(", ")")})" else render()
+    val text = render()
+    return when {
+        text.startsWith("(") && text.endsWith(")") -> text
+        type is DefinitelyNotNullType || type?.isFunctionType == true -> "($text)"
+        else -> text
+    }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-23789

```
fun <T> foo(x: T&Any) {
}
```
<img width="579" alt="スクリーンショット 2022-12-15 13 16 10" src="https://user-images.githubusercontent.com/1121855/207773065-24ec26d5-2563-4e49-bf1e-1a794c76f31a.png">


```
fun bar(f: String.() -> Int) {
}
```
<img width="583" alt="スクリーンショット 2022-12-15 13 16 28" src="https://user-images.githubusercontent.com/1121855/207773085-53d867ee-e15f-4cce-b72f-92ef92c2d860.png">
