### PR TITLE
IDEA-319974 Expose updateModifiedProperty more generally

### DIFF
--- a/platform/editor-ui-api/src/com/intellij/openapi/fileEditor/FileEditorWithUpdatableModified.java
+++ b/platform/editor-ui-api/src/com/intellij/openapi/fileEditor/FileEditorWithUpdatableModified.java
@@ -1,0 +1,6 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.openapi.fileEditor;
+
+public interface FileEditorWithUpdatableModified extends FileEditor {
+  void updateModifiedProperty();
+}

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/TextEditorWithPreview.java
@@ -56,7 +56,7 @@ import static com.intellij.openapi.actionSystem.ActionPlaces.TEXT_EDITOR_WITH_PR
  *
  * @author Konstantin Bulenkov
  */
-public class TextEditorWithPreview extends UserDataHolderBase implements TextEditor {
+public class TextEditorWithPreview extends UserDataHolderBase implements TextEditor, FileEditorWithUpdatableModified {
   protected final TextEditor myEditor;
   protected final FileEditor myPreview;
   private final @NotNull MyListenersMultimap myListenersGenerator = new MyListenersMultimap();
@@ -316,6 +316,17 @@ public class TextEditorWithPreview extends UserDataHolderBase implements TextEdi
 
   public Layout getLayout() {
     return myLayout;
+  }
+
+  @Override
+  public void updateModifiedProperty() {
+    if (myEditor instanceof FileEditorWithUpdatableModified) {
+      ((FileEditorWithUpdatableModified)myEditor).updateModifiedProperty();
+    }
+
+    if (myPreview instanceof FileEditorWithUpdatableModified) {
+      ((FileEditorWithUpdatableModified)myPreview).updateModifiedProperty();
+    }
   }
 
   public static class MyFileEditorState implements FileEditorState {

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileDocumentManagerImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileDocumentManagerImpl.java
@@ -443,8 +443,8 @@ public class FileDocumentManagerImpl extends FileDocumentManagerBase implements 
     for (Project project : ProjectManager.getInstance().getOpenProjects()) {
       FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
       for (FileEditor editor : fileEditorManager.getAllEditors(file)) {
-        if (editor instanceof TextEditorImpl) {
-          ((TextEditorImpl)editor).updateModifiedProperty();
+        if (editor instanceof FileEditorWithUpdatableModified) {
+          ((FileEditorWithUpdatableModified)editor).updateModifiedProperty();
         }
       }
     }

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/text/TextEditorImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/text/TextEditorImpl.kt
@@ -39,7 +39,9 @@ private val TRANSIENT_EDITOR_STATE_KEY = Key.create<TransientEditorState>("trans
 open class TextEditorImpl @Internal constructor(@JvmField protected val project: Project,
                                                 @JvmField protected val file: VirtualFile,
                                                 editor: EditorImpl,
-                                                private val asyncLoader: AsyncEditorLoader) : UserDataHolderBase(), TextEditor {
+                                                private val asyncLoader: AsyncEditorLoader) : UserDataHolderBase(),
+                                                                                              TextEditor,
+                                                                                              FileEditorWithUpdatableModified {
   @Suppress("LeakingThis")
   private val changeSupport = PropertyChangeSupport(this)
   private val component: TextEditorComponent
@@ -160,7 +162,7 @@ open class TextEditorImpl @Internal constructor(@JvmField protected val project:
 
   override fun isValid(): Boolean = component.isEditorValid
 
-  fun updateModifiedProperty() {
+  override fun updateModifiedProperty() {
     component.updateModifiedProperty()
   }
 


### PR DESCRIPTION
Some editors other than TextEditorImpl need to have their modified property updated when a file is dropped from the unsaved file list. An example is a split editor used for markdown files.

Bug: https://youtrack.jetbrains.com/issue/IDEA-319974