### PR TITLE
KTIJ-25433: always highlight Kotlin diffs

### DIFF
--- a/plugins/kotlin/base/highlighting/src/org/jetbrains/kotlin/idea/base/highlighting/KotlinHighlightingUtils.kt
+++ b/plugins/kotlin/base/highlighting/src/org/jetbrains/kotlin/idea/base/highlighting/KotlinHighlightingUtils.kt
@@ -7,10 +7,8 @@ package org.jetbrains.kotlin.idea.base.highlighting
 import com.intellij.codeInsight.daemon.OutsidersPsiFileSupport
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.DumbService
-import com.intellij.psi.PsiManager
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.kotlin.idea.base.util.KotlinPlatformUtils
-import org.jetbrains.kotlin.idea.base.util.getOutsiderFileOrigin
 import org.jetbrains.kotlin.idea.base.projectStructure.RootKindFilter
 import org.jetbrains.kotlin.idea.base.projectStructure.matches
 import org.jetbrains.kotlin.idea.base.projectStructure.moduleInfo
@@ -49,9 +47,7 @@ fun KtFile.shouldHighlightFile(): Boolean {
     if (isCompiled) return false
 
     if (OutsidersPsiFileSupport.isOutsiderFile(virtualFile)) {
-        val origin = getOutsiderFileOrigin(project, virtualFile) ?: return false
-        val psiFileOrigin = PsiManager.getInstance(project).findFile(origin) as? KtFile ?: return false
-        return psiFileOrigin.shouldHighlightFile()
+        return true
     }
 
     val shouldCheckScript = shouldCheckScript()


### PR DESCRIPTION
"Outsider" PSI files are always meant to be highlighted, even if they no longer have an associated context file in the local file system.

Issue link: https://youtrack.jetbrains.com/issue/KTIJ-25433