### PR TITLE
Fix an AlreadyDisposedException

### DIFF
--- a/plugins/kotlin/base/scripting/src/org/jetbrains/kotlin/idea/base/scripting/ScriptingTargetPlatformDetector.kt
+++ b/plugins/kotlin/base/scripting/src/org/jetbrains/kotlin/idea/base/scripting/ScriptingTargetPlatformDetector.kt
@@ -77,11 +77,10 @@ internal class ScriptingTargetPlatformDetector : TargetPlatformDetector {
         }
 
         private fun getScriptSettings(project: Project, virtualFile: VirtualFile, definition: ScriptDefinition): ScriptLanguageSettings {
-            val scriptModule = getScriptModule(project, virtualFile)
-
             val environmentCompilerOptions = definition.defaultCompilerOptions
             val args = definition.compilerOptions
             return if (environmentCompilerOptions.none() && args.none()) {
+                val scriptModule = getScriptModule(project, virtualFile)
                 val languageVersionSettings = scriptModule?.languageVersionSettings ?: project.languageVersionSettings
                 val platformVersion = detectDefaultTargetPlatformVersion(scriptModule?.platform)
                 ScriptLanguageSettings(languageVersionSettings, platformVersion)
@@ -97,6 +96,7 @@ internal class ScriptingTargetPlatformDetector : TargetPlatformDetector {
                         MessageCollector.NONE,
                         mapOf(AnalysisFlags.ideMode to true)
                     )
+                    val scriptModule = getScriptModule(project, virtualFile)
                     val platformVersion = compilerArguments.jvmTarget?.let { JvmTarget.fromString(it) }
                         ?: detectDefaultTargetPlatformVersion(scriptModule?.platform)
 


### PR DESCRIPTION
The module for a given Kotlin script is not necessarily the same throughout the lifetime of a project; a sync might destroy and re-create a module, meaning that we must recompute the module each time we compute the target platform (rather than re-using the module we initially computed).

Move the call to getScriptModule to close to its use, making it clear that one is immediately-used and the other is at an arbitrarily later time.