### PR TITLE
Use NameMapper From PositionManagerImpl

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/impl/DebuggerManagerImpl.java
+++ b/java/debugger/impl/src/com/intellij/debugger/impl/DebuggerManagerImpl.java
@@ -140,6 +140,7 @@ public class DebuggerManagerImpl extends DebuggerManagerEx implements Persistent
       busConnection.subscribe(DebuggerManagerListener.TOPIC, myDispatcher.getMulticaster());
     }
     myBreakpointManager.addListeners(busConnection);
+    myNameMappers.addAll(NameMapper.EP_NAME.getExtensionList());
   }
 
   @Nullable

--- a/java/debugger/openapi/src/com/intellij/debugger/DebuggerManager.java
+++ b/java/debugger/openapi/src/com/intellij/debugger/DebuggerManager.java
@@ -20,8 +20,16 @@ public abstract class DebuggerManager {
 
   public abstract boolean isDebuggerManagerThread();
 
+  /**
+   * @deprecated Use {@link NameMapper#EP_NAME}
+   */
+  @Deprecated
   public abstract void addClassNameMapper(NameMapper mapper);
 
+  /**
+   * @deprecated Use {@link NameMapper#EP_NAME}
+   */
+  @Deprecated
   public abstract void removeClassNameMapper(NameMapper mapper);
 
   public abstract String getVMClassQualifiedName(PsiClass aClass);

--- a/java/debugger/openapi/src/com/intellij/debugger/NameMapper.java
+++ b/java/debugger/openapi/src/com/intellij/debugger/NameMapper.java
@@ -15,8 +15,10 @@
  */
 package com.intellij.debugger;
 
+import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.psi.PsiClass;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Compilers of some java-based languages (like Scala) produce classes with names different from those declared in sources.
@@ -27,9 +29,22 @@ import org.jetbrains.annotations.NotNull;
  * PsiClass.getQualifiedName() will be used as a qualified name of the compiled class
  */
 public interface NameMapper {
+  ExtensionPointName<NameMapper> EP_NAME = ExtensionPointName.create("com.intellij.debugger.nameMapper");
+
   /**
    * @param aClass a top-level class
-   * @return a qualified name of the corresponding compiled class or null if default machanism of getting qualified names must be used
+   * @return a qualified name of the corresponding compiled class or null if default mechanism of getting qualified names must be used
    */
+  @Nullable
+
   String getQualifiedName(@NotNull PsiClass aClass);
+
+  /**
+   * @param aClass a top-level class
+   * @return an alternative JVM name of the corresponding compiled class or null if default mechanism of getting JVM names must be used
+   */
+  @Nullable
+  default String getAlternativeJvmName(@NotNull PsiClass aClass) {
+    return null;
+  }
 }

--- a/java/java-impl/src/META-INF/JavaPlugin.xml
+++ b/java/java-impl/src/META-INF/JavaPlugin.xml
@@ -249,6 +249,7 @@
     <extensionPoint qualifiedName="com.intellij.debugger.nodeNameAdjuster"
                     interface="com.intellij.debugger.ui.tree.NodeDescriptorNameAdjuster" dynamic="true"/>
 
+    <extensionPoint qualifiedName="com.intellij.debugger.nameMapper" interface="com.intellij.debugger.NameMapper" dynamic="true"/>
 
     <extensionPoint qualifiedName="com.intellij.compiler.inspectionValidator"
                     interface="com.intellij.openapi.compiler.util.InspectionValidator"


### PR DESCRIPTION
This allows Android Plugin to support desugared classes.

NameMapper is now an Extension Point. Also updated DebuggerManagerImpl to use the EP rather than inject NameMappers manually.

https://youtrack.jetbrains.com/issue/IDEA-321559/Feature-Request-Make-PositionManagerImpl-Support-Desugared-Androi-Classes