### PR TITLE
Make TextEditorWithPreview#getTabs() non-final

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
@@ -441,7 +441,7 @@ public class TextEditorWithPreview extends UserDataHolderBase implements TextEdi
   }
 
   @Override
-  public final @NotNull ActionGroup getTabActions() {
+  public @NotNull ActionGroup getTabActions() {
     AnAction[] actions = createTabActions();
     return new ConditionalActionGroup(actions, () -> isShowActionsInTabs());
   }


### PR DESCRIPTION
This method is overridden in the Android Plugin to control the tabs visibility.