### PR TITLE
Fix stepping out of inline lambdas

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
@@ -56,8 +56,9 @@ class KotlinStepOverRequestHint(
     stepThread: ThreadReferenceProxyImpl,
     suspendContext: SuspendContextImpl,
     private val filter: KotlinMethodFilter,
-    parentHint: RequestHint?
-) : RequestHint(stepThread, suspendContext, StepRequest.STEP_LINE, StepRequest.STEP_OVER, filter, parentHint) {
+    parentHint: RequestHint?,
+    stepSize: Int
+) : RequestHint(stepThread, suspendContext, stepSize, StepRequest.STEP_OVER, filter, parentHint) {
     private companion object {
         private val LOG = Logger.getInstance(KotlinStepOverRequestHint::class.java)
     }

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinStepAction.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinStepAction.kt
@@ -28,9 +28,9 @@ sealed class KotlinStepAction {
         }
     }
 
-    class KotlinStepOver(private val filter: KotlinMethodFilter) : KotlinStepAction() {
+    class KotlinStepOver(private val filter: KotlinMethodFilter, private val stepSize: Int = StepRequest.STEP_LINE) : KotlinStepAction() {
         override fun createCommand(debugProcess: DebugProcessImpl, suspendContext: SuspendContextImpl, ignoreBreakpoints: Boolean): DebugProcessImpl.StepCommand {
-            return KotlinStepActionFactory.createKotlinStepOverCommand(debugProcess, suspendContext, ignoreBreakpoints, filter)
+            return KotlinStepActionFactory.createKotlinStepOverCommand(debugProcess, suspendContext, ignoreBreakpoints, filter, stepSize)
         }
     }
 

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinStepActionFactory.java
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinStepActionFactory.java
@@ -21,9 +21,10 @@ public final class KotlinStepActionFactory {
             DebugProcessImpl debugProcess,
             SuspendContextImpl suspendContext,
             boolean ignoreBreakpoints,
-            @NotNull KotlinMethodFilter methodFilter
+            @NotNull KotlinMethodFilter methodFilter,
+            int stepSize
     ) {
-        return debugProcess.new StepOverCommand(suspendContext, ignoreBreakpoints, methodFilter, StepRequest.STEP_LINE) {
+        return debugProcess.new StepOverCommand(suspendContext, ignoreBreakpoints, methodFilter, stepSize) {
             @Override
             protected @NotNull String getStatusText() {
                 return KotlinDebuggerCoreBundle.message("stepping.over.inline");
@@ -31,7 +32,7 @@ public final class KotlinStepActionFactory {
 
             @Override
             public @NotNull RequestHint getHint(SuspendContextImpl suspendContext, ThreadReferenceProxyImpl stepThread, @Nullable RequestHint parentHint) {
-                KotlinStepOverRequestHint hint = new KotlinStepOverRequestHint(stepThread, suspendContext, methodFilter, parentHint);
+                KotlinStepOverRequestHint hint = new KotlinStepOverRequestHint(stepThread, suspendContext, methodFilter, parentHint, stepSize);
                 hint.setResetIgnoreFilters(!debugProcess.getSession().shouldIgnoreSteppingFilters());
                 hint.setRestoreBreakpoints(ignoreBreakpoints);
                 try {

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/filter/KotlinStepOverFilter.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/filter/KotlinStepOverFilter.kt
@@ -6,6 +6,7 @@ import com.intellij.debugger.engine.DebugProcess.JAVA_STRATUM
 import com.intellij.debugger.engine.DebugProcessImpl
 import com.intellij.debugger.engine.SuspendContextImpl
 import com.intellij.util.Range
+import com.sun.jdi.LocalVariable
 import com.sun.jdi.Location
 import com.sun.jdi.StackFrame
 import org.jetbrains.kotlin.codegen.inline.isFakeLocalVariableForInline
@@ -27,17 +28,17 @@ data class StepOverCallerInfo(val declaringType: String, val methodName: String?
     }
 }
 
-data class LocationToken(val lineNumber: Int, val inlineVariables: List<String>) {
+data class LocationToken(val lineNumber: Int, val inlineVariables: List<LocalVariable>) {
     companion object {
         fun from(stackFrame: StackFrame): LocationToken {
             val location = stackFrame.location()
             val lineNumber = location.safeLineNumber(JAVA_STRATUM)
-            val methodVariables = ArrayList<String>(0)
+            val methodVariables = ArrayList<LocalVariable>(0)
 
             for (variable in location.safeMethod()?.safeVariables() ?: emptyList()) {
                 val name = variable.name()
                 if (variable.isVisible(stackFrame) && isFakeLocalVariableForInline(name)) {
-                    methodVariables += name
+                    methodVariables += variable
                 }
             }
 

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinSteppingTestGenerated.java
@@ -1520,6 +1520,16 @@ public abstract class K2IdeK1CodeKotlinSteppingTestGenerated extends AbstractK2I
             runTest("../testData/stepping/custom/stepOutInlineFunctionStdlib.kt");
         }
 
+        @TestMetadata("stepOutOfInlineLambdas.kt")
+        public void testStepOutOfInlineLambdas() throws Exception {
+            runTest("../testData/stepping/custom/stepOutOfInlineLambdas.kt");
+        }
+
+        @TestMetadata("stepOutOfNestedInlineLambdas.kt")
+        public void testStepOutOfNestedInlineLambdas() throws Exception {
+            runTest("../testData/stepping/custom/stepOutOfNestedInlineLambdas.kt");
+        }
+
         @TestMetadata("stepOverInvokeMethodInLambda.kt")
         public void testStepOverInvokeMethodInLambda() throws Exception {
             runTest("../testData/stepping/custom/stepOverInvokeMethodInLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
@@ -1520,6 +1520,16 @@ public abstract class K2IndyLambdaKotlinSteppingTestGenerated extends AbstractK2
             runTest("../testData/stepping/custom/stepOutInlineFunctionStdlib.kt");
         }
 
+        @TestMetadata("stepOutOfInlineLambdas.kt")
+        public void testStepOutOfInlineLambdas() throws Exception {
+            runTest("../testData/stepping/custom/stepOutOfInlineLambdas.kt");
+        }
+
+        @TestMetadata("stepOutOfNestedInlineLambdas.kt")
+        public void testStepOutOfNestedInlineLambdas() throws Exception {
+            runTest("../testData/stepping/custom/stepOutOfNestedInlineLambdas.kt");
+        }
+
         @TestMetadata("stepOverInvokeMethodInLambda.kt")
         public void testStepOverInvokeMethodInLambda() throws Exception {
             runTest("../testData/stepping/custom/stepOverInvokeMethodInLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
@@ -1520,6 +1520,16 @@ public abstract class IndyLambdaKotlinSteppingTestGenerated extends AbstractIndy
             runTest("testData/stepping/custom/stepOutInlineFunctionStdlib.kt");
         }
 
+        @TestMetadata("stepOutOfInlineLambdas.kt")
+        public void testStepOutOfInlineLambdas() throws Exception {
+            runTest("testData/stepping/custom/stepOutOfInlineLambdas.kt");
+        }
+
+        @TestMetadata("stepOutOfNestedInlineLambdas.kt")
+        public void testStepOutOfNestedInlineLambdas() throws Exception {
+            runTest("testData/stepping/custom/stepOutOfNestedInlineLambdas.kt");
+        }
+
         @TestMetadata("stepOverInvokeMethodInLambda.kt")
         public void testStepOverInvokeMethodInLambda() throws Exception {
             runTest("testData/stepping/custom/stepOverInvokeMethodInLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -1520,6 +1520,16 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/custom/stepOutInlineFunctionStdlib.kt");
         }
 
+        @TestMetadata("stepOutOfInlineLambdas.kt")
+        public void testStepOutOfInlineLambdas() throws Exception {
+            runTest("testData/stepping/custom/stepOutOfInlineLambdas.kt");
+        }
+
+        @TestMetadata("stepOutOfNestedInlineLambdas.kt")
+        public void testStepOutOfNestedInlineLambdas() throws Exception {
+            runTest("testData/stepping/custom/stepOutOfNestedInlineLambdas.kt");
+        }
+
         @TestMetadata("stepOverInvokeMethodInLambda.kt")
         public void testStepOverInvokeMethodInLambda() throws Exception {
             runTest("testData/stepping/custom/stepOverInvokeMethodInLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -1521,6 +1521,16 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/custom/stepOutInlineFunctionStdlib.kt");
         }
 
+        @TestMetadata("stepOutOfInlineLambdas.kt")
+        public void testStepOutOfInlineLambdas() throws Exception {
+            runTest("testData/stepping/custom/stepOutOfInlineLambdas.kt");
+        }
+
+        @TestMetadata("stepOutOfNestedInlineLambdas.kt")
+        public void testStepOutOfNestedInlineLambdas() throws Exception {
+            runTest("testData/stepping/custom/stepOutOfNestedInlineLambdas.kt");
+        }
+
         @TestMetadata("stepOverInvokeMethodInLambda.kt")
         public void testStepOverInvokeMethodInLambda() throws Exception {
             runTest("testData/stepping/custom/stepOverInvokeMethodInLambda.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfInlineLambdas.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfInlineLambdas.kt
@@ -1,0 +1,38 @@
+package stepOutOfInlineLambdas
+
+fun foo1() = 1
+fun foo2() = 2
+fun foo3() = 3
+
+fun main() {
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x1 = 1
+
+    // SMART_STEP_INTO_BY_INDEX: 1
+    // STEP_INTO: 1
+    // STEP_OUT: 2
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_INTO: 1
+    // STEP_OUT: 2
+    // SMART_STEP_INTO_BY_INDEX: 3
+    // STEP_INTO: 1
+    // RESUME: 1
+    x1.let { foo1(); println() }.let { foo2(); println() }.let { foo3() }
+
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x2 = 2
+
+    // SMART_STEP_INTO_BY_INDEX: 1
+    // STEP_OUT: 1
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_OUT: 1
+    x2.let {
+        it + 1
+    }.let {
+        it + 2
+    }
+}
+
+// IGNORE_K2

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfInlineLambdas.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfInlineLambdas.out
@@ -1,0 +1,25 @@
+LineBreakpoint created at stepOutOfInlineLambdas.kt:10
+LineBreakpoint created at stepOutOfInlineLambdas.kt:25
+Run Java
+Connected to the target VM
+stepOutOfInlineLambdas.kt:10
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:3
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:4
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:21
+stepOutOfInlineLambdas.kt:5
+stepOutOfInlineLambdas.kt:25
+stepOutOfInlineLambdas.kt:31
+stepOutOfInlineLambdas.kt:32
+stepOutOfInlineLambdas.kt:31
+stepOutOfInlineLambdas.kt:34
+stepOutOfInlineLambdas.kt:33
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfNestedInlineLambdas.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfNestedInlineLambdas.kt
@@ -1,0 +1,30 @@
+package stepOutOfNestedInlineLambdas
+
+inline fun foo(f: () -> Int): Int {
+    var x = 1
+    x += x.bar { x +  1 }
+    return f()
+}
+
+inline fun Int.bar(f: () -> Int): Int {
+    var result = f()
+    result *= 2
+    return result
+}
+
+fun main() {
+    var x = 1
+    x.let {
+        foo {
+            foo { 1 }.bar {
+                // STEP_OUT: 5
+                //Breakpoint!
+                x += 1
+                x * 2
+            }
+            foo { 1 }.bar {
+                2
+            }
+        }
+    }
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfNestedInlineLambdas.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/stepOutOfNestedInlineLambdas.out
@@ -1,0 +1,11 @@
+LineBreakpoint created at stepOutOfNestedInlineLambdas.kt:22
+Run Java
+Connected to the target VM
+stepOutOfNestedInlineLambdas.kt:22
+stepOutOfNestedInlineLambdas.kt:10
+stepOutOfNestedInlineLambdas.kt:25
+stepOutOfNestedInlineLambdas.kt:6
+stepOutOfNestedInlineLambdas.kt:17
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-24239/Debugger-stepping-out-of-inline-lambdas-on-one-line-doesnt-work

Previously when trying to step out of an inline lambda, the debugger would always perform a line-wise stepping out. This behaviour resulted in errors when trying to step out of one-line inline lambdas - you would always jump to the next line. This commit sets the minimal stepping size when trying to step out of an inline lambda.

I have to admit, that after merging https://github.com/JetBrains/intellij-community/pull/2342, this pull request will also improve the smart stepping experience. Right now, when trying to smart step into inline lambdas like: `1.let { it }.let { it + 1 }.let { it + 2 }`, the debugger will always stop in `{ it }` because of crossing the Kotlin fake line number. After merging the mentioned pr, we will still not be able to smart step into `{ it + 1 }` or `{ it + 2 }` because of https://youtrack.jetbrains.com/issue/KTIJ-24239/Debugger-stepping-out-of-inline-lambdas-on-one-line-doesnt-work. The debugger will always jump to the next line. Current pull request will allow performing smart stepping correctly.
