### PR TITLE
fix: escape HTML entities in RecursivePropertyAccessor.html

### DIFF
--- a/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/RecursivePropertyAccessor.html
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/RecursivePropertyAccessor.html
@@ -8,14 +8,14 @@
 <pre><code>
   var counter: Int = 0
       set(value) {
-          <b>counter</b> = if (value < 0) 0 else value
+          <b>counter</b> = if (value &lt; 0) 0 else value
       }
 </code></pre>
 <p>After the quick-fix is applied:</p>
 <pre><code>
   var counter: Int = 0
       set(value) {
-          <b>field</b> = if (value < 0) 0 else value
+          <b>field</b> = if (value &lt; 0) 0 else value
       }
 </code></pre>
 </body>


### PR DESCRIPTION
Sorry for the tiny patch, I noticed that the `<` symbol is missing from this inspection description:

![image](https://github.com/JetBrains/intellij-community/assets/858456/d2c5fa0a-d7e7-4561-931c-0d3c0d738525)

I checked [another inspection](https://github.com/JetBrains/intellij-community/blob/3cb3c721240b1127bf1fa993ac4dc32da44e5e09/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/Destructure.html#L19) to see that escaping with an entity here is the correct thing to do.