### PR TITLE
Prevent flickering of editor notifications

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/EditorNotificationPanel.java
+++ b/platform/platform-api/src/com/intellij/ui/EditorNotificationPanel.java
@@ -386,7 +386,7 @@ public class EditorNotificationPanel extends JPanel implements IntentionActionPr
 
   @Override
   public double getWeight() {
-    return 0;
+    return (this.getClass().hashCode() % Integer.MAX_VALUE) / (double) Integer.MAX_VALUE;
   }
 
   protected @Nullable @IntentionName String getIntentionActionText() {


### PR DESCRIPTION
If more than one editor notification panel is active for an editor, any global update to the notifications might result in them being added in an arbitrary order.

Rather than have them all have a weight of 0 by default, override getWeight() so that each notification by default has a class-based weight somewhere between 0 (inclusive) and 1 (exclusive).  This allows subclasses to deterministically place themselves before or after all those using the default implementation, while providing a stable order in practice for all existing notification panels.