### PR TITLE
Fix multiModuleProjectDirectory discovery in case of nested projects

### DIFF
--- a/plugins/maven-server-api/src/main/java/org/jetbrains/idea/maven/server/MavenServerUtil.java
+++ b/plugins/maven-server-api/src/main/java/org/jetbrains/idea/maven/server/MavenServerUtil.java
@@ -52,12 +52,12 @@ public final class MavenServerUtil {
   public static File findMavenBasedir(@NotNull File workingDir) {
     File baseDir = workingDir;
     File dir = workingDir;
-    while ((dir = dir.getParentFile()) != null) {
+    do {
       if (new File(dir, ".mvn").exists()) {
         baseDir = dir;
         break;
       }
-    }
+    } while ((dir = dir.getParentFile()) != null);
     try {
       return baseDir.getCanonicalFile();
     }


### PR DESCRIPTION
This change fixes the discovery logic for the maven.multiModuleProjectDirectory property used in the Maven execution configuration to be consistent with the behavior of the Maven command line and Maven wrapper.
This change also makes the discovery logic consistent with a similar mechanism implemented in MavenUtil#getVFileBaseDir.

A test project demonstrating the bug can be found here: https://github.com/mnk/intellij-maven-test
When invoking the verify lifecycle phase from IntelliJ on project2, the output is ".../intellij-maven-test - value1" instead of the expected ".../intellij-maven-test/project2 - value2". When invoking the verify lifecycle phase on module2, the output is ".../intellij-maven-test/project2 - value2" as expected.