### PR TITLE
Disallow Java in-place rename in non-Java files

### DIFF
--- a/java/java-impl-refactorings/src/com/intellij/lang/java/JavaRefactoringSupportProvider.java
+++ b/java/java-impl-refactorings/src/com/intellij/lang/java/JavaRefactoringSupportProvider.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.lang.java;
 
+import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.lang.refactoring.RefactoringSupportProvider;
 import com.intellij.psi.*;
 import com.intellij.psi.javadoc.PsiDocComment;
@@ -58,6 +59,7 @@ public class JavaRefactoringSupportProvider extends JavaBaseRefactoringSupportPr
 
   @Override
   public boolean isMemberInplaceRenameAvailable(@NotNull PsiElement elementToRename, @Nullable PsiElement context) {
+    if (context != null && context.getContainingFile().getFileType() != JavaFileType.INSTANCE) return false;
     return elementToRename instanceof PsiMember || elementToRename instanceof PsiJavaModule || isCanonicalConstructorParameter(elementToRename);
   }
 


### PR DESCRIPTION
The Java in-place renamer currently allows in-place renaming for members in any file where a reference appears. But this doesn't always work when the reference to the member is in a non-Java file.

This change prevents Java's in-place rename from running when the reference being renamed is not in a Java file. The target language still has the chance to provide their own renamer if desired.

This change addresses https://youtrack.jetbrains.com/issue/IDEA-321110