### PR TITLE
Don't compare Android Studio and IDEA versions

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/PluginStartupActivity.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/PluginStartupActivity.kt
@@ -65,7 +65,8 @@ internal class PluginStartupActivity : ProjectPostStartupActivity {
         val rawVersion = KotlinIdePlugin.version
         val kotlinPluginVersion = KotlinIdePluginVersion.parse(rawVersion).getOrNull() ?: return
 
-        if (kotlinPluginVersion.platformVersion != platformVersion || kotlinPluginVersion.isAndroidStudio != isAndroidStudio) {
+        if ((kotlinPluginVersion.platformVersion != platformVersion && !isAndroidStudio)  // Android Studio version diverges from IDEA
+            || kotlinPluginVersion.isAndroidStudio != isAndroidStudio) {
             val ideName = ApplicationInfo.getInstance().versionName
 
             runInEdt {


### PR DESCRIPTION
@jreznot, @yanex
This comparison causes PluginStartupActivity.checkPluginCompatibility to fail because Android Studio's version numbers don't match IDEA's.
See for example android.googlesource.com/platform/tools/idea/+/efacdfcb.