### PR TITLE
KTIJ-24247 K2 IDE: RedundantElvisReturnNullInspection (redundant elvis return null) highlights code as a warning instead of unused code

### DIFF
--- a/plugins/kotlin/code-insight/inspections-k2/resources/kotlin.code-insight.inspections-k2.xml
+++ b/plugins/kotlin/code-insight/inspections-k2/resources/kotlin.code-insight.inspections-k2.xml
@@ -98,7 +98,7 @@
                      enabledByDefault="true"
                      cleanupTool="true"
                      level="WARNING"
-                     language="kotlin"
+                     language="kotlin" editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
                      key="inspection.redundant.elvis.return.null.display.name"
                      bundle="messages.KotlinBundle" />
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24247