### PR TITLE
Expose A Disposable Object

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/engine/DebugProcessImpl.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/DebugProcessImpl.java
@@ -1011,6 +1011,10 @@ public abstract class DebugProcessImpl extends UserDataHolderBase implements Deb
     myRequestManager.setFilterThread(null);
   }
 
+  public @NotNull Disposable getDisposable() {
+    return myDisposable;
+  }
+
   @Override
   public @NotNull DebuggerManagerThreadImpl getManagerThread() {
     return myDebuggerManagerThread;


### PR DESCRIPTION
This can be used by owners such as PositionManager's for example to register on the MessageBus etc.