### PR TITLE
IDEA-319974 Expose updateModifiedProperty more generally

### DIFF
--- a/platform/editor-ui-api/src/com/intellij/openapi/fileEditor/FileEditorWithUpdatableModified.java
+++ b/platform/editor-ui-api/src/com/intellij/openapi/fileEditor/FileEditorWithUpdatableModified.java
@@ -1,0 +1,6 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.openapi.fileEditor;
+
+public interface FileEditorWithUpdatableModified extends FileEditor {
+  void updateModifiedProperty();
+}

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
@@ -56,7 +56,7 @@ import static com.intellij.openapi.actionSystem.ActionPlaces.TEXT_EDITOR_WITH_PR
  *
  * @author Konstantin Bulenkov
  */
-public class TextEditorWithPreview extends UserDataHolderBase implements TextEditor {
+public class TextEditorWithPreview extends UserDataHolderBase implements TextEditor, FileEditorWithUpdatableModified {
   protected final TextEditor myEditor;
   protected final FileEditor myPreview;
   private final @NotNull MyListenersMultimap myListenersGenerator = new MyListenersMultimap();
@@ -316,6 +316,17 @@ public class TextEditorWithPreview extends UserDataHolderBase implements TextEdi
 
   public Layout getLayout() {
     return myLayout;
+  }
+
+  @Override
+  public void updateModifiedProperty() {
+    if (myEditor instanceof FileEditorWithUpdatableModified) {
+      ((FileEditorWithUpdatableModified)myEditor).updateModifiedProperty();
+    }
+
+    if (myPreview instanceof FileEditorWithUpdatableModified) {
+      ((FileEditorWithUpdatableModified)myPreview).updateModifiedProperty();
+    }
   }
 
   public static class MyFileEditorState implements FileEditorState {

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileDocumentManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileDocumentManagerImpl.java
@@ -443,8 +443,8 @@ public class FileDocumentManagerImpl extends FileDocumentManagerBase implements 
     for (Project project : ProjectManager.getInstance().getOpenProjects()) {
       FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
       for (FileEditor editor : fileEditorManager.getAllEditors(file)) {
-        if (editor instanceof TextEditorImpl) {
-          ((TextEditorImpl)editor).updateModifiedProperty();
+        if (editor instanceof FileEditorWithUpdatableModified) {
+          ((FileEditorWithUpdatableModified)editor).updateModifiedProperty();
         }
       }
     }

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/text/TextEditorImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/text/TextEditorImpl.java
@@ -35,7 +35,7 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.Objects;
 
-public class TextEditorImpl extends UserDataHolderBase implements TextEditor {
+public class TextEditorImpl extends UserDataHolderBase implements TextEditor, FileEditorWithUpdatableModified {
   private static final Logger LOG = Logger.getInstance(TextEditorImpl.class);
 
   private static final Key<TransientEditorState> TRANSIENT_EDITOR_STATE_KEY = Key.create("transientState");
@@ -169,6 +169,7 @@ public class TextEditorImpl extends UserDataHolderBase implements TextEditor {
     return myComponent.isEditorValid();
   }
 
+  @Override
   public void updateModifiedProperty() {
     myComponent.updateModifiedProperty();
   }


### PR DESCRIPTION
Some editors other than TextEditorImpl need to have their modified property updated when a file is dropped from the unsaved file list. An example is a split editor used for markdown files.

Bug: https://youtrack.jetbrains.com/issue/IDEA-319974