### PR TITLE
Make SourceSearcher an extension point

### DIFF
--- a/java/idea-ui/src/com/intellij/jarFinder/InternetAttachSourceProvider.java
+++ b/java/idea-ui/src/com/intellij/jarFinder/InternetAttachSourceProvider.java
@@ -121,8 +121,7 @@ public final class InternetAttachSourceProvider extends AbstractAttachSourceProv
           public void run(@NotNull final ProgressIndicator indicator) {
             String artifactUrl = null;
 
-            SourceSearcher[] searchers = {new MavenCentralSourceSearcher(), new SonatypeSourceSearcher()};
-            for (SourceSearcher searcher : searchers) {
+            for (SourceSearcher searcher : SourceSearcher.EP_NAME.getExtensionList()) {
               try {
                 artifactUrl = searcher.findSourceJar(indicator, artifactId, version, jar);
               }

--- a/java/java-impl/src/META-INF/JavaPlugin.xml
+++ b/java/java-impl/src/META-INF/JavaPlugin.xml
@@ -279,6 +279,7 @@
     <extensionPoint qualifiedName="com.intellij.jarRepositoryAuthenticationDataProvider"
                     interface="com.intellij.jarRepository.JarRepositoryAuthenticationDataProvider" dynamic="true"/>
     <extensionPoint qualifiedName="com.intellij.jpsServerAuthExtension" interface="com.intellij.compiler.cache.client.JpsServerAuthExtension" dynamic="true"/>
+    <extensionPoint qualifiedName="com.intellij.sourceSearcher" interface="com.intellij.jarFinder.SourceSearcher" dynamic="true"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.intellij">
@@ -2385,6 +2386,9 @@
     <dataflowIRProvider language="JAVA" implementationClass="com.intellij.codeInspection.dataFlow.java.JavaDataFlowIRProvider"/>
     <java.effectively.final.fixer implementation="com.intellij.codeInsight.daemon.impl.quickfix.makefinal.MoveInitializerToIfBranchFixer"/>
     <java.effectively.final.fixer implementation="com.intellij.codeInspection.streamMigration.ConvertToStreamFixer"/>
+
+    <sourceSearcher id="mavenCentral" implementation="com.intellij.jarFinder.MavenCentralSourceSearcher"/>
+    <sourceSearcher id="sonatype" implementation="com.intellij.jarFinder.SonatypeSourceSearcher"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.jetbrains">

--- a/java/java-impl/src/com/intellij/jarFinder/MavenCentralSourceSearcher.java
+++ b/java/java-impl/src/com/intellij/jarFinder/MavenCentralSourceSearcher.java
@@ -1,7 +1,6 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.jarFinder;
 
-import com.intellij.ide.IdeBundle;
 import com.intellij.ide.IdeCoreBundle;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -13,15 +12,17 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 
+import static com.intellij.jarFinder.MavenSourceSearcherUtils.*;
+
 /**
  * @author Sergey Evdokimov
  */
-public class MavenCentralSourceSearcher extends SourceSearcher {
+public class MavenCentralSourceSearcher implements SourceSearcher {
   private static final Logger LOG = Logger.getInstance(MavenCentralSourceSearcher.class);
 
   @Nullable
   @Override
-  protected String findSourceJar(@NotNull ProgressIndicator indicator,
+  public String findSourceJar(@NotNull ProgressIndicator indicator,
                                  @NotNull String artifactId,
                                  @NotNull String version,
                                  @NotNull VirtualFile classesJar) throws SourceSearchException {

--- a/java/java-impl/src/com/intellij/jarFinder/MavenSourceSearcherUtils.java
+++ b/java/java-impl/src/com/intellij/jarFinder/MavenSourceSearcherUtils.java
@@ -1,0 +1,75 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.jarFinder;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.util.JDOMUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.io.HttpRequests;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.filter2.Filters;
+import org.jdom.xpath.XPathFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * @author Edoardo Luppi
+ */
+public class MavenSourceSearcherUtils {
+  private static final String MAVEN_POM_ENTRY_PREFIX = "META-INF/maven/";
+
+  @Nullable
+  public static String findMavenGroupId(@NotNull final VirtualFile classesJar, @NotNull final String artifactId) throws IOException {
+    try (final JarFile jarFile = new JarFile(VfsUtilCore.virtualToIoFile(classesJar))) {
+      final Enumeration<JarEntry> entries = jarFile.entries();
+
+      while (entries.hasMoreElements()) {
+        final JarEntry entry = entries.nextElement();
+        final String name = entry.getName();
+
+        if (StringUtil.startsWith(name, MAVEN_POM_ENTRY_PREFIX) &&
+            StringUtil.endsWith(name, "/" + artifactId + "/pom.xml")) {
+          final int index = name.indexOf('/', MAVEN_POM_ENTRY_PREFIX.length());
+          return index != -1
+                 ? name.substring(MAVEN_POM_ENTRY_PREFIX.length(), index)
+                 : null;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  @NotNull
+  public static List<Element> findElements(
+    @NotNull final String expression,
+    @NotNull final Element element) {
+    return XPathFactory.instance()
+      .compile(expression, Filters.element())
+      .evaluate(element);
+  }
+
+  @NotNull
+  public static Element readElementCancelable(
+    @NotNull final ProgressIndicator indicator,
+    @NotNull final String url) throws IOException {
+    return HttpRequests.request(url)
+      .accept("application/xml")
+      .connect(request -> {
+        try {
+          return JDOMUtil.load(request.getReader(indicator));
+        }
+        catch (final JDOMException e) {
+          throw new IOException(e);
+        }
+      });
+  }
+}

--- a/java/java-impl/src/com/intellij/jarFinder/SonatypeSourceSearcher.java
+++ b/java/java-impl/src/com/intellij/jarFinder/SonatypeSourceSearcher.java
@@ -1,7 +1,6 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.jarFinder;
 
-import com.intellij.ide.IdeBundle;
 import com.intellij.ide.IdeCoreBundle;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -13,10 +12,12 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 
+import static com.intellij.jarFinder.MavenSourceSearcherUtils.*;
+
 /**
  * @author Sergey Evdokimov
  */
-public class SonatypeSourceSearcher extends SourceSearcher {
+public class SonatypeSourceSearcher implements SourceSearcher {
   private static final Logger LOG = Logger.getInstance(SonatypeSourceSearcher.class);
 
   @Nullable

--- a/java/java-impl/src/com/intellij/jarFinder/SourceSearchException.java
+++ b/java/java-impl/src/com/intellij/jarFinder/SourceSearchException.java
@@ -1,0 +1,13 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.jarFinder;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Edoardo Luppi
+ */
+public class SourceSearchException extends Exception {
+  public SourceSearchException(@NotNull final String message) {
+    super(message);
+  }
+}

--- a/java/java-impl/src/com/intellij/jarFinder/SourceSearcher.java
+++ b/java/java-impl/src/com/intellij/jarFinder/SourceSearcher.java
@@ -1,97 +1,25 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.jarFinder;
 
+import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.util.JDOMUtil;
-import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.util.io.HttpRequests;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.filter2.Filters;
-import org.jdom.xpath.XPathFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
 /**
  * @author Sergey Evdokimov
  */
-public abstract class SourceSearcher {
-  private static final String MAVEN_POM_ENTRY_PREFIX = "META-INF/maven/";
-
-  @NotNull
-  protected static List<Element> findElements(@NotNull String expression, @NotNull Element element) {
-    return XPathFactory.instance()
-      .compile(expression, Filters.element())
-      .evaluate(element);
-  }
+public interface SourceSearcher {
+  ExtensionPointName<SourceSearcher> EP_NAME = ExtensionPointName.create("com.intellij.sourceSearcher");
 
   /**
-   * @return url of found artifact
+   * Returns the URL of the found source artifact, or {@code null} if none.
    */
   @Nullable
-  protected String findSourceJar(@NotNull final ProgressIndicator indicator, @NotNull String artifactId, @NotNull String version)
-    throws SourceSearchException {
-    return null;
-  }
-
-  /**
-   * @param classesJar classes jar
-   * @return url of found artifact
-   */
-  @Nullable
-  protected String findSourceJar(@NotNull final ProgressIndicator indicator,
-                                 @NotNull String artifactId,
-                                 @NotNull String version,
-                                 @NotNull VirtualFile classesJar) throws SourceSearchException {
-    return findSourceJar(indicator, artifactId, version);
-  }
-
-  @NotNull
-  protected static Element readElementCancelable(final ProgressIndicator indicator, String url) throws IOException {
-    return HttpRequests.request(url)
-      .accept("application/xml")
-      .connect(new HttpRequests.RequestProcessor<>() {
-        @Override
-        public Element process(@NotNull HttpRequests.Request request) throws IOException {
-          try {
-            return JDOMUtil.load(request.getReader(indicator));
-          }
-          catch (JDOMException e) {
-            throw new IOException(e);
-          }
-        }
-      });
-  }
-
-  @Nullable
-  protected static String findMavenGroupId(@NotNull VirtualFile classesJar, String artifactId) {
-    try (JarFile jarFile = new JarFile(VfsUtilCore.virtualToIoFile(classesJar))) {
-      final Enumeration<JarEntry> entries = jarFile.entries();
-      while (entries.hasMoreElements()) {
-        JarEntry entry = entries.nextElement();
-        final String name = entry.getName();
-        if (StringUtil.startsWith(name, MAVEN_POM_ENTRY_PREFIX) && StringUtil.endsWith(name, "/" + artifactId + "/pom.xml")) {
-          final int index = name.indexOf('/', MAVEN_POM_ENTRY_PREFIX.length());
-          return index != -1 ? name.substring(MAVEN_POM_ENTRY_PREFIX.length(), index) : null;
-        }
-      }
-    }
-    catch (IOException ignore) {
-    }
-    return null;
-  }
-}
-
-class SourceSearchException extends Exception {
-  SourceSearchException(String message) {
-    super(message);
-  }
+  String findSourceJar(
+    @NotNull final ProgressIndicator indicator,
+    @NotNull final String artifactId,
+    @NotNull final String version,
+    @NotNull final VirtualFile classesJar) throws SourceSearchException;
 }


### PR DESCRIPTION
This allows third parties to contribute ways to retrieve sources for possibly non-standard JAR files.
Building block for https://github.com/JetBrains/intellij-community/pull/2127

A question: can we delegate to `SourceSearcher`s the extraction of `groupId`, `artifactId`, and `version`?
This is currently done in `InternetAttachSourceProvider`, but the logic used is not always correct.

Usage example might be `P2SourceSearcher`, which finds source JARs in p2 repositories.