### PR TITLE
Handle initial whitespace in Toml files

### DIFF
--- a/plugins/toml/core/src/main/kotlin/org/toml/lang/parse/TomlParserUtil.kt
+++ b/plugins/toml/core/src/main/kotlin/org/toml/lang/parse/TomlParserUtil.kt
@@ -50,7 +50,11 @@ object TomlParserUtil : GeneratedParserUtilBase() {
 
 private fun isNextAfterNewLine(b: PsiBuilder): Boolean {
     val prevToken = b.rawLookup(-1)
-    return prevToken == null || prevToken == TokenType.WHITE_SPACE && b.rawLookupText(-1).contains("\n")
+    return when (prevToken) {
+        null -> true
+        TokenType.WHITE_SPACE -> b.rawLookupText(-1).contains("\n") || b.rawLookup(-2) == null
+        else -> false
+    }
 }
 
 


### PR DESCRIPTION
If there is initial whitespace in a Toml file, it is logically next after a newline (in terms of parser states) despite that whitespace not actually containing a newline character.