### PR TITLE
Add language tag hint to hreflang attribute

### DIFF
--- a/xml/impl/src/com/intellij/codeInsight/completion/HtmlCompletionContributor.java
+++ b/xml/impl/src/com/intellij/codeInsight/completion/HtmlCompletionContributor.java
@@ -115,7 +115,7 @@ public class HtmlCompletionContributor extends CompletionContributor implements 
       if ("target".equals(name) || "formtarget".equals(name)) {
         return TARGET;
       }
-      else if (("lang".equals(name) || "xml:lang".equals(name)) && tagName.equalsIgnoreCase("html")) {
+      else if (("lang".equals(name) || "xml:lang".equals(name)) && tagName.equalsIgnoreCase("html") || "hreflang".equals(name)) {
         return LANG;
       }
       else if ("enctype".equals(name)) {


### PR DESCRIPTION
Adds BCP47 hints to [hreflang](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-hreflang) attribute.