### PR TITLE
Expose externalProjectPath on ExternalSystemNotificationExtension.customize()

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemRunnableState.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/execution/ExternalSystemRunnableState.java
@@ -326,7 +326,8 @@ public class ExternalSystemRunnableState extends UserDataHolderBase implements R
         public void onFailure(@NotNull ExternalSystemTaskId id, @NotNull Exception e) {
           DataContext dataContext = BuildConsoleUtils.getDataContext(id, progressListener);
           FailureResult failureResult = ExternalSystemUtil.createFailureResult(
-            executionName + " " + BuildBundle.message("build.status.failed"), e, id.getProjectSystemId(), myProject, dataContext);
+            executionName + " " + BuildBundle.message("build.status.failed"), e, id.getProjectSystemId(), myProject,
+            mySettings.getExternalProjectPath(), dataContext);
           eventDispatcher.onEvent(id, new FinishBuildEventImpl(id, null, System.currentTimeMillis(),
                                                                BuildBundle.message("build.status.failed"), failureResult));
           processHandler.notifyProcessTerminated(1);

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/notification/ExternalSystemNotificationExtension.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/notification/ExternalSystemNotificationExtension.java
@@ -36,13 +36,28 @@ public interface ExternalSystemNotificationExtension {
   /**
    * Allows to customize external system processing notification.
    *
-   * @param notificationData notification data
-   * @param project target ide project
-   * @param error   error occurred during external system processing
+   * @param notificationData    notification data
+   * @param project             target ide project
+   * @param externalProjectPath path of the target external project
+   * @param error               error occurred during external system processing
    */
   void customize(@NotNull NotificationData notificationData,
                  @NotNull Project project,
+                 @NotNull String externalProjectPath,
                  @Nullable Throwable error);
+
+  /**
+   * Allows to customize external system processing notification.
+   * @deprecated Use {@link #customize(NotificationData, Project, String, Throwable)} instead
+   * @param notificationData    notification data
+   * @param project             target ide project
+   * @param error               error occurred during external system processing
+   */
+  @Deprecated
+  default void customize(@NotNull NotificationData notificationData,
+                         @NotNull Project project,
+                         @Nullable Throwable error) {
+  }
 
   /**
    * Allows to determine internal errors comes from external system which might be confusing for IDE users.

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/notification/ExternalSystemNotificationExtensionImpl.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/notification/ExternalSystemNotificationExtensionImpl.java
@@ -36,6 +36,7 @@ public class ExternalSystemNotificationExtensionImpl implements ExternalSystemNo
   @Override
   public void customize(@NotNull NotificationData notification,
                         @NotNull Project project,
+                        @NotNull String externalProjectPath,
                         @Nullable Throwable error) {
     if (error == null) return;
     Throwable unwrapped = RemoteUtil.unwrap(error);

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/notification/ExternalSystemNotificationManager.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/notification/ExternalSystemNotificationManager.java
@@ -102,6 +102,7 @@ public final class ExternalSystemNotificationManager implements Disposable {
                                                        @NotNull Throwable error,
                                                        @NotNull ProjectSystemId externalSystemId,
                                                        @NotNull Project project,
+                                                       @NotNull String externalProjectPath,
                                                        @NotNull DataContext dataContext) {
     if (isInternalError(error, externalSystemId)) {
       return null;
@@ -141,6 +142,7 @@ public final class ExternalSystemNotificationManager implements Disposable {
       if (!externalSystemId.equals(targetExternalSystemId) && !targetExternalSystemId.equals(ProjectSystemId.IDE)) {
         continue;
       }
+      extension.customize(notificationData, project, externalProjectPath, error);
       extension.customize(notificationData, project, error);
     }
     return notificationData;

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/util/ExternalSystemUtil.java
@@ -416,7 +416,7 @@ public final class ExternalSystemUtil {
             var externalSystemName = externalSystemId.getReadableName();
             var title = ExternalSystemBundle.message("notification.project.refresh.fail.title", externalSystemName, projectName);
             var dataContext = BuildConsoleUtils.getDataContext(id, syncViewManager);
-            var eventResult = createFailureResult(title, e, externalSystemId, project, dataContext);
+            var eventResult = createFailureResult(title, e, externalSystemId, project, externalProjectPath, dataContext);
             return new FinishBuildEventImpl(id, null, eventTime, eventMessage, eventResult);
           });
           processHandler.notifyProcessTerminated(1);
@@ -585,7 +585,7 @@ public final class ExternalSystemUtil {
         var systemName = externalSystemId.getReadableName();
         var projectName = resolveProjectTask.getProjectName();
         var title = ExternalSystemBundle.message("notification.project.refresh.fail.title", systemName, projectName);
-        var eventResult = createFailureResult(title, t, externalSystemId, project, DataContext.EMPTY_CONTEXT);
+        var eventResult = createFailureResult(title, t, externalSystemId, project, externalProjectPath, DataContext.EMPTY_CONTEXT);
         return new FinishBuildEventImpl(taskId, null, eventTime, eventMessage, eventResult);
       });
     }
@@ -699,9 +699,10 @@ public final class ExternalSystemUtil {
                                                                @NotNull Throwable exception,
                                                                @NotNull ProjectSystemId externalSystemId,
                                                                @NotNull Project project,
+                                                               @NotNull String externalProjectPath,
                                                                @NotNull DataContext dataContext) {
     var notificationManager = ExternalSystemNotificationManager.getInstance(project);
-    var notificationData = notificationManager.createNotification(title, exception, externalSystemId, project, dataContext);
+    var notificationData = notificationManager.createNotification(title, exception, externalSystemId, project, externalProjectPath, dataContext);
     if (notificationData == null) {
       return new FailureResultImpl();
     }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/notification/GradleNotificationExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/notification/GradleNotificationExtension.java
@@ -80,6 +80,7 @@ public class GradleNotificationExtension implements ExternalSystemNotificationEx
   @Override
   public void customize(@NotNull NotificationData notification,
                         @NotNull Project project,
+                        @NotNull String externalProjectPath,
                         @Nullable Throwable error) {
     if (error == null) return;
     Throwable unwrapped = RemoteUtil.unwrap(error);


### PR DESCRIPTION
This was added to be able to support multiple gradle root projects, providing the `externalProjectPath` on the  `ExternalSystemNotification.customize` allowing to provide better error message to users