### PR TITLE
KTIJ-25503 - Create ClassImportFilter and associated EP

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2023 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.jetbrains.kotlin.idea.util
 
 import com.intellij.openapi.extensions.ExtensionPointName

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.kotlin.idea.util
+
+import com.intellij.openapi.extensions.ExtensionPointName
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+
+/** Filter that can block classes from being automatically imported as a side-effect of other actions. */
+fun interface ClassImportFilter {
+    /** Returns whether to allow this class to be imported. */
+    fun allowClassImport(descriptor: DeclarationDescriptor, contextFile: KtFile) : Boolean
+
+    companion object {
+        val EP_NAME = ExtensionPointName.create<ClassImportFilter>("org.jetbrains.kotlin.classImportFilter")
+        fun allowClassImport(descriptor: DeclarationDescriptor, contextFile: KtFile) =
+            EP_NAME.extensions.all { it.allowClassImport(descriptor, contextFile) }
+    }
+}

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
@@ -2,7 +2,6 @@ package org.jetbrains.kotlin.idea.util
 
 import com.intellij.openapi.extensions.ExtensionPointName
 import org.jetbrains.kotlin.descriptors.ClassKind
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.name.FqName

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/ClassImportFilter.kt
@@ -1,17 +1,27 @@
 package org.jetbrains.kotlin.idea.util
 
 import com.intellij.openapi.extensions.ExtensionPointName
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibility
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtFile
 
 /** Filter that can block classes from being automatically imported as a side-effect of other actions. */
 fun interface ClassImportFilter {
+    /**
+     * This class holds information that implementations of ClassImportFilter might need to decide whether to import a given class.
+     * By packaging this information in a data class, we avoid the need to change the API when we need to add more/different information.
+     */
+    data class ClassInfo(val fqName: FqName, val classKind: ClassKind, val modality: Modality, val visibility: Visibility, val isNested: Boolean)
+
     /** Returns whether to allow this class to be imported. */
-    fun allowClassImport(descriptor: DeclarationDescriptor, contextFile: KtFile) : Boolean
+    fun allowClassImport(classInfo: ClassInfo, contextFile: KtFile) : Boolean
 
     companion object {
         val EP_NAME = ExtensionPointName.create<ClassImportFilter>("org.jetbrains.kotlin.classImportFilter")
-        fun allowClassImport(descriptor: DeclarationDescriptor, contextFile: KtFile) =
-            EP_NAME.extensions.all { it.allowClassImport(descriptor, contextFile) }
+        fun allowClassImport(classInfo: ClassInfo, contextFile: KtFile) =
+            EP_NAME.extensions.all { it.allowClassImport(classInfo, contextFile) }
     }
 }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/AbstractImportsTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/AbstractImportsTest.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.idea.core.formatter.KotlinPackageEntry
 import org.jetbrains.kotlin.idea.core.script.ScriptConfigurationManager
 import org.jetbrains.kotlin.idea.formatter.kotlinCustomSettings
 import org.jetbrains.kotlin.idea.test.*
+import org.jetbrains.kotlin.idea.util.ClassImportFilter
 import org.jetbrains.kotlin.idea.util.application.executeWriteCommand
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
@@ -58,6 +59,11 @@ abstract class AbstractImportsTest : KotlinLightCodeInsightFixtureTestCase() {
 
             InTextDirectivesUtils.findLinesWithPrefixesRemoved(fileText, "// PACKAGES_TO_USE_STAR_IMPORTS:").forEach {
                 codeStyleSettings.PACKAGES_TO_USE_STAR_IMPORTS.addEntry(KotlinPackageEntry(it.trim(), true))
+            }
+
+            InTextDirectivesUtils.findLinesWithPrefixesRemoved(fileText, "// CLASS_IMPORT_FILTER_VETO_REGEX:").forEach {
+                val filterExtension = ClassImportFilter { descriptor, _ -> !descriptor.name.asString().matches(Regex(it.trim())) }
+                ClassImportFilter.EP_NAME.point.registerExtension(filterExtension, testRootDisposable)
             }
 
             val log = if (runTestInWriteCommand) {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/AbstractImportsTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/AbstractImportsTest.kt
@@ -62,7 +62,7 @@ abstract class AbstractImportsTest : KotlinLightCodeInsightFixtureTestCase() {
             }
 
             InTextDirectivesUtils.findLinesWithPrefixesRemoved(fileText, "// CLASS_IMPORT_FILTER_VETO_REGEX:").forEach {
-                val filterExtension = ClassImportFilter { descriptor, _ -> !descriptor.name.asString().matches(Regex(it.trim())) }
+                val filterExtension = ClassImportFilter { classInfo, _ -> !classInfo.fqName.asString().matches(Regex(it.trim())) }
                 ClassImportFilter.EP_NAME.point.registerExtension(filterExtension, testRootDisposable)
             }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/AbstractImportsTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/AbstractImportsTest.kt
@@ -62,7 +62,8 @@ abstract class AbstractImportsTest : KotlinLightCodeInsightFixtureTestCase() {
             }
 
             InTextDirectivesUtils.findLinesWithPrefixesRemoved(fileText, "// CLASS_IMPORT_FILTER_VETO_REGEX:").forEach {
-                val filterExtension = ClassImportFilter { classInfo, _ -> !classInfo.fqName.asString().matches(Regex(it.trim())) }
+                val regex = Regex(".*${it.trim()}.*")
+                val filterExtension = ClassImportFilter { classInfo, _ -> !classInfo.fqName.asString().matches(regex) }
                 ClassImportFilter.EP_NAME.point.registerExtension(filterExtension, testRootDisposable)
             }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/shortenRefs/ShortenRefsTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/shortenRefs/ShortenRefsTestGenerated.java
@@ -137,6 +137,16 @@ public abstract class ShortenRefsTestGenerated extends AbstractShortenRefsTest {
             KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
         }
 
+        @TestMetadata("filteredClassImport.kt")
+        public void testFilteredClassImport() throws Exception {
+            runTest("testData/shortenRefs/java/filteredClassImport.kt");
+        }
+
+        @TestMetadata("filteredClassNoImports.kt")
+        public void testFilteredClassNoImports() throws Exception {
+            runTest("testData/shortenRefs/java/filteredClassNoImports.kt");
+        }
+
         @TestMetadata("innerClassImport.kt")
         public void testInnerClassImport() throws Exception {
             runTest("testData/shortenRefs/java/innerClassImport.kt");

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassImport.dependency.java
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassImport.dependency.java
@@ -1,0 +1,7 @@
+class A {
+    public class B {
+        public B(String s) {
+
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassImport.kt
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassImport.kt
@@ -1,0 +1,6 @@
+// IMPORT_NESTED_CLASSES: true
+// CLASS_IMPORT_FILTER_VETO_REGEX: Other
+
+fun bar(s: String) {
+    <selection>val t: A.B = A().B(s)</selection>
+}

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassImport.kt.after
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassImport.kt.after
@@ -1,0 +1,8 @@
+import A.B
+
+// IMPORT_NESTED_CLASSES: true
+// CLASS_IMPORT_FILTER_VETO_REGEX: Other
+
+fun bar(s: String) {
+    val t: B = A().B(s)
+}

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassNoImports.dependency.java
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassNoImports.dependency.java
@@ -1,0 +1,7 @@
+class A {
+    public class B {
+        public B(String s) {
+
+        }
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassNoImports.kt
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassNoImports.kt
@@ -1,0 +1,8 @@
+// IMPORT_NESTED_CLASSES: true
+// CLASS_IMPORT_FILTER_VETO_REGEX: Other
+// CLASS_IMPORT_FILTER_VETO_REGEX: B
+
+fun bar(s: String) {
+    <selection>val t: A.B = A().B(s)</selection>
+}
+

--- a/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassNoImports.kt.after
+++ b/plugins/kotlin/idea/tests/testData/shortenRefs/java/filteredClassNoImports.kt.after
@@ -1,0 +1,8 @@
+// IMPORT_NESTED_CLASSES: true
+// CLASS_IMPORT_FILTER_VETO_REGEX: Other
+// CLASS_IMPORT_FILTER_VETO_REGEX: B
+
+fun bar(s: String) {
+    val t: A.B = A().B(s)
+}
+

--- a/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
+++ b/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
@@ -57,6 +57,10 @@
             qualifiedName="org.jetbrains.kotlin.ktModuleFactory"
             interface="org.jetbrains.kotlin.idea.base.projectStructure.KtModuleFactory"
             dynamic="true"/>
+    <extensionPoint
+            qualifiedName="org.jetbrains.kotlin.classImportFilter"
+            interface="org.jetbrains.kotlin.idea.util.ClassImportFilter"
+            dynamic="true"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
This change addresses https://youtrack.jetbrains.com/issue/KTIJ-25503

Currently, some actions like refactoring cause imports to happen
as a side-effect, notably for nested classes. For certain classes,
it is almost never correct to import them. An example here is in
Android Studio where R.string, R.values, R.drawable, etc. are
technically nested classes (despite the lowercase letter).

This change creates a new ClassImportFilter interface and associated
Extension Point, which plugins can use to veto the import of particular
classes.