### PR TITLE
Make KotlinLambdaMethodFilter rely on psi while checking location inside an inline lambda

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class K2IndyLambdaKotlinSteppingTestGenerated extends AbstractK2
             runTest("../testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasInFunctionsWithSameName.kt")
+        public void testSmartStepIntoInlineLambdasInFunctionsWithSameName() throws Exception {
+            runTest("../testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("../testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IrKotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class K2IrKotlinSteppingTestGenerated extends AbstractK2IrKotlin
             runTest("../testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasInFunctionsWithSameName.kt")
+        public void testSmartStepIntoInlineLambdasInFunctionsWithSameName() throws Exception {
+            runTest("../testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("../testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class IndyLambdaKotlinSteppingTestGenerated extends AbstractIndy
             runTest("testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasInFunctionsWithSameName.kt")
+        public void testSmartStepIntoInlineLambdasInFunctionsWithSameName() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasInFunctionsWithSameName.kt")
+        public void testSmartStepIntoInlineLambdasInFunctionsWithSameName() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -1355,6 +1355,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/custom/smartStepIntoInlineFun.kt");
         }
 
+        @TestMetadata("smartStepIntoInlineLambdasInFunctionsWithSameName.kt")
+        public void testSmartStepIntoInlineLambdasInFunctionsWithSameName() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.kt");
+        }
+
         @TestMetadata("smartStepIntoInlinedFunLiteral.kt")
         public void testSmartStepIntoInlinedFunLiteral() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoInlinedFunLiteral.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.kt
@@ -1,0 +1,41 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package smartStepIntoInlineLambdasInFunctionsWithSameName
+
+fun foo(x: Int) {
+    val l = listOf(1)
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_OVER: 1
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // RESUME: 1
+    //Breakpoint!
+    l.forEach {
+        println(it)
+        l.forEach {
+            println(it)
+        }
+    }
+}
+
+suspend fun foo(x: Int, y: Int) {
+    val l = listOf(1)
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_OVER: 1
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // RESUME: 1
+    //Breakpoint!
+    l.forEach {
+        println(it)
+        l.forEach {
+            println(it)
+        }
+    }
+}
+
+suspend fun main() {
+    foo(1)
+    foo(1, 2)
+}
+
+// IGNORE_K2

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoInlineLambdasInFunctionsWithSameName.out
@@ -1,0 +1,15 @@
+LineBreakpoint created at smartStepIntoInlineLambdasInFunctionsWithSameName.kt:12
+LineBreakpoint created at smartStepIntoInlineLambdasInFunctionsWithSameName.kt:28
+Run Java
+Connected to the target VM
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:12
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:13
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:14
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:15
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:28
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:29
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:30
+smartStepIntoInlineLambdasInFunctionsWithSameName.kt:31
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-23965/Debugger-smart-stepping-into-inline-lambdas-doesnt-work-when-lambdas-are-declared-in-functions-with-the-same-name

This commit improves the design of KotlinLambdaMethodFilter, so instead of using ClassNameCalculator directly to detect if we should stop in a lambda, the filter now relies on KotlinPositionManager and the provided source positions.

Unfortunately this pr will not solve issues like this:
```
fun foo (x: Int) {
  x.let { it }.let { it + 1 }
}

fun foo (x: Int, y: Int) {
  x.let { it }.let { it + 1 } // Smart stepping here will not work
}

fun main() {
  foo(1)
  foo(1, 2)
}
```
The reason is that ClassNameCalculator doesn't calculate lambda names correctly in this case. You can read more about ClassNameCalculator issues [here](https://github.com/JetBrains/intellij-community/pull/2279). 