### PR TITLE
IJPL-126: Migrate public APIs to use "Predicate" instead of "com.intellij.openapi.util.Condition"

### DIFF
--- a/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightClassUtil.java
+++ b/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightClassUtil.java
@@ -913,7 +913,7 @@ public final class HighlightClassUtil {
           if (!PsiUtil.isInnerClass(base)) return;
 
           if (resolve == resolved && baseClass != null && (!PsiTreeUtil.isAncestor(baseClass, extendRef, true) || aClass.hasModifierProperty(PsiModifier.STATIC)) &&
-              !InheritanceUtil.hasEnclosingInstanceInScope(baseClass, extendRef, psiClass -> psiClass != aClass, true) &&
+              !InheritanceUtil.hasEnclosingInstanceInScope(baseClass, extendRef, true, psiClass -> psiClass != aClass) &&
               !qualifiedNewCalledInConstructors(aClass)) {
             String description = JavaErrorBundle.message("no.enclosing.instance.in.scope", HighlightUtil.formatClass(baseClass));
             infos[0] = HighlightInfo.newHighlightInfo(HighlightInfoType.ERROR).range(extendRef).descriptionAndTooltip(description);

--- a/java/java-analysis-impl/src/com/intellij/codeInspection/visibility/AccessCanBeTightenedInspection.java
+++ b/java/java-analysis-impl/src/com/intellij/codeInspection/visibility/AccessCanBeTightenedInspection.java
@@ -338,7 +338,7 @@ class AccessCanBeTightenedInspection extends AbstractBaseJavaLocalInspectionTool
     private static boolean calledOnInheritor(@NotNull PsiElement element, PsiClass memberClass) {
       PsiExpression qualifier = getQualifier(element);
       if (qualifier == null) {
-        PsiClass enclosingInstance = InheritanceUtil.findEnclosingInstanceInScope(memberClass, element, Conditions.alwaysTrue(), true);
+        PsiClass enclosingInstance = InheritanceUtil.findEnclosingInstanceInScope(memberClass, element, true, s -> true);
         return enclosingInstance != null && enclosingInstance != memberClass;
       }
       PsiClass qClass = PsiUtil.resolveClassInClassTypeOnly(qualifier.getType());

--- a/java/java-impl-refactorings/src/com/intellij/refactoring/extractMethod/newImpl/ExtractMethodHelper.kt
+++ b/java/java-impl-refactorings/src/com/intellij/refactoring/extractMethod/newImpl/ExtractMethodHelper.kt
@@ -283,7 +283,7 @@ object ExtractMethodHelper {
   private fun getPhysicalPsiRange(expression: PsiExpression?): PsiRange? {
     val range: TextRange = expression?.getUserData(ElementToWorkOn.TEXT_RANGE)?.textRange ?: return null
     val parent: PsiElement = expression.getUserData(ElementToWorkOn.PARENT) ?: return null
-    val rangeParent = PsiTreeUtil.findFirstParent(parent) { element -> range in element.textRange } ?: return null
+    val rangeParent = PsiTreeUtil.findFirstParent({ element -> range in element.textRange }, parent) ?: return null
     if (rangeParent.textRange in range) return PsiRange(rangeParent.parent, rangeParent, rangeParent)
     val children = rangeParent.children
     val first = children.firstOrNull { child -> child.textRange in range } ?: return null

--- a/java/java-impl-refactorings/src/com/intellij/refactoring/memberPushDown/JavaPushDownDelegate.java
+++ b/java/java-impl-refactorings/src/com/intellij/refactoring/memberPushDown/JavaPushDownDelegate.java
@@ -215,7 +215,7 @@ public class JavaPushDownDelegate extends PushDownDelegate<MemberInfo, PsiMember
               if (pushDownData.preserveExternalLinks() && !PsiTreeUtil.isAncestor(targetElement, element, false)) {
                 continue;
               }
-              PsiClass inheritor = InheritanceUtil.findEnclosingInstanceInScope(sourceClass, element, Conditions.alwaysTrue(), false);
+              PsiClass inheritor = InheritanceUtil.findEnclosingInstanceInScope(sourceClass, element, false, s -> true);
               if (inheritor != null && inheritor != targetClass) {
                 //usages in other targets should be updated on corresponding turns
                 continue;

--- a/java/java-impl/src/com/intellij/codeInsight/generation/GenerateMembersUtil.java
+++ b/java/java-impl/src/com/intellij/codeInsight/generation/GenerateMembersUtil.java
@@ -458,7 +458,7 @@ public final class GenerateMembersUtil {
           paramName = generator.generateUniqueName("p");
         }
       }
-      else if (!generator.value(paramName)) {
+      else if (!generator.test(paramName)) {
         paramName = generator.generateUniqueName(paramName);
       }
       generator.addExistingName(paramName);

--- a/java/java-psi-api/src/com/intellij/psi/util/InheritanceUtil.java
+++ b/java/java-psi-api/src/com/intellij/psi/util/InheritanceUtil.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public final class InheritanceUtil {
   private InheritanceUtil() { }
@@ -119,26 +120,37 @@ public final class InheritanceUtil {
                                                     PsiElement scope,
                                                     boolean isSuperClassAccepted,
                                                     boolean isTypeParamsAccepted) {
-    return hasEnclosingInstanceInScope(aClass, scope, psiClass -> isSuperClassAccepted, isTypeParamsAccepted);
+    return hasEnclosingInstanceInScope(aClass, scope, isTypeParamsAccepted, psiClass -> isSuperClassAccepted);
   }
 
   public static boolean hasEnclosingInstanceInScope(@NotNull PsiClass aClass,
                                                     PsiElement scope,
+                                                    boolean isTypeParamsAccepted,
+                                                    @NotNull Predicate<? super PsiClass> isSuperClassAccepted) {
+    return findEnclosingInstanceInScope(aClass, scope, isTypeParamsAccepted, isSuperClassAccepted) != null;
+  }
+
+  /**
+   * @deprecated use {@link InheritanceUtil#hasEnclosingInstanceInScope(PsiClass, PsiElement, boolean, Predicate)}
+   */
+  @Deprecated
+  public static boolean hasEnclosingInstanceInScope(@NotNull PsiClass aClass,
+                                                    PsiElement scope,
                                                     @NotNull Condition<? super PsiClass> isSuperClassAccepted,
                                                     boolean isTypeParamsAccepted) {
-    return findEnclosingInstanceInScope(aClass, scope, isSuperClassAccepted, isTypeParamsAccepted) != null;
+    return hasEnclosingInstanceInScope(aClass, scope, isTypeParamsAccepted, isSuperClassAccepted);
   }
 
   @Nullable
   public static PsiClass findEnclosingInstanceInScope(@NotNull PsiClass aClass,
                                                       PsiElement scope,
-                                                      @NotNull Condition<? super PsiClass> isSuperClassAccepted,
-                                                      boolean isTypeParamsAccepted) {
+                                                      boolean isTypeParamsAccepted,
+                                                      @NotNull Predicate<? super PsiClass> isSuperClassAccepted) {
     PsiManager manager = aClass.getManager();
     PsiElement place = scope;
     while (place != null && !(place instanceof PsiFile)) {
       if (place instanceof PsiClass) {
-        if (isSuperClassAccepted.value((PsiClass)place)) {
+        if (isSuperClassAccepted.test((PsiClass)place)) {
           if (isInheritorOrSelf((PsiClass)place, aClass, true)) return (PsiClass)place;
         }
         else {
@@ -157,6 +169,18 @@ public final class InheritanceUtil {
       place = place.getParent();
     }
     return null;
+  }
+
+  /**
+   * @deprecated use {@link InheritanceUtil#findEnclosingInstanceInScope(PsiClass, PsiElement, boolean, Predicate)}
+   */
+  @Deprecated
+  @Nullable
+  public static PsiClass findEnclosingInstanceInScope(@NotNull PsiClass aClass,
+                                                      PsiElement scope,
+                                                      @NotNull Condition<? super PsiClass> isSuperClassAccepted,
+                                                      boolean isTypeParamsAccepted) {
+    return findEnclosingInstanceInScope(aClass, scope, isTypeParamsAccepted, isSuperClassAccepted);
   }
 
   public static boolean processSuperTypes(@NotNull PsiType type, boolean includeSelf, @NotNull Processor<? super PsiType> processor) {

--- a/java/java-psi-api/src/com/intellij/psi/util/InheritanceUtil.java
+++ b/java/java-psi-api/src/com/intellij/psi/util/InheritanceUtil.java
@@ -131,7 +131,7 @@ public final class InheritanceUtil {
   }
 
   /**
-   * @deprecated use {@link InheritanceUtil#hasEnclosingInstanceInScope(PsiClass, PsiElement, boolean, Predicate)}
+   * @deprecated use {@link InheritanceUtil#hasEnclosingInstanceInScope(PsiClass, PsiElement, boolean, Predicate)} instead
    */
   @Deprecated
   public static boolean hasEnclosingInstanceInScope(@NotNull PsiClass aClass,
@@ -172,7 +172,7 @@ public final class InheritanceUtil {
   }
 
   /**
-   * @deprecated use {@link InheritanceUtil#findEnclosingInstanceInScope(PsiClass, PsiElement, boolean, Predicate)}
+   * @deprecated use {@link InheritanceUtil#findEnclosingInstanceInScope(PsiClass, PsiElement, boolean, Predicate)} instead
    */
   @Deprecated
   @Nullable

--- a/java/java-psi-api/src/com/intellij/psi/util/PsiTypesUtil.java
+++ b/java/java-psi-api/src/com/intellij/psi/util/PsiTypesUtil.java
@@ -211,7 +211,7 @@ public final class PsiTypesUtil {
   }
 
   /**
-   * @deprecated use {@link PsiTypesUtil#patchMethodGetClassReturnType(PsiExpression, PsiReferenceExpression, PsiMethod, LanguageLevel, Predicate)}
+   * @deprecated use {@link PsiTypesUtil#patchMethodGetClassReturnType(PsiExpression, PsiReferenceExpression, PsiMethod, LanguageLevel, Predicate)} instead
    */
   @Deprecated
   public static PsiType patchMethodGetClassReturnType(@NotNull PsiExpression call,

--- a/java/java-psi-api/src/com/intellij/psi/util/PsiTypesUtil.java
+++ b/java/java-psi-api/src/com/intellij/psi/util/PsiTypesUtil.java
@@ -182,8 +182,8 @@ public final class PsiTypesUtil {
   public static PsiType patchMethodGetClassReturnType(@NotNull PsiExpression call,
                                                       @NotNull PsiReferenceExpression methodExpression,
                                                       @NotNull PsiMethod method,
-                                                      @NotNull Condition<? super IElementType> condition,
-                                                      @NotNull LanguageLevel languageLevel) {
+                                                      @NotNull LanguageLevel languageLevel,
+                                                      @NotNull Predicate<? super IElementType> predicate) {
     //JLS3 15.8.2
     if (languageLevel.isAtLeast(LanguageLevel.JDK_1_5) && isGetClass(method)) {
       PsiExpression qualifier = methodExpression.getQualifierExpression();
@@ -194,7 +194,7 @@ public final class PsiTypesUtil {
       }
       else {
         PsiElement parent = call.getContext();
-        while (parent != null && condition.value(parent instanceof StubBasedPsiElement ? ((StubBasedPsiElement<?>)parent).getElementType()
+        while (parent != null && predicate.test(parent instanceof StubBasedPsiElement ? ((StubBasedPsiElement<?>)parent).getElementType()
                                                                                        : parent.getNode().getElementType())) {
           parent = parent.getContext();
         }
@@ -208,6 +208,18 @@ public final class PsiTypesUtil {
       return createJavaLangClassType(methodExpression, qualifierType, true);
     }
     return null;
+  }
+
+  /**
+   * @deprecated use {@link PsiTypesUtil#patchMethodGetClassReturnType(PsiExpression, PsiReferenceExpression, PsiMethod, LanguageLevel, Predicate)}
+   */
+  @Deprecated
+  public static PsiType patchMethodGetClassReturnType(@NotNull PsiExpression call,
+                                                      @NotNull PsiReferenceExpression methodExpression,
+                                                      @NotNull PsiMethod method,
+                                                      @NotNull Condition<? super IElementType> condition,
+                                                      @NotNull LanguageLevel languageLevel) {
+    return patchMethodGetClassReturnType(call, methodExpression, method, languageLevel, condition);
   }
 
   public static boolean isGetClass(@NotNull PsiMethod method) {

--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/PsiMethodCallExpressionImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/PsiMethodCallExpressionImpl.java
@@ -189,9 +189,9 @@ public class PsiMethodCallExpressionImpl extends ExpressionPsiElement implements
 
       boolean is15OrHigher = languageLevel.compareTo(LanguageLevel.JDK_1_5) >= 0;
       final PsiType getClassReturnType = PsiTypesUtil.patchMethodGetClassReturnType(
-        call, methodExpression, method,
-        type -> type != JavaElementType.CLASS && type != JavaElementType.ANONYMOUS_CLASS, // enum can be created inside enum only, no need to mention it here
-        languageLevel);
+        call, methodExpression, method, languageLevel,
+        type -> type != JavaElementType.CLASS && type != JavaElementType.ANONYMOUS_CLASS // enum can be created inside enum only, no need to mention it here
+      );
 
       if (getClassReturnType != null) {
         return getClassReturnType;

--- a/jps/model-impl/src/org/jetbrains/jps/model/impl/JpsElementCollectionImpl.java
+++ b/jps/model-impl/src/org/jetbrains/jps/model/impl/JpsElementCollectionImpl.java
@@ -22,6 +22,7 @@ import org.jetbrains.jps.model.*;
 import org.jetbrains.jps.model.ex.JpsElementBase;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 public final class JpsElementCollectionImpl<E extends JpsElement> extends JpsElementBase<JpsElementCollectionImpl<E>> implements JpsElementCollection<E> {
   private final List<E> myElements;
@@ -129,7 +130,7 @@ public final class JpsElementCollectionImpl<E extends JpsElement> extends JpsEle
     public Iterator<X> iterator() {
       //noinspection unchecked
       Iterator<JpsTypedElement<?>> iterator = (Iterator<JpsTypedElement<?>>)myElements.iterator();
-      return new FilteringIterator<>(iterator, e -> e.getType().equals(myType));
+      return new FilteringIterator<>(iterator, (Predicate<? super JpsTypedElement<?>>)e -> e.getType().equals(myType));
     }
   }
 }

--- a/platform/analysis-impl/src/com/intellij/codeInsight/daemon/impl/Divider.java
+++ b/platform/analysis-impl/src/com/intellij/codeInsight/daemon/impl/Divider.java
@@ -4,7 +4,6 @@ package com.intellij.codeInsight.daemon.impl;
 import com.intellij.lang.Language;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressManager;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.TextRangeScalarUtil;
@@ -110,7 +109,7 @@ public final class Divider {
     int startOffset = TextRangeScalarUtil.startOffset(restrictRange);
     int endOffset = TextRangeScalarUtil.endOffset(restrictRange);
 
-    Condition<PsiElement>[] filters = CollectHighlightsUtil.EP_NAME.getExtensions();
+    Predicate<PsiElement>[] filters = CollectHighlightsUtil.EP_NAME.getExtensions();
 
     IntStack starts = new IntArrayList(STARTING_TREE_HEIGHT);
     starts.push(startOffset);
@@ -123,8 +122,8 @@ public final class Divider {
     while (true) {
       ProgressManager.checkCanceled();
 
-      for (Condition<PsiElement> filter : filters) {
-        if (!filter.value(element)) {
+      for (Predicate<PsiElement> filter : filters) {
+        if (!filter.test(element)) {
           assert child == HAVE_TO_GET_CHILDREN;
           child = null; // do not want to process children
           break;

--- a/platform/analysis-impl/src/com/intellij/psi/impl/source/resolve/reference/impl/providers/FileReferenceCompletionImpl.java
+++ b/platform/analysis-impl/src/com/intellij/psi/impl/source/resolve/reference/impl/providers/FileReferenceCompletionImpl.java
@@ -5,7 +5,6 @@ import com.intellij.codeInsight.completion.PrioritizedLookupElement;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.fileTypes.FileType;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Iconable;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -26,6 +25,7 @@ import javax.swing.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 public final class FileReferenceCompletionImpl extends FileReferenceCompletion {
   private static final HashingStrategy<PsiElement> VARIANTS_HASHING_STRATEGY = new HashingStrategy<>() {
@@ -56,7 +56,7 @@ public final class FileReferenceCompletionImpl extends FileReferenceCompletion {
       return ArrayUtilRt.EMPTY_OBJECT_ARRAY;
     }
 
-    Condition<PsiFileSystemItem> filter = reference.getFileReferenceSet().getReferenceCompletionFilter();
+    Predicate<PsiFileSystemItem> filter = reference.getFileReferenceSet().getReferenceCompletionFilter();
     final CommonProcessors.CollectProcessor<PsiFileSystemItem> collector =
       new CommonProcessors.CollectProcessor<>(CollectionFactory.createCustomHashingStrategySet(VARIANTS_HASHING_STRATEGY));
     final PsiElementProcessor<PsiFileSystemItem> processor = new PsiElementProcessor<>() {

--- a/platform/core-api/src/com/intellij/psi/util/PsiTreeUtil.java
+++ b/platform/core-api/src/com/intellij/psi/util/PsiTreeUtil.java
@@ -339,34 +339,52 @@ public class PsiTreeUtil {
     return null;
   }
 
+  public static @Nullable PsiElement findFirstParent(@NotNull Predicate<? super  PsiElement> predicate, @Nullable PsiElement element) {
+    return findFirstParent(element, predicate, false);
+  }
+
+  @ApiStatus.Obsolete
   public static @Nullable PsiElement findFirstParent(@Nullable PsiElement element, @NotNull Condition<? super PsiElement> condition) {
-    return findFirstParent(element, false, condition);
+    return findFirstParent(condition, element);
   }
 
+  public static @Nullable PsiElement findFirstParent(@Nullable PsiElement element, @NotNull Predicate<? super PsiElement> predicate, boolean strict) {
+    if (strict && element != null) {
+      element = element.getParent();
+    }
+    while (element != null) {
+      if (predicate.test(element)) {
+        return element;
+      }
+      element = element.getParent();
+    }
+    return null;
+  }
+
+  @ApiStatus.Obsolete
   public static @Nullable PsiElement findFirstParent(@Nullable PsiElement element, boolean strict, @NotNull Condition<? super PsiElement> condition) {
+    return findFirstParent(element, condition, strict);
+  }
+
+  public static @Nullable PsiElement findFirstContext(@Nullable PsiElement element, @NotNull Predicate<? super PsiElement> predicate, boolean strict) {
     if (strict && element != null) {
-      element = element.getParent();
+      element = element.getContext();
     }
     while (element != null) {
-      if (condition.value(element)) {
+      if (predicate.test(element)) {
         return element;
       }
-      element = element.getParent();
+      element = element.getContext();
     }
     return null;
   }
 
+  /**
+   * @deprecated use {@link PsiTreeUtil#findFirstContext(PsiElement, Predicate, boolean)} instead
+   */
+  @Deprecated
   public static @Nullable PsiElement findFirstContext(@Nullable PsiElement element, boolean strict, @NotNull Condition<? super PsiElement> condition) {
-    if (strict && element != null) {
-      element = element.getContext();
-    }
-    while (element != null) {
-      if (condition.value(element)) {
-        return element;
-      }
-      element = element.getContext();
-    }
-    return null;
+    return findFirstContext(element, condition, strict);
   }
 
   public static @NotNull <T extends PsiElement> T getRequiredChildOfType(@NotNull PsiElement element, @NotNull Class<T> aClass) {

--- a/platform/core-impl/src/com/intellij/codeInsight/daemon/impl/CollectHighlightsUtil.java
+++ b/platform/core-impl/src/com/intellij/codeInsight/daemon/impl/CollectHighlightsUtil.java
@@ -5,7 +5,6 @@ package com.intellij.codeInsight.daemon.impl;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.progress.ProgressIndicatorProvider;
-import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -18,9 +17,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 public final class CollectHighlightsUtil {
-  static final ExtensionPointName<Condition<PsiElement>> EP_NAME = ExtensionPointName.create("com.intellij.elementsToHighlightFilter");
+  static final ExtensionPointName<Predicate<PsiElement>> EP_NAME = ExtensionPointName.create("com.intellij.elementsToHighlightFilter");
 
   private static final Logger LOG = Logger.getInstance(CollectHighlightsUtil.class);
 
@@ -62,12 +62,12 @@ public final class CollectHighlightsUtil {
     PsiElement element = parent;
 
     PsiElement child = PsiUtilCore.NULL_PSI_ELEMENT;
-    Condition<PsiElement> @NotNull [] filters = EP_NAME.getExtensions();
+    Predicate<PsiElement> @NotNull [] filters = EP_NAME.getExtensions();
     while (true) {
       ProgressIndicatorProvider.checkCanceled();
 
-      for (Condition<PsiElement> filter : filters) {
-        if (!filter.value(element)) {
+      for (Predicate<PsiElement> filter : filters) {
+        if (!filter.test(element)) {
           assert child == PsiUtilCore.NULL_PSI_ELEMENT;
           child = null; // do not want to process children
           break;

--- a/platform/lang-api/src/com/intellij/ide/projectView/ProjectViewNode.java
+++ b/platform/lang-api/src/com/intellij/ide/projectView/ProjectViewNode.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * A node in the project view tree.
@@ -184,15 +185,21 @@ public abstract class ProjectViewNode <Value> extends AbstractTreeNode<Value> im
     });
   }
 
+  public boolean canHaveChildrenMatching(Predicate<? super PsiFile> predicate) {
+    return true;
+  }
+
   /**
    * Efficiently checks if there are nodes under the project view node which match the specified condition. Should
    * return true if it's not possible to perform the check efficiently (for example, if recursive traversal of
    * all child nodes is required to check the condition).
    *
    * @param condition the condition to check the nodes.
+   * @deprecated use {@link ProjectViewNode#canHaveChildrenMatching(Predicate)} instead
    */
+  @Deprecated
   public boolean canHaveChildrenMatching(Condition<? super PsiFile> condition) {
-    return true;
+    return canHaveChildrenMatching((Predicate<? super PsiFile>) condition);
   }
 
   @Nullable

--- a/platform/lang-impl/src/com/intellij/codeInsight/hints/PopupActions.kt
+++ b/platform/lang-impl/src/com/intellij/codeInsight/hints/PopupActions.kt
@@ -239,8 +239,7 @@ class EnableCustomHintsOption: IntentionAction, HighPriorityAction {
     val element = file.findElementAt(offset) ?: return null
     val provider = InlayParameterHintsExtension.forLanguage(file.language) ?: return null
 
-    val target = PsiTreeUtil.findFirstParent(element) { it is PsiFile
-                                                        || provider.hasDisabledOptionHintInfo(it, file) }
+    val target = PsiTreeUtil.findFirstParent({ it is PsiFile || provider.hasDisabledOptionHintInfo(it, file) }, element)
     if (target == null || target is PsiFile) return null
     return provider.getHintInfo(target, file) as? HintInfo.OptionInfo
   }
@@ -337,11 +336,12 @@ private fun getInfoForElement(file: PsiFile,
                               editor: Editor): HintInfo? {
   val provider = InlayParameterHintsExtension.forLanguage(file.language) ?: return null
 
-  val method = PsiTreeUtil.findFirstParent(element) {
-    it is PsiFile
-    // hint owned by element
-    || (provider.getHintInfo(it, file)?.isOwnedByPsiElement(it, editor) ?: false)
-  }
+  val method = PsiTreeUtil.findFirstParent(
+    {
+      it is PsiFile
+      // hint owned by element
+      || (provider.getHintInfo(it, file)?.isOwnedByPsiElement(it, editor) ?: false)
+    }, element)
   if (method == null || method is PsiFile) return null
   return provider.getHintInfo(method, file)
 }

--- a/platform/lang-impl/src/com/intellij/ide/util/TreeFileChooserDialog.java
+++ b/platform/lang-impl/src/com/intellij/ide/util/TreeFileChooserDialog.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.fileTypes.FileTypeRegistry;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
@@ -54,6 +53,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.util.List;
 import java.util.*;
+import java.util.function.Predicate;
 
 public final class TreeFileChooserDialog extends DialogWrapper implements TreeFileChooser {
 
@@ -407,7 +407,7 @@ public final class TreeFileChooserDialog extends DialogWrapper implements TreeFi
   }
 
   private Object[] filterFiles(final Object[] list) {
-    Condition<PsiFile> condition = psiFile -> {
+    Predicate<PsiFile> condition = psiFile -> {
       if (myFilter != null && !myFilter.accept(psiFile)) {
         return false;
       }
@@ -430,7 +430,7 @@ public final class TreeFileChooserDialog extends DialogWrapper implements TreeFi
       else {
         psiFile = null;
       }
-      if (psiFile != null && !condition.value(psiFile)) {
+      if (psiFile != null && !condition.test(psiFile)) {
         continue;
       }
       else {

--- a/platform/platform-api/src/com/intellij/ui/ListUtil.java
+++ b/platform/platform-api/src/com/intellij/ui/ListUtil.java
@@ -65,7 +65,7 @@ public final class ListUtil {
 
   @NotNull
   public static <T> List<T> removeSelectedItems(@NotNull JList<T> list) {
-    return removeSelectedItems(list, null);
+    return removeSelectedItems(null, list);
   }
 
   @NotNull
@@ -143,7 +143,7 @@ public final class ListUtil {
   }
 
   public static <T> boolean canRemoveSelectedItems(@NotNull JList<T> list) {
-    return canRemoveSelectedItems(list, null);
+    return canRemoveSelectedItems(null, list);
   }
 
   public static <T> boolean canRemoveSelectedItems(@Nullable Predicate<? super T> predicate, @NotNull JList<T> list) {

--- a/platform/platform-api/src/com/intellij/ui/ListUtil.java
+++ b/platform/platform-api/src/com/intellij/ui/ListUtil.java
@@ -15,6 +15,7 @@ import java.awt.event.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 public final class ListUtil {
   public static final String SELECTED_BY_MOUSE_EVENT = "byMouseEvent";
@@ -73,9 +74,18 @@ public final class ListUtil {
   }
 
   @NotNull
-  public static <T> List<T> removeSelectedItems(@NotNull JList<T> list, @Nullable Condition<? super T> condition) {
+  public static <T> List<T> removeSelectedItems(@Nullable Predicate<? super T> predicate, @NotNull JList<T> list) {
     int[] indices = list.getSelectedIndices();
-    return removeIndices(list, indices, condition);
+    return removeIndices(list, indices, predicate);
+  }
+
+  /**
+   * @deprecated use {@link ListUtil#removeSelectedItems(Predicate, JList)} instead
+   */
+  @Deprecated
+  @NotNull
+  public static <T> List<T> removeSelectedItems(@NotNull JList<T> list, @Nullable Condition<? super T> condition) {
+    return removeSelectedItems(condition, list);
   }
 
   public static <T> T getItem(@NotNull ListModel<T> model, int index) {
@@ -98,7 +108,7 @@ public final class ListUtil {
     getExtension(model).addAll(model, items);
   }
 
-  private static <T> List<T> removeIndices(@NotNull JList<T> list, int @NotNull [] indices, @Nullable Condition<? super T> condition) {
+  private static <T> List<T> removeIndices(@NotNull JList<T> list, int @NotNull [] indices, @Nullable Predicate<? super T> predicate) {
     if (indices.length == 0) {
       return new ArrayList<>(0);
     }
@@ -111,7 +121,7 @@ public final class ListUtil {
       int index = idx1 - deletedCount;
       if (index < 0 || index >= model.getSize()) continue;
       T obj = extension.get(model, index);
-      if (condition == null || condition.value(obj)) {
+      if (predicate == null || predicate.test(obj)) {
         removedItems.add(obj);
         extension.remove(model, index);
         deletedCount++;
@@ -136,7 +146,7 @@ public final class ListUtil {
     return canRemoveSelectedItems(list, null);
   }
 
-  public static <T> boolean canRemoveSelectedItems(@NotNull JList<T> list, @Nullable Condition<? super T> condition) {
+  public static <T> boolean canRemoveSelectedItems(@Nullable Predicate<? super T> predicate, @NotNull JList<T> list) {
     int[] indices = list.getSelectedIndices();
     if (indices.length == 0) {
       return false;
@@ -146,12 +156,20 @@ public final class ListUtil {
     for (int index : indices) {
       if (index < 0 || index >= model.getSize()) continue;
       T obj = extension.get(model, index);
-      if (condition == null || condition.value(obj)) {
+      if (predicate == null || predicate.test(obj)) {
         return true;
       }
     }
 
     return false;
+  }
+
+  /**
+   * @deprecated use {@link ListUtil#canRemoveSelectedItems(Predicate, JList)} instead
+   */
+  @Deprecated
+  public static <T> boolean canRemoveSelectedItems(@NotNull JList<T> list, @Nullable Condition<? super T> condition) {
+    return canRemoveSelectedItems(condition, list);
   }
 
   public static <T> int moveSelectedItemsUp(@NotNull JList<T> list) {

--- a/platform/platform-api/src/com/intellij/ui/ReorderableListController.java
+++ b/platform/platform-api/src/com/intellij/ui/ReorderableListController.java
@@ -214,12 +214,12 @@ public abstract class ReorderableListController <T> {
           if (myConfirmation != null && !myConfirmation.value((List<T>)Arrays.asList(myList.getSelectedValues()))) {
             return Collections.emptyList();
           }
-          return ListUtil.removeSelectedItems(myList, myEnableCondition);
+          return ListUtil.removeSelectedItems(myEnableCondition, myList);
         }
 
         @Override
         public void updateAction(@NotNull final AnActionEvent e) {
-          e.getPresentation().setEnabled(ListUtil.canRemoveSelectedItems(myList, myEnableCondition));
+          e.getPresentation().setEnabled(ListUtil.canRemoveSelectedItems(myEnableCondition, myList));
         }
       };
       final BaseAction action = createAction(behaviour);

--- a/platform/platform-api/src/com/intellij/ui/ReorderableListController.java
+++ b/platform/platform-api/src/com/intellij/ui/ReorderableListController.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.*;
+import java.util.function.Predicate;
 
 public abstract class ReorderableListController <T> {
   private final JList myList;
@@ -199,8 +200,8 @@ public abstract class ReorderableListController <T> {
 
   public class RemoveActionDescription extends CustomActionDescription<List<T>> {
     private final @NlsActions.ActionText String myActionName;
-    private Condition<? super List<T>> myConfirmation;
-    private Condition<? super T> myEnableCondition;
+    private Predicate<? super List<T>> myConfirmation;
+    private Predicate<? super T> myEnableCondition;
 
     public RemoveActionDescription(final @NlsActions.ActionText String actionName) {
       myActionName = actionName;
@@ -211,7 +212,7 @@ public abstract class ReorderableListController <T> {
       final ActionBehaviour<List<T>> behaviour = new ActionBehaviour<>() {
         @Override
         public List<T> performAction(@NotNull final AnActionEvent e) {
-          if (myConfirmation != null && !myConfirmation.value((List<T>)Arrays.asList(myList.getSelectedValues()))) {
+          if (myConfirmation != null && !myConfirmation.test((List<T>)Arrays.asList(myList.getSelectedValues()))) {
             return Collections.emptyList();
           }
           return ListUtil.removeSelectedItems(myEnableCondition, myList);
@@ -237,12 +238,28 @@ public abstract class ReorderableListController <T> {
       return myActionName;
     }
 
-    public void setConfirmation(final Condition<? super List<T>> confirmation) {
+    public void setConfirmation(final Predicate<? super List<T>> confirmation) {
       myConfirmation = confirmation;
     }
 
-    public void setEnableCondition(final Condition<? super T> enableCondition) {
+    /**
+     * @deprecated use {@link ReorderableListController.RemoveActionDescription#setConfirmation(Predicate)}
+     */
+    @Deprecated
+    public void setConfirmation(final Condition<? super List<T>> confirmation) {
+      setConfirmation((Predicate<? super List<T>>) confirmation);
+    }
+
+    public void setEnableCondition(final Predicate<? super T> enableCondition) {
       myEnableCondition = enableCondition;
+    }
+
+    /**
+     * @deprecated use {@link ReorderableListController.RemoveActionDescription#setEnableCondition(Predicate)}
+     */
+    @Deprecated
+    public void setEnableCondition(final Condition<? super T> enableCondition) {
+      setEnableCondition((Predicate<? super T>) enableCondition);
     }
 
     public JList getList() {

--- a/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringListModel.java
+++ b/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringListModel.java
@@ -17,7 +17,7 @@ import java.util.function.Predicate;
 public class FilteringListModel<T> extends AbstractListModel<T> {
   private final ListModel<T> myOriginalModel;
   private final List<T> myData = new ArrayList<>();
-  private Predicate<? super T> myCondition = null;
+  private Predicate<? super T> myPredicate = null;
 
   private final ListDataListener myListDataListener = new ListDataListener() {
     @Override
@@ -46,7 +46,7 @@ public class FilteringListModel<T> extends AbstractListModel<T> {
   }
 
   public void setFilter(Predicate<? super T> predicate) {
-    myCondition = predicate;
+    myPredicate = predicate;
     refilter();
   }
 
@@ -110,7 +110,7 @@ public class FilteringListModel<T> extends AbstractListModel<T> {
   }
 
   private boolean passElement(T element) {
-    return myCondition == null || myCondition.test(element);
+    return myPredicate == null || myPredicate.test(element);
   }
 
   public boolean contains(T value) {

--- a/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringListModel.java
+++ b/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringListModel.java
@@ -50,9 +50,6 @@ public class FilteringListModel<T> extends AbstractListModel<T> {
     refilter();
   }
 
-  /**
-   * Please use {@link FilteringListModel#setFilter(Predicate)} instead
-   */
   @ApiStatus.Obsolete
   public void setFilter(Condition<? super T> condition) {
     setFilter((Predicate<? super T>) condition);

--- a/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringListModel.java
+++ b/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringListModel.java
@@ -3,6 +3,7 @@ package com.intellij.ui.speedSearch;
 
 import com.intellij.openapi.util.Condition;
 import com.intellij.ui.ListUtil;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -11,11 +12,12 @@ import javax.swing.event.ListDataListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 
 public class FilteringListModel<T> extends AbstractListModel<T> {
   private final ListModel<T> myOriginalModel;
   private final List<T> myData = new ArrayList<>();
-  private Condition<? super T> myCondition = null;
+  private Predicate<? super T> myCondition = null;
 
   private final ListDataListener myListDataListener = new ListDataListener() {
     @Override
@@ -43,9 +45,17 @@ public class FilteringListModel<T> extends AbstractListModel<T> {
     myOriginalModel.removeListDataListener(myListDataListener);
   }
 
-  public void setFilter(Condition<? super T> condition) {
-    myCondition = condition;
+  public void setFilter(Predicate<? super T> predicate) {
+    myCondition = predicate;
     refilter();
+  }
+
+  /**
+   * Please use {@link FilteringListModel#setFilter(Predicate)} instead
+   */
+  @ApiStatus.Obsolete
+  public void setFilter(Condition<? super T> condition) {
+    setFilter((Predicate<? super T>) condition);
   }
 
   private void removeAllElements() {
@@ -100,7 +110,7 @@ public class FilteringListModel<T> extends AbstractListModel<T> {
   }
 
   private boolean passElement(T element) {
-    return myCondition == null || myCondition.value(element);
+    return myCondition == null || myCondition.test(element);
   }
 
   public boolean contains(T value) {

--- a/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringTableModel.java
+++ b/platform/platform-api/src/com/intellij/ui/speedSearch/FilteringTableModel.java
@@ -16,18 +16,20 @@
 package com.intellij.ui.speedSearch;
 
 import com.intellij.openapi.util.Condition;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.swing.event.TableModelListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 public class FilteringTableModel<T> extends AbstractTableModel {
   private final TableModel myOriginalModel;
   private final List<List<T>> myData = new ArrayList<>();
   private final Class<T> myClz;
-  private Condition<? super T> myCondition = null;
+  private Predicate<? super T> myPredicate = null;
   private final ArrayList<Integer> myIndex = new ArrayList<>();
 
   private final TableModelListener myListDataListener = e -> refilter();
@@ -42,9 +44,14 @@ public class FilteringTableModel<T> extends AbstractTableModel {
     myOriginalModel.removeTableModelListener(myListDataListener);
   }
 
-  public void setFilter(Condition<? super T> condition) {
-    myCondition = condition;
+  public void setFilter(Predicate<? super T> predicate) {
+    myPredicate = predicate;
     refilter();
+  }
+
+  @ApiStatus.Obsolete
+  public void setFilter(Condition<? super T> condition) {
+    setFilter((Predicate<? super T>) condition);
   }
 
   private void removeAllElements() {
@@ -117,7 +124,7 @@ public class FilteringTableModel<T> extends AbstractTableModel {
   }
 
   private boolean passElement(T element) {
-    return myCondition == null || myCondition.value(element);
+    return myPredicate == null || myPredicate.test(element);
   }
 
   @Override

--- a/platform/platform-api/src/com/intellij/ui/speedSearch/NameFilteringListModel.java
+++ b/platform/platform-api/src/com/intellij/ui/speedSearch/NameFilteringListModel.java
@@ -23,8 +23,10 @@ import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.Function;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.swing.*;
+import java.util.function.Predicate;
 
 /**
  * @param <T> list elements generic type
@@ -48,6 +50,17 @@ public class NameFilteringListModel<T> extends FilteringListModel<T> {
     list.setModel(this);
   }
 
+  public NameFilteringListModel(ListModel<T> model,
+                                Function<? super T, String> namer,
+                                Predicate<? super String> filter,
+                                Computable<String> pattern) {
+    super(model);
+    myPattern = pattern;
+    myNamer = namer;
+    setFilter(namer != null ? (Predicate<? super T>) t -> filter.test(namer.fun(t)) : null);
+  }
+
+  @ApiStatus.Obsolete
   public NameFilteringListModel(ListModel<T> model,
                                 Function<? super T, String> namer,
                                 Condition<? super String> filter,

--- a/platform/platform-api/src/com/intellij/util/ui/tree/TreeUtil.java
+++ b/platform/platform-api/src/com/intellij/util/ui/tree/TreeUtil.java
@@ -329,22 +329,28 @@ public final class TreeUtil {
   }
 
   public static @Nullable DefaultMutableTreeNode findNodeWithObject(final @NotNull DefaultMutableTreeNode aRoot, final Object aObject) {
-    return findNode(aRoot, node -> Comparing.equal(node.getUserObject(), aObject));
+    return findNode(aRoot, (Predicate<? super DefaultMutableTreeNode>) node -> Comparing.equal(node.getUserObject(), aObject));
   }
 
   public static @Nullable DefaultMutableTreeNode findNode(final @NotNull DefaultMutableTreeNode aRoot,
-                                                          final @NotNull Condition<? super DefaultMutableTreeNode> condition) {
-    if (condition.value(aRoot)) {
+                                                          final @NotNull Predicate<? super DefaultMutableTreeNode> predicate) {
+    if (predicate.test(aRoot)) {
       return aRoot;
     } else {
       for (int i = 0; i < aRoot.getChildCount(); i++) {
-        final DefaultMutableTreeNode candidate = findNode((DefaultMutableTreeNode)aRoot.getChildAt(i), condition);
+        final DefaultMutableTreeNode candidate = findNode((DefaultMutableTreeNode)aRoot.getChildAt(i), predicate);
         if (null != candidate) {
           return candidate;
         }
       }
       return null;
     }
+  }
+
+  @ApiStatus.Obsolete
+  public static @Nullable DefaultMutableTreeNode findNode(final @NotNull DefaultMutableTreeNode aRoot,
+                                                          final @NotNull Condition<? super DefaultMutableTreeNode> condition) {
+    return findNode(aRoot, (Predicate<? super DefaultMutableTreeNode>) condition);
   }
 
   /**

--- a/platform/platform-impl/src/com/intellij/execution/impl/EditorHyperlinkSupport.java
+++ b/platform/platform-impl/src/com/intellij/execution/impl/EditorHyperlinkSupport.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.editor.event.EditorMouseListener;
 import com.intellij.openapi.editor.event.EditorMouseMotionListener;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.editor.ex.MarkupModelEx;
+import com.intellij.openapi.editor.ex.RangeHighlighterEx;
 import com.intellij.openapi.editor.markup.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
@@ -33,6 +34,7 @@ import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.util.List;
 import java.util.*;
+import java.util.function.Predicate;
 
 public class EditorHyperlinkSupport {
   private static final Key<TextAttributes> OLD_HYPERLINK_TEXT_ATTRIBUTES = Key.create("OLD_HYPERLINK_TEXT_ATTRIBUTES");
@@ -199,7 +201,7 @@ public class EditorHyperlinkSupport {
                                         @NotNull Processor<? super RangeHighlighter> processor) {
     MarkupModelEx markupModel = (MarkupModelEx)editor.getMarkupModel();
     markupModel.processRangeHighlightersOverlappingWith(startOffset, endOffset,
-      new FilteringProcessor<>(rangeHighlighterEx -> rangeHighlighterEx.isValid() && getHyperlinkInfo(rangeHighlighterEx) != null, processor)
+      new FilteringProcessor<>((Predicate<? super RangeHighlighterEx>) rangeHighlighterEx -> rangeHighlighterEx.isValid() && getHyperlinkInfo(rangeHighlighterEx) != null, processor)
     );
   }
 

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorFilteringMarkupModelEx.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorFilteringMarkupModelEx.java
@@ -21,12 +21,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 public class EditorFilteringMarkupModelEx implements MarkupModelEx {
   @NotNull private final EditorImpl myEditor;
   @NotNull private final MarkupModelEx myDelegate;
 
-  private final Condition<RangeHighlighter> IS_AVAILABLE = this::isAvailable;
+  private final Predicate<RangeHighlighter> IS_AVAILABLE = this::isAvailable;
 
   EditorFilteringMarkupModelEx(@NotNull EditorImpl editor, @NotNull MarkupModelEx delegate) {
     myEditor = editor;
@@ -67,7 +68,7 @@ public class EditorFilteringMarkupModelEx implements MarkupModelEx {
 
   @Override
   public RangeHighlighter @NotNull [] getAllHighlighters() {
-    List<RangeHighlighter> list = ContainerUtil.filter(myDelegate.getAllHighlighters(), IS_AVAILABLE);
+    List<RangeHighlighter> list = ContainerUtil.filter(myDelegate.getAllHighlighters(), (Condition<? super RangeHighlighter>) IS_AVAILABLE);
     return list.toArray(RangeHighlighter.EMPTY_ARRAY);
   }
 

--- a/platform/projectModel-api/src/com/intellij/openapi/roots/ImmutableSyntheticLibrary.java
+++ b/platform/projectModel-api/src/com/intellij/openapi/roots/ImmutableSyntheticLibrary.java
@@ -10,20 +10,21 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 @ApiStatus.Internal
 class ImmutableSyntheticLibrary extends SyntheticLibrary {
   private final List<VirtualFile> mySourceRoots;
   private final List<VirtualFile> myBinaryRoots;
   private final Set<VirtualFile> myExcludedRoots;
-  private final Condition<? super VirtualFile> myExcludeCondition;
+  private final Predicate<? super VirtualFile> myExcludeCondition;
   private final int hashCode;
 
   ImmutableSyntheticLibrary(@Nullable String comparisonId,
                             @NotNull List<? extends VirtualFile> sourceRoots,
                             @NotNull List<? extends VirtualFile> binaryRoots,
                             @NotNull Set<? extends VirtualFile> excludedRoots,
-                            @Nullable Condition<? super VirtualFile> excludeCondition,
+                            @Nullable Predicate<? super VirtualFile> excludeCondition,
                             @Nullable ExcludeFileCondition constantCondition) {
     super(comparisonId, constantCondition);
     mySourceRoots = immutableOrEmptyList(sourceRoots);
@@ -31,6 +32,19 @@ class ImmutableSyntheticLibrary extends SyntheticLibrary {
     myExcludedRoots = ContainerUtil.unmodifiableOrEmptySet(excludedRoots);
     myExcludeCondition = excludeCondition;
     hashCode = Objects.hash(mySourceRoots, myBinaryRoots, myExcludedRoots, myExcludeCondition);
+  }
+
+  /**
+   * @deprecated use {@link ImmutableSyntheticLibrary#ImmutableSyntheticLibrary(String, List, List, Set, Predicate, ExcludeFileCondition)} instead
+   */
+  @Deprecated
+  ImmutableSyntheticLibrary(@Nullable String comparisonId,
+                            @NotNull List<? extends VirtualFile> sourceRoots,
+                            @NotNull List<? extends VirtualFile> binaryRoots,
+                            @NotNull Set<? extends VirtualFile> excludedRoots,
+                            @Nullable Condition<? super VirtualFile> excludeCondition,
+                            @Nullable ExcludeFileCondition constantCondition) {
+    this(comparisonId, sourceRoots, binaryRoots, excludedRoots, (Predicate<? super VirtualFile>) excludeCondition, constantCondition);
   }
 
   @NotNull

--- a/platform/projectModel-api/src/com/intellij/openapi/roots/SyntheticLibrary.java
+++ b/platform/projectModel-api/src/com/intellij/openapi/roots/SyntheticLibrary.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
 /**
  * A lightweight library definition comparing to {@link com.intellij.openapi.roots.libraries.Library}.
@@ -154,28 +155,46 @@ public abstract class SyntheticLibrary {
 
   @NotNull
   public static SyntheticLibrary newImmutableLibrary(@NotNull List<? extends VirtualFile> sourceRoots) {
-    return newImmutableLibrary(sourceRoots, Collections.emptySet(), null);
+    return newImmutableLibrary(sourceRoots, null, Collections.emptySet());
+  }
+
+  public static SyntheticLibrary newImmutableLibrary(@NotNull List<? extends VirtualFile> sourceRoots,
+                                                     @Nullable Predicate<? super VirtualFile> excludeCondition,
+                                                     @NotNull Set<? extends VirtualFile> excludedRoots) {
+    return newImmutableLibrary(sourceRoots, Collections.emptyList(), excludeCondition, excludedRoots);
   }
 
   /**
    * @see SyntheticLibrary#newImmutableLibrary(String, List, List, Set, ExcludeFileCondition)
+   * @deprecated use {@link SyntheticLibrary#newImmutableLibrary(List, Predicate, Set)}
    */
+  @Deprecated
   @NotNull
   public static SyntheticLibrary newImmutableLibrary(@NotNull List<? extends VirtualFile> sourceRoots,
                                                      @NotNull Set<? extends VirtualFile> excludedRoots,
                                                      @Nullable Condition<? super VirtualFile> excludeCondition) {
-    return newImmutableLibrary(sourceRoots, Collections.emptyList(), excludedRoots, excludeCondition);
+    return newImmutableLibrary(sourceRoots, excludeCondition, excludedRoots);
+  }
+
+  @NotNull
+  public static SyntheticLibrary newImmutableLibrary(@NotNull List<? extends VirtualFile> sourceRoots,
+                                                     @NotNull List<? extends VirtualFile> binaryRoots,
+                                                     @Nullable Predicate<? super VirtualFile> excludeCondition,
+                                                     @NotNull Set<? extends VirtualFile> excludedRoots) {
+    return new ImmutableSyntheticLibrary(null, sourceRoots, binaryRoots, excludedRoots, excludeCondition, null);
   }
 
   /**
    * @see SyntheticLibrary#newImmutableLibrary(String, List, List, Set, ExcludeFileCondition)
+   * @deprecated use {@link SyntheticLibrary#newImmutableLibrary(List, List, Predicate, Set)} instead
    */
+  @Deprecated
   @NotNull
   public static SyntheticLibrary newImmutableLibrary(@NotNull List<? extends VirtualFile> sourceRoots,
                                                      @NotNull List<? extends VirtualFile> binaryRoots,
                                                      @NotNull Set<? extends VirtualFile> excludedRoots,
                                                      @Nullable Condition<? super VirtualFile> excludeCondition) {
-    return new ImmutableSyntheticLibrary(null, sourceRoots, binaryRoots, excludedRoots, excludeCondition, null);
+    return newImmutableLibrary(sourceRoots, binaryRoots, excludeCondition, excludedRoots);
   }
 
   /**
@@ -192,7 +211,7 @@ public abstract class SyntheticLibrary {
                                                      @NotNull List<? extends VirtualFile> binaryRoots,
                                                      @NotNull Set<? extends VirtualFile> excludedRoots,
                                                      @Nullable ExcludeFileCondition excludeCondition) {
-    return new ImmutableSyntheticLibrary(comparisonId, sourceRoots, binaryRoots, excludedRoots, null, excludeCondition);
+    return new ImmutableSyntheticLibrary(comparisonId, sourceRoots, binaryRoots, excludedRoots, (Predicate<? super VirtualFile>) null, excludeCondition);
   }
 
   @NotNull

--- a/platform/projectModel-impl/src/com/intellij/openapi/roots/JavaSyntheticLibrary.java
+++ b/platform/projectModel-impl/src/com/intellij/openapi/roots/JavaSyntheticLibrary.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class JavaSyntheticLibrary extends ImmutableSyntheticLibrary {
 
@@ -13,6 +14,6 @@ public class JavaSyntheticLibrary extends ImmutableSyntheticLibrary {
                               @NotNull List<? extends VirtualFile> sourceRoots,
                               @NotNull List<? extends VirtualFile> binaryRoots,
                               @NotNull Set<? extends VirtualFile> excludedRoots) {
-    super(comparisonId, sourceRoots, binaryRoots, excludedRoots, null, null);
+    super(comparisonId, sourceRoots, binaryRoots, excludedRoots, (Predicate<? super VirtualFile>) null, null);
   }
 }

--- a/platform/util/src/com/intellij/openapi/util/Condition.java
+++ b/platform/util/src/com/intellij/openapi/util/Condition.java
@@ -13,6 +13,7 @@ import java.util.function.Predicate;
  * See {@link Conditions} for chained conditions.
  */
 @FunctionalInterface
+@ApiStatus.Obsolete
 public interface Condition<T> extends Predicate<T> {
   boolean value(T t);
 

--- a/platform/util/src/com/intellij/util/FilteringProcessor.java
+++ b/platform/util/src/com/intellij/util/FilteringProcessor.java
@@ -4,18 +4,28 @@ package com.intellij.util;
 import com.intellij.openapi.util.Condition;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.function.Predicate;
+
 public class FilteringProcessor<T> implements Processor<T> {
-  private final Condition<? super T> myFilter;
+  private final Predicate<? super T> myFilter;
   private final Processor<? super T> myProcessor;
 
-  public FilteringProcessor(@NotNull Condition<? super T> filter, @NotNull Processor<? super T> processor) {
+  public FilteringProcessor(@NotNull Predicate<? super T> filter, @NotNull Processor<? super T> processor) {
     myFilter = filter;
     myProcessor = processor;
   }
 
+  /**
+   * @deprecated use {@link FilteringProcessor#FilteringProcessor(Predicate, Processor)} instead
+   */
+  @Deprecated
+  public FilteringProcessor(@NotNull Condition<? super T> filter, @NotNull Processor<? super T> processor) {
+    this((Predicate<? super T>) filter, processor);
+  }
+
   @Override
   public boolean process(final T t) {
-    if (!myFilter.value(t)) return true;
+    if (!myFilter.test(t)) return true;
     return myProcessor.process(t);
   }
 }

--- a/platform/util/src/com/intellij/util/containers/FilteringIterator.java
+++ b/platform/util/src/com/intellij/util/containers/FilteringIterator.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Predicate;
 
 /**
  * {@link #remove} throws {@link IllegalStateException} if called after {@link #hasNext}
@@ -14,15 +15,23 @@ import java.util.NoSuchElementException;
  */
 public final class FilteringIterator<Dom, E extends Dom> implements PeekableIterator<E> {
   private final Iterator<? extends Dom> myDelegate;
-  private final Condition<? super Dom> myCondition;
+  private final Predicate<? super Dom> myCondition;
   private boolean myNextObtained;
   private boolean myCurrentIsValid;
   private Dom myCurrent;
   private Boolean myCurrentPassedFilter;
 
-  public FilteringIterator(@NotNull Iterator<? extends Dom> delegate, @NotNull Condition<? super Dom> condition) {
+  public FilteringIterator(@NotNull Iterator<? extends Dom> delegate, @NotNull Predicate<? super Dom> predicate) {
     myDelegate = delegate;
-    myCondition = condition;
+    myCondition = predicate;
+  }
+
+  /**
+   * @deprecated use {@link FilteringIterator#FilteringIterator(Iterator, Predicate)} instead
+   */
+  @Deprecated
+  public FilteringIterator(@NotNull Iterator<? extends Dom> delegate, @NotNull Condition<? super Dom> condition) {
+    this(delegate, (Predicate<? super Dom>) condition);
   }
 
   private void obtainNext() {
@@ -56,7 +65,7 @@ public final class FilteringIterator<Dom, E extends Dom> implements PeekableIter
     if (myCurrentPassedFilter != null) {
       return myCurrentPassedFilter;
     }
-    boolean passed = myCondition.value(myCurrent);
+    boolean passed = myCondition.test(myCurrent);
     myCurrentPassedFilter = passed;
     return passed;
   }

--- a/platform/util/src/com/intellij/util/containers/InternalIterator.java
+++ b/platform/util/src/com/intellij/util/containers/InternalIterator.java
@@ -18,6 +18,7 @@ package com.intellij.util.containers;
 import com.intellij.openapi.util.Condition;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 @FunctionalInterface
 public interface InternalIterator<T>{
@@ -44,21 +45,34 @@ public interface InternalIterator<T>{
   }
 
   class Filtering<T> implements InternalIterator<T> {
-    private final Condition<? super T> myFilter;
+    private final Predicate<? super T> myFilter;
     private final InternalIterator<? super T> myIterator;
 
-    public Filtering(InternalIterator<? super T> iterator, Condition<? super T> filter) {
+    public Filtering(InternalIterator<? super T> iterator, Predicate<? super T> filter) {
       myIterator = iterator;
       myFilter = filter;
     }
 
-    @Override
-    public boolean visit(T value) {
-      return !myFilter.value(value) || myIterator.visit(value);
+    /**
+     * @deprecated use {@link Filtering#Filtering(InternalIterator, Predicate)} instead
+     */
+    @Deprecated
+    public Filtering(InternalIterator<? super T> iterator, Condition<? super T> filter) {
+      this(iterator, (Predicate<? super T>) filter);
     }
 
-    public static <T> InternalIterator<T> create(InternalIterator<? super T> iterator, Condition<? super T> filter) {
+    @Override
+    public boolean visit(T value) {
+      return !myFilter.test(value) || myIterator.visit(value);
+    }
+
+    public static <T> InternalIterator<T> create(InternalIterator<? super T> iterator, Predicate<? super T> filter) {
       return new Filtering<>(iterator, filter);
+    }
+
+    @Deprecated
+    public static <T> InternalIterator<T> create(InternalIterator<? super T> iterator, Condition<? super T> filter) {
+      return create(iterator, (Predicate<? super T>) filter);
     }
 
     public static <T, V extends T> InternalIterator<T> createInstanceOf(InternalIterator<V> iterator, FilteringIterator.InstanceOf<V> filter) {

--- a/platform/util/src/com/intellij/util/containers/SLRUMap.java
+++ b/platform/util/src/com/intellij/util/containers/SLRUMap.java
@@ -154,14 +154,6 @@ public class SLRUMap<K,V> {
     }
   }
 
-  /**
-   * @deprecated use {@link SLRUMap#clearByPredicate(Predicate, LinkedHashMap)} instead
-   */
-  @Deprecated
-  private void clearByCondition(@NotNull Condition<? super V> condition, @NotNull LinkedHashMap<K, V> queue) {
-    clearByPredicate(condition, queue);
-  }
-
   public void clear() {
     try {
       if (!myProtectedQueue.isEmpty()) {

--- a/platform/util/src/com/intellij/util/containers/SLRUMap.java
+++ b/platform/util/src/com/intellij/util/containers/SLRUMap.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class SLRUMap<K,V> {
   private final LinkedHashMap<K,V> myProtectedQueue;
@@ -129,20 +130,36 @@ public class SLRUMap<K,V> {
     return set;
   }
 
-  public void clearByCondition(@NotNull Condition<? super V> condition) {
-    clearByCondition(condition, myProtectedQueue);
-    clearByCondition(condition, myProbationalQueue);
+  public void clearByPredicate(@NotNull Predicate<? super V> predicate) {
+    clearByPredicate(predicate, myProtectedQueue);
+    clearByPredicate(predicate, myProbationalQueue);
   }
 
-  private void clearByCondition(@NotNull Condition<? super V> condition, @NotNull LinkedHashMap<K, V> queue) {
+  /**
+   * @deprecated use {@link SLRUMap#clearByPredicate(Predicate)} instead
+   */
+  @Deprecated
+  public void clearByCondition(@NotNull Condition<? super V> condition) {
+    clearByPredicate(condition);
+  }
+
+  private void clearByPredicate(@NotNull Predicate<? super V> predicate, @NotNull LinkedHashMap<K, V> queue) {
     Iterator<Map.Entry<K, V>> iterator = queue.entrySet().iterator();
     while (iterator.hasNext()) {
       Map.Entry<K, V> entry = iterator.next();
-      if (condition.value(entry.getValue())) {
+      if (predicate.test(entry.getValue())) {
         onDropFromCache(entry.getKey(), entry.getValue());
         iterator.remove();
       }
     }
+  }
+
+  /**
+   * @deprecated use {@link SLRUMap#clearByPredicate(Predicate, LinkedHashMap)} instead
+   */
+  @Deprecated
+  private void clearByCondition(@NotNull Condition<? super V> condition, @NotNull LinkedHashMap<K, V> queue) {
+    clearByPredicate(condition, queue);
   }
 
   public void clear() {

--- a/platform/util/src/com/intellij/util/indexing/InvertedIndexUtil.java
+++ b/platform/util/src/com/intellij/util/indexing/InvertedIndexUtil.java
@@ -12,11 +12,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 public final class InvertedIndexUtil {
+
   public static @NotNull <K, V, I> IntSet collectInputIdsContainingAllKeys(@NotNull InvertedIndex<? super K, V, I> index,
                                                                            @NotNull Collection<? extends K> dataKeys,
-                                                                           @Nullable Condition<? super V> valueChecker,
+                                                                           @Nullable Predicate<? super V> valueChecker,
                                                                            @Nullable IntPredicate idChecker)
     throws StorageException {
     IntSet mainIntersection = null;
@@ -29,7 +31,7 @@ public final class InvertedIndexUtil {
 
       for (ValueContainer.ValueIterator<V> valueIt = container.getValueIterator(); valueIt.hasNext(); ) {
         final V value = valueIt.next();
-        if (valueChecker != null && !valueChecker.value(value)) {
+        if (valueChecker != null && !valueChecker.test(value)) {
           continue;
         }
         IOCancellationCallbackHolder.checkCancelled();
@@ -65,9 +67,21 @@ public final class InvertedIndexUtil {
     return mainIntersection == null ? IntSets.EMPTY_SET : mainIntersection;
   }
 
+  /**
+   * @deprecated use {@link InvertedIndexUtil#collectInputIdsContainingAllKeys(InvertedIndex, Collection, Predicate, IntPredicate)} instead
+   */
+  @Deprecated
+  public static @NotNull <K, V, I> IntSet collectInputIdsContainingAllKeys(@NotNull InvertedIndex<? super K, V, I> index,
+                                                                           @NotNull Collection<? extends K> dataKeys,
+                                                                           @Nullable Condition<? super V> valueChecker,
+                                                                           @Nullable IntPredicate idChecker)
+    throws StorageException {
+    return collectInputIdsContainingAllKeys(index, dataKeys, (Predicate<? super V>) valueChecker, idChecker);
+  }
+
   public static @NotNull <K, V, I> IntSet collectInputIdsContainingAnyKey(@NotNull InvertedIndex<? super K, V, I> index,
                                                                           @NotNull Collection<? extends K> dataKeys,
-                                                                          @Nullable Condition<? super V> valueChecker,
+                                                                          @Nullable Predicate<? super V> valueChecker,
                                                                           @Nullable IntPredicate idChecker) throws StorageException {
     IntSet result = null;
     for (K dataKey : dataKeys) {
@@ -75,7 +89,7 @@ public final class InvertedIndexUtil {
       ValueContainer<V> container = index.getData(dataKey);
       for (ValueContainer.ValueIterator<V> valueIt = container.getValueIterator(); valueIt.hasNext(); ) {
         V value = valueIt.next();
-        if (valueChecker != null && !valueChecker.value(value)) {
+        if (valueChecker != null && !valueChecker.test(value)) {
           continue;
         }
         IOCancellationCallbackHolder.checkCancelled();
@@ -89,5 +103,13 @@ public final class InvertedIndexUtil {
       }
     }
     return result == null ? IntSets.EMPTY_SET : result;
+  }
+
+  @Deprecated
+  public static @NotNull <K, V, I> IntSet collectInputIdsContainingAnyKey(@NotNull InvertedIndex<? super K, V, I> index,
+                                                                          @NotNull Collection<? extends K> dataKeys,
+                                                                          @Nullable Condition<? super V> valueChecker,
+                                                                          @Nullable IntPredicate idChecker) throws StorageException {
+    return collectInputIdsContainingAnyKey(index, dataKeys, (Predicate<? super V>) valueChecker, idChecker);
   }
 }

--- a/platform/util/src/com/intellij/util/text/UniqueNameGenerator.java
+++ b/platform/util/src/com/intellij/util/text/UniqueNameGenerator.java
@@ -5,14 +5,16 @@ import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.Function;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
-public class UniqueNameGenerator implements Condition<String> {
+public class UniqueNameGenerator implements Predicate<String> {
   private final Set<String> myExistingNames = new HashSet<>();
 
   public <T> UniqueNameGenerator(@NotNull Collection<? extends T> elements, @Nullable Function<? super T, String> namer) {
@@ -25,7 +27,7 @@ public class UniqueNameGenerator implements Condition<String> {
   }
 
   @Override
-  public final boolean value(@NotNull String candidate) {
+  public final boolean test(@NotNull String candidate) {
     return isUnique(candidate);
   }
 
@@ -34,7 +36,7 @@ public class UniqueNameGenerator implements Condition<String> {
   }
 
   public final boolean isUnique(@NotNull String name, @NotNull String prefix, @NotNull String suffix) {
-    return value(prefix + name + suffix);
+    return test(prefix + name + suffix);
   }
 
   public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull Collection<String> existingNames) {
@@ -45,28 +47,48 @@ public class UniqueNameGenerator implements Condition<String> {
     return generateUniqueName(defaultName, prefix, suffix, s -> !existingNames.contains(s));
   }
 
-  public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull Condition<? super String> validator) {
+  public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull Predicate<? super String> validator) {
     return generateUniqueName(defaultName, "", "", validator);
   }
 
-  public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull String prefix, @NotNull String suffix, @NotNull Condition<? super String> validator) {
+  @ApiStatus.Obsolete
+  public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull Condition<? super String> validator) {
+    return generateUniqueName(defaultName, (Predicate<? super String>) validator);
+  }
+
+  public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull String prefix, @NotNull String suffix, @NotNull Predicate<? super String> validator) {
     return generateUniqueName(defaultName, prefix, suffix, "", "", validator);
+  }
+
+  /**
+   * @deprecated use {@link UniqueNameGenerator#generateUniqueName(String, String, String, Predicate)} instead
+   */
+  @Deprecated
+  public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull String prefix, @NotNull String suffix, @NotNull Condition<? super String> validator) {
+    return generateUniqueName(defaultName, prefix, suffix, (Predicate<? super String>) validator);
   }
 
   public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull String prefix, @NotNull String suffix,
                                                             @NotNull String beforeNumber, @NotNull String afterNumber,
-                                                            @NotNull Condition<? super String> validator) {
+                                                            @NotNull Predicate<? super String> validator) {
     String defaultFullName = (prefix + defaultName + suffix).trim();
-    if (validator.value(defaultFullName)) {
+    if (validator.test(defaultFullName)) {
       return defaultFullName;
     }
 
     for (int i = 2; ; i++) {
       String fullName = (prefix + defaultName + beforeNumber + i + afterNumber + suffix).trim();
-      if (validator.value(fullName)) {
+      if (validator.test(fullName)) {
         return fullName;
       }
     }
+  }
+
+  @ApiStatus.Obsolete
+  public static @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull String prefix, @NotNull String suffix,
+                                                            @NotNull String beforeNumber, @NotNull String afterNumber,
+                                                            @NotNull Condition<? super String> validator) {
+    return generateUniqueName(defaultName, prefix, suffix, beforeNumber, afterNumber, (Predicate<? super String>) validator);
   }
 
   public @NlsSafe @NotNull String generateUniqueName(@NotNull String defaultName, @NotNull String prefix, @NotNull String suffix) {

--- a/platform/util/ui/src/com/intellij/util/ui/tree/WideSelectionTreeUI.java
+++ b/platform/util/ui/src/com/intellij/util/ui/tree/WideSelectionTreeUI.java
@@ -2,8 +2,6 @@
 package com.intellij.util.ui.tree;
 
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Conditions;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.ui.render.RenderingUtil;
 import com.intellij.ui.scale.JBUIScale;
@@ -11,7 +9,6 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.ui.MouseEventAdapter;
 import com.intellij.util.ui.StartupUiUtil;
 import com.intellij.util.ui.UIUtil;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,6 +25,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.lang.reflect.Method;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static com.intellij.util.ReflectionUtil.getMethod;
 
@@ -48,7 +46,7 @@ public class WideSelectionTreeUI extends BasicTreeUI {
   private static final Logger LOG = Logger.getInstance(WideSelectionTreeUI.class);
   private static final Set<String> LOGGED_RENDERERS = ContainerUtil.newConcurrentSet();
 
-  @NotNull private final Condition<? super Integer> myWideSelectionCondition;
+  @NotNull private final Predicate<? super Integer> myWideSelectionCondition;
   private final boolean myWideSelection;
   private boolean myOldRepaintAllRowValue;
   private static final boolean mySkinny = false;
@@ -105,7 +103,7 @@ public class WideSelectionTreeUI extends BasicTreeUI {
   };
 
   public WideSelectionTreeUI() {
-    this(true, Conditions.alwaysTrue());
+    this(true, s -> true);
   }
 
   /**
@@ -115,7 +113,7 @@ public class WideSelectionTreeUI extends BasicTreeUI {
    * @param wideSelectionCondition  strategy that determine if wide selection should be used for a target row (it's zero-based index
    *                                is given to the condition as an argument)
    */
-  public WideSelectionTreeUI(final boolean wideSelection, @NotNull Condition<? super Integer> wideSelectionCondition) {
+  public WideSelectionTreeUI(final boolean wideSelection, @NotNull Predicate<? super Integer> wideSelectionCondition) {
     myWideSelection = wideSelection;
     myWideSelectionCondition = wideSelectionCondition;
   }
@@ -293,7 +291,7 @@ public class WideSelectionTreeUI extends BasicTreeUI {
             LIST_SELECTION_BACKGROUND_PAINTER.paintBorder(tree, rowGraphics, xOffset, bounds.y, containerWidth, bounds.height);
           }
         }
-        else if (myWideSelectionCondition.value(row)) {
+        else if (myWideSelectionCondition.test(row)) {
           rowGraphics.setColor(background);
           rowGraphics.fillRect(xOffset, bounds.y, containerWidth, bounds.height);
         }
@@ -302,7 +300,7 @@ public class WideSelectionTreeUI extends BasicTreeUI {
         if (selected && (UIUtil.isUnderAquaBasedLookAndFeel() || StartupUiUtil.isUnderDarcula() || UIUtil.isUnderIntelliJLaF())) {
           Color bg = RenderingUtil.getSelectionBackground(tree);
 
-          if (myWideSelectionCondition.value(row)) {
+          if (myWideSelectionCondition.test(row)) {
             rowGraphics.setColor(bg);
             rowGraphics.fillRect(xOffset, bounds.y, containerWidth, bounds.height);
           }
@@ -350,7 +348,7 @@ public class WideSelectionTreeUI extends BasicTreeUI {
     final int lastVisibleRow = tr.getClosestRowForLocation(rect.x, rect.y + rect.height);
 
     for (int row = firstVisibleRow; row <= lastVisibleRow; row++) {
-      if (tr.getSelectionModel().isRowSelected(row) && myWideSelectionCondition.value(row)) {
+      if (tr.getSelectionModel().isRowSelected(row) && myWideSelectionCondition.test(row)) {
           final Rectangle bounds = tr.getRowBounds(row);
         g.setColor(RenderingUtil.getSelectionBackground(tree));
         g.fillRect(0, bounds.y, tr.getWidth(), bounds.height);

--- a/xml/dom-openapi/src/com/intellij/util/xml/ui/ComboControl.java
+++ b/xml/dom-openapi/src/com/intellij/util/xml/ui/ComboControl.java
@@ -40,6 +40,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.List;
 import java.util.*;
+import java.util.function.Predicate;
 
 public class ComboControl extends BaseModifiableControl<JComboBox<Pair<String, Icon>>, String> {
   private static final Pair<String, Icon> EMPTY = new ComboBoxItem(" ", null);
@@ -128,7 +129,7 @@ public class ComboControl extends BaseModifiableControl<JComboBox<Pair<String, I
       comboBox.addItem(new ComboBoxItem(pair));
       standardValues.add(pair.first);
     }
-    return initComboBox(comboBox, object -> standardValues.contains(object));
+    return initComboBox(comboBox, (Predicate<? super String>) object -> standardValues.contains(object));
   }
 
   private static class ComboBoxItem extends Pair<String, Icon> {
@@ -147,7 +148,7 @@ public class ComboControl extends BaseModifiableControl<JComboBox<Pair<String, I
   }
 
   static JComboBox<Pair<String, Icon>> initComboBox(final JComboBox<Pair<String, Icon>> comboBox,
-                                                    final Condition<? super String> validity) {
+                                                    final Predicate<? super String> validity) {
     comboBox.setEditable(false);
     comboBox.setPrototypeDisplayValue(new ComboBoxItem("A", null));
     comboBox.setRenderer(new DefaultListCellRenderer() {
@@ -158,7 +159,7 @@ public class ComboControl extends BaseModifiableControl<JComboBox<Pair<String, I
         final @NlsSafe String text = Pair.getFirst(pair);
         setText(text);
         final Dimension dimension = getPreferredSize();
-        if (!validity.value(text)) {
+        if (!validity.test(text)) {
           setFont(getFont().deriveFont(Font.ITALIC));
           setForeground(JBColor.RED);
         }
@@ -170,9 +171,18 @@ public class ComboControl extends BaseModifiableControl<JComboBox<Pair<String, I
     return comboBox;
   }
 
+  /**
+   * @deprecated use {@link ComboControl#initComboBox(JComboBox, Predicate)} instead
+   */
+  @Deprecated
+  static JComboBox<Pair<String, Icon>> initComboBox(final JComboBox<Pair<String, Icon>> comboBox,
+                                                    final Condition<? super String> validity) {
+    return initComboBox(comboBox, (Predicate<? super String>) validity);
+  }
+
   @Override
   protected JComboBox<Pair<String, Icon>> createMainComponent(final JComboBox<Pair<String, Icon>> boundedComponent) {
-    return initComboBox(boundedComponent == null ? new JComboBox<>() : boundedComponent, object -> isValidValue(object));
+    return initComboBox(boundedComponent == null ? new JComboBox<>() : boundedComponent, (Predicate<? super String>) object -> isValidValue(object));
   }
 
   public boolean isValidValue(final String object) {

--- a/xml/dom-openapi/src/com/intellij/util/xml/ui/ComboTableCellEditor.java
+++ b/xml/dom-openapi/src/com/intellij/util/xml/ui/ComboTableCellEditor.java
@@ -25,6 +25,7 @@ import java.awt.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class ComboTableCellEditor extends DefaultCellEditor {
   private final boolean myNullable;
@@ -40,7 +41,7 @@ public class ComboTableCellEditor extends DefaultCellEditor {
     JComboBox<Pair<String, Icon>> comboBox = (JComboBox<Pair<String, Icon>>)editorComponent;
     comboBox.setBorder(null);
     comboBox.putClientProperty("JComboBox.isTableCellEditor", Boolean.TRUE);
-    ComboControl.initComboBox(comboBox, object -> myData != null && myData.containsKey(object) || myNullable && Strings.areSameInstance(EMPTY.first, object));
+    ComboControl.initComboBox(comboBox, (Predicate<? super String>) object -> myData != null && myData.containsKey(object) || myNullable && Strings.areSameInstance(EMPTY.first, object));
   }
 
   public ComboTableCellEditor(Class<? extends Enum> anEnum, final boolean nullable) {


### PR DESCRIPTION
This is a WIP pull request. It addresses: https://youtrack.jetbrains.com/issue/IJPL-126

This pull request migrates the IntelliJ platform public APIs to use `java.util.function.Predicate` instead of `com.intellij.openapi.util.Condition`.

Currently I have only migrated functions that have `Condition` as their parameter type, and variables, as there isn't much information given as to how to migrate abstract functions, interfaces, etc. I would like to migrate these too if anyone can provide me with information.

If there are classes that shouldn't have been migrated, then please let me know and I will revert the changes. Also do let me know of classes which I may have left and need to be migrated as well.