### PR TITLE
Prevent unintended internal API usage error for `CodeVisionProvider` implementers

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/codeVision/CodeVisionProvider.kt
+++ b/platform/lang-impl/src/com/intellij/codeInsight/codeVision/CodeVisionProvider.kt
@@ -87,6 +87,7 @@ interface CodeVisionProvider<T> {
   @Deprecated("use getPlaceholderCollector")
   fun collectPlaceholders(editor: Editor): List<TextRange> = emptyList()
 
+  @JvmDefault // Prevent Kotlin to generate a method in the client code, as CodeVisionPlaceholderCollector is internal
   fun getPlaceholderCollector(editor: Editor, psiFile: PsiFile?) : CodeVisionPlaceholderCollector? = null
 
   /**


### PR DESCRIPTION
`CodeVisionPlaceholderCollector` is an internal API, however implementing `CodeVisionProvider` in kotlin when the class is compiled, an "overload" of this method is generated and calls the "default" implementation. But in doing so it triggers the plugin verifier.

```
  // access flags 0x1
  public getPlaceholderCollector(Lcom/intellij/openapi/editor/Editor;Lcom/intellij/psi/PsiFile;)Lcom/intellij/codeInsight/codeVision/CodeVisionPlaceholderCollector;
  @Lorg/jetbrains/annotations/Nullable;() // invisible
...
    INVOKESTATIC com/intellij/codeInsight/codeVision/CodeVisionProvider$DefaultImpls.getPlaceholderCollector (Lcom/intellij/codeInsight/codeVision/CodeVisionProvider;Lcom/intellij/openapi/editor/Editor;Lcom/intellij/psi/PsiFile;)Lcom/intellij/codeInsight/codeVision/CodeVisionPlaceholderCollector;
...
```

This problem will also be present for Java implementation of `CodeVisionProvider`, because `getPlaceholderCollector` has no default implementation, and as such forces to write an implementation in Java.

Ref: https://youtrack.jetbrains.com/issue/MP-5395/Reports-internal-usage-when-extending-an-interface-with-default-method-having-internal-type