### PR TITLE
KTIJ-18084 False positive Redundant semicolon inspection after companion object declaration

### DIFF
--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspections/redundantSemicolon/Test.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspections/redundantSemicolon/Test.kt
@@ -42,7 +42,7 @@ fun baz(args: Array<String>) {
 enum class Foo {
     ; //not redundant
     ;
-    companion object;
+    companion object; //not redundant
     ;
 }
 

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspections/redundantSemicolon/inspectionData/expected.xml
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspections/redundantSemicolon/inspectionData/expected.xml
@@ -90,15 +90,6 @@
 
     <problem>
         <file>Test.kt</file>
-        <line>45</line>
-        <module>light_idea_test_case</module>
-        <entry_point TYPE="file" FQNAME="temp:///src/Test.kt" />
-        <problem_class severity="WARNING" attribute_key="NOT_USED_ELEMENT_ATTRIBUTES">Redundant semicolon</problem_class>
-        <description>Redundant semicolon</description>
-    </problem>
-
-    <problem>
-        <file>Test.kt</file>
         <line>46</line>
         <module>light_idea_test_case</module>
         <entry_point TYPE="file" FQNAME="temp:///src/Test.kt" />

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeFun.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeFun.kt
@@ -1,3 +1,4 @@
+// PROBLEM: none
 class Test {
     companion object<caret>;
 

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeFun.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeFun.kt.after
@@ -1,7 +1,0 @@
-class Test {
-    companion object
-
-    fun test() {}
-}
-
-fun Test.Companion.foo() {}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeVal.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeVal.kt
@@ -1,3 +1,4 @@
+// PROBLEM: none
 class Test {
     companion object<caret>;
 

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeVal.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionBeforeVal.kt.after
@@ -1,7 +1,0 @@
-class Test {
-    companion object
-
-    val bar = 1
-}
-
-fun Test.Companion.foo() {}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionInLast.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionInLast.kt
@@ -1,3 +1,4 @@
+// PROBLEM: none
 class Test {
     companion object<caret>;
 }

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionInLast.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/companionInLast.kt.after
@@ -1,5 +1,0 @@
-class Test {
-    companion object
-}
-
-fun Test.Companion.foo() {}

--- a/plugins/kotlin/code-insight/utils/src/org/jetbrains/kotlin/idea/codeinsight/utils/RedundantSemicolonUtils.kt
+++ b/plugins/kotlin/code-insight/utils/src/org/jetbrains/kotlin/idea/codeinsight/utils/RedundantSemicolonUtils.kt
@@ -72,12 +72,12 @@ private fun PsiElement?.isBeforeLeftBrace(): Boolean {
 }
 
 private fun isSemicolonRequired(semicolon: PsiElement): Boolean {
-    if (isRequiredForCompanion(semicolon)) {
-        return true
-    }
-
     val prevSibling = semicolon.getPrevSiblingIgnoringWhitespaceAndComments()
     val nextSibling = semicolon.getNextSiblingIgnoringWhitespaceAndComments()
+
+    if (prevSibling is KtObjectDeclaration && prevSibling.isCompanion() && prevSibling.nameIdentifier == null && prevSibling.body == null) {
+        return true
+    }
 
     if (prevSibling is KtNameReferenceExpression && prevSibling.text in softModifierKeywords && nextSibling is KtDeclaration) {
         // enum; class Foo
@@ -92,16 +92,6 @@ private fun isSemicolonRequired(semicolon: PsiElement): Boolean {
     }
 
     return false
-}
-
-private fun isRequiredForCompanion(semicolon: PsiElement): Boolean {
-    val prev = semicolon.getPrevSiblingIgnoringWhitespaceAndComments() as? KtObjectDeclaration ?: return false
-    if (!prev.isCompanion()) return false
-    if (prev.nameIdentifier != null || prev.getChildOfType<KtClassBody>() != null) return false
-
-    val next = semicolon.getNextSiblingIgnoringWhitespaceAndComments() ?: return false
-    val firstChildNode = next.firstChild?.node ?: return false
-    return !KtTokens.KEYWORDS.contains(firstChildNode.elementType)
 }
 
 private val softModifierKeywords: List<String> = KtTokens.SOFT_KEYWORDS.types.mapNotNull { (it as? KtModifierKeywordToken)?.toString() }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-18084