### PR TITLE
fix: USER_SCALE_FACTOR_PROPERTY was public before kotlin conversion

### DIFF
--- a/platform/util/ui/src/com/intellij/ui/scale/JBUIScale.kt
+++ b/platform/util/ui/src/com/intellij/ui/scale/JBUIScale.kt
@@ -27,7 +27,7 @@ object JBUIScale {
   @Internal
   val SCALE_VERBOSE = java.lang.Boolean.getBoolean("ide.ui.scale.verbose")
 
-  private const val USER_SCALE_FACTOR_PROPERTY = "JBUIScale.userScaleFactor"
+  const val USER_SCALE_FACTOR_PROPERTY = "JBUIScale.userScaleFactor"
 
   /**
    * The user scale factor, see [ScaleType.USR_SCALE].


### PR DESCRIPTION
Public field in the Java version of this file in 222 : 

https://github.com/JetBrains/intellij-community/blob/41f222c6ce05145064e1f1365fe5bf6c92fa0e90/platform/util/ui/src/com/intellij/ui/scale/JBUIScale.java#LL29C46-L29C46