### PR TITLE
IDEA-320384 Display Gradle unsupported Java version based on SupportMatrix

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/IncompatibleGradleJdkIssueChecker.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/IncompatibleGradleJdkIssueChecker.kt
@@ -65,20 +65,15 @@ class IncompatibleGradleJdkIssueChecker : GradleIssueChecker {
       }
     }
 
-    var isJavaGroovyCompatibilityIssue = false
-    var isJavaByteCodeCompatibilityIssue = false
-    if (javaVersionUsed != null && gradleVersionUsed != null && !isSupported(gradleVersionUsed, javaVersionUsed)) {
-      isJavaGroovyCompatibilityIssue = isJavaGroovyCompatibilityIssue(rootCauseText)
-      isJavaByteCodeCompatibilityIssue = isJavaByteCodeCompatibilityIssue(rootCauseText)
-    }
+    val isUnsupportedJavaVersionForGradle =
+      javaVersionUsed != null && gradleVersionUsed != null && !isSupported(gradleVersionUsed, javaVersionUsed)
 
-    if (!isUnsupportedClassVersionErrorIssue &&
+    if (!isUnsupportedJavaVersionForGradle &&
+        !isUnsupportedClassVersionErrorIssue &&
         !isUnsupportedJavaRuntimeIssue &&
         !isRemovedUnsafeDefineClassMethodInJDK11Issue &&
         !unableToStartDaemonProcessForJDK11 &&
-        !unableToStartDaemonProcessForJDK9 &&
-        !isJavaGroovyCompatibilityIssue &&
-        !isJavaByteCodeCompatibilityIssue) {
+        !unableToStartDaemonProcessForJDK9) {
       return null
     }
 
@@ -101,7 +96,7 @@ class IncompatibleGradleJdkIssueChecker : GradleIssueChecker {
           .append("Unsupported Java. \n") // title
           .append("Your build is currently configured to use $incompatibleJavaVersion. You need to use at least Java 7.")
       }
-      isJavaGroovyCompatibilityIssue || isJavaByteCodeCompatibilityIssue -> {
+      isUnsupportedJavaVersionForGradle -> {
         issueDescription
           .append("Unsupported Java. \n") // title
           .append("Your build is currently configured to use Java $javaVersionUsed and Gradle ${gradleVersionUsed!!.version}.")
@@ -167,14 +162,6 @@ class IncompatibleGradleJdkIssueChecker : GradleIssueChecker {
       override val quickFixes = quickFixes
       override fun getNavigatable(project: Project): Navigatable? = null
     }
-  }
-
-  private fun isJavaGroovyCompatibilityIssue(rootCauseText: String): Boolean {
-    return rootCauseText.startsWith("java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.")
-  }
-
-  private fun isJavaByteCodeCompatibilityIssue(rootCauseText: String): Boolean {
-    return rootCauseText.contains("Unsupported class file major version")
   }
 
   override fun consumeBuildOutputFailureMessage(message: String,


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-320384/

The existing implementation of [IncompatibleGradleJdkIssueChecker](https://github.com/JetBrains/intellij-community/blob/master/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/IncompatibleGradleJdkIssueChecker.kt) is able to handle properly this kind of exceptions when Gradle version is `<= 5.0` but when using `4.10.1` the following exception is thrown:

```
* What went wrong:
Unable to make protected void java.net.URLClassLoader.addURL(java.net.URL) accessible: module java.base does not "opens java.net" to unnamed module @7a187f14

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
java.lang.reflect.InaccessibleObjectException: Unable to make protected void java.net.URLClassLoader.addURL(java.net.URL) accessible: module java.base does not "opens java.net" to unnamed module @7a187f14
	at org.gradle.internal.reflect.JavaMethod.<init>(JavaMethod.java:42)
	at org.gradle.internal.reflect.JavaMethod.<init>(JavaMethod.java:32)
	at org.gradle.internal.reflect.JavaMethod.<init>(JavaMethod.java:36)
```
- After
<img width="1225" alt="Screenshot 2023-05-12 at 12 10 20" src="https://github.com/JetBrains/intellij-community/assets/18151158/e8b57b33-8b31-45dc-9558-7f509d53d1dd">

