### PR TITLE
IDEA-302663: Introduce the deepin file manager support

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/actions/RevealFileAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/RevealFileAction.java
@@ -32,6 +32,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileSystem;
 import com.intellij.openapi.vfs.newvfs.ArchiveFileSystem;
 import com.intellij.util.SystemProperties;
+import com.intellij.util.containers.ContainerUtil;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Ole32;
@@ -204,6 +205,9 @@ public class RevealFileAction extends DumbAwareAction implements LightEditCompat
       if (fmApp.endsWith("dolphin") && toSelect != null) {
         spawn(fmApp, "--select", toSelect);
       }
+      else if (fmApp.endsWith("dde-file-manager") && toSelect != null) {
+        spawn(fmApp, "--show-item", toSelect);
+      }
       else {
         spawn(fmApp, toSelect != null ? toSelect : dir);
       }
@@ -283,10 +287,12 @@ public class RevealFileAction extends DumbAwareAction implements LightEditCompat
   }
 
   private static class Holder {
+    private static final String[] supportedFileManagers = {"nautilus", "pantheon-files", "dolphin", "dde-file-manager"};
+
     private static final String fileManagerApp =
       readDesktopEntryKey("Exec")
         .map(line -> line.split(" ")[0])
-        .filter(exec -> exec.endsWith("nautilus") || exec.endsWith("pantheon-files") || exec.endsWith("dolphin"))
+        .filter(exec -> ContainerUtil.exists(supportedFileManagers, supportedFileManager -> exec.endsWith(supportedFileManager)))
         .orElse(null);
 
     private static final String fileManagerName =


### PR DESCRIPTION
How to test (arch-based linux distros):
1. Install the deepin file manager:
```
yay -S deepin-file-manager
```
2. Install the dolphin file manager:
```
yay -S dolphin
```
3. Install the nautilus file manager:
```
yay -S nautilus
```
4. Install the pantheon files:
```
yay -S pantheon-files
```
(after install of each of them, the previous one will be overridden, so, you will get the action for the last one on each step)

5. Uninstall (with all transitive dependencies):
```
yay -Rs deepin-file-manager
yay -Rs dolphin
yay -Rs nautilus
yay -Rs pantheon-files
```
The result:
![image](https://user-images.githubusercontent.com/21011268/216177768-900bdd42-f3b8-480a-9851-1d53a5bf0615.png)
