### PR TITLE
IDEA-289267 Change highlight to highlight unused code on new inspections (2/2)

### DIFF
--- a/java/java-impl-inspections/src/com/intellij/codeInspection/lambda/RedundantLambdaParameterTypeInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/lambda/RedundantLambdaParameterTypeInspection.java
@@ -6,25 +6,27 @@ import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.java.JavaBundle;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.psi.JavaElementVisitor;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiLambdaExpression;
-import com.intellij.psi.PsiParameterList;
+import com.intellij.psi.*;
 import org.jetbrains.annotations.NotNull;
 
 public class RedundantLambdaParameterTypeInspection extends AbstractBaseJavaLocalInspectionTool {
   public static final Logger LOG = Logger.getInstance(RedundantLambdaParameterTypeInspection.class);
 
   @Override
-  public @NotNull PsiElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
+  @NotNull
+  public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
     return new JavaElementVisitor() {
       @Override
       public void visitParameterList(@NotNull PsiParameterList parameterList) {
         super.visitParameterList(parameterList);
         if (parameterList.getParent() instanceof PsiLambdaExpression &&
             RemoveRedundantParameterTypesFix.isApplicable(parameterList)) {
-          holder.registerProblem(parameterList, JavaBundle.message("inspection.message.lambda.parameter.type.is.redundant"),
-                                 new RemoveRedundantParameterTypesFix((PsiLambdaExpression)parameterList.getParent()));
+          for (PsiParameter parameter : parameterList.getParameters()) {
+            if (parameter.getTypeElement() != null) {
+              holder.registerProblem(parameter.getTypeElement(), JavaBundle.message("inspection.message.lambda.parameter.type.is.redundant"),
+                                     new RemoveRedundantParameterTypesFix((PsiLambdaExpression)parameterList.getParent()));
+            }
+          }
         }
       }
     };

--- a/java/java-impl-inspections/src/com/intellij/codeInspection/miscGenerics/RedundantArrayForVarargsCallInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/miscGenerics/RedundantArrayForVarargsCallInspection.java
@@ -4,6 +4,7 @@ package com.intellij.codeInspection.miscGenerics;
 import com.intellij.codeInspection.*;
 import com.intellij.java.JavaBundle;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiUtil;
 import com.intellij.util.CommonJavaRefactoringUtil;
@@ -41,7 +42,7 @@ public class RedundantArrayForVarargsCallInspection extends AbstractBaseJavaLoca
     private static final CallMatcher LOGGER_MESSAGE_CALL = exactInstanceCall("org.slf4j.Logger", LOGGER_NAMES)
       .parameterTypes(String.class.getName(), "java.lang.Object...");
 
-    private static final LocalQuickFix myQuickFixAction = new MyQuickFix();
+    private static final LocalQuickFix redundantArrayForVarargsCallFixAction = new RedundantArrayForVarargsCallFix();
 
     private @NotNull final ProblemsHolder myHolder;
 
@@ -68,19 +69,33 @@ public class RedundantArrayForVarargsCallInspection extends AbstractBaseJavaLoca
           !CommonJavaRefactoringUtil.isSafeToFlattenToVarargsCall(expression, initializers)) {
         return;
       }
-      final String message = JavaBundle.message("inspection.redundant.array.creation.for.varargs.call.descriptor");
       PsiExpressionList argumentList = expression.getArgumentList();
       PsiExpression[] args = Objects.requireNonNull(argumentList).getExpressions();
-      myHolder.registerProblem(Objects.requireNonNull(PsiUtil.skipParenthesizedExprDown(args[args.length - 1])), message, myQuickFixAction);
+      PsiExpression arrayCreation = Objects.requireNonNull(PsiUtil.skipParenthesizedExprDown(args[args.length - 1]));
+      if (!(arrayCreation instanceof PsiNewExpression)) return;
+      final String message = JavaBundle.message("inspection.redundant.array.creation.for.varargs.call.descriptor");
+      PsiArrayInitializerExpression arrayInitializer = ((PsiNewExpression)arrayCreation).getArrayInitializer();
+      if (arrayInitializer == null) {
+        myHolder.registerProblem(
+          arrayCreation,
+          message,
+          redundantArrayForVarargsCallFixAction);
+      } else {
+        myHolder.registerProblem(
+          arrayCreation,
+          new TextRange(0, arrayInitializer.getStartOffsetInParent()),
+          message,
+          redundantArrayForVarargsCallFixAction);
+      }
     }
 
 
-    private static final class MyQuickFix implements LocalQuickFix {
+    private static final class RedundantArrayForVarargsCallFix implements LocalQuickFix {
       @Override
       public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
-        PsiNewExpression arrayCreation = (PsiNewExpression)descriptor.getPsiElement();
-        if (arrayCreation == null) return;
-        CommonJavaRefactoringUtil.inlineArrayCreationForVarargs(arrayCreation);
+        PsiElement arrayCreation = descriptor.getPsiElement();
+        if (!(arrayCreation instanceof PsiNewExpression)) return;
+        CommonJavaRefactoringUtil.inlineArrayCreationForVarargs((PsiNewExpression)arrayCreation);
       }
 
       @Override

--- a/java/java-impl/src/META-INF/JavaPlugin.xml
+++ b/java/java-impl/src/META-INF/JavaPlugin.xml
@@ -1523,7 +1523,7 @@
     <localInspection groupPath="Java" language="JAVA" shortName="RedundantLambdaParameterType"
                      groupBundle="messages.InspectionsBundle"
                      groupKey="group.names.declaration.redundancy" enabledByDefault="true" level="INFORMATION"
-                     implementationClass="com.intellij.codeInspection.lambda.RedundantLambdaParameterTypeInspection"
+                     implementationClass="com.intellij.codeInspection.lambda.RedundantLambdaParameterTypeInspection" editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
                      key="inspection.redundant.lambda.parameter.type.display.name" bundle="messages.JavaBundle"/>
     <localInspection groupPath="Java" language="JAVA" shortName="ReplaceInefficientStreamCount"
                      groupBundle="messages.InspectionsBundle"
@@ -1813,7 +1813,7 @@
                      key="inspection.redundant.array.creation.display.name"
                      groupKey="group.names.verbose.or.redundant.code.constructs" groupBundle="messages.InspectionsBundle"
                      enabledByDefault="true" level="WARNING" cleanupTool="true"
-                     implementationClass="com.intellij.codeInspection.miscGenerics.RedundantArrayForVarargsCallInspection"/>
+                     editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES" implementationClass="com.intellij.codeInspection.miscGenerics.RedundantArrayForVarargsCallInspection"/>
     <localInspection groupPath="Java" language="JAVA" shortName="CharsetObjectCanBeUsed" bundle="messages.JavaBundle"
                      key="inspection.charset.object.can.be.used.display.name"
                      groupKey="group.names.code.style.issues" groupBundle="messages.InspectionsBundle"

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/afterRawArray.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/afterRawArray.java
@@ -1,0 +1,14 @@
+// "Remove explicit array creation" "true"
+import java.util.Arrays;
+import java.util.List;
+import java.util.Date;
+
+public class RedundantArrayForVarargsCall {
+  {
+    try {
+      String.class.getConstructor(String.class);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/afterSeveralValues.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/afterSeveralValues.java
@@ -1,0 +1,10 @@
+// "Remove explicit array creation" "true"
+import java.util.Arrays;
+import java.util.List;
+import java.util.Date;
+
+public class RedundantArrayForVarargsCall {
+  public List<Date> severalValues() {
+    return Arrays.asList(new Date(), new Date());
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/beforeRawArray.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/beforeRawArray.java
@@ -1,0 +1,14 @@
+// "Remove explicit array creation" "true"
+import java.util.Arrays;
+import java.util.List;
+import java.util.Date;
+
+public class RedundantArrayForVarargsCall {
+  {
+    try {
+      String.class.getConstructor(new Class<caret>[]{String.class});
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/beforeSeveralValues.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall/beforeSeveralValues.java
@@ -1,0 +1,10 @@
+// "Remove explicit array creation" "true"
+import java.util.Arrays;
+import java.util.List;
+import java.util.Date;
+
+public class RedundantArrayForVarargsCall {
+  public List<Date> severalValues() {
+    return Arrays.asList(new <caret>Date[] {new Date(), new Date()});
+  }
+}

--- a/java/java-tests/testData/inspection/redundantArrayForVarargs/CheckEnumConstant.java
+++ b/java/java-tests/testData/inspection/redundantArrayForVarargs/CheckEnumConstant.java
@@ -1,6 +1,6 @@
 
 public enum CheckEnumConstant {
-  A(<warning descr="Redundant array creation for calling varargs method">new String[]{"1", "2"}</warning>);
+  A(<warning descr="Redundant array creation for calling varargs method">new String[]</warning>{"1", "2"});
 
   CheckEnumConstant(String... ss) {
   }

--- a/java/java-tests/testData/inspection/redundantArrayForVarargs/Generic.java
+++ b/java/java-tests/testData/inspection/redundantArrayForVarargs/Generic.java
@@ -7,7 +7,7 @@ class Generic {
     B b = new B();
     C<A> l = asC(new A[]{b});
     A a = new A();
-    C<A> m = asC(<warning descr="Redundant array creation for calling varargs method">new A[]{a}</warning>);
+    C<A> m = asC(<warning descr="Redundant array creation for calling varargs method">new A[]</warning>{a});
   }
 
   public static <T> C<T> asC(T... ts) {
@@ -17,6 +17,6 @@ class Generic {
   class C<T> {}
 
   void m() {
-    System.out.println(String.format("%s %s", <warning descr="Redundant array creation for calling varargs method">new Object[] {"Z", "X"}</warning>));
+    System.out.println(String.format("%s %s", <warning descr="Redundant array creation for calling varargs method">new Object[] </warning>{"Z", "X"}));
   }
 }

--- a/java/java-tests/testData/inspection/redundantArrayForVarargs/IDEADEV15215.java
+++ b/java/java-tests/testData/inspection/redundantArrayForVarargs/IDEADEV15215.java
@@ -15,6 +15,6 @@ public class IDEADEV15215 {
 
     
     public static void extra(String... args) {
-      extra(<warning descr="Redundant array creation for calling varargs method">new String[]{"vvv","aaa"}</warning>);
+      extra(<warning descr="Redundant array creation for calling varargs method">new String[]</warning>{"vvv","aaa"});
     }
 }

--- a/java/java-tests/testData/inspection/redundantArrayForVarargs/NestedArray.java
+++ b/java/java-tests/testData/inspection/redundantArrayForVarargs/NestedArray.java
@@ -12,8 +12,8 @@ public class NestedArray {
     public void main(String[] args) {
         String[] params = new String[]{ "0", "1" };
         method(new Object[]{params});
-        method(<warning descr="Redundant array creation for calling varargs method">new Object[]{"2", params}</warning>);
-        method(<warning descr="Redundant array creation for calling varargs method">new Object[]{params, params}</warning>);
+        method(<warning descr="Redundant array creation for calling varargs method">new Object[]</warning>{"2", params});
+        method(<warning descr="Redundant array creation for calling varargs method">new Object[]</warning>{params, params});
     }
 
     public static Collection quickFixErrorIDEA165068() {
@@ -26,11 +26,11 @@ public class NestedArray {
     }
 
     public static Collection quickFixError2() {
-        return Arrays.asList(<warning descr="Redundant array creation for calling varargs method">new String[][]{
+        return Arrays.asList(<warning descr="Redundant array creation for calling varargs method">new String[][]</warning>{
           new String[] {"bla", " bla"},
           new String[] {"bla", " bla"},
           new String[] {"bla", " bla"},
           new String[] {"bla", " bla"},
-        }</warning>);
+        });
     }
 }

--- a/java/java-tests/testData/inspection/redundantArrayForVarargs/RawArray.java
+++ b/java/java-tests/testData/inspection/redundantArrayForVarargs/RawArray.java
@@ -1,7 +1,7 @@
 public class RawArray {
   {
     try {
-      String.class.getConstructor(<warning descr="Redundant array creation for calling varargs method">new Class[]{String.class}</warning>);
+      String.class.getConstructor(<warning descr="Redundant array creation for calling varargs method">new Class[]</warning>{String.class});
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/java/java-tests/testData/inspection/redundantLambdaParameterType/RedundantLambdaParameterType.java
+++ b/java/java-tests/testData/inspection/redundantLambdaParameterType/RedundantLambdaParameterType.java
@@ -1,0 +1,12 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+import java.util.List;
+import java.util.Map;
+
+class C {
+    void singleParameter(List<String> list) {
+      list.forEach((<warning descr="Lambda parameter type is redundant">String</warning> s) -> System.out.println("#" + s));
+    }
+  void twoParameters(Map<String, Integer> map) {
+    map.forEach((<warning descr="Lambda parameter type is redundant">String</warning> s, <warning descr="Lambda parameter type is redundant">Integer</warning> i) -> System.out.println(s + "=" + i));
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantArrayForVarargsCallFixTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantArrayForVarargsCallFixTest.java
@@ -1,0 +1,21 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.java.codeInspection;
+
+import com.intellij.codeInsight.daemon.quickFix.LightQuickFixParameterizedTestCase;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.miscGenerics.RedundantArrayForVarargsCallInspection;
+import org.jetbrains.annotations.NotNull;
+
+public class RedundantArrayForVarargsCallFixTest extends LightQuickFixParameterizedTestCase {
+  @Override
+  protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
+    return new LocalInspectionTool[]{
+      new RedundantArrayForVarargsCallInspection()
+    };
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/codeInsight/daemonCodeAnalyzer/quickFix/redundantArrayForVarargsCall";
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantLambdaParameterTypeFixTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantLambdaParameterTypeFixTest.java
@@ -1,0 +1,97 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.java.codeInspection;
+
+import com.intellij.JavaTestUtil;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.lambda.RedundantLambdaParameterTypeInspection;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class RedundantLambdaParameterTypeFixTest extends LightJavaCodeInsightFixtureTestCase {
+  private static final String ourIntentionName = "Remove redundant parameter types";
+
+  @Override
+  protected String getBasePath() {
+    return JavaTestUtil.getRelativeJavaTestDataPath() + "/codeInspection/redundantLambdaParameterType";
+  }
+
+  @NotNull
+  @Override
+  protected LightProjectDescriptor getProjectDescriptor() {
+    return JAVA_8;
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    myFixture.enableInspections(new RedundantLambdaParameterTypeInspection());
+  }
+
+  public void testAssignment() {
+    doTest();
+  }
+
+  public void testAssignmentNoParams() {
+    assertIntentionNotAvailable();
+  }
+
+  public void testAssignmentNoTypes() {
+    assertIntentionNotAvailable();
+  }
+
+  public void testAtVarargPlace() {
+    assertIntentionNotAvailable();
+  }
+
+  public void testCallNoTypeArgs() {
+    assertIntentionNotAvailable();
+  }
+
+  public void testCallNoTypeArgs1() {
+    assertIntentionNotAvailable();
+  }
+
+  public void testCallNoTypeArgs2() {
+    assertIntentionNotAvailable();
+  }
+
+  public void testCallWithTypeArgs() {
+    doTest();
+  }
+
+  public void testInferredFromOtherArgs() {
+    doTest();
+  }
+
+  public void testNoSelfTypeParam() {
+    doTest();
+  }
+
+  public void testTypeParam() {
+    assertIntentionNotAvailable();
+  }
+
+  public void testInChain() { // disabled till the functionality is available
+    doTest();
+  }
+
+  public void testNotApplicableDueToChainedCall() {
+    assertIntentionNotAvailable();
+  }
+
+  private void doTest() {
+    myFixture.configureByFiles(getTestName(false) + ".java");
+    final IntentionAction singleIntention = myFixture.findSingleIntention(ourIntentionName);
+    myFixture.launchAction(singleIntention);
+    myFixture.checkResultByFile(getTestName(false) + ".java", getTestName(false) + "_after.java", true);
+  }
+
+  private void assertIntentionNotAvailable() {
+    myFixture.configureByFiles(getTestName(false) + ".java");
+    final List<IntentionAction> intentionActions = myFixture.filterAvailableIntentions(ourIntentionName);
+    assertEmpty(ourIntentionName + " is not expected", intentionActions);
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantLambdaParameterTypeInspectionTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/RedundantLambdaParameterTypeInspectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 JetBrains s.r.o.
+ * Copyright 2000-2022 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,15 @@
 package com.intellij.java.codeInspection;
 
 import com.intellij.JavaTestUtil;
-import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.codeInspection.lambda.RedundantLambdaParameterTypeInspection;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 public class RedundantLambdaParameterTypeInspectionTest extends LightJavaCodeInsightFixtureTestCase {
-  private static final String ourIntentionName = "Remove redundant parameter types";
-
   @Override
   protected String getBasePath() {
-    return JavaTestUtil.getRelativeJavaTestDataPath() + "/codeInspection/redundantLambdaParameterType";
+    return JavaTestUtil.getRelativeJavaTestDataPath() + "/inspection/redundantLambdaParameterType";
   }
 
   @NotNull
@@ -38,74 +33,12 @@ public class RedundantLambdaParameterTypeInspectionTest extends LightJavaCodeIns
     return JAVA_8;
   }
 
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-    myFixture.enableInspections(new RedundantLambdaParameterTypeInspection());
-  }
-
-  public void testAssignment() {
-    doTest();
-  }
-
-  public void testAssignmentNoParams() {
-    assertIntentionNotAvailable();
-  }
-
-  public void testAssignmentNoTypes() {
-    assertIntentionNotAvailable();
-  }
-
-  public void testAtVarargPlace() {
-    assertIntentionNotAvailable();
-  }
-
-  public void testCallNoTypeArgs() {
-    assertIntentionNotAvailable();
-  }
-
-  public void testCallNoTypeArgs1() {
-    assertIntentionNotAvailable();
-  }
-
-  public void testCallNoTypeArgs2() {
-    assertIntentionNotAvailable();
-  }
-
-  public void testCallWithTypeArgs() {
-    doTest();
-  }
-
-  public void testInferredFromOtherArgs() {
-    doTest();
-  }
-
-  public void testNoSelfTypeParam() {
-    doTest();
-  }
-
-  public void testTypeParam() {
-    assertIntentionNotAvailable();
-  }
-
-  public void testInChain() { // disabled till the functionality is available
-    doTest();
-  }
-
-  public void testNotApplicableDueToChainedCall() {
-    assertIntentionNotAvailable();
-  }
-
   private void doTest() {
-    myFixture.configureByFiles(getTestName(false) + ".java");
-    final IntentionAction singleIntention = myFixture.findSingleIntention(ourIntentionName);
-    myFixture.launchAction(singleIntention);
-    myFixture.checkResultByFile(getTestName(false) + ".java", getTestName(false) + "_after.java", true);
+    myFixture.enableInspections(new RedundantLambdaParameterTypeInspection() {});
+    myFixture.testHighlighting(getTestName(false) + ".java");
   }
 
-  private void assertIntentionNotAvailable() {
-    myFixture.configureByFiles(getTestName(false) + ".java");
-    final List<IntentionAction> intentionActions = myFixture.filterAvailableIntentions(ourIntentionName);
-    assertEmpty(ourIntentionName + " is not expected", intentionActions);
+  public void testRedundantLambdaParameterType() {
+    doTest();
   }
 }


### PR DESCRIPTION
Hi @amaembo,

***What steps will reproduce the issue?***

1. Go to *File* → *Settings..*. → *Editor* → *Inspections*
2. Enable *Redundant Array For Varargs Call*
3. Enable Severity: *Warning*
4. Add the `List<String>texts = Arrays.asList(new String[] {"foo", "bar"});` statement in a Java class

***What is the expected result?***
The `new String[]` constructor is highlighted as a useless code.

***What happens instead?***
The `new String[] {"foo", "bar"}` expression is highlighted as a standard warning.

***Which inspections are concerned?***

1. *RedundantArrayForVarargsCall*
9. *RedundantLambdaParameterType*

***Which inspections already work like this?***

 1. *FinalPrivateMethodInspection*
 2. *FinalStaticMethodInspection*
 3. *ConfusingElseInspection*
 4. *SimplifiableEqualsExpressionInspection*
 5. *UnnecessaryBreakInspection*
 6. *UnnecessaryContinueInspection*
 7. *UnnecessaryDefaultInspection*
 9. *UnnecessaryLabelOnBreakStatementInspection*
 11. *UnnecessaryLabelOnContinueStatementInspection*
12. *UnnecessaryReturnInspection*
13. *DeleteUnnecessaryStatementFix*
14. *JavaLangImportInspection*
15. *SamePackageImportInspection*
16. *UnnecessaryInheritDocInspection*
17. *UnusedLabelInspection*
18. *TransientFieldInNonSerializableClassInspection*
19. *UnnecessaryConstructorInspection*
20. *UnnecessaryFinalOnLocalVariableOrParameterInspection*
21. *EmptySynchronizedStatementInspection*
22. *TrivialFunctionalExpressionUsageInspection*
23. *UnnecessaryInitCauseInspection*
24. *EmptyFinallyBlockInspection*
25. *UnnecessaryExplicitNumericCastInspection*
26. *...*

Unit tests have been added. All the unit tests have successfully worked. I have split the PR to isolate the new inspections. When it will be merged, I will update the ticket.