### PR TITLE
KTIJ-22529: Guard against loading resource keys from Kotlin bundle if they don't exist

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/hints/KotlinInlayHintsTopHitProvider.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/codeInsight/hints/KotlinInlayHintsTopHitProvider.kt
@@ -32,25 +32,32 @@ class KotlinInlayHintsTopHitProvider : OptionsSearchTopHitProvider.ProjectLevelP
 
     override fun getId(): String = "kotlin.inlay.hints"
 
-    override fun getOptions(project: Project): MutableCollection<OptionDescription> =
-        InlaySettingsProvider.EP.getExtensions().flatMap { it.createModels(project, KotlinLanguage.INSTANCE) }.flatMap {
-            listOf(
-                CheckboxDescriptor(
-                    KotlinBundle.message(it.id),
-                    getter = it::isEnabled,
-                    setter = { newValue ->
-                        with(it) {
-                            isEnabled = newValue
-                            apply()
-                            refreshHints(project)
+    override fun getOptions(project: Project): MutableCollection<OptionDescription> {
+        val options = mutableListOf<OptionDescription>()
+
+        InlaySettingsProvider.EP.getExtensions().flatMap { it.createModels(project, KotlinLanguage.INSTANCE) }.forEach {
+            KotlinBundle.messageOrNull(it.id)?.let { msg ->
+                options.add(
+                    CheckboxDescriptor(
+                        msg,
+                        getter = it::isEnabled,
+                        setter = { newValue ->
+                            with(it) {
+                                isEnabled = newValue
+                                apply()
+                                refreshHints(project)
+                            }
                         }
-                    }
-                ).asOptionDescriptor()
-            ) +
-                    it.cases.map { case ->
+                    ).asOptionDescriptor()
+                )
+            }
+
+            it.cases.forEach { case ->
+                // TODO: Have to clean up this hidden "gem" - maybe make `Case` open ?
+                KotlinBundle.messageOrNull("${it.id}.${case.id}")?.let { msg ->
+                    options.add(
                         CheckboxDescriptor(
-                            // TODO: Have to clean up this hidden "gem" - maybe make `Case` open ?
-                            KotlinBundle.message("${it.id}.${case.id}"),
+                            msg,
                             getter = case::value,
                             setter = { newValue ->
                                 case.value = newValue
@@ -60,7 +67,11 @@ class KotlinInlayHintsTopHitProvider : OptionsSearchTopHitProvider.ProjectLevelP
                                 it.apply()
                                 refreshHints(project)
                             }
-                        ).asOptionDescriptor()
-                    }
-        }.toMutableList()
+                        ).asOptionDescriptor())
+                }
+            }
+        }
+
+        return options
+    }
 }


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/KTIJ-22529 where the Kotlin plugin assumes that any inlays that are for Kotlin are only provided by the Kotlin plugin

Without patch on master, the error has changed from when youtrack issue was created, it is now:
```
   Unhandled exception in [CoroutineName(Project Activity: com.intellij.ide.ui.OptionsTopHitProvider$Activity), StandaloneCoroutine{Cancelling}@23a57b8d, Dispatchers.Default]
   
   java.lang.AssertionError: 'no settings' is not found in java.util.PropertyResourceBundle@45594004(messages.KotlinBundle)
	at com.intellij.openapi.diagnostic.DefaultLogger.error(DefaultLogger.java:54)
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:366)
	at com.intellij.BundleBase.useDefaultValue(BundleBase.java:166)
	at com.intellij.BundleBase.messageOrDefault(BundleBase.java:105)
	at com.intellij.AbstractBundle.getMessage(AbstractBundle.java:59)
	at org.jetbrains.kotlin.idea.base.resources.KotlinBundle.message(KotlinBundle.kt:15)
	at org.jetbrains.kotlin.idea.codeInsight.hints.KotlinInlayHintsTopHitProvider.getOptions(KotlinInlayHintsTopHitProvider.kt:42)
	at com.intellij.ide.ui.TopHitCache$getCachedOptions$1.invoke(TopHitCache.kt:60)
	at com.intellij.ide.ui.TopHitCache$getCachedOptions$1.invoke(TopHitCache.kt:47)
	at com.intellij.ide.ui.TopHitCache.getCachedOptions$lambda$0(TopHitCache.kt:47)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at com.intellij.ide.ui.TopHitCache.getCachedOptions(TopHitCache.kt:47)
	at com.intellij.ide.ui.OptionsTopHitProvider$Activity.execute(OptionsTopHitProvider.kt:162)
	at com.intellij.ide.ui.OptionsTopHitProvider$Activity$execute$1.invokeSuspend(OptionsTopHitProvider.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [CoroutineName(Project Activity: com.intellij.ide.ui.OptionsTopHitProvider$Activity), StandaloneCoroutine{Cancelled}@23a57b8d, Dispatchers.Default]
Caused by: java.lang.Throwable: 'no settings' is not found in java.util.PropertyResourceBundle@45594004(messages.KotlinBundle)
	... 19 more

```

Tested using the following patch:
```
Subject: [PATCH] Test patch for KTIJ-22529
---
Index: plugins/devkit/intellij.kotlin.devkit/src/TestCodeInsightProvider.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/devkit/intellij.kotlin.devkit/src/TestCodeInsightProvider.kt b/plugins/devkit/intellij.kotlin.devkit/src/TestCodeInsightProvider.kt
new file mode 100644
--- /dev/null	(date 1681231780434)
+++ b/plugins/devkit/intellij.kotlin.devkit/src/TestCodeInsightProvider.kt	(date 1681231780434)
@@ -0,0 +1,30 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.idea.devkit.kotlin
+
+import com.intellij.codeInsight.hints.*
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class TestCodeInsightProvider : InlayHintsProvider<NoSettings> {
+  override val name: String = "Test KTIJ-22529"
+  override val key: SettingsKey<NoSettings> =  SettingsKey("no settings")
+  override val previewText: String = ""
+
+  override fun getCollectorFor(file: PsiFile, editor: Editor, settings: NoSettings, sink: InlayHintsSink): InlayHintsCollector? {
+    return null
+  }
+
+  override fun createSettings(): NoSettings {
+    return NoSettings()
+  }
+
+  override fun createConfigurable(settings: NoSettings): ImmediateConfigurable {
+    return object : ImmediateConfigurable {
+      override fun createComponent(listener: ChangeListener): JComponent {
+        return JPanel()
+      }
+    }
+  }
+}
\ No newline at end of file
Index: plugins/devkit/intellij.kotlin.devkit/resources/intellij.kotlin.devkit.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/devkit/intellij.kotlin.devkit/resources/intellij.kotlin.devkit.xml b/plugins/devkit/intellij.kotlin.devkit/resources/intellij.kotlin.devkit.xml
--- a/plugins/devkit/intellij.kotlin.devkit/resources/intellij.kotlin.devkit.xml	(revision 3168a443ef12742327b7424893a5d9eed6ac73d8)
+++ b/plugins/devkit/intellij.kotlin.devkit/resources/intellij.kotlin.devkit.xml	(date 1681233489546)
@@ -41,6 +41,8 @@
                      enabledByDefault="false" level="WARNING"
                      implementationClass="org.jetbrains.idea.devkit.kotlin.inspections.OpenOrNonInternalExtensionClassInspection"
                      key="inspection.open.or.non.internal.extension.class.display.name"/>
+
+    <codeInsight.inlayProvider implementationClass="org.jetbrains.idea.devkit.kotlin.TestCodeInsightProvider" language="kotlin" />
   </extensions>
 
   <extensions defaultExtensionNs="DevKit.lang">
```