### PR TITLE
KTIJ-25561 "Redundant 'with' call" inspection with expression body function should preserve the return value

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10427,6 +10427,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/redundantWith/emptyExpressionInReturn.kt");
         }
 
+        @TestMetadata("expressionBodyFunction.kt")
+        public void testExpressionBodyFunction() throws Exception {
+            runTest("testData/inspectionsLocal/redundantWith/expressionBodyFunction.kt");
+        }
+
         @TestMetadata("nested.kt")
         public void testNested() throws Exception {
             runTest("testData/inspectionsLocal/redundantWith/nested.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/expressionBodyFunction.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/expressionBodyFunction.kt
@@ -1,0 +1,6 @@
+// WITH_STDLIB
+fun f() = <caret>with(Unit) {
+    42
+}
+
+val answer: Int = f()

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/expressionBodyFunction.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/redundantWith/expressionBodyFunction.kt.after
@@ -1,0 +1,4 @@
+// WITH_STDLIB
+fun f() = 42
+
+val answer: Int = f()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-25561