### PR TITLE
KTIJ-24556 OVERRIDE_DEPRECATION quickfix: "Copy '@Deprecated' annotation" from super method doesn't escape quotes

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddAnnotationWithArgumentsFix.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/quickfix/AddAnnotationWithArgumentsFix.kt
@@ -4,6 +4,7 @@ package org.jetbrains.kotlin.idea.quickfix
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.SmartPsiElementPointer
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
@@ -128,7 +129,10 @@ class AddAnnotationWithArgumentsFix(
          // A custom pretty-printer for the `@Deprecated` annotation that deals with optional named arguments and varargs.
         private fun formatDeprecatedAnnotationArguments(annotation: AnnotationDescriptor): List<String> {
             val arguments = mutableListOf<String>()
-            annotation.allValueArguments[MESSAGE_ARGUMENT]?.safeAs<StringValue>()?.let { arguments.add(it.toString()) }
+            annotation.allValueArguments[MESSAGE_ARGUMENT]?.safeAs<StringValue>()
+                ?.toString()
+                ?.removeSurrounding("\"")
+                ?.let { arguments.add("\"${StringUtil.escapeStringCharacters(it)}\"") }
             val replaceWith = annotation.allValueArguments[REPLACE_WITH_ARGUMENT]?.safeAs<AnnotationValue>()?.value
             if (replaceWith != null) {
                 val expression = replaceWith.allValueArguments[EXPRESSION_ARGUMENT]?.safeAs<StringValue>()?.toString()

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/K1QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/K1QuickFixTestGenerated.java
@@ -11338,6 +11338,11 @@ public abstract class K1QuickFixTestGenerated extends AbstractK1QuickFixTest {
                 runTest("testData/quickfix/override/overrideDeprecation/copyDeprecationProperty.kt");
             }
 
+            @TestMetadata("copyDeprecationWithEscapedMessage.kt")
+            public void testCopyDeprecationWithEscapedMessage() throws Exception {
+                runTest("testData/quickfix/override/overrideDeprecation/copyDeprecationWithEscapedMessage.kt");
+            }
+
             @TestMetadata("suppressWarning.kt")
             public void testSuppressWarning() throws Exception {
                 runTest("testData/quickfix/override/overrideDeprecation/suppressWarning.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/override/overrideDeprecation/copyDeprecationWithEscapedMessage.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/override/overrideDeprecation/copyDeprecationWithEscapedMessage.kt
@@ -1,0 +1,12 @@
+// "Copy '@Deprecated' annotation from 'MyInterface.deprecatedFun' to 'MyImplementation.deprecatedFun'" "true"
+// WITH_STDLIB
+
+interface MyInterface {
+    @Deprecated("A \"deprecated\" message with quotes")
+    fun deprecatedFun()
+}
+
+class MyImplementation : MyInterface {
+    override fun <caret>deprecatedFun() {
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/override/overrideDeprecation/copyDeprecationWithEscapedMessage.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/override/overrideDeprecation/copyDeprecationWithEscapedMessage.kt.after
@@ -1,0 +1,13 @@
+// "Copy '@Deprecated' annotation from 'MyInterface.deprecatedFun' to 'MyImplementation.deprecatedFun'" "true"
+// WITH_STDLIB
+
+interface MyInterface {
+    @Deprecated("A \"deprecated\" message with quotes")
+    fun deprecatedFun()
+}
+
+class MyImplementation : MyInterface {
+    @Deprecated("A \"deprecated\" message with quotes")
+    override fun deprecatedFun() {
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24556