### PR TITLE
[jira] IDEA-149504 add support for Jira Server Personal Access Tokens

### DIFF
--- a/platform/tasks-platform-api/resources/messages/TaskApiBundle.properties
+++ b/platform/tasks-platform-api/resources/messages/TaskApiBundle.properties
@@ -13,5 +13,6 @@ te.st=Te&st
 use=Use...
 use.domain.login.format.for.ntlm.authentication=Use DOMAIN\\\\Login format for NTLM authentication
 use.http.authentication=Use &HTTP authentication
+use.personal.access.token=Use personal access &token
 use.prox.y=Use prox&y
 userna.me=Userna&me:


### PR DESCRIPTION
Adds support for Personal Access Tokens on Jira Server / Datacenter (not Jira Cloud).  This uses the `Authorization: Bearer` HTTP header.

Personal Access Tokens for Jira are documented here: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html#UsingPersonalAccessTokens-UsingPATs

### Implementation notes:

Added support for bearer tokens to the `BaseRepository` and subclasses, including a new repository field, form checkbox, and handlers.  Checking the token checkbox will hide the username field and change the password label to "API Token".

The HTTP library used by the task services doesn't natively support bearer tokens authentication, so this PR disables built-in authentication and explicitly adds the header to requests.

Tested manually against an internal Jira server.

### Screenshot

<img width="1094" alt="jira-server-api-token" src="https://user-images.githubusercontent.com/1460628/232106926-c6f7f0bd-b89f-451b-a105-debef19523a2.png">
