### PR TITLE
KTIJ-20298 "Call chain on collection type may be simplified" to replace `map` and `sum` with `sumOf` produces "overload resolution ambiguity"

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/SimplifiableCallChainInspection.kt
@@ -16,13 +16,12 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
-import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.bindingContextUtil.getTargetFunction
+import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.getType
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.types.typeUtil.builtIns
@@ -48,7 +47,7 @@ class SimplifiableCallChainInspection : AbstractCallChainChecker() {
                     ) return@check false
                 }
                 if (conversion.replacement in listOf("maxBy", "minBy", "minByOrNull", "maxByOrNull")) {
-                    val functionalArgumentReturnType = firstResolvedCall.lastFunctionalArgumentReturnType(context) ?: return@check false
+                    val functionalArgumentReturnType = firstResolvedCall.lastFunctionalArgument(context)?.returnType ?: return@check false
                     if (functionalArgumentReturnType.isNullable()) return@check false
                 }
                 if (conversion.removeNotNullAssertion &&
@@ -60,11 +59,16 @@ class SimplifiableCallChainInspection : AbstractCallChainChecker() {
                 }
 
                 if (conversion.firstName == "map" && conversion.secondName == "sum" && conversion.replacement == "sumOf") {
-                    val type = firstResolvedCall.lastFunctionalArgumentReturnType(context) ?: return@check false
-                    if (!KotlinBuiltIns.isInt(type) && !KotlinBuiltIns.isLong(type) &&
+                    val lastFunctionalArgument = firstResolvedCall.lastFunctionalArgument(context) ?: return@check false
+                    val type = lastFunctionalArgument.returnType ?: return@check false
+                    val isInt = KotlinBuiltIns.isInt(type)
+                    if (!isInt && !KotlinBuiltIns.isLong(type) &&
                         !KotlinBuiltIns.isUInt(type) && !KotlinBuiltIns.isULong(type) &&
                         !KotlinBuiltIns.isDouble(type)
                     ) return@check false
+                    if (isInt && lastFunctionalArgument.isLambda && lastFunctionalArgument.lastStatement.isLiteralValue()) {
+                        return@check false
+                    }
                 }
                 return@check conversion.enableSuspendFunctionCall || !containsSuspendFunctionCall(firstResolvedCall, context)
             } ?: return
@@ -97,22 +101,45 @@ class SimplifiableCallChainInspection : AbstractCallChainChecker() {
         })
     }
 
-    private fun ResolvedCall<*>.lastFunctionalArgumentReturnType(context: BindingContext): KotlinType? {
+    private class FunctionalArgument(val isLambda: Boolean, val returnType: KotlinType?, val lastStatement: KtExpression?)
+
+    private fun ResolvedCall<*>.lastFunctionalArgument(context: BindingContext): FunctionalArgument? {
         val argument = valueArguments.entries.lastOrNull()?.value?.arguments?.firstOrNull()
         return when (val argumentExpression = argument?.getArgumentExpression()) {
             is KtLambdaExpression -> {
-                val functionLiteral = argumentExpression.functionLiteral
-                val body = argumentExpression.bodyExpression
-                val lastStatementType = body?.statements?.lastOrNull()?.getType(context)
-                val returnedTypes = body
-                    ?.collectDescendantsOfType<KtReturnExpression> { it.getTargetFunction(context) == functionLiteral }
-                    ?.mapNotNull { it.returnedExpression?.getType(context) }
-                    .orEmpty()
-                val types = listOfNotNull(lastStatementType) + returnedTypes
-                types.firstOrNull { it.isNullable() } ?: types.firstOrNull()
+                val lastStatement = argumentExpression.bodyExpression?.lastBlockStatementOrThis()
+                FunctionalArgument(
+                    isLambda = true,
+                    returnType = lastStatement?.getType(context),
+                    lastStatement = lastStatement
+                )
             }
-            is KtNamedFunction -> argumentExpression.typeReference?.let { context[BindingContext.TYPE, it] }
+
+            is KtNamedFunction -> {
+                FunctionalArgument(
+                    isLambda = false,
+                    returnType = argumentExpression.typeReference?.let { context[BindingContext.TYPE, it] },
+                    lastStatement = argumentExpression.lastBlockStatementOrThis()
+                )
+            }
+
             else -> null
+        }
+    }
+
+    private fun KtExpression?.isLiteralValue(): Boolean {
+        return this != null && when (val expr = KtPsiUtil.safeDeparenthesize(this)) {
+            is KtBinaryExpression -> expr.left.isLiteralValue() && expr.right.isLiteralValue()
+
+            is KtIfExpression -> expr.then?.lastBlockStatementOrThis().isLiteralValue() &&
+                    expr.`else`?.lastBlockStatementOrThis().isLiteralValue()
+
+            is KtWhenExpression -> expr.entries.all { it.expression?.lastBlockStatementOrThis().isLiteralValue() }
+
+            is KtTryExpression -> expr.tryBlock.lastBlockStatementOrThis().isLiteralValue() &&
+                    expr.catchClauses.all { c -> c.catchBody?.lastBlockStatementOrThis().isLiteralValue() }
+
+            else -> expr is KtConstantExpression
         }
     }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1758,6 +1758,89 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         @TestMetadata("testData/inspectionsLocal/collections/simplifiableCallChain")
         public abstract static class SimplifiableCallChain extends AbstractLocalInspectionTest {
             @RunWith(JUnit3RunnerWithInners.class)
+            @TestMetadata("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant")
+            public static class MapSumWithConstant extends AbstractLocalInspectionTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+                }
+
+                @TestMetadata("const.kt")
+                public void testConst() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/const.kt");
+                }
+
+                @TestMetadata("intLiteral.kt")
+                public void testIntLiteral() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteral.kt");
+                }
+
+                @TestMetadata("intLiteralInAnonymousFun.kt")
+                public void testIntLiteralInAnonymousFun() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInAnonymousFun.kt");
+                }
+
+                @TestMetadata("intLiteralInBinary.kt")
+                public void testIntLiteralInBinary() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInBinary.kt");
+                }
+
+                @TestMetadata("intLiteralInIf.kt")
+                public void testIntLiteralInIf() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInIf.kt");
+                }
+
+                @TestMetadata("intLiteralInIf2.kt")
+                public void testIntLiteralInIf2() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInIf2.kt");
+                }
+
+                @TestMetadata("intLiteralInTryCatch.kt")
+                public void testIntLiteralInTryCatch() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInTryCatch.kt");
+                }
+
+                @TestMetadata("intLiteralInWhen.kt")
+                public void testIntLiteralInWhen() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInWhen.kt");
+                }
+
+                @TestMetadata("intLiteralInWhen2.kt")
+                public void testIntLiteralInWhen2() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInWhen2.kt");
+                }
+
+                @TestMetadata("longLiteral.kt")
+                public void testLongLiteral() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteral.kt");
+                }
+
+                @TestMetadata("longLiteralInBinary.kt")
+                public void testLongLiteralInBinary() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInBinary.kt");
+                }
+
+                @TestMetadata("longLiteralInIf.kt")
+                public void testLongLiteralInIf() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInIf.kt");
+                }
+
+                @TestMetadata("variable.kt")
+                public void testVariable() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variable.kt");
+                }
+
+                @TestMetadata("variableInBinary.kt")
+                public void testVariableInBinary() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInBinary.kt");
+                }
+
+                @TestMetadata("variableInIf.kt")
+                public void testVariableInIf() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInIf.kt");
+                }
+            }
+
+            @RunWith(JUnit3RunnerWithInners.class)
             @TestMetadata("testData/inspectionsLocal/collections/simplifiableCallChain/primitiveArray")
             public static class PrimitiveArray extends AbstractLocalInspectionTest {
                 private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/const.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/const.kt
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+const val i = 1
+fun test(list: List<Int>) {
+    list.map<caret> { i }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/const.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/const.kt.after
@@ -1,0 +1,5 @@
+// WITH_STDLIB
+const val i = 1
+fun test(list: List<Int>) {
+    list.sumOf { i }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteral.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteral.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.map<caret> { 1 }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInAnonymousFun.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInAnonymousFun.kt
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.<caret>map(fun(it: Int): Int {
+        return 1
+    }).sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInAnonymousFun.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInAnonymousFun.kt.after
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.sumOf(fun(it: Int): Int {
+        return 1
+    })
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInBinary.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInBinary.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> { 1 + 2 }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInIf.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInIf.kt
@@ -1,0 +1,5 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> { if (i == 1) 1 else if (i == 2) 2 else 3 }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInIf2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInIf2.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> {
+        if (i == 1) {
+            if (true) 1 else 0
+        } else if (i == 2) {
+            2
+        } else {
+            3
+        }
+    }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInTryCatch.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInTryCatch.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.map<caret> {
+        try {
+            1
+        } catch (e: Exception) {
+            if (true) 1 else 0
+        }
+    }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInWhen.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInWhen.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> {
+        when (i) {
+            1 -> 1
+            2 -> 2
+            else -> 3
+        }
+    }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInWhen2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/intLiteralInWhen2.kt
@@ -1,0 +1,17 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> {
+        when (i) {
+            1 -> {
+                if (true) 1 else 0
+            }
+            2 -> {
+                2
+            }
+            else -> {
+                3
+            }
+        }
+    }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteral.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteral.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.map<caret> { 1L }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteral.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteral.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.sumOf { 1L }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInBinary.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInBinary.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.map<caret> { 1 + 2L }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInBinary.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInBinary.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>) {
+    list.sumOf { 1 + 2L }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInIf.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInIf.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> { if (i == 1) 1 else if (i == 2) 2 else 3L }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInIf.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/longLiteralInIf.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.sumOf { if (i == 1) 1 else if (i == 2) 2 else 3L }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variable.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variable.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> { i }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variable.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variable.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.sumOf { i }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInBinary.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInBinary.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> { 1 + i }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInBinary.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInBinary.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.sumOf { 1 + i }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInIf.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInIf.kt
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.map<caret> { if (i == 1) i else if (i == 2) 2 else 3 }.sum()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInIf.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/simplifiableCallChain/mapSumWithConstant/variableInIf.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun test(list: List<Int>, i: Int) {
+    list.sumOf { if (i == 1) i else if (i == 2) 2 else 3 }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-20298
https://youtrack.jetbrains.com/issue/KTIJ-24252