### PR TITLE
 PY-37855 Use getWorkingDirectorySafe for getting a correct directory

### DIFF
--- a/python/src/com/jetbrains/python/run/PythonCommandLineState.java
+++ b/python/src/com/jetbrains/python/run/PythonCommandLineState.java
@@ -372,13 +372,11 @@ public abstract class PythonCommandLineState extends CommandLineState {
    * @param targetEnvironmentRequest the environment to explore for the working directory upload
    * @return the promise to the working directory path
    */
-  protected @Nullable Function<TargetEnvironment, String> getPythonExecutionWorkingDir(@NotNull TargetEnvironmentRequest targetEnvironmentRequest) {
+  @NotNull
+  protected Function<TargetEnvironment, String> getPythonExecutionWorkingDir(@NotNull TargetEnvironmentRequest targetEnvironmentRequest) {
     // the following working directory is located on the local machine
-    String workingDir = myConfig.getWorkingDirectory();
-    if (!StringUtil.isEmptyOrSpaces(workingDir)) {
-      return getTargetPath(targetEnvironmentRequest, Path.of(workingDir));
-    }
-    return null;
+    String workingDir = myConfig.getWorkingDirectorySafe();
+    return getTargetPath(targetEnvironmentRequest, Path.of(workingDir));
   }
 
   /**

--- a/python/src/com/jetbrains/python/testing/PythonTestCommandLineStateBase.java
+++ b/python/src/com/jetbrains/python/testing/PythonTestCommandLineStateBase.java
@@ -119,15 +119,6 @@ public abstract class PythonTestCommandLineStateBase<T extends AbstractPythonRun
     return testScriptExecution;
   }
 
-  @Override
-  protected @Nullable Function<TargetEnvironment, String> getPythonExecutionWorkingDir(@NotNull TargetEnvironmentRequest request) {
-    Function<TargetEnvironment, String> workingDir = super.getPythonExecutionWorkingDir(request);
-    if (workingDir != null) {
-      return workingDir;
-    }
-    return TargetEnvironmentFunctions.targetPath(Path.of(myConfiguration.getWorkingDirectorySafe()));
-  }
-
   protected void setWorkingDirectory(@NotNull final GeneralCommandLine cmd) {
     String workingDirectory = myConfiguration.getWorkingDirectory();
     if (StringUtil.isEmptyOrSpaces(workingDirectory)) {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/PY-37855/Working-directory-is-automatically-set-to-PyCharm-bin-folder-when-empty-in-Run-Debug-configuration