### PR TITLE
Add type constraints for <Wrapper>.TYPE fields

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/impl/compiled/ClsFieldImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/compiled/ClsFieldImpl.java
@@ -92,11 +92,6 @@ public class ClsFieldImpl extends ClsMemberImpl<PsiFieldStub> implements PsiFiel
       return null;
     }
 
-    PsiExpression initializer = getInitializer();
-    if (initializer == null) {
-      return null;
-    }
-
     PsiClass containingClass = getContainingClass();
     if (containingClass != null) {
       String qName = containingClass.getQualifiedName();
@@ -112,6 +107,43 @@ public class ClsFieldImpl extends ClsMemberImpl<PsiFieldStub> implements PsiFiel
         if ("NEGATIVE_INFINITY".equals(name)) return Double.NEGATIVE_INFINITY;
         if ("NaN".equals(name)) return Double.NaN;
       }
+      // Wrapper classes have a TYPE field holding the Class object of the primitive type
+      if (qName != null && "TYPE".equals(getName())) {
+        switch (qName) {
+          case "java.lang.Byte": {
+            return PsiTypes.byteType();
+          }
+          case "java.lang.Character": {
+            return PsiTypes.charType();
+          }
+          case "java.lang.Double": {
+            return PsiTypes.doubleType();
+          }
+          case "java.lang.Float": {
+            return PsiTypes.floatType();
+          }
+          case "java.lang.Integer": {
+            return PsiTypes.intType();
+          }
+          case "java.lang.Long": {
+            return PsiTypes.longType();
+          }
+          case "java.lang.Short": {
+            return PsiTypes.shortType();
+          }
+          case "java.lang.Boolean": {
+            return PsiTypes.booleanType();
+          }
+          case "java.lang.Void": {
+            return PsiTypes.voidType();
+          }
+        }
+      }
+    }
+
+    PsiExpression initializer = getInitializer();
+    if (initializer == null) {
+      return null;
     }
 
     return PsiConstantEvaluationHelperImpl.computeCastTo(initializer, getType(), visitedVars);

--- a/java/java-tests/testData/inspection/dataFlow/fixture/PrimitiveTypeFieldInWrapper.java
+++ b/java/java-tests/testData/inspection/dataFlow/fixture/PrimitiveTypeFieldInWrapper.java
@@ -1,0 +1,13 @@
+public class PrimitiveTypeFieldInWrapper {
+  void foo() {
+    boolean B = <warning descr="Condition 'Byte.TYPE == byte.class' is always 'true'">Byte.TYPE == byte.class</warning>;
+    boolean C = <warning descr="Condition 'Character.TYPE == char.class' is always 'true'">Character.TYPE == char.class</warning>;
+    boolean D = <warning descr="Condition 'Double.TYPE == double.class' is always 'true'">Double.TYPE == double.class</warning>;
+    boolean F = <warning descr="Condition 'Float.TYPE == float.class' is always 'true'">Float.TYPE == float.class</warning>;
+    boolean I = <warning descr="Condition 'Integer.TYPE == int.class' is always 'true'">Integer.TYPE == int.class</warning>;
+    boolean J = <warning descr="Condition 'Long.TYPE == long.class' is always 'true'">Long.TYPE == long.class</warning>;
+    boolean S = <warning descr="Condition 'Short.TYPE == short.class' is always 'true'">Short.TYPE == short.class</warning>;
+    boolean Z = <warning descr="Condition 'Boolean.TYPE == boolean.class' is always 'true'">Boolean.TYPE == boolean.class</warning>;
+    boolean V = <warning descr="Condition 'Void.TYPE == void.class' is always 'true'">Void.TYPE == void.class</warning>;
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/DataFlowInspectionTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/DataFlowInspectionTest.java
@@ -726,4 +726,5 @@ public class DataFlowInspectionTest extends DataFlowInspectionTestCase {
   public void testBooleanOrEquals() { doTest(); }
   public void testDuplicatedByPointlessBooleanInspection() { doTest(); }
   public void testSystemOutNullSource() { doTest(); }
+  public void testPrimitiveTypeFieldInWrapper() { doTest(); }
 }


### PR DESCRIPTION
Primitive type wrappers have a `TYPE` field which holds the `Class` instance for their primitive type.
While IDEA already provides inspections for `Class` types, it doesn't have type information about the fields.
With this PR, e.g. `Integer.TYPE` and `int.class` are correctly recognized as the same value.

I added a testcase which showcases the effect of the change.