### PR TITLE
Fix debugger freeze while searching for inline function call sites

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/resources/messages/KotlinDebuggerCoreBundle.properties
+++ b/plugins/kotlin/jvm-debugger/core/resources/messages/KotlinDebuggerCoreBundle.properties
@@ -1,4 +1,4 @@
-find.inline.calls.task.compute.names=Compute class names for declaration {0}
+find.inline.calls.task.compute.names=Compute Class Names For Declaration {0}
 find.inline.calls.task.cancelled=Debugger can skip some executions of {0} because the computation of class names was interrupted
 
 alternative.sources.notification.title=Alternative source available for file {0}

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/ClassNameProvider.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/ClassNameProvider.kt
@@ -3,8 +3,8 @@
 package org.jetbrains.kotlin.idea.debugger.core
 
 import com.intellij.debugger.SourcePosition
-import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.util.ProgressIndicatorBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageType
 import com.intellij.psi.PsiClass
@@ -168,7 +168,7 @@ class ClassNameProvider(
             ProgressManager.getInstance().runProcessWithProgressSynchronously(task, progressMessage, true, project)
         } else {
             try {
-                ProgressManager.getInstance().runProcess(task, EmptyProgressIndicator())
+                ProgressManager.getInstance().runProcess(task, ProgressIndicatorBase())
                 true
             } catch (e: InterruptedException) {
                 false


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-24736/Debugger-IDE-freeze-due-to-long-read-action-in-ClassNameProvider.findInlinedCalls

Previously when trying to place a breakpoint in an inline function, the debugger would have to find all of its call sites to perform this action. If you, for example, put a breakpoint in one of standard library functions, the searching would take a huge amount of time. Things became worse, when you wanted to unset a breakpoint and the searching process was still not finished. Unsetting a breakpoint required a write action, which waited for the previously launched read action to find all the inline function call sites. As a result freeze could happen and the debugger UI would be unresponsive until all of the call sites were found. This pr replaces EmptyProgressIndicator with ProgressIndicatorBase, which allows the action to be cancelled when needed.


