### PR TITLE
KTIJ-24175 False positive inspection "Useless call on collection type" using filterIsInstance for iterables with contravariant generics

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2396,6 +2396,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                 runTest("testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForFlexibleOnSequence.kt");
             }
 
+            @TestMetadata("FilterIsForInVariance.kt")
+            public void testFilterIsForInVariance() throws Exception {
+                runTest("testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForInVariance.kt");
+            }
+
+            @TestMetadata("FilterIsForOutVariance.kt")
+            public void testFilterIsForOutVariance() throws Exception {
+                runTest("testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForOutVariance.kt");
+            }
+
             @TestMetadata("FilterIsSupertypeInstance.kt")
             public void testFilterIsSupertypeInstance() throws Exception {
                 runTest("testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsSupertypeInstance.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForInVariance.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForInVariance.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+inline fun <reified T> test(x: Array<in T>) {
+    val y: List<T> = x.<caret>filterIsInstance<T>()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForOutVariance.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForOutVariance.kt
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+inline fun <reified T> test(x: Array<out T>) {
+    val y: List<T> = x.<caret>filterIsInstance<T>()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForOutVariance.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/uselessCallOnCollection/FilterIsForOutVariance.kt.after
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+
+inline fun <reified T> test(x: Array<out T>) {
+    val y: List<T> = x.toList()
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24175