### PR TITLE
Fix KTS unresolved symbols by using the same jdk.table entry as project JDK

### DIFF
--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/extensions/SdkExtensions.kt
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/extensions/SdkExtensions.kt
@@ -1,0 +1,47 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.extensions
+
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.VfsTestUtil
+import java.io.File
+import java.io.FileNotFoundException
+
+val Sdk.rootsFiles
+  get() = OrderRootType.getAllTypes().flatMap { rootType ->
+    rootProvider.getFiles(rootType).map { it to rootType }
+  }
+
+val Sdk.rootsUrls
+  get() = OrderRootType.getAllTypes().flatMap { rootType ->
+    rootProvider.getUrls(rootType).map { it to rootType }
+  }
+
+fun Sdk.cloneWithCorruptedRoots(tempDir: File): Sdk {
+  val sdkClone = clone() as Sdk
+  val corruptedRoots = generateCorruptedJdkRoots(sdkClone, tempDir)
+  sdkClone.sdkModificator.run {
+    removeAllRoots()
+    corruptedRoots.forEach { (type, file) ->
+      addRoot(type, file)
+    }
+    commitChanges()
+  }
+  return sdkClone
+}
+
+private fun generateCorruptedJdkRoots(
+  jdk: Sdk,
+  tempDir: File,
+): List<Pair<VirtualFile, OrderRootType>> {
+  val vfsTempDir = VfsUtil.findFile(tempDir.toPath(), true) ?: throw FileNotFoundException("Unable to find ${tempDir.path}")
+  val rootsTempDir = VfsTestUtil.createDir(vfsTempDir, "corrupted-roots")
+  return jdk.rootsFiles.map { (file, type) ->
+    val rootFile = VfsTestUtil.createFile(rootsTempDir, file.name)
+    Pair(rootFile, type).also {
+      rootFile.delete(Sdk::class)
+    }
+  }
+}

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleImportingTestCase.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleImportingTestCase.java
@@ -75,10 +75,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -115,7 +112,7 @@ public abstract class GradleImportingTestCase extends JavaExternalSystemImportin
 
     super.setUp();
 
-    WriteAction.runAndWait(this::configureJDKTable);
+    WriteAction.runAndWait(this::configureJdkTable);
     System.setProperty(ExternalSystemExecutionSettings.REMOTE_PROCESS_IDLE_TTL_IN_MS_KEY, String.valueOf(GRADLE_DAEMON_TTL_MS));
 
     ExtensionTestUtil.maskExtensions(UnknownSdkResolver.EP_NAME, List.of(TestUnknownSdkResolver.INSTANCE), getTestRootDisposable());
@@ -125,19 +122,34 @@ public abstract class GradleImportingTestCase extends JavaExternalSystemImportin
     cleanScriptsCacheIfNeeded();
   }
 
-  protected void configureJDKTable() throws Exception {
+  protected void configureJdkTable() {
+    cleanJdkTable();
+    ArrayList<Sdk> jdks = new ArrayList<>(Arrays.asList(createJdkFromJavaHome()));
+    populateJdkTable(jdks);
+  }
+
+  protected void cleanJdkTable() {
     removedSdks.clear();
     for (Sdk sdk : ProjectJdkTable.getInstance().getAllJdks()) {
       ProjectJdkTable.getInstance().removeJdk(sdk);
       if (GRADLE_JDK_NAME.equals(sdk.getName())) continue;
       removedSdks.add(sdk);
     }
+  }
+
+  protected void populateJdkTable(@NotNull List<Sdk> jdks) {
+    for (Sdk jdk : jdks) {
+      ProjectJdkTable.getInstance().addJdk(jdk);
+    }
+  }
+
+  private Sdk createJdkFromJavaHome() {
     VirtualFile jdkHomeDir = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(new File(myJdkHome));
     JavaSdk javaSdk = JavaSdk.getInstance();
     SdkType javaSdkType = javaSdk == null ? SimpleJavaSdkType.getInstance() : javaSdk;
     Sdk jdk = SdkConfigurationUtil.setupSdk(new Sdk[0], jdkHomeDir, javaSdkType, true, null, GRADLE_JDK_NAME);
     assertNotNull("Cannot create JDK for " + myJdkHome, jdk);
-    ProjectJdkTable.getInstance().addJdk(jdk);
+    return jdk;
   }
 
   @Override


### PR DESCRIPTION
### Description
<img width="1554" alt="affects IntelliJ" src="https://user-images.githubusercontent.com/18151158/224314068-d9102ce8-66b9-43a9-adaf-8f69fa8901dd.png">

The reason for those unresolved symbols in the KTS, is in fact an issue with picking the JDK table entry from the jdk.table.xml in the [ScriptSdksBuilder.getScriptSdkByJavaHome](https://github.com/JetBrains/intellij-kotlin/blob/e2c105911e1fca5b7fe6b9dc10cf9f75463a3c13/core/src/org/jetbrains/kotlin/idea/core/script/ucache/ScriptSdksBuilder.kt#L71) that will end up been used to resolve the symbols for the KTS files. In particular, given a JDK path, the first entry is returned that contains the same `homePath`.

<img width="1322" alt="platform return first jdk table entry given  a path" src="https://user-images.githubusercontent.com/18151158/224314069-ac0125f7-daee-4eb1-8781-3852e3061802.png">

Unfortunately, this logic doesn't take into consideration that may exist different entries for the same `homePath` with corrupted roots and at the same time this entry may not be the same as the one used by the `Project JDK` (entry name specified under `.idea/misc.xml`). Meaning that depending on the user `jdk.table.xml` ordering they may end up facing this issue, making it difficult to predict how many of them will be affected.

### Example:
Given a `Project JDK` using `project-jdk-name="jbr-17"`

- [OK scenario](https://user-images.githubusercontent.com/18151158/224314059-5f36d38f-169a-4137-84d4-937beede8822.png) ✅ 
```xml
<jdk version="2"> 
    <name value="jbr-17" />
    <homePath value="$USER_HOME$/jdk17/mac-arm64/Contents/Home" />
     <roots>
        <classPath>
            <root url="jrt:///USER_HOME$/jdk17/mac-arm64/Contents/Home!/java.base" type="simple" /> #valid paths
...
<jdk version="2"> 
    <name value="jbr-17-corrupted" />
    <homePath value="$USER_HOME$/jdk17/mac-arm64/Contents/Home" />
     <roots>
        <classPath>
            <root url="jrt:///INVALID/jdk17/mac-arm64/Contents/Home!/java.base" type="simple" /> #invalid paths
... 
```

- [KO scenario](https://user-images.githubusercontent.com/18151158/224314050-99c9f6fd-c5a1-4571-8aca-6b70739ebb3a.png) ❌ 
```xml
<jdk version="2"> 
    <name value="jbr-17-corrupted" />
    <homePath value="$USER_HOME$/jdk17/mac-arm64/Contents/Home" />
     <roots>
        <classPath>
            <root url="jrt:///INVALID/jdk17/mac-arm64/Contents/Home!/java.base" type="simple" /> #invalid paths
...
<jdk version="2"> 
    <name value="jbr-17" />
    <homePath value="$USER_HOME$/jdk17/mac-arm64/Contents/Home" />
     <roots>
        <classPath>
            <root url="jrt:///USER_HOME$/jdk17/mac-arm64/Contents/Home!/java.base" type="simple" /> #valid paths
...
```

### Solution
In order to keeping consistency cross project when possible we suggesting to reuse same `jdk.table` entry specified for the `Project JDK`, this will keep things aligned regarding which JDK will be used to resolve symbols.
