### PR TITLE
Fix breakpoint stuttering in one line lambdas

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinSteppingTestGenerated.java
@@ -1105,6 +1105,11 @@ public abstract class K2IdeK1CodeKotlinSteppingTestGenerated extends AbstractK2I
             runTest("../testData/stepping/custom/breakpointOnWhen.kt");
         }
 
+        @TestMetadata("breakpointsInOneLineLambdas.kt")
+        public void testBreakpointsInOneLineLambdas() throws Exception {
+            runTest("../testData/stepping/custom/breakpointsInOneLineLambdas.kt");
+        }
+
         @TestMetadata("constantConditions.kt")
         public void testConstantConditions() throws Exception {
             runTest("../testData/stepping/custom/constantConditions.kt");

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
@@ -1105,6 +1105,11 @@ public abstract class K2IndyLambdaKotlinSteppingTestGenerated extends AbstractK2
             runTest("../testData/stepping/custom/breakpointOnWhen.kt");
         }
 
+        @TestMetadata("breakpointsInOneLineLambdas.kt")
+        public void testBreakpointsInOneLineLambdas() throws Exception {
+            runTest("../testData/stepping/custom/breakpointsInOneLineLambdas.kt");
+        }
+
         @TestMetadata("constantConditions.kt")
         public void testConstantConditions() throws Exception {
             runTest("../testData/stepping/custom/constantConditions.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
@@ -1105,6 +1105,11 @@ public abstract class IndyLambdaKotlinSteppingTestGenerated extends AbstractIndy
             runTest("testData/stepping/custom/breakpointOnWhen.kt");
         }
 
+        @TestMetadata("breakpointsInOneLineLambdas.kt")
+        public void testBreakpointsInOneLineLambdas() throws Exception {
+            runTest("testData/stepping/custom/breakpointsInOneLineLambdas.kt");
+        }
+
         @TestMetadata("constantConditions.kt")
         public void testConstantConditions() throws Exception {
             runTest("testData/stepping/custom/constantConditions.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -1105,6 +1105,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/custom/breakpointOnWhen.kt");
         }
 
+        @TestMetadata("breakpointsInOneLineLambdas.kt")
+        public void testBreakpointsInOneLineLambdas() throws Exception {
+            runTest("testData/stepping/custom/breakpointsInOneLineLambdas.kt");
+        }
+
         @TestMetadata("constantConditions.kt")
         public void testConstantConditions() throws Exception {
             runTest("testData/stepping/custom/constantConditions.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -1106,6 +1106,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/custom/breakpointOnWhen.kt");
         }
 
+        @TestMetadata("breakpointsInOneLineLambdas.kt")
+        public void testBreakpointsInOneLineLambdas() throws Exception {
+            runTest("testData/stepping/custom/breakpointsInOneLineLambdas.kt");
+        }
+
         @TestMetadata("constantConditions.kt")
         public void testConstantConditions() throws Exception {
             runTest("testData/stepping/custom/constantConditions.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/breakpointsInOneLineLambdas.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/breakpointsInOneLineLambdas.kt
@@ -1,0 +1,13 @@
+package breakpointsInOneLineLambdas
+
+fun foo(f: (Int) -> Unit) = f(1)
+
+inline fun Int.bar(f: (Int) -> Int) = f(this)
+
+fun main() {
+    // RESUME: 1
+    //Breakpoint! (lambdaOrdinal = 1)
+    foo { "${println(it)}"}
+    //Breakpoint! (lambdaOrdinal = 1)
+    foo { 1.bar { it }.bar { it + 1 }.bar { it + 2} }
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/breakpointsInOneLineLambdas.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/breakpointsInOneLineLambdas.out
@@ -1,0 +1,9 @@
+LineBreakpoint created at breakpointsInOneLineLambdas.kt:10 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInOneLineLambdas.kt:12 lambdaOrdinal = 1
+Run Java
+Connected to the target VM
+breakpointsInOneLineLambdas.kt:10
+breakpointsInOneLineLambdas.kt:12
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-19168/Debugger-lambda-breakpoint-stops-debugging-twice