### PR TITLE
[java] Improve Android SDK detection pattern [IDEA-313492]

### DIFF
--- a/java/idea-ui/src/com/intellij/codeInsight/daemon/impl/LibrarySourceNotificationProvider.kt
+++ b/java/idea-ui/src/com/intellij/codeInsight/daemon/impl/LibrarySourceNotificationProvider.kt
@@ -27,7 +27,8 @@ class LibrarySourceNotificationProvider : EditorNotificationProvider {
   private companion object {
 
     private val LOG = logger<LibrarySourceNotificationProvider>()
-    private val ANDROID_SDK_PATTERN = ".*/platforms/android-\\d+/android.jar!/.*".toRegex()
+    // Support releases (e.g. "android-30") as well as previews (e.g. "android-tiramisu")
+    private val ANDROID_SDK_PATTERN = ".*/platforms/android-\\w+/android.jar!/.*".toRegex()
 
     private const val FIELD = SHOW_NAME or SHOW_TYPE or SHOW_FQ_CLASS_NAMES or SHOW_RAW_TYPE
     private const val METHOD = SHOW_NAME or SHOW_PARAMETERS or SHOW_RAW_TYPE


### PR DESCRIPTION
Update the regex to detect Android SDK paths to support pre-release versions of the platform (e.g. "/platforms/android-Tiramisu") in addition to official releases (e.g. "/platforms/android-33")

Original bug: https://youtrack.jetbrains.com/issue/IDEA-154245

Original fix: https://github.com/JetBrains/intellij-community/commit/d993011c1e15e9392708282d169d1c5afc6857cd

Change-Id: I4989df8db490479e35f80d5e4203b72c7ec01749