### PR TITLE
IDEA-315065: Exclude JUnit3 from IDE classpath

### DIFF
--- a/build/tasks/src/org/jetbrains/intellij/build/tasks/reorderJars.kt
+++ b/build/tasks/src/org/jetbrains/intellij/build/tasks/reorderJars.kt
@@ -18,7 +18,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 @Suppress("ReplaceJavaStaticMethodWithKotlinAnalog")
-private val excludedLibJars = java.util.Set.of("testFramework.jar")
+private val excludedLibJars = java.util.Set.of("testFramework.jar", "junit.jar")
 
 private fun getClassLoadingLog(): InputStream {
   val osName = System.getProperty("os.name")


### PR DESCRIPTION
It clashes with junit4.jar, but cannot be removed from IntelliJ entirely because an old IntelliJ quickfix once suggested to add it to the user's classpath.

---

Issue link: https://youtrack.jetbrains.com/issue/IDEA-315065