### PR TITLE
Set `basefont` html element as deprecated

### DIFF
--- a/xml/xml-psi-impl/src/com/intellij/psi/impl/source/html/dtd/HtmlElementDescriptorImpl.java
+++ b/xml/xml-psi-impl/src/com/intellij/psi/impl/source/html/dtd/HtmlElementDescriptorImpl.java
@@ -45,6 +45,7 @@ public class HtmlElementDescriptorImpl extends BaseXmlElementDescriptorImpl impl
   private final Set<String> ourHtml4DeprecatedTags = ContainerUtil.newHashSet("applet", "basefont", "center", "dir",
                                                                               "font", "frame", "frameset", "isindex", "menu",
                                                                               "noframes", "s", "strike", "u", "xmp");
+  private final Set<String> ourHtml5DeprecatedTags = ContainerUtil.newHashSet("basefont");
 
   private final XmlElementDescriptor myDelegate;
   private final boolean myRelaxed;
@@ -249,12 +250,12 @@ public class HtmlElementDescriptorImpl extends BaseXmlElementDescriptorImpl impl
     boolean html4Deprecated = ourHtml4DeprecatedTags.contains(myDelegate.getName());
     MdnSymbolDocumentation documentation = doIfNotNull(
       myDelegate.getDeclaration(), declaration -> MdnDocumentationKt.getHtmlMdnDocumentation(declaration, null));
-    boolean deprecatedInHtml5 = documentation != null && documentation.isDeprecated();
-    if (!html4Deprecated && !deprecatedInHtml5) {
+    boolean html5Deprecated = documentation != null && documentation.isDeprecated() || ourHtml5DeprecatedTags.contains(myDelegate.getName());
+    if (!html4Deprecated && !html5Deprecated) {
       return false;
     }
     boolean inHtml5 = HtmlUtil.isHtml5Schema(getNSDescriptor());
-    return inHtml5 && deprecatedInHtml5 || !inHtml5 && html4Deprecated;
+    return inHtml5 && html5Deprecated || !inHtml5 && html4Deprecated;
   }
 
   private String toLowerCaseIfNeeded(String name) {


### PR DESCRIPTION
Adds strikethrough effect to code completion hint of `basefont` HTML element. This element was not set as deprecated, because it doesn't have an MDN page, but it exists in the HTML validator schema(inside `legacy` file).