### PR TITLE
Set IS_ENSURE_NEWLINE_AT_EOF = true by default

### DIFF
--- a/platform/ide-core-impl/src/com/intellij/openapi/editor/ex/EditorSettingsExternalizable.java
+++ b/platform/ide-core-impl/src/com/intellij/openapi/editor/ex/EditorSettingsExternalizable.java
@@ -53,7 +53,7 @@ public class EditorSettingsExternalizable implements PersistentStateComponent<Ed
     public boolean IS_VIRTUAL_SPACE = false;
     public boolean IS_CARET_INSIDE_TABS;
     @NonNls public String STRIP_TRAILING_SPACES = STRIP_TRAILING_SPACES_CHANGED;
-    public boolean IS_ENSURE_NEWLINE_AT_EOF = false;
+    public boolean IS_ENSURE_NEWLINE_AT_EOF = true;
     public boolean REMOVE_TRAILING_BLANK_LINES = false;
     public boolean SHOW_QUICK_DOC_ON_MOUSE_OVER_ELEMENT = true;
     public boolean SHOW_INSPECTION_WIDGET = true;


### PR DESCRIPTION
With this option false, the editor omits newlines at EOF
for both existing and newly created files. This is bad behavior.
Here are some explanations why:

joachimschuster.de/posts/why-inserting-newline-at-the-end-of-file
thoughtbot.com/blog/no-newline-at-end-of-file
medium.com/@alexey.inkin/fdf76d1d090e

Here are some complaints about this behavior in IntelliJ-based IDEs:

itecnote.com/tecnote/android-how-to-configure-android-studio-to-add-new-line-at-end-of-file
reddit.com/r/Hyperskill/comments/h9pyyr/warning_pep_8_w292_no_newline_at_end_of_file_in
stackoverflow.com/questions/36043061#comment67201459_37260222

Users can still override the default by unchecking the box
or by setting insert_final_newline=false in .editorconfig.