### PR TITLE
KTIJ-11579 Recursive call icon in gutter not shown if function name is not a valid java identifier (but still a valid Kotlin&JVM identifier)

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/highlighter/KotlinRecursiveCallLineMarkerProvider.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
+import org.jetbrains.kotlin.idea.base.psi.unquoteKotlinIdentifier
 import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.highlighter.markers.LineMarkerInfos
@@ -141,7 +142,7 @@ private fun PsiElement.getLineNumber(): Int {
 private fun getCallNameFromPsi(element: KtElement): Name? {
     when (element) {
         is KtSimpleNameExpression -> when (val elementParent = element.getParent()) {
-            is KtCallExpression -> return Name.identifier(element.getText())
+            is KtCallExpression -> return Name.identifier(element.getText().unquoteKotlinIdentifier())
             is KtOperationExpression -> {
                 val operationReference = elementParent.operationReference
                 if (element == operationReference) {
@@ -152,9 +153,9 @@ private fun getCallNameFromPsi(element: KtElement): Name? {
                         else
                             OperatorConventions.getNameForOperationSymbol(node)
 
-                        conventionName ?: Name.identifier(element.getText())
+                        conventionName ?: Name.identifier(element.getText().unquoteKotlinIdentifier())
                     } else {
-                        Name.identifier(element.getText())
+                        Name.identifier(element.getText().unquoteKotlinIdentifier())
                     }
                 }
             }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/LineMarkersTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/codeInsight/LineMarkersTestGenerated.java
@@ -230,6 +230,11 @@ public abstract class LineMarkersTestGenerated extends AbstractLineMarkersTest {
             KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
         }
 
+        @TestMetadata("backticksInName.kt")
+        public void testBackticksInName() throws Exception {
+            runTest("testData/codeInsight/lineMarker/recursiveCall/backticksInName.kt");
+        }
+
         @TestMetadata("companionInvoke.kt")
         public void testCompanionInvoke() throws Exception {
             runTest("testData/codeInsight/lineMarker/recursiveCall/companionInvoke.kt");

--- a/plugins/kotlin/idea/tests/testData/codeInsight/lineMarker/recursiveCall/backticksInName.kt
+++ b/plugins/kotlin/idea/tests/testData/codeInsight/lineMarker/recursiveCall/backticksInName.kt
@@ -1,0 +1,1 @@
+fun `b `(): Unit = <lineMarker descr="Recursive call">`b `</lineMarker>()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-11579