### PR TITLE
PY-58672 - add support for highlighting global and local variables

### DIFF
--- a/python/src/META-INF/python-core-common.xml
+++ b/python/src/META-INF/python-core-common.xml
@@ -396,6 +396,7 @@
 
     <breadcrumbsInfoProvider implementation="com.jetbrains.python.breadcrumbs.PyBreadcrumbsInfoProvider"/>
     <highlightVisitor implementation="com.jetbrains.python.highlighting.PyRainbowVisitor"/>
+    <highlightVisitor implementation="com.jetbrains.python.highlighting.PyLocalGlobalHighlightVisitor"/>
 
     <projectService serviceImplementation="com.jetbrains.python.debugger.containerview.PyDataView"/>
     <createFromTemplateHandler implementation="com.jetbrains.python.packaging.setupPy.PyCreateSetupPyFromTemplateHandler"/>

--- a/python/src/com/jetbrains/python/highlighting/PyLocalGlobalHighlightVisitor.kt
+++ b/python/src/com/jetbrains/python/highlighting/PyLocalGlobalHighlightVisitor.kt
@@ -98,7 +98,7 @@ class PyLocalGlobalHighlightVisitor: HighlightVisitor {
     if (parent is PyGlobalStatement) return targetExpression.containingFile
     if (parent is PyNonlocalStatement) {
       val outerResolved = targetExpression.reference.resolve()
-      return if (outerResolved is PyTargetExpression) getTargetContext(outerResolved) else null
+      return if (outerResolved is PyTargetExpression && outerResolved != targetExpression) getTargetContext(outerResolved) else null
     }
 
     val context = TypeEvalContext.codeInsightFallback(targetExpression.project)

--- a/python/src/com/jetbrains/python/highlighting/PyLocalGlobalHighlightVisitor.kt
+++ b/python/src/com/jetbrains/python/highlighting/PyLocalGlobalHighlightVisitor.kt
@@ -1,0 +1,139 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.python.highlighting
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.codeInsight.daemon.impl.HighlightInfoType
+import com.intellij.codeInsight.daemon.impl.HighlightInfoType.HighlightInfoTypeImpl
+import com.intellij.codeInsight.daemon.impl.HighlightVisitor
+import com.intellij.codeInsight.daemon.impl.analysis.HighlightInfoHolder
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.jetbrains.python.codeInsight.controlflow.ScopeOwner
+import com.jetbrains.python.codeInsight.dataflow.scope.ScopeUtil
+import com.jetbrains.python.highlighting.PyLocalGlobalHighlightVisitor.Holder.LG_MARKER
+import com.jetbrains.python.psi.*
+import com.jetbrains.python.psi.resolve.PyResolveContext
+import com.jetbrains.python.psi.types.TypeEvalContext
+
+class PyLocalGlobalHighlightVisitor: HighlightVisitor {
+
+  object Holder {
+    val LG_MARKER: HighlightInfoType = HighlightInfoTypeImpl(HighlightSeverity.INFORMATION, DefaultLanguageHighlighterColors.LOCAL_VARIABLE)
+  }
+
+  private var myHolder: HighlightInfoHolder? = null
+
+  override fun suitableForFile(file: PsiFile): Boolean = file is PyFile
+
+  override fun visit(element: PsiElement) {
+    when (element) {
+      is PyReferenceExpression -> processReference(element)
+      is PyTargetExpression -> processTarget(element)
+    }
+  }
+
+  override fun analyze(file: PsiFile, updateWholeFile: Boolean, holder: HighlightInfoHolder, action: Runnable): Boolean {
+    myHolder = holder
+    try {
+      action.run()
+    }
+    finally {
+      myHolder = null
+    }
+    return true
+  }
+
+  private fun addInfo(element: PsiElement, context: PsiElement) {
+    val attributes = getTextAttributes(element, context) ?: return
+    myHolder!!.add(createInfo(element, attributes))
+  }
+
+  private fun createInfo(element: PsiElement, attributes: TextAttributesKey): HighlightInfo? {
+    return HighlightInfo
+      .newHighlightInfo(LG_MARKER)
+      .textAttributes(attributes)
+      .range(element)
+      .create()
+  }
+
+  private fun getTextAttributes(element: PsiElement, context: PsiElement): TextAttributesKey? {
+    return if (element.parent is PyGlobalStatement || context is PyFile) {
+      DefaultLanguageHighlighterColors.GLOBAL_VARIABLE
+    } else DefaultLanguageHighlighterColors.LOCAL_VARIABLE
+  }
+
+  override fun clone(): HighlightVisitor = PyLocalGlobalHighlightVisitor()
+
+  private fun processReference(referenceExpression: PyReferenceExpression) {
+    val context = getReferenceContext(referenceExpression, mutableSetOf()) ?: return
+    addInfo(referenceExpression, context)
+  }
+
+  private fun processTarget(targetExpression: PyTargetExpression) {
+    val context = getTargetContext(targetExpression) ?: return
+    addInfo(targetExpression, context)
+  }
+
+  private fun getReferenceContext(referenceExpression: PyReferenceExpression, visitedReferenceExpressions: MutableSet<PyReferenceExpression>): PsiElement? {
+    if (referenceExpression.isQualified) return null
+
+    return when (val resolved = referenceExpression.reference.resolve()) {
+      is PyTargetExpression -> getTargetContext(resolved)
+      is PyReferenceExpression -> {
+        if (!visitedReferenceExpressions.add(resolved)) return getLeastCommonScope(visitedReferenceExpressions)
+        return if (resolved.parent is PyAugAssignmentStatement) getReferenceContext(resolved, visitedReferenceExpressions) else null
+      }
+      else -> null
+    }
+  }
+
+  private fun getTargetContext(targetExpression: PyTargetExpression): PsiElement? {
+    if (targetExpression.isQualified) return null
+
+    val parent = targetExpression.parent
+    if (parent is PyGlobalStatement) return targetExpression.containingFile
+    if (parent is PyNonlocalStatement) {
+      val outerResolved = targetExpression.reference.resolve()
+      return if (outerResolved is PyTargetExpression) getTargetContext(outerResolved) else null
+    }
+
+    val context = TypeEvalContext.codeInsightFallback(targetExpression.project)
+    val resolveResults = targetExpression.getReference(PyResolveContext.defaultContext(context)).multiResolve(false)
+
+    val resolvesToGlobal = resolveResults
+      .asSequence()
+      .map { it.element }
+      .any { it is PyTargetExpression && it.parent is PyGlobalStatement }
+    if (resolvesToGlobal) return targetExpression.containingFile
+
+    val resolvedNonLocal = resolveResults
+      .asSequence()
+      .map { it.element }
+      .filterIsInstance<PyTargetExpression>()
+      .find { it.parent is PyNonlocalStatement }
+    if (resolvedNonLocal != null) return getTargetContext(resolvedNonLocal)
+
+    val scopeOwner = ScopeUtil.getScopeOwner(targetExpression)
+    return if (scopeOwner is PyFile || scopeOwner is PyFunction || scopeOwner is PyLambdaExpression) scopeOwner else null
+  }
+
+  private fun getLeastCommonScope(elements: Collection<PsiElement>): ScopeOwner? {
+    var result: ScopeOwner? = null
+
+    elements.forEach {
+      val currentScopeOwner = ScopeUtil.getScopeOwner(it)
+      if (result == null) {
+        result = currentScopeOwner
+      }
+      else if (result != currentScopeOwner && currentScopeOwner != null && PsiTreeUtil.isAncestor(result, currentScopeOwner, true)) {
+        result = currentScopeOwner
+      }
+    }
+
+    return result
+  }
+}

--- a/python/src/com/jetbrains/python/highlighting/PythonColorsPage.java
+++ b/python/src/com/jetbrains/python/highlighting/PythonColorsPage.java
@@ -87,6 +87,7 @@ public class PythonColorsPage implements RainbowColorSettingsPage, InspectionCol
     .put("mcall", PyHighlighter.PY_METHOD_CALL)
     .put("annotation", PyHighlighter.PY_ANNOTATION)
     .put("localVar", DefaultLanguageHighlighterColors.LOCAL_VARIABLE)
+    .put("globalVar", DefaultLanguageHighlighterColors.GLOBAL_VARIABLE)
     .putAll(RainbowHighlighter.createRainbowHLM())
     .build();
 
@@ -151,7 +152,7 @@ public class PythonColorsPage implements RainbowColorSettingsPage, InspectionCol
       "    def <funcDef>make_sense</funcDef>(<self>self</self>, <param>whatever</param>):\n" +
       "        <self>self</self>.sense = <param>whatever</param>\n" +
       "\n" +
-      "<localVar>x</localVar> = <builtin>len</builtin>('abc')\n" +
+      "<globalVar>x</globalVar> = <builtin>len</builtin>('abc')\n" +
       "print(f.<predefinedUsage>__doc__</predefinedUsage>)"
     ;
   }

--- a/python/testSrc/com/jetbrains/python/PyLocalGlobalHighlightingTest.kt
+++ b/python/testSrc/com/jetbrains/python/PyLocalGlobalHighlightingTest.kt
@@ -1,0 +1,154 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.python
+
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
+import com.jetbrains.python.fixtures.PyTestCase
+import com.jetbrains.python.highlighting.PyLocalGlobalHighlightVisitor.Holder.LG_MARKER
+import java.awt.Color
+
+class PyLocalGlobalHighlightingTest : PyTestCase() {
+  fun testLocalVariable() {
+    doTest("""
+             def f():
+                 <h local>p</h> = "1"
+                 print(<h local>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameGlobalAndLocalVariable() {
+    doTest("""
+             <h global>p</h> = "1"
+             def f():
+                 <h local>p</h> = "2"
+                 print(<h local>p</h>)
+             print(<h global>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameGlobalVariable() {
+    doTest("""
+             <h global>p</h> = "1"
+             def f():
+                 print(<h global>p</h>)
+             print(<h global>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameGlobalVariableWithReassignment() {
+    doTest("""
+             <h global>p</h> = "1"
+             def f():
+                 global <h global>p</h>
+                 <h global>p</h> = "2"
+                 print(<h global>p</h>)
+             print(<h global>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameGlobalAndNonlocalVariable() {
+    doTest("""
+             <h global>p</h> = "1"
+             def outer():
+                 <h local>p</h> = "2"
+                 def nested():
+                     nonlocal <h local>p</h>
+                     <h local>p</h> = "3"
+                 print(<h local>p</h>)
+             print(<h global>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameGlobalAndAmbiguityVariable() {
+    doTest("""
+             <h global>p</h> = "1"
+             def f():
+                 print(p) # ambiguity - "UnboundLocalError: local variable 'p' referenced before assignment"
+                 <h local>p</h> = "2"
+                 print(<h local>p</h>)
+             print(<h global>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameOuterAndNonLocalVariable() {
+    doTest("""
+            def outer():
+                <h local>p</h> = "1"
+                def nested():
+                    nonlocal <h local>p</h>
+                    print(<h local>p</h>)
+                    <h local>p</h> = "2"
+                    print(<h local>p</h>
+                print(<h local>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameGlobalVariableAndParameter() {
+    doTest("""
+             <h global>p</h> = "1"
+             def f(p):
+                 print(p)
+             print(<h global>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameLocalVariableAndParameter() {
+    doTest("""
+             <h global>p</h> = "1"
+             def f(p):
+                 <h local>p</h> = "1"
+                 print(<h local>p</h>)
+             print(<h global>p</h>)
+                 """.trimIndent())
+  }
+
+  fun testSameNameAttributeAndLocalVariableAndParameter() {
+    doTest("""
+             class A:
+                 def __init__(self):
+                     self.a = None
+
+                 def f(self, a):
+                     self.a = 2
+                     <h local>a</h> = a
+                     print(<h local>a</h>)
+                 """.trimIndent())
+  }
+
+  fun testVariableAfterAugAssignment() {
+    doTest("""
+            def f():
+                <h local>p</h> = 1
+                <h local>p</h> += 1
+                print(<h local>p</h>)
+             """.trimIndent())
+  }
+
+  private fun doTest(text: String) {
+    val scheme = EditorColorsManager.getInstance().globalScheme
+    val lAttributes = scheme.getAttributes(DefaultLanguageHighlighterColors.LOCAL_VARIABLE)
+    val gAttributes = scheme.getAttributes(DefaultLanguageHighlighterColors.GLOBAL_VARIABLE)
+    scheme.setAttributes(DefaultLanguageHighlighterColors.LOCAL_VARIABLE, TextAttributes().apply { foregroundColor = Color.RED })
+    scheme.setAttributes(DefaultLanguageHighlighterColors.GLOBAL_VARIABLE, TextAttributes().apply { foregroundColor = Color.GREEN })
+
+    try {
+      val file = myFixture.configureByText("a.py", text.replace("<h [a-z]+>(.*)</h>".toRegex(), "$1"))
+      val highlighting = myFixture.doHighlighting().filter { it.type == LG_MARKER }
+      assertEquals(
+        text,
+        CodeInsightTestFixtureImpl.getTagsFromSegments(myFixture.getDocument(file).text, highlighting, "h") {
+          when (it.getTextAttributes(null, null)?.foregroundColor) {
+            Color.RED -> "local"
+            Color.GREEN -> "global"
+            else -> "?"
+          }
+        })
+    }
+    finally {
+      scheme.setAttributes(DefaultLanguageHighlighterColors.LOCAL_VARIABLE, lAttributes)
+      scheme.setAttributes(DefaultLanguageHighlighterColors.GLOBAL_VARIABLE, gAttributes)
+    }
+  }
+}

--- a/python/testSrc/com/jetbrains/python/PyLocalGlobalHighlightingTest.kt
+++ b/python/testSrc/com/jetbrains/python/PyLocalGlobalHighlightingTest.kt
@@ -126,6 +126,13 @@ class PyLocalGlobalHighlightingTest : PyTestCase() {
              """.trimIndent())
   }
 
+  fun testNoEndlessResolveLoopForNonlocalTarget() {
+    doTest("""
+            def func():
+                nonlocal p
+    """.trimIndent())
+  }
+
   private fun doTest(text: String) {
     val scheme = EditorColorsManager.getInstance().globalScheme
     val lAttributes = scheme.getAttributes(DefaultLanguageHighlighterColors.LOCAL_VARIABLE)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/PY-58672/The-Python-Color-Scheme-Settings-preview-incorrectly-shows-that-colors-for-things-like-local-variables-will-be-applied-when-in