### PR TITLE
Fix smart stepping into lambdas inlined multiple times

### DIFF
--- a/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinLambdaMethodFilter.kt
+++ b/plugins/kotlin/jvm-debugger/core-fe10/src/org/jetbrains/kotlin/idea/debugger/stepping/smartStepInto/KotlinLambdaMethodFilter.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 
 package org.jetbrains.kotlin.idea.debugger.stepping.smartStepInto
 
@@ -11,9 +11,10 @@ import com.intellij.util.Range
 import com.sun.jdi.Location
 import org.jetbrains.kotlin.codegen.coroutines.INVOKE_SUSPEND_METHOD_NAME
 import org.jetbrains.kotlin.idea.base.psi.isMultiLine
+import org.jetbrains.kotlin.idea.debugger.base.util.safeMethod
 import org.jetbrains.kotlin.idea.debugger.core.DebuggerUtils.isGeneratedIrBackendLambdaMethodName
 import org.jetbrains.kotlin.idea.debugger.core.DebuggerUtils.trimIfMangledInBytecode
-import org.jetbrains.kotlin.idea.debugger.base.util.safeMethod
+import org.jetbrains.kotlin.idea.debugger.core.stepping.StopOnReachedMethodFilter
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtFunction
@@ -23,7 +24,7 @@ class KotlinLambdaMethodFilter(
     lambda: KtFunction,
     private val callingExpressionLines: Range<Int>?,
     private val lambdaInfo: KotlinLambdaInfo
-) : BreakpointStepMethodFilter {
+) : BreakpointStepMethodFilter, StopOnReachedMethodFilter {
     private val lambdaPtr = lambda.createSmartPointer()
     private val firstStatementPosition: SourcePosition?
     private val lastStatementLine: Int

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
@@ -160,6 +160,8 @@ class KotlinStepOverRequestHint(
     }
 }
 
+interface StopOnReachedMethodFilter
+
 class KotlinStepIntoRequestHint(
     stepThread: ThreadReferenceProxyImpl,
     suspendContext: SuspendContextImpl,
@@ -188,6 +190,12 @@ class KotlinStepIntoRequestHint(
                 lastWasKotlinFakeLineNumber = false
                 return STOP
             }
+
+            val filter = methodFilter
+            if (filter is StopOnReachedMethodFilter && filter.locationMatches(context.debugProcess, location)) {
+                return STOP
+            }
+
             return super.getNextStepDepth(context)
         } catch (ignored: VMDisconnectedException) {
         } catch (e: EvaluateException) {

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinSteppingTestGenerated.java
@@ -1450,6 +1450,11 @@ public abstract class K2IdeK1CodeKotlinSteppingTestGenerated extends AbstractK2I
             runTest("../testData/stepping/custom/smartStepIntoMethodReference.kt");
         }
 
+        @TestMetadata("smartStepIntoMultiplyInlinedLambdas.kt")
+        public void testSmartStepIntoMultiplyInlinedLambdas() throws Exception {
+            runTest("../testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.kt");
+        }
+
         @TestMetadata("smartStepIntoNullSafeFunctionCalls.kt")
         public void testSmartStepIntoNullSafeFunctionCalls() throws Exception {
             runTest("../testData/stepping/custom/smartStepIntoNullSafeFunctionCalls.kt");

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IndyLambdaKotlinSteppingTestGenerated.java
@@ -1450,6 +1450,11 @@ public abstract class K2IndyLambdaKotlinSteppingTestGenerated extends AbstractK2
             runTest("../testData/stepping/custom/smartStepIntoMethodReference.kt");
         }
 
+        @TestMetadata("smartStepIntoMultiplyInlinedLambdas.kt")
+        public void testSmartStepIntoMultiplyInlinedLambdas() throws Exception {
+            runTest("../testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.kt");
+        }
+
         @TestMetadata("smartStepIntoNullSafeFunctionCalls.kt")
         public void testSmartStepIntoNullSafeFunctionCalls() throws Exception {
             runTest("../testData/stepping/custom/smartStepIntoNullSafeFunctionCalls.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaKotlinSteppingTestGenerated.java
@@ -1450,6 +1450,11 @@ public abstract class IndyLambdaKotlinSteppingTestGenerated extends AbstractIndy
             runTest("testData/stepping/custom/smartStepIntoMethodReference.kt");
         }
 
+        @TestMetadata("smartStepIntoMultiplyInlinedLambdas.kt")
+        public void testSmartStepIntoMultiplyInlinedLambdas() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.kt");
+        }
+
         @TestMetadata("smartStepIntoNullSafeFunctionCalls.kt")
         public void testSmartStepIntoNullSafeFunctionCalls() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoNullSafeFunctionCalls.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinSteppingTestGenerated.java
@@ -1450,6 +1450,11 @@ public abstract class IrKotlinSteppingTestGenerated extends AbstractIrKotlinStep
             runTest("testData/stepping/custom/smartStepIntoMethodReference.kt");
         }
 
+        @TestMetadata("smartStepIntoMultiplyInlinedLambdas.kt")
+        public void testSmartStepIntoMultiplyInlinedLambdas() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.kt");
+        }
+
         @TestMetadata("smartStepIntoNullSafeFunctionCalls.kt")
         public void testSmartStepIntoNullSafeFunctionCalls() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoNullSafeFunctionCalls.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinSteppingTestGenerated.java
@@ -1451,6 +1451,11 @@ public abstract class KotlinSteppingTestGenerated extends AbstractKotlinStepping
             runTest("testData/stepping/custom/smartStepIntoMethodReference.kt");
         }
 
+        @TestMetadata("smartStepIntoMultiplyInlinedLambdas.kt")
+        public void testSmartStepIntoMultiplyInlinedLambdas() throws Exception {
+            runTest("testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.kt");
+        }
+
         @TestMetadata("smartStepIntoNullSafeFunctionCalls.kt")
         public void testSmartStepIntoNullSafeFunctionCalls() throws Exception {
             runTest("testData/stepping/custom/smartStepIntoNullSafeFunctionCalls.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.kt
@@ -1,0 +1,49 @@
+package smartStepIntoMultiplyInlinedLambdas
+
+fun foo1() = 1
+fun foo2() = 2
+fun foo3() = 3
+
+inline fun foo() {
+    1.let { foo1() }.let { foo2() }.let { foo3() }
+}
+
+fun main() {
+    // STEP_INTO: 1
+    // SMART_STEP_INTO_BY_INDEX: 1
+    // STEP_INTO: 1
+    // STEP_OUT: 1
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_INTO: 1
+    // STEP_OUT: 1
+    // SMART_STEP_INTO_BY_INDEX: 3
+    // STEP_INTO: 1
+    // RESUME: 1
+    //Breakpoint!
+    foo()
+    // STEP_INTO: 1
+    // SMART_STEP_INTO_BY_INDEX: 1
+    // STEP_INTO: 1
+    // STEP_OUT: 1
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_INTO: 1
+    // STEP_OUT: 1
+    // SMART_STEP_INTO_BY_INDEX: 3
+    // STEP_INTO: 1
+    // RESUME: 1
+    //Breakpoint!
+    foo()
+    // STEP_INTO: 1
+    // SMART_STEP_INTO_BY_INDEX: 1
+    // STEP_INTO: 1
+    // STEP_OUT: 1
+    // SMART_STEP_INTO_BY_INDEX: 2
+    // STEP_INTO: 1
+    // STEP_OUT: 1
+    // SMART_STEP_INTO_BY_INDEX: 3
+    // STEP_INTO: 1
+    //Breakpoint!
+    foo()
+}
+
+// IGNORE_K2

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/custom/smartStepIntoMultiplyInlinedLambdas.out
@@ -1,0 +1,38 @@
+LineBreakpoint created at smartStepIntoMultiplyInlinedLambdas.kt:23
+LineBreakpoint created at smartStepIntoMultiplyInlinedLambdas.kt:35
+LineBreakpoint created at smartStepIntoMultiplyInlinedLambdas.kt:46
+Run Java
+Connected to the target VM
+smartStepIntoMultiplyInlinedLambdas.kt:23
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:3
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:4
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:5
+smartStepIntoMultiplyInlinedLambdas.kt:35
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:3
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:4
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:5
+smartStepIntoMultiplyInlinedLambdas.kt:46
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:3
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:4
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:8
+smartStepIntoMultiplyInlinedLambdas.kt:5
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-25635/Debugger-smart-stepping-into-inline-lambdas-doesnt-work-when-they-are-inlined-multiple-times

The smart stepping machinery is designed in a way that it needs to put a breakpoint in a place of interest, and then it is trying to step until the breakpoint is hit. However, when trying to smart step into inline lambda that is inside an inline function that is inlined several times, it may happen that multiple locations in a class file are sufficient candidates for the smart stepping breakpoint. In that case the breakpoint will be placed only on the first sufficient location, others will be ignored. That's why when trying to step into inline lambda in its first inlined call site, smart stepping works, but it never succeeds after that. This commit adds a workaround for this issue, it makes smart stepping machinery stop if we think that we are already inside a lambda of interest PSI wise.