### PR TITLE
Add catch for potentially missing directories

### DIFF
--- a/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/IconsClassGenerator.kt
+++ b/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/IconsClassGenerator.kt
@@ -681,7 +681,11 @@ private fun getPluginPackageIfPossible(module: JpsModule): String? {
     var pluginXml = root.resolve("META-INF/plugin.xml")
     if (!Files.exists(pluginXml)) {
       // ok, any xml file
-      pluginXml = Files.newDirectoryStream(root).use { files -> files.find { it.toString().endsWith(".xml") } } ?: break
+      try {
+        pluginXml = Files.newDirectoryStream(root).use { files -> files.find { it.toString().endsWith(".xml") } } ?: break
+      } catch(e: NoSuchFileException) {
+        println("Directory attempted to be used but did not exist ${e.message}")
+      }
     }
 
     try {


### PR DESCRIPTION
When using the IconsClassGenerator script for generating icons and one of the modules depends on a module that gets dynamically generated, the script will crash out, as it may not exist. Needed for Android.

Change-Id: I0a2d9a0cbc26649bf429fef8329c6b0ab4de2131