### PR TITLE
KTIJ-25857 False positive "Accessor call that can be replaced with property access syntax" when setter is used as expression

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/K1IntentionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/intentions/K1IntentionTestGenerated.java
@@ -18457,6 +18457,16 @@ public abstract class K1IntentionTestGenerated extends AbstractK1IntentionTest {
             runTest("testData/intentions/usePropertyAccessSyntax/setAsExpressionBodyUnqualified.kt");
         }
 
+        @TestMetadata("setAsPropertyInitializer.kt")
+        public void testSetAsPropertyInitializer() throws Exception {
+            runTest("testData/intentions/usePropertyAccessSyntax/setAsPropertyInitializer.kt");
+        }
+
+        @TestMetadata("setAsReturnedExpression.kt")
+        public void testSetAsReturnedExpression() throws Exception {
+            runTest("testData/intentions/usePropertyAccessSyntax/setAsReturnedExpression.kt");
+        }
+
         @TestMetadata("setFunctionReferenceArgument.kt")
         public void testSetFunctionReferenceArgument() throws Exception {
             runTest("testData/intentions/usePropertyAccessSyntax/setFunctionReferenceArgument.kt");

--- a/plugins/kotlin/idea/tests/testData/intentions/usePropertyAccessSyntax/setAsPropertyInitializer.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/usePropertyAccessSyntax/setAsPropertyInitializer.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun foo(thread: Thread) {
+    val x = thread.setName("name")<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/intentions/usePropertyAccessSyntax/setAsReturnedExpression.kt
+++ b/plugins/kotlin/idea/tests/testData/intentions/usePropertyAccessSyntax/setAsReturnedExpression.kt
@@ -1,0 +1,5 @@
+// IS_APPLICABLE: false
+// WITH_STDLIB
+fun foo(thread: Thread) {
+    return thread.setName("name")<caret>
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-25857