### PR TITLE
Make KotlinRequestHint continue stepping after the Kotlin fake line number in case of smart stepping

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
@@ -180,10 +180,10 @@ class KotlinStepIntoRequestHint(
                 lastWasKotlinFakeLineNumber = true
                 return StepRequest.STEP_INTO
             }
-            // If the last line was a fake line number, the next non-fake line number
-            // is always of interest (otherwise, we wouldn't have had to insert the
-            // fake line number in the first place).
-            if (lastWasKotlinFakeLineNumber) {
+            // If the last line was a fake line number, and we are not smart-stepping,
+            // the next non-fake line number is always of interest (otherwise, we wouldn't
+            // have had to insert the fake line number in the first place).
+            if (lastWasKotlinFakeLineNumber && methodFilter == null) {
                 lastWasKotlinFakeLineNumber = false
                 return STOP
             }

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class K2IrKotlinSteppingTestGenerated extends AbstractK2IrKotlin
             runTest("../testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasOnSameLine.kt")
+        public void testSmartStepIntoInlineLambdasOnSameLine() throws Exception {
+            runTest("../testData/stepping/custom/smartStepIntoInlineLambdasOnSameLine.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("../testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasOnSameLine.kt")
+        public void testSmartStepIntoInlineLambdasOnSameLine() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoInlineLambdasOnSameLine.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasOnSameLine.kt")
+        public void testSmartStepIntoInlineLambdasOnSameLine() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoInlineLambdasOnSameLine.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasOnSameLine.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasOnSameLine.kt
@@ -1,0 +1,69 @@
+package smartStepIntoInlineLambdasOnSameLine
+
+fun foo1() = 1
+fun foo2() = 2
+fun foo3() = 3
+
+fun main() {
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x1 = 1
+
+    // SMART_STEP_INTO_BY_INDEX: 1
+    // STEP_INTO: 1
+    // RESUME: 1
+    x1.let { foo1() }.let { foo2() }.let { foo3() }
+
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x2 = 2
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_INTO: 1
+    // RESUME: 1
+    x2.let { foo1() }.let { foo2() }.let { foo3() }
+
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x3 = 3
+
+    // SMART_STEP_INTO_BY_INDEX: 3
+    // STEP_INTO: 1
+    // RESUME: 1
+    x3.let { foo1() }.let { foo2() }.let { foo3() }
+
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x4 = 4
+
+    // SMART_STEP_INTO_BY_INDEX: 1
+    // RESUME: 1
+    x4
+        .let { foo1() }
+        .let { foo2() }
+        .let { foo3() }
+
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x5 = 5
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // RESUME: 1
+    x5
+        .let { foo1() }
+        .let { foo2() }
+        .let { foo3() }
+
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x6 = 6
+
+    // SMART_STEP_INTO_BY_INDEX: 3
+    // RESUME: 1
+    x6
+        .let { foo1() }
+        .let { foo2() }
+        .let { foo3() }
+}
+
+// IGNORE_K2

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasOnSameLine.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasOnSameLine.out
@@ -1,0 +1,32 @@
+LineBreakpoint created at smartStepIntoInlineLambdasOnSameLine.kt:10
+LineBreakpoint created at smartStepIntoInlineLambdasOnSameLine.kt:19
+LineBreakpoint created at smartStepIntoInlineLambdasOnSameLine.kt:28
+LineBreakpoint created at smartStepIntoInlineLambdasOnSameLine.kt:37
+LineBreakpoint created at smartStepIntoInlineLambdasOnSameLine.kt:48
+LineBreakpoint created at smartStepIntoInlineLambdasOnSameLine.kt:59
+Run Java
+Connected to the target VM
+smartStepIntoInlineLambdasOnSameLine.kt:10
+smartStepIntoInlineLambdasOnSameLine.kt:15
+smartStepIntoInlineLambdasOnSameLine.kt:15
+smartStepIntoInlineLambdasOnSameLine.kt:3
+smartStepIntoInlineLambdasOnSameLine.kt:19
+smartStepIntoInlineLambdasOnSameLine.kt:24
+smartStepIntoInlineLambdasOnSameLine.kt:24
+smartStepIntoInlineLambdasOnSameLine.kt:4
+smartStepIntoInlineLambdasOnSameLine.kt:28
+smartStepIntoInlineLambdasOnSameLine.kt:33
+smartStepIntoInlineLambdasOnSameLine.kt:33
+smartStepIntoInlineLambdasOnSameLine.kt:5
+smartStepIntoInlineLambdasOnSameLine.kt:37
+smartStepIntoInlineLambdasOnSameLine.kt:41
+smartStepIntoInlineLambdasOnSameLine.kt:42
+smartStepIntoInlineLambdasOnSameLine.kt:48
+smartStepIntoInlineLambdasOnSameLine.kt:52
+smartStepIntoInlineLambdasOnSameLine.kt:54
+smartStepIntoInlineLambdasOnSameLine.kt:59
+smartStepIntoInlineLambdasOnSameLine.kt:63
+smartStepIntoInlineLambdasOnSameLine.kt:66
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoLambdaWithparametersDestructuring.ir.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoLambdaWithparametersDestructuring.ir.out
@@ -3,8 +3,8 @@ Run Java
 Connected to the target VM
 smartStepIntoLambdaWithparametersDestructuring.kt:6
 smartStepIntoLambdaWithparametersDestructuring.kt:10
-smartStepIntoLambdaWithparametersDestructuring.kt:10
 smartStepIntoLambdaWithparametersDestructuring.kt:11
+smartStepIntoLambdaWithparametersDestructuring.kt:10
 Disconnected from the target VM
 
 Process finished with exit code 0


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-24091/Debugger-smart-stepping-steps-into-a-wrong-inline-lambda-on-the-same-line

Consider the example: `1.let { it }.let { it + 1 }.let { it + 2 }`. Previously when trying to smart step into `{ it + 1 }` or `{ it + 2 }` the debugger would stop in `{ it }`, because during smart stepping the debugger would cross a fake line number that marks the end of an inline lambda, and KotlinRequestHint would stop the smart stepping process.

I must admit that merging this pr will uncover another smart stepping issue.
Consider the example:
```
inline fun foo() {
  1.let { it }.let { it + 1 }.let { it + 2 }
}

fun main() {
  foo()
  foo() // Breakpoint here
}
```
Run the debugger and stop on a breakpoint, then invoke the step into action and stop in `foo`, and then try to smart step into `{ it + 1 }` or `{ it + 2 }`. It will not work. 

When we try to smart step into a lambda, we set a StepIntoBreakpoint on a location inside of this lambda. After that we start the smart stepping process, and eventually the debugger will hit that breakpoint, and the desirable lambda will be reached. This works well for Java lambdas and ordinary Kotlin lambdas. Things get worse when we are trying to smart step into an inline lambda. In the above example each of the inlined sites of the foo function contains locations inside the lambda of interest. However, only one StepIntoBreakpoint is set, this can be seen here com/intellij/debugger/ui/breakpoints/StepIntoBreakpoint.java:74. It means that smart stepping will only work for the first inlined site of the foo function.

Before this pr we would always stop in `{ it }`, because of crossing the Kotlin fake line number. 

I believe that the described issue has to be fixed, but in a separate pr.
