### PR TITLE
IDEA-292947 Skip checking of UNC root in FsRoot

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/impl/FsRoot.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/impl/FsRoot.java
@@ -2,6 +2,7 @@
 package com.intellij.openapi.vfs.newvfs.impl;
 
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.SystemInfoRt;
 import com.intellij.openapi.util.io.FileAttributes;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.newvfs.NewVirtualFileSystem;
@@ -62,6 +63,10 @@ public final class FsRoot extends VirtualDirectoryImpl {
   private static boolean looksCanonical(@NotNull String pathBeforeSlash) {
     if (pathBeforeSlash.endsWith("/")) {
       return false;
+    }
+    // Don't try to check UNC roots.
+    if (SystemInfoRt.isWindows && pathBeforeSlash.startsWith("//")) {
+      return true;
     }
     int start = 0;
     while (true) {


### PR DESCRIPTION
LocalFileSystemBase.extractRootPath will happily return a UNC path root like "//server/..", but this is rejected by FsRoot because it contains "/..". Change FsRoot to skip this check for UNC roots.

Bug: https://youtrack.jetbrains.com/issue/IDEA-292947