### PR TITLE
[maven] IDEA-320329 - non-case sensitive unique artifactId in maven project import

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenModuleNameMapper.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/MavenModuleNameMapper.java
@@ -13,7 +13,10 @@ import org.jetbrains.idea.maven.project.MavenProject;
 import java.io.File;
 import java.util.*;
 
+import static java.util.Locale.ROOT;
+
 public final class MavenModuleNameMapper {
+
   public static void map(Collection<MavenProject> projects,
                          Map<MavenProject, Module> mavenProjectToModule,
                          Map<MavenProject, String> mavenProjectToModuleName,
@@ -45,14 +48,15 @@ public final class MavenModuleNameMapper {
 
     Arrays.sort(names);
 
-    Map<String, Integer> nameCounters = new HashMap<>();
+    Map<String, Integer> nameCountersLowerCase = new HashMap<>();
 
     for (i = 0; i < names.length; i++) {
       if (names[i].hasDuplicatedGroup) continue;
 
       for (int k = i + 1; k < names.length; k++) {
-        if (names[i].originalName.equals(names[k].originalName)) {
-          nameCounters.put(names[i].originalName, 0);
+        // IDEA-320329 check should be non case-sensitive
+        if (names[i].originalName.equalsIgnoreCase(names[k].originalName)) {
+          nameCountersLowerCase.put(names[i].originalName.toLowerCase(ROOT), 0);
 
           if (names[i].groupId.equals(names[k].groupId)) {
             names[i].hasDuplicatedGroup = true;
@@ -74,11 +78,11 @@ public final class MavenModuleNameMapper {
     for (NameItem nameItem : names) {
       if (nameItem.module == null) {
 
-        Integer c = nameCounters.get(nameItem.originalName);
+        Integer c = nameCountersLowerCase.get(nameItem.originalName.toLowerCase(ROOT));
 
         if (c != null) {
           nameItem.number = c;
-          nameCounters.put(nameItem.originalName, c + 1);
+          nameCountersLowerCase.put(nameItem.originalName.toLowerCase(ROOT), c + 1);
         }
 
         do {
@@ -86,7 +90,7 @@ public final class MavenModuleNameMapper {
           if (existingNames.add(name)) break;
 
           nameItem.number++;
-          nameCounters.put(nameItem.originalName, nameItem.number + 1);
+          nameCountersLowerCase.put(nameItem.originalName.toLowerCase(ROOT), nameItem.number + 1);
         }
         while (true);
       }

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/importing/MavenModuleNameMapperTest.java
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/importing/MavenModuleNameMapperTest.java
@@ -1,0 +1,114 @@
+package org.jetbrains.idea.maven.importing;
+
+import com.intellij.openapi.module.Module;
+import org.jetbrains.idea.maven.model.MavenId;
+import org.jetbrains.idea.maven.project.MavenProject;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MavenModuleNameMapperTest {
+
+  @Test
+  public void shouldMapUniqueArtifactIds() {
+    MavenProject project1 = mock(MavenProject.class);
+    when(project1.getMavenId()).thenReturn(new MavenId("com.demo:maven-module-1"));
+    when(project1.getPath()).thenReturn("maven-module-path-1");
+    MavenProject project2 = mock(MavenProject.class);
+    when(project2.getMavenId()).thenReturn(new MavenId("com.demo:maven-module-2"));
+    when(project2.getPath()).thenReturn("maven-module-path-2");
+
+    Collection<MavenProject> projects = List.of(
+      project1,
+      project2
+    );
+    Map<MavenProject, Module> mavenProjectToModule = new HashMap<>();
+    Map<MavenProject, String> mavenProjectToModuleName = new HashMap<>();
+    Map<MavenProject, String> mavenProjectToModulePath = new HashMap<>();
+    String dedicatedModuleDir = null;
+
+    MavenModuleNameMapper.map(
+      projects,
+      mavenProjectToModule,
+      mavenProjectToModuleName,
+      mavenProjectToModulePath,
+      dedicatedModuleDir
+    );
+
+    assertEquals(Map.of(
+      project1, "maven-module-1",
+      project2, "maven-module-2"
+    ), mavenProjectToModuleName);
+  }
+
+  @Test
+  public void shouldMapNonUniqueArtifactIdsCaseSensitive() {
+    MavenProject project1 = mock(MavenProject.class);
+    when(project1.getMavenId()).thenReturn(new MavenId("com.demo:maven-module"));
+    when(project1.getPath()).thenReturn("maven-module-path-1");
+    MavenProject project2 = mock(MavenProject.class);
+    when(project2.getMavenId()).thenReturn(new MavenId("com.demo.sub:maven-module"));
+    when(project2.getPath()).thenReturn("maven-module-path-2");
+
+    Collection<MavenProject> projects = List.of(
+      project1,
+      project2
+    );
+    Map<MavenProject, Module> mavenProjectToModule = new HashMap<>();
+    Map<MavenProject, String> mavenProjectToModuleName = new HashMap<>();
+    Map<MavenProject, String> mavenProjectToModulePath = new HashMap<>();
+    String dedicatedModuleDir = null;
+
+    MavenModuleNameMapper.map(
+      projects,
+      mavenProjectToModule,
+      mavenProjectToModuleName,
+      mavenProjectToModulePath,
+      dedicatedModuleDir
+    );
+
+    assertEquals(Map.of(
+      project1, "maven-module (1) (com.demo)",
+      project2, "maven-module (2) (com.demo.sub)"
+    ), mavenProjectToModuleName);
+  }
+
+  // covers IDEA-320329
+  @Test
+  public void shouldMapNonUniqueArtifactIdsNonCaseSensitive() {
+    MavenProject project1 = mock(MavenProject.class);
+    when(project1.getMavenId()).thenReturn(new MavenId("com.demo:MavenModule"));
+    when(project1.getPath()).thenReturn("maven-module-path-1");
+    MavenProject project2 = mock(MavenProject.class);
+    when(project2.getMavenId()).thenReturn(new MavenId("com.demo.sub:mavenmodule"));
+    when(project2.getPath()).thenReturn("maven-module-path-2");
+
+    Collection<MavenProject> projects = List.of(
+      project1,
+      project2
+    );
+    Map<MavenProject, Module> mavenProjectToModule = new HashMap<>();
+    Map<MavenProject, String> mavenProjectToModuleName = new HashMap<>();
+    Map<MavenProject, String> mavenProjectToModulePath = new HashMap<>();
+    String dedicatedModuleDir = null;
+
+    MavenModuleNameMapper.map(
+      projects,
+      mavenProjectToModule,
+      mavenProjectToModuleName,
+      mavenProjectToModulePath,
+      dedicatedModuleDir
+    );
+
+    assertEquals(Map.of(
+      project1, "MavenModule (1) (com.demo)",
+      project2, "mavenmodule (2) (com.demo.sub)"
+    ), mavenProjectToModuleName);
+  }}


### PR DESCRIPTION
## Motivation

Fixes https://youtrack.jetbrains.com/issue/IDEA-320329

## Proposed fix
Do a non-case sensitive comparison when calculating possible repeated module names.

## Notes
This implementation does not fix the conflicting module names if according IDEA module already exists, it will only work if the module is new or project is under initial import.
This change can break shared run configurations for multi-module projects with non-unique artifactId names as some modules will now have another name on import from scratch.