### PR TITLE
[PY-57582] Add support for `dataclasses.KW_ONLY` type

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/codeInsight/PyDataclasses.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/codeInsight/PyDataclasses.kt
@@ -32,6 +32,7 @@ object PyDataclassNames {
     const val DATACLASSES_FIELD = "dataclasses.field"
     const val DATACLASSES_REPLACE = "dataclasses.replace"
     const val DUNDER_POST_INIT = "__post_init__"
+    const val DATACLASSES_KW_ONLY_TYPE = "dataclasses.KW_ONLY"
     val DECORATOR_PARAMETERS = listOf("init", "repr", "eq", "order", "unsafe_hash", "frozen")
     val HELPER_FUNCTIONS = setOf(DATACLASSES_FIELDS, DATACLASSES_ASDICT, "dataclasses.astuple", DATACLASSES_REPLACE)
   }

--- a/python/testData/inspections/PyDataclassInspection/fieldsOrderKwOnly.py
+++ b/python/testData/inspections/PyDataclassInspection/fieldsOrderKwOnly.py
@@ -1,0 +1,8 @@
+import dataclasses
+
+
+@dataclasses.dataclass
+class A1:
+    bar1: int = 1
+    _: dataclasses.KW_ONLY
+    bar2: int

--- a/python/testSrc/com/jetbrains/python/inspections/PyDataclassInspectionTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/PyDataclassInspectionTest.java
@@ -48,6 +48,11 @@ public class PyDataclassInspectionTest extends PyInspectionTestCase {
     doTest();
   }
 
+  // PY-57582
+  public void testFieldsOrderKwOnly() {
+    doTest();
+  }
+
   // PY-26354
   public void testAttrsFieldsOrder() {
     doTest();


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/PY-57582/dataclasses-field-with-default-value-preceding-KWONLY-shows-false-positive-warning.