### PR TITLE
IDEA-321906 Exclude module-info.java files from sources zip

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
@@ -177,7 +177,7 @@ val SUPPORTED_DISTRIBUTIONS: PersistentList<SupportedDistribution> = persistentL
 )
 
 private fun isSourceFile(path: String): Boolean {
-  return path.endsWith(".java") || path.endsWith(".groovy") || path.endsWith(".kt")
+  return path.endsWith(".java") && path != "module-info.java" || path.endsWith(".groovy") || path.endsWith(".kt")
 }
 
 private fun getLocalArtifactRepositoryRoot(global: JpsGlobal): Path {


### PR DESCRIPTION
zipSourcesOfModules() aggregates sources from many modules and libraries, resulting in conflicting module-info.java files in the output.

These module-info.java files break Kotlin debugging functionality occasionally because they cause JvmModuleAccessibilityChecker to compute an incorrect Java module name for app.jar.

---

Issue link: https://youtrack.jetbrains.com/issue/IDEA-321906