### PR TITLE
KTIJ-24949 False negative "Redundant 'suspend' modifier" in function that calls itself but with different receiver with type

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSuspendModifierInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSuspendModifierInspection.kt
@@ -66,12 +66,12 @@ class RedundantSuspendModifierInspection : AbstractKotlinInspection() {
             if (kind is SuspendCallKind.FunctionCall) {
                 val resolvedCall = kind.element.getResolvedCall(bindingContext)
                 if (resolvedCall != null) {
-                    val isRecursiveCall = when (resolvedCall) {
-                        is VariableAsFunctionResolvedCall -> selfDescriptor == resolvedCall.functionCall.candidateDescriptor
-                        else -> selfDescriptor == resolvedCall.candidateDescriptor
+                    val isSelfCall = when (resolvedCall) {
+                        is VariableAsFunctionResolvedCall -> selfDescriptor == resolvedCall.functionCall.candidateDescriptor.original
+                        else -> selfDescriptor == resolvedCall.candidateDescriptor.original
                     }
 
-                    if (isRecursiveCall) {
+                    if (isSelfCall) {
                         return@anyDescendantOfType false
                     }
                 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10067,6 +10067,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         public void testRecursiveCall() throws Exception {
             runTest("testData/inspectionsLocal/redundantSuspend/recursiveCall.kt");
         }
+
+        @TestMetadata("selfCallWithDifferentReceiver.kt")
+        public void testSelfCallWithDifferentReceiver() throws Exception {
+            runTest("testData/inspectionsLocal/redundantSuspend/selfCallWithDifferentReceiver.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/selfCallWithDifferentReceiver.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/selfCallWithDifferentReceiver.kt
@@ -1,0 +1,9 @@
+// WITH_STDLIB
+class Task<T> {
+    private val tasks: List<Task<T>> = listOf()
+    <caret>suspend fun register(f: Task<String>) {
+        tasks.forEach {
+            it.register(f)
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/selfCallWithDifferentReceiver.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantSuspend/selfCallWithDifferentReceiver.kt.after
@@ -1,0 +1,9 @@
+// WITH_STDLIB
+class Task<T> {
+    private val tasks: List<Task<T>> = listOf()
+    fun register(f: Task<String>) {
+        tasks.forEach {
+            it.register(f)
+        }
+    }
+}

--- a/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
+++ b/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
@@ -1552,6 +1552,11 @@ public abstract class Fe10BindingLocalInspectionTestGenerated extends AbstractFe
         public void testRecursiveCall() throws Exception {
             runTest("../idea/tests/testData/inspectionsLocal/redundantSuspend/recursiveCall.kt");
         }
+
+        @TestMetadata("selfCallWithDifferentReceiver.kt")
+        public void testSelfCallWithDifferentReceiver() throws Exception {
+            runTest("../idea/tests/testData/inspectionsLocal/redundantSuspend/selfCallWithDifferentReceiver.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24949