### PR TITLE
ControlFlow: Generate WRITE for field initializers

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/controlFlow/ControlFlowAnalyzer.java
+++ b/java/java-psi-impl/src/com/intellij/psi/controlFlow/ControlFlowAnalyzer.java
@@ -648,12 +648,9 @@ final class ControlFlowAnalyzer extends JavaElementVisitor {
 
   @Override
   public void visitField(@NotNull PsiField field) {
-    final PsiExpression initializer = field.getInitializer();
-    if (initializer != null) {
-      startElement(field);
-      initializer.accept(this);
-      finishElement(field);
-    }
+    startElement(field);
+    processVariable(field);
+    finishElement(field);
   }
 
   @Override

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/psi/ControlFlowTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/psi/ControlFlowTest.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ex.PathManagerEx;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiCodeBlock;
+import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiJavaFile;
 import com.intellij.psi.controlFlow.*;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -79,5 +80,18 @@ public class ControlFlowTest extends LightJavaCodeInsightTestCase {
     IntList exitPoints = new IntArrayList();
     ControlFlowUtil.findExitPointsAndStatements(flow, 0, flow.getSize() -1 , exitPoints, ControlFlowUtil.DEFAULT_EXIT_STATEMENTS_CLASSES);
     assertEquals(1, exitPoints.size());
+  }
+
+  public void testWriteToFieldByInitializer() throws Exception {
+    @Language("JAVA")
+    String text = """
+      public class Foo {
+        int i = 3;
+      }""";
+    configureFromFileText("a.java", text);
+    final PsiField field = ((PsiJavaFile)getFile()).getClasses()[0].getFields()[0];
+    ControlFlow flow = ControlFlowFactory.getInstance(getProject()).getControlFlow(field, AllVariablesControlFlowPolicy.getInstance());
+    assertSize(1, flow.getInstructions());
+    assertInstanceOf(flow.getInstructions().get(0), WriteVariableInstruction.class);
   }
 }


### PR DESCRIPTION
Fresh PR after #2387 broke due to the force-push.
Original description:

Previously, the ControlFlowAnalyzer did not emit a WRITE instruction for field initializers. This is rather unexpected, as it generates instructions for other field writes. Looking at the processVariable method, it also looks like such usage was already intended: It checks if the variable is either a local variable or a field.

cc @amaembo 