### PR TITLE
Patch path so it reflects changes in patched arguments

### DIFF
--- a/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
+++ b/python/helpers/pydev/_pydev_bundle/pydev_monkey.py
@@ -439,6 +439,8 @@ def create_warn_multiproc(original_name):
 
     return new_warn_multiproc
 
+def patch_path(path, args):
+    return args[0] if is_python(path) and args[0] == sys.executable else path
 
 def create_execl(original_name):
     def new_execl(path, *args):
@@ -451,6 +453,7 @@ def create_execl(original_name):
         import os
         args = patch_args(args)
         if is_python_args(args):
+            path = patch_path(path, args)
             send_process_will_be_substituted()
         return getattr(os, original_name)(path, *args)
     return new_execl
@@ -465,6 +468,7 @@ def create_execv(original_name):
         import os
         args = patch_args(args)
         if is_python_args(args):
+            path = patch_path(path, args)
             send_process_will_be_substituted()
         return getattr(os, original_name)(path, args)
     return new_execv
@@ -479,6 +483,7 @@ def create_execve(original_name):
         import os
         args = patch_args(args)
         if is_python_args(args):
+            path = patch_path(path, args)
             send_process_will_be_substituted()
         return getattr(os, original_name)(path, args, env)
     return new_execve


### PR DESCRIPTION
Given arguments in the form of: `os.execv("../file.py", ["../file.py", arg1, ...]) `
They will be patched to: `os.execv("../file.py", ["python", "../../pydevd.py", "--host", "--port", "--file", "../file.py", arg1, ...])`
This will end up with os.execv thinking the actual executable is  "../file.py" thus running it instead of pydevd resulting in the error `file.py: error: unrecognized arguments: host, port`

I think this bug was introduced by commit 7ec061b4182a183ef3193a24ecb9c6b0490799ad so I was careful to make sure my changes wouldn't reintroduce the bug from PY-37311.