### PR TITLE
PY-49293 - improve install package suggestion

### DIFF
--- a/python/src/com/jetbrains/python/inspections/unresolvedReference/PyUnresolvedReferencesInspection.java
+++ b/python/src/com/jetbrains/python/inspections/unresolvedReference/PyUnresolvedReferencesInspection.java
@@ -7,10 +7,12 @@ import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.codeInspection.options.OptPane;
 import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.Predicates;
 import com.intellij.profile.codeInspection.InspectionProjectProfileManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -101,7 +103,11 @@ public class PyUnresolvedReferencesInspection extends PyUnresolvedReferencesInsp
             return StreamEx
               .of(packageName)
               .append(PyPsiPackageUtil.PACKAGES_TOPLEVEL.getOrDefault(packageName, Collections.emptyList()))
-              .filter(PyPIPackageUtil.INSTANCE::isInPyPI)
+              .filter(
+                ApplicationManager.getApplication().isUnitTestMode()
+                      ? Predicates.alwaysTrue()
+                      : PyPIPackageUtil.INSTANCE::isInPyPI
+              )
               .map(pkg -> getInstallPackageAction(pkg, module, sdk));
           }
         }

--- a/python/testSrc/com/jetbrains/python/quickFixes/PyInstallPackageQuickFixTest.java
+++ b/python/testSrc/com/jetbrains/python/quickFixes/PyInstallPackageQuickFixTest.java
@@ -1,0 +1,67 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.python.quickFixes;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.jetbrains.python.PyBundle;
+import com.jetbrains.python.PyQuickFixTestCase;
+import com.jetbrains.python.PythonFileType;
+import com.jetbrains.python.inspections.unresolvedReference.PyUnresolvedReferencesInspection;
+import one.util.streamex.StreamEx;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+public class PyInstallPackageQuickFixTest extends PyQuickFixTestCase {
+
+  public void testImport1() {
+    doTest("import xyz", List.of("xyz"));
+  }
+
+  public void testImport2() {
+    doTest("import xyz as x, uvw as u", List.of("xyz", "uvw"));
+  }
+
+  public void testFromImport1() {
+    doTest("from rich import xyz, uvw as u", List.of("rich"));
+  }
+
+  public void testFromImport2() {
+    doTest("from rich import (xyz,\nuvw as u)", List.of("rich"));
+  }
+
+  public void testFromImport3() {
+    doTest("from rich import *", List.of("rich"));
+  }
+
+  public void testFromImport4() {
+    doTest("from . import xyz", List.of());
+  }
+
+  private void doTest(@NotNull String text, @NotNull Collection<@NotNull String> expectedInstallPackageNames) {
+    myFixture.enableInspections(PyUnresolvedReferencesInspection.class);
+    myFixture.configureByText(PythonFileType.INSTANCE, text);
+    String hint = getInstallPackageHint("");
+
+    List<String> actual = StreamEx
+      .of(myFixture.getAllQuickFixes())
+      .map(IntentionAction::getText)
+      .filter(t -> t.startsWith(hint))
+      .sorted()
+      .toList();
+
+    List<String> expected = StreamEx
+      .of(expectedInstallPackageNames)
+      .map(PyInstallPackageQuickFixTest::getInstallPackageHint)
+      .sorted()
+      .toList();
+
+    assertSameElements(actual, expected);
+  }
+
+  @Contract(pure = true)
+  private static @NotNull String getInstallPackageHint(@NotNull String packageName) {
+    return PyBundle.message("python.unresolved.reference.inspection.install.package", packageName);
+  }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/PY-49293

This PR improves only the `Install package` suggestion and doesn't provide a solution for the whole issue.

I had to turn off the `PyPIPackageUtil.INSTANCE::isInPyPI` check when running the unit tests because I couldn't find another way to write tests. I'm unsure if this OK.