### PR TITLE
Fix groovy highlighter error

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/transformations/HierarchyView.kt
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/transformations/HierarchyView.kt
@@ -41,7 +41,7 @@ internal class HierarchyView(
   override fun getSuperClass(): PsiClass? = GrClassImplUtil.getSuperClass(myCodeClass, myExtendsTypes)
   override fun isInheritor(baseClass: PsiClass, checkDeep: Boolean): Boolean = InheritanceImplUtil.isInheritor(this, baseClass, checkDeep)
 
-  override fun getDelegate(): PsiClass = error("must not be called")
+  override fun getDelegate(): PsiClass = myCodeClass
   override fun copy(): PsiElement = error("must not be called")
   override fun toString(): String = "[Hierarchy view] $name"
 }


### PR DESCRIPTION
Hi, i recently stumbled upon an error when i was working on a legacy java project in which i was migrating some classes from java to groovy. For certain java classes that inherited from groovy abstract classes the highlighter stopped working and even code analysis stopped reporting inspections results. Searching in logs i found that the error was caused by an exception deliberately thrown in the class HierarchyView.kt when it's method getDelegate() was called. I tried to remove the exception and returning the codeClass that HerarchyView wraps and this seems to have fixed the issue. Can this be merged in mainstream?