### PR TITLE
In `External documentation`, allow default URL patterns to be deleted.

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/documentation/PythonDocumentationMap.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/documentation/PythonDocumentationMap.java
@@ -80,8 +80,8 @@ public class PythonDocumentationMap implements PersistentStateComponent<PythonDo
   @Override
   public void loadState(@NotNull State state) {
     myState = state;
-
-    addAbsentEntriesFromDefaultState(myState);
+    if(state.getEntries().isEmpty())
+      addAbsentEntriesFromDefaultState(myState);
   }
 
   private static void addAbsentEntriesFromDefaultState(@NotNull State state) {


### PR DESCRIPTION
If a URL pattern is not provided for a module in `DEFAULT_ENTRIES`, a default will be written at PyCharm startup, even if it was deleted by the user previously. This prevents a `PythonDocumentationLinkProvider` from working since the URL pattern takes precedence over a `PythonDocumentationLinkProvider`.