### PR TITLE
IDEA-297051: Ensure parametrized model builders are shared across builds

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/JetGradlePlugin.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/JetGradlePlugin.gradle
@@ -48,12 +48,13 @@ class JetGradlePlugin implements Plugin<Gradle> {
       rootGradle = rootGradle.parent
     }
     ToolingModelBuilderRegistry rootRegistry = (rootGradle as GradleInternal).services.get(ToolingModelBuilderRegistry)
-    jetModelBuilder = findJetModelBuilder(rootRegistry)
+    jetModelBuilder = rootGradle.extensions.findByName("jetModelBuilder")
     if(jetModelBuilder == null) {
       jetModelBuilder = GradleVersion.current() >= GradleVersion.version("4.4")
         ? (ToolingModelBuilder) ExtraModelBuilder.class.classLoader.loadClass(ExtraModelBuilder.class.typeName + "\$ForGradle44").newInstance()
         : new ExtraModelBuilder();
       rootRegistry.register(jetModelBuilder)
+      rootGradle.extensions.add("jetModelBuilder", jetModelBuilder)
     }
     if (registry != rootRegistry) {
       registry.register(jetModelBuilder)


### PR DESCRIPTION
... while still supporting parametrized model builders. This change stores the root build model builder with the Gradle extension container, so that included builds can fetch this instance. Because ToolingModelBuilderRegistry.getBuilder() returns non-parametrized model builder, supporting Android single variant sync did not work. This change fixes that.