### PR TITLE
IDEA-314175: Handle relative classpath jar paths

### DIFF
--- a/platform/util-class-loader/src/com/intellij/util/lang/ClassPath.java
+++ b/platform/util-class-loader/src/com/intellij/util/lang/ClassPath.java
@@ -339,7 +339,7 @@ public final class ClassPath {
         return null;
       }
 
-      Path path = files[searchOffset++];
+      Path path = files[searchOffset++].toAbsolutePath();
       try {
         Loader loader = createLoader(path);
         if (loader != null) {

--- a/platform/util/testSrc/com/intellij/util/lang/PathClassLoaderTest.kt
+++ b/platform/util/testSrc/com/intellij/util/lang/PathClassLoaderTest.kt
@@ -4,11 +4,13 @@
 package com.intellij.util.lang
 
 import com.intellij.util.io.Compressor
+import com.intellij.util.io.systemIndependentPath
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.net.URL
 import java.nio.file.Path
+import java.nio.file.Paths
 
 class PathClassLoaderTest {
   @Test
@@ -23,5 +25,18 @@ class PathClassLoaderTest {
     val resource = classPath.findResource("help/help.html")
     assertThat(resource).isNotNull()
     assertThat(URL(resource!!.url, "screenshot.png").content).isEqualTo(expectedData)
+  }
+
+  @Test
+  fun `relative jar path`(@TempDir dir: Path) {
+    // Regression test for IDEA-314175.
+    val jarAbsolutePath = dir.resolve("lib.jar")
+    Compressor.Zip(jarAbsolutePath.toFile()).use { compressor ->
+      compressor.addFile("resource.txt", "contents".toByteArray(Charsets.UTF_8))
+    }
+    val jarRelativePath = Paths.get("").toAbsolutePath().relativize(jarAbsolutePath)
+    val classPath = ClassPath(listOf(jarRelativePath), UrlClassLoader.build(), PathClassLoader.RESOURCE_FILE_FACTORY, true)
+    val resource = checkNotNull(classPath.findResource("resource.txt"))
+    assertThat(resource.url.toString()).isEqualTo("jar:file:${jarAbsolutePath.systemIndependentPath}!/resource.txt")
   }
 }


### PR DESCRIPTION
We convert paths to absolute paths because JarLoader and clients thereof are unprepared for relative paths.

This change is necessary for certain environments (such as Bazel tests) in which relative paths are used for the sake of hermeticity. Previously, using PathClassLoader in Bazel would result in invalid resource paths and other runtime errors.

This change should have no effect on existing environments where absolute paths are already used.

---

Issue link: https://youtrack.jetbrains.com/issue/IDEA-314175
Test: launch the IDE in both source builds and release builds
Test: use PathClassLoader in Bazel tests