### PR TITLE
Check if project is disposed in project root manager

### DIFF
--- a/platform/lang-impl/src/com/intellij/openapi/roots/impl/ProjectRootManagerComponent.kt
+++ b/platform/lang-impl/src/com/intellij/openapi/roots/impl/ProjectRootManagerComponent.kt
@@ -129,7 +129,7 @@ open class ProjectRootManagerComponent(project: Project) : ProjectRootManagerImp
   }
 
   init {
-    if (!myProject.isDefault) {
+    if (!myProject.isDefault && !myProject.isDisposed) {
       registerListeners()
     }
   }
@@ -190,7 +190,7 @@ open class ProjectRootManagerComponent(project: Project) : ProjectRootManagerImp
   }
 
   private fun addRootsToWatch() {
-    if (myProject.isDefault) {
+    if (myProject.isDefault || myProject.isDisposed) {
       return
     }
 


### PR DESCRIPTION
We have some integration tests fail with the following stack trace (with different call points ending up here) occasionally. I believe this should at least help mitigate the issue. 

```
        ....
	at com.intellij.openapi.roots.impl.CompilerProjectExtensionImpl.getRootsToWatch(CompilerProjectExtensionImpl.java:84)
	at com.intellij.openapi.roots.impl.CompilerProjectExtensionImpl$MyWatchedRootsProvider.getRootsToWatch(CompilerProjectExtensionImpl.java:134)
	at com.intellij.openapi.roots.impl.ProjectRootManagerComponent.collectWatchRoots(ProjectRootManagerComponent.kt:274)
	at com.intellij.openapi.roots.impl.ProjectRootManagerComponent.addRootsToWatch(ProjectRootManagerComponent.kt:193)
	at com.intellij.openapi.roots.impl.ProjectRootManagerComponent.access$addRootsToWatch(ProjectRootManagerComponent.kt:58)
	at com.intellij.openapi.roots.impl.ProjectRootManagerComponent$registerListeners$1.projectOpened(ProjectRootManagerComponent.kt:135)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeMethod(MessageBusImpl.kt:655)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:625)
	```