### PR TITLE
Project structure mapping improvements (IDEA-311411)

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
@@ -143,14 +143,9 @@ class BuildTasksImpl(context: BuildContext) : BuildTasks {
  * Generates a JSON file containing mapping between files in the product distribution and modules and libraries in the project configuration
  */
 suspend fun generateProjectStructureMapping(targetFile: Path, context: BuildContext) {
-  val pluginLayoutRoot = withContext(Dispatchers.IO) {
-    Files.createDirectories(context.paths.tempDir)
-    Files.createTempDirectory(context.paths.tempDir, "pluginLayoutRoot")
-  }
   writeProjectStructureReport(
     entries = generateProjectStructureMapping(context = context,
-                                              state = DistributionBuilderState(pluginsToPublish = emptySet(), context = context),
-                                              pluginLayoutRoot = pluginLayoutRoot),
+                                              state = DistributionBuilderState(pluginsToPublish = emptySet(), context = context)),
     file = targetFile,
     buildPaths = context.paths
   )

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/DistributionJARsBuilder.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/DistributionJARsBuilder.kt
@@ -227,8 +227,7 @@ class DistributionJARsBuilder {
       if (e.path.startsWith(pluginLayoutRoot)) {
         val relPath = pluginLayoutRoot.relativize(e.path)
         // For plugins our classloader load jars only from lib folder
-        val parent = relPath.parent
-        if ((parent?.parent) == null && (relPath.parent.toString() == "lib")) {
+        if (relPath.nameCount == 3 && relPath.getName(1).toString() == "lib") {
           pluginsEntries.add(e)
         }
       }
@@ -454,7 +453,7 @@ internal suspend fun generateProjectStructureMapping(context: BuildContext,
     for (plugin in allPlugins) {
       if (satisfiesBundlingRequirements(plugin = plugin, osFamily = null, arch = null, withEphemeral = true, context = context)) {
         entries.addAll(layoutDistribution(layout = plugin,
-                                          targetDirectory = pluginLayoutRoot,
+                                          targetDirectory = pluginLayoutRoot.resolve(plugin.directoryName),
                                           copyFiles = false,
                                           simplify = false,
                                           moduleOutputPatcher = moduleOutputPatcher,


### PR DESCRIPTION
This PR includes two commits:
1. Include plugin dirs in project structure mapping (2-line change)
2. Cleanup: use default dist dir for plugin layout

Only the first change is required for our purposes.
But the second change is nice-to-have too.

Issue link: https://youtrack.jetbrains.com/issue/IDEA-311411