### PR TITLE
Register WebP support as an ImageIO plugin

### DIFF
--- a/plugins/webp/resources/META-INF/plugin.xml
+++ b/plugins/webp/resources/META-INF/plugin.xml
@@ -8,6 +8,5 @@
     ]]></description>
   <extensions defaultExtensionNs="com.intellij">
     <fileType name="Image" extensions="webp"/>
-    <applicationService serviceImplementation="com.android.tools.adtui.webp.WebpMetadata$WebpMetadataRegistrar" preload="true"/>
   </extensions>
 </idea-plugin>

--- a/plugins/webp/resources/META-INF/services/javax.imageio.spi.ImageReaderSpi
+++ b/plugins/webp/resources/META-INF/services/javax.imageio.spi.ImageReaderSpi
@@ -1,0 +1,2 @@
+# Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+com.android.tools.adtui.webp.WebpImageReaderSpi

--- a/plugins/webp/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
+++ b/plugins/webp/resources/META-INF/services/javax.imageio.spi.ImageWriterSpi
@@ -1,0 +1,2 @@
+# Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+com.android.tools.adtui.webp.WebpImageWriterSpi

--- a/plugins/webp/src/com/android/tools/adtui/webp/WebpImageReaderSpi.java
+++ b/plugins/webp/src/com/android/tools/adtui/webp/WebpImageReaderSpi.java
@@ -47,7 +47,7 @@ public class WebpImageReaderSpi extends ImageReaderSpi {
 
   private static final int MAX_FILE_SIZE = 0x06400000;  // 100 MiBs
 
-  WebpImageReaderSpi() {
+  public WebpImageReaderSpi() {
     vendorName = WebpMetadata.WEBP_VENDOR;
     version = WebpNativeLibHelper.getDecoderVersion();
     suffixes = WebpMetadata.WEBP_SUFFIXES;

--- a/plugins/webp/src/com/android/tools/adtui/webp/WebpImageWriterSpi.java
+++ b/plugins/webp/src/com/android/tools/adtui/webp/WebpImageWriterSpi.java
@@ -35,7 +35,7 @@ import java.util.Locale;
  * Encoder for WebP. This needs the webp jni library loaded to function.
  */
 public class WebpImageWriterSpi extends ImageWriterSpi {
-  WebpImageWriterSpi() {
+  public WebpImageWriterSpi() {
     vendorName = WebpMetadata.WEBP_VENDOR;
     version = WebpNativeLibHelper.getEncoderVersion();
     suffixes = WebpMetadata.WEBP_SUFFIXES;

--- a/plugins/webp/src/com/android/tools/adtui/webp/WebpMetadata.java
+++ b/plugins/webp/src/com/android/tools/adtui/webp/WebpMetadata.java
@@ -20,9 +20,6 @@ import org.w3c.dom.Node;
 import javax.imageio.metadata.IIOInvalidTreeException;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.spi.IIORegistry;
-import javax.imageio.spi.ImageReaderSpi;
-import javax.imageio.spi.ImageWriterSpi;
 
 public final class WebpMetadata extends IIOMetadata {
   public static final String WEBP_FORMAT_LOWER_CASE = "webp";
@@ -34,21 +31,6 @@ public final class WebpMetadata extends IIOMetadata {
   public static final String WEBP_VENDOR = "Google LLC";
   public static final float DEFAULT_ENCODING_QUALITY = 0.75f;
   public static final boolean DEFAULT_LOSSLESS = true;
-
-  static final class WebpMetadataRegistrar {
-    private WebpMetadataRegistrar() {
-      ensureWebpRegistered();
-    }
-  }
-
-  /**
-   * Ensures that service providers are registered.
-   */
-  public static void ensureWebpRegistered() {
-    IIORegistry defaultInstance = IIORegistry.getDefaultInstance();
-    defaultInstance.registerServiceProvider(new WebpImageReaderSpi(), ImageReaderSpi.class);
-    defaultInstance.registerServiceProvider(new WebpImageWriterSpi(), ImageWriterSpi.class);
-  }
 
   @Override
   public boolean isReadOnly() {


### PR DESCRIPTION
Currently, WebP support is manually registered on startup using the application service mechanism. For this it tries to get the IIORegistry default instance. If it had not yet been created, but is in the process of being created in another thread, that will lead to a race condition where only one of the instances will be retained and the WebP support might be lost.
Instead of manually registering the WebP support, this makes use of the plugin facility of ImageIO, where plugins that are present in the classpath will be automatically registered.
Defining an ImageIO plugin requires having files in META-INF/services which specify which services are implemented and where to find their implementations.