### PR TITLE
KTIJ-24933 K2 IDE: [NON_FINAL_MEMBER_IN_OBJECT] miss the quick fix for removing the open keyword

### DIFF
--- a/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/quickfix/KotlinK2QuickFixRegistrar.kt
+++ b/plugins/kotlin/fir/src/org/jetbrains/kotlin/idea/quickfix/KotlinK2QuickFixRegistrar.kt
@@ -34,6 +34,10 @@ class KotlinK2QuickFixRegistrar : KotlinQuickFixRegistrar() {
             RemoveModifierFixBase.removeOpenModifier
         )
         registerPsiQuickFixes(
+            KtFirDiagnostic.NonFinalMemberInObject::class,
+            RemoveModifierFixBase.removeOpenModifier
+        )
+        registerPsiQuickFixes(
             KtFirDiagnostic.PrivateSetterForOpenProperty::class,
             AddModifierFix.addFinalToProperty,
             RemoveModifierFixBase.removePrivateModifier

--- a/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
+++ b/plugins/kotlin/fir/test/org/jetbrains/kotlin/idea/fir/quickfix/HighLevelQuickFixTestGenerated.java
@@ -1039,6 +1039,11 @@ public abstract class HighLevelQuickFixTestGenerated extends AbstractHighLevelQu
             runTest("../idea/tests/testData/quickfix/modifiers/openMemberInFinalClass4.kt");
         }
 
+        @TestMetadata("openMemberInObject.kt")
+        public void testOpenMemberInObject() throws Exception {
+            runTest("../idea/tests/testData/quickfix/modifiers/openMemberInObject.kt");
+        }
+
         @TestMetadata("openModifierInEnum.kt")
         public void testOpenModifierInEnum() throws Exception {
             runTest("../idea/tests/testData/quickfix/modifiers/openModifierInEnum.kt");

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/K1QuickFixTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/quickfix/K1QuickFixTestGenerated.java
@@ -10357,6 +10357,11 @@ public abstract class K1QuickFixTestGenerated extends AbstractK1QuickFixTest {
                 runTest("testData/quickfix/modifiers/openMemberInFinalClass4.kt");
             }
 
+            @TestMetadata("openMemberInObject.kt")
+            public void testOpenMemberInObject() throws Exception {
+                runTest("testData/quickfix/modifiers/openMemberInObject.kt");
+            }
+
             @TestMetadata("openModifierInEnum.kt")
             public void testOpenModifierInEnum() throws Exception {
                 runTest("testData/quickfix/modifiers/openModifierInEnum.kt");

--- a/plugins/kotlin/idea/tests/testData/quickfix/modifiers/openMemberInObject.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/modifiers/openMemberInObject.kt
@@ -1,0 +1,4 @@
+// "Make 'bar' not open" "true"
+object Foo {
+    <caret>open fun bar() {}
+}

--- a/plugins/kotlin/idea/tests/testData/quickfix/modifiers/openMemberInObject.kt.after
+++ b/plugins/kotlin/idea/tests/testData/quickfix/modifiers/openMemberInObject.kt.after
@@ -1,0 +1,4 @@
+// "Make 'bar' not open" "true"
+object Foo {
+    fun bar() {}
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24933