### PR TITLE
Better check for emulated breakpoint capability

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/ui/breakpoints/MethodBreakpoint.java
+++ b/java/debugger/impl/src/com/intellij/debugger/ui/breakpoints/MethodBreakpoint.java
@@ -190,7 +190,7 @@ public class MethodBreakpoint extends BreakpointWithHighlighter<JavaMethodBreakp
                                                     @NotNull ReferenceType classType,
                                                     @NotNull ClassesByNameProvider classesByName,
                                                     boolean base) {
-    if (!MethodBreakpointBase.canBeEmulated(debugProcess)) {
+    if (breakpoint.isWatchExit() && !MethodBreakpointBase.canBeWatchExitEmulated(debugProcess)) {
       breakpoint.disableEmulation();
       return;
     }

--- a/java/debugger/impl/src/com/intellij/debugger/ui/breakpoints/MethodBreakpointBase.java
+++ b/java/debugger/impl/src/com/intellij/debugger/ui/breakpoints/MethodBreakpointBase.java
@@ -22,7 +22,7 @@ public interface MethodBreakpointBase extends FilteredRequestor {
 
   void disableEmulation();
 
-  static boolean canBeEmulated(DebugProcessImpl debugProcess) {
+  static boolean canBeWatchExitEmulated(DebugProcessImpl debugProcess) {
     VirtualMachineProxyImpl virtualMachineProxy = debugProcess.getVirtualMachineProxy();
     return virtualMachineProxy.canGetBytecodes() && virtualMachineProxy.canGetConstantPool();
   }


### PR DESCRIPTION
Problem: Emulated Method Breakpoints are not supported on ART (Android) VM. This is happening because there is a requirements for the VM to support both canGetBytecodes(which ART supports) and canGetConstantPool (which ART does not supports).

The current test for Emulated Method Breakpoint support is done at the beginning of 'createRequestForPreparedClassEmulated'. However this test generates false negatives. Only if the breakpoint is WATCH_EXIT it will need access to bytecode() and constant_pool() from JDI.

Solution: Narrowing down the test to only fallback on METHOD_ENTRY/METHOD_EXIT event listeners when the breakpoint is at least a WATCH_EXIT. If the breakpoint is only WATCH_ENTRY, allow emulation. This allows most use cases (and the default behavior) where user create a METHOD_ENTRY breakpoint to be emulated. Only if user chose to make the Method breakpoint also trigger on EXIT, then we default back to legacy METHOD_EXIT events listener.

Test: Local build, run Android project, create method breakpoint, check that an Emulated BreakPoint was created.