### PR TITLE
Fix the issue when debugger is stuck in an infinite loop in Android project

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stackFrameUtils.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stackFrameUtils.kt
@@ -78,7 +78,10 @@ fun Method.sortedVariablesWithLocation(): List<VariableWithLocation> {
         // any bytecode index - so the variable ends exactly one index later.
         val otherVariables = startOffsets[endOffset.codeIndex() + 1] ?: continue
         for (other in otherVariables) {
-            if (variable.name() == other.name() && variable.signature() == other.signature()) {
+            if (variable.name() == other.name() &&
+                variable.signature() == other.signature() &&
+                variable != other)
+            {
                 replacements[other] = variable
                 break
             }
@@ -89,7 +92,11 @@ fun Method.sortedVariablesWithLocation(): List<VariableWithLocation> {
         while (true) {
             alias = replacements[alias] ?: break
         }
-        replacements[variable] = alias
+
+        if (variable != alias) {
+            replacements[variable] = alias
+        }
+
         alias.getBorders()?.let {
             VariableWithLocation(variable, it.start)
         }

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/mock/MockLocalVariable.kt
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/mock/MockLocalVariable.kt
@@ -11,6 +11,7 @@ import com.sun.jdi.*
 import org.jetbrains.kotlin.idea.debugger.test.mock.MockLocation
 import org.jetbrains.kotlin.idea.debugger.test.mock.MockMethod
 
+@Suppress("EqualsOrHashCode")
 class MockLocalVariable(
     val startPc: Int,
     val length: Int,
@@ -39,6 +40,13 @@ class MockLocalVariable(
     // That's the only reason we have to override it.
     override fun isVisible(frame: StackFrame): Boolean =
         frame.location().codeIndex().toInt() in startPc until startPc + length
+
+    // [LocalVariableImpl.equals] checks the equality of virtual machines
+    // via the `vm` variable, that's why we have to override this method.
+    override fun equals(other: Any?): Boolean =
+        other is MockLocalVariable &&
+                slot() == other.slot() &&
+                scopeStart == other.scopeStart
 
     override fun compareTo(other: LocalVariable): Int {
         error("`LocalVariable.compareTo` does not provide a stable ordering and should not be used.")


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-24259/Debugger-is-stuck-in-an-infinite-loop-in-an-Android-project

It could happen that the `replacements` map for an arbitrary key contained a value that is equal to that key. This resulted in an infinite loop, which affected all the debugger behaviour.