### PR TITLE
Suggest to run all inherited tests for KMP common source set

### DIFF
--- a/plugins/kotlin/base/fe10/code-insight/src/org/jetbrains/kotlin/idea/base/fe10/codeInsight/tooling/Fe10GenericTestIconProvider.kt
+++ b/plugins/kotlin/base/fe10/code-insight/src/org/jetbrains/kotlin/idea/base/fe10/codeInsight/tooling/Fe10GenericTestIconProvider.kt
@@ -9,11 +9,14 @@ import org.jetbrains.kotlin.idea.base.codeInsight.KotlinTestAvailabilityChecker
 import org.jetbrains.kotlin.idea.base.codeInsight.tooling.AbstractGenericTestIconProvider
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
 
 object Fe10GenericTestIconProvider : AbstractGenericTestIconProvider() {
     override fun isKotlinTestDeclaration(declaration: KtClassOrObject): Boolean {
         val descriptor = declaration.resolveToDescriptorIfAny() ?: return false
-        return isKotlinTestDeclaration(descriptor)
+        return descriptor.getAllSuperClassifiers().any {
+            isKotlinTestDeclaration(it)
+        }
     }
 
     private tailrec fun isIgnored(descriptor: DeclarationDescriptor): Boolean {

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/kotlinTestClassUtils.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/kotlinTestClassUtils.kt
@@ -5,10 +5,11 @@ package org.jetbrains.kotlin.idea.gradleJava.run
 import com.intellij.execution.Location
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
-import org.jetbrains.kotlin.asJava.elements.KtLightElement
-import org.jetbrains.kotlin.asJava.classes.KtFakeLightClass
+import org.jetbrains.kotlin.asJava.LightClassUtil
 import org.jetbrains.kotlin.asJava.classes.KtFakeLightMethod
+import org.jetbrains.kotlin.asJava.elements.KtLightElement
 import org.jetbrains.kotlin.asJava.toFakeLightClass
+import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -20,7 +21,7 @@ internal fun getTestMethodForKotlinTest(location: Location<*>): PsiMethod? {
         else -> psi
     }
     val function = leaf?.getParentOfType<KtNamedFunction>(false) ?: return null
-    return KtFakeLightMethod.get(function)
+    return LightClassUtil.getLightClassMethod(function) ?: KtFakeLightMethod.get(function)
 }
 
 internal fun getTestClassForKotlinTest(location: Location<*>): PsiClass? {
@@ -29,5 +30,5 @@ internal fun getTestClassForKotlinTest(location: Location<*>): PsiClass? {
         else -> psi
     }
     val owner = leaf?.getParentOfType<KtDeclaration>(false) as? KtClassOrObject ?: return null
-    return owner.toFakeLightClass()
+    return owner.toLightClass() ?: owner.toFakeLightClass()
 }

--- a/plugins/kotlin/gradle/gradle-java/tests/test/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleTestRunConfigurationAndHighlightingTest.kt
+++ b/plugins/kotlin/gradle/gradle-java/tests/test/org/jetbrains/kotlin/idea/codeInsight/gradle/GradleTestRunConfigurationAndHighlightingTest.kt
@@ -6,11 +6,16 @@ import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.execution.PsiLocation
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.ConfigurationFromContext
+import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.externalSystem.model.execution.ExternalSystemTaskExecutionSettings
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
-import com.intellij.openapi.options.advanced.AdvancedSettings
-import com.intellij.openapi.options.advanced.AdvancedSettingsImpl
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.PopupChooserBuilder
 import com.intellij.psi.PsiFile
+import com.intellij.testFramework.replaceService
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.popup.PopupFactoryImpl
+import com.intellij.util.application
 import org.jetbrains.kotlin.gradle.GradleDaemonAnalyzerTestCase
 import org.jetbrains.kotlin.gradle.checkFiles
 import org.jetbrains.kotlin.idea.run.KotlinRunConfiguration
@@ -18,11 +23,20 @@ import org.jetbrains.kotlin.idea.test.TagsTestDataUtil
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
 import org.junit.Test
+import java.awt.Point
 import java.io.File
+import javax.swing.JList
 
 class GradleTestRunConfigurationAndHighlightingTest23 : KotlinGradleImportingTestCase() {
     @Test
     fun testExpectClassWithTests() {
+        enableExperimentalMPP(true)
+        doTest()
+    }
+
+    @Test
+    fun testMultiplatformInheritedTests() {
+        mockInheritorPopup()
         enableExperimentalMPP(true)
         doTest()
     }
@@ -147,6 +161,16 @@ class GradleTestRunConfigurationAndHighlightingTest23 : KotlinGradleImportingTes
         val context = ConfigurationContext.createEmptyContextForLocation(location)
 
         return context.configurationsFromContext.orEmpty()
+    }
+
+    private fun mockInheritorPopup() {
+        application.replaceService(
+            JBPopupFactory::class.java, object : PopupFactoryImpl() {
+                override fun <T : Any?> createPopupChooserBuilder(list: MutableList<out T>) = PopupChooserBuilder<T>(JList())
+                override fun guessBestPopupLocation(dataContext: DataContext) = RelativePoint(Point())
+            },
+            testRootDisposable
+        )
     }
 
     override fun testDataDirName(): String = "multiplatform/testRunConfigurations"

--- a/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/build.gradle
+++ b/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform' version '1.3.61'
+}
+repositories {
+    mavenCentral()
+}
+group 'com.example'
+version '0.0.1'
+
+apply plugin: 'maven-publish'
+
+kotlin {
+    jvm()
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation kotlin('stdlib-common')
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation kotlin('test-common')
+                implementation kotlin('test-annotations-common')
+            }
+        }
+        jvmMain {
+            dependencies {
+                implementation kotlin('stdlib-jdk8')
+            }
+        }
+        jvmTest {
+            dependencies {
+                implementation kotlin('test')
+                implementation kotlin('test-junit')
+            }
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/gradle.properties
+++ b/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+kotlin.js.compiler=legacy

--- a/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/settings.gradle
+++ b/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'mppLibrary'
+
+enableFeaturePreview('GRADLE_METADATA')

--- a/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/src/commonTest/kotlin/sample/SampleTests.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/src/commonTest/kotlin/sample/SampleTests.kt
@@ -1,0 +1,12 @@
+package sample
+
+import kotlin.test.Test
+
+abstract class <lineMarker descr="Run Test" settings="null"><lineMarker descr="Is subclassed by ChildCommon1 (sample) ChildCommon2 (sample) Press ⌥⌘B to navigate">BaseTestCommon</lineMarker></lineMarker> {
+    @Test
+    fun <lineMarker descr="Run Test" settings="null">myTest</lineMarker>() {}
+}
+
+class <lineMarker descr="Run Test" settings=":cleanJvmTest :jvmTest --tests \"sample.ChildCommon1\"">ChildCommon1</lineMarker> : BaseTestCommon()
+
+class <lineMarker descr="Run Test" settings=":cleanJvmTest :jvmTest --tests \"sample.ChildCommon2\"">ChildCommon2</lineMarker> : BaseTestCommon()

--- a/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/src/jvmTest/kotlin/sample/SampleTestsJVM.kt
+++ b/plugins/kotlin/idea/tests/testData/gradle/multiplatform/testRunConfigurations/multiplatformInheritedTests/src/jvmTest/kotlin/sample/SampleTestsJVM.kt
@@ -1,0 +1,12 @@
+package sample
+
+import kotlin.test.Test
+
+abstract class <lineMarker descr="Run Test" settings="null"><lineMarker descr="Is subclassed by ChildTestJvm1 (sample) ChildTestJvm2 (sample) Press ⌥⌘B to navigate">BaseTestJvm</lineMarker></lineMarker> {
+    @Test
+    fun <lineMarker descr="Run Test" settings="null">myTest</lineMarker>() {}
+}
+
+class <lineMarker descr="Run Test" settings=":cleanJvmTest :jvmTest --tests \"sample.ChildTestJvm1\"">ChildTestJvm1</lineMarker> : BaseTestJvm()
+
+class <lineMarker descr="Run Test" settings=":cleanJvmTest :jvmTest --tests \"sample.ChildTestJvm2\"">ChildTestJvm2</lineMarker> : BaseTestJvm()


### PR DESCRIPTION
### Description
This issue was reported on studio side https://issuetracker.google.com/issues/275409155, where given a KMP project  containing the bellow code in `commonTest` source set, the run gutter icon on the `myTest()` doesn't display the sub-class to run the test, instead asks for the target (jvm, android, etc). At the same time, the `Child1` and `Child2` aren't marked as test classes (displaying the run gutter icon), since they are implementing a class that contains a test.

```kotlin
abstract class BaseTestCommon {
    @Test
    fun myTest() {}
}

class Child1 : BaseTestCommon()

class Child2 : BaseTestCommon()
```

As a note this works properly when the same test is under `androidTest` or `jvmTest` source set, meaning that is `common` specific. 

### Changes
The `InheritorChooser.runMethodInAbstractClass()` is responsible to display the popup regarding which implementation of abstract class to use for the test execution, been triggered from:
 - when is class: `AbstractKotlinMultiplatformTestClassGradleConfigurationProducer`
 - when is method: `AbstractKotlinMultiplatformTestMethodGradleConfigurationProducer`
 
At the same time, each source set implements its own `GradleConfigurationProducer`. This validates given a method if its `PsiClass` contains a modified property `abstract`. Due that in case of `common` the `getPsiMethodForLocation()` and `getPsiClassForLocation()` respectively returning `fakes` objects causing to be unable to determine given a dummy class/method if contains or not `abstract` modifier. Those changes where introduced by the following [commit](https://github.com/JetBrains/intellij-community/commit/d051ad23f886d5101a20542e12131038d8548f83) addressing  [KTIJ-15137](https://youtrack.jetbrains.com/issue/KTIJ-15137/) that is still required to be considered due that the `expect` and `actual` modifiers aren't  supported by the existing `KotlinAsJavaSupport` returning `null` on those cases, when trying to create the `lightClass` or `lightMethod`. 

Regarding the fact that `Child1` and `Child2` aren't marked as test classes is because the existing implementation of `Fe10GenericTestIconProvider.isKotlinTestDeclaration()` doesn't take into consideration inherence of any type interfaces or abstract classes, for this reason, now the `isKotlinTestDeclaration()` will be invoked for all class super classifiers.

### Overview
- Before
<img width="728" alt="Screenshot 2023-04-08 at 20 39 20" src="https://user-images.githubusercontent.com/18151158/231167680-114da22d-89df-4ff5-8adb-3cfc3661544b.png">

- After

https://user-images.githubusercontent.com/18151158/231167616-a0b44cab-0c78-43e3-a8ba-58529c360007.mov

