### PR TITLE
Fix double form enctype hints

### DIFF
--- a/xml/impl/src/com/intellij/codeInsight/completion/HtmlCompletionContributor.java
+++ b/xml/impl/src/com/intellij/codeInsight/completion/HtmlCompletionContributor.java
@@ -45,7 +45,6 @@ import static com.intellij.util.ObjectUtils.doIfNotNull;
 public class HtmlCompletionContributor extends CompletionContributor implements DumbAware {
 
   public static final String[] TARGET = {"_blank", "_top", "_self", "_parent"};
-  public static final String[] ENCTYPE = {"multipart/form-data", "application/x-www-form-urlencoded"};
   public static final String[] REL = {"alternate", "author", "bookmark", "help", "icon", "license", "next", "nofollow",
     "noreferrer", "noopener", "prefetch", "prev", "search", "stylesheet", "tag", "start", "contents", "index",
     "glossary", "copyright", "chapter", "section", "subsection", "appendix", "script", "import",
@@ -117,9 +116,6 @@ public class HtmlCompletionContributor extends CompletionContributor implements 
       }
       else if (("lang".equals(name) || "xml:lang".equals(name)) && tagName.equalsIgnoreCase("html")) {
         return LANG;
-      }
-      else if ("enctype".equals(name)) {
-        return ENCTYPE;
       }
       else if ("rel".equals(name) || "rev".equals(name)) {
         return REL;


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/WEB-53640/Double-hint-information-in-html-form-enctype-attribute