### PR TITLE
Prepare For a `ComposeFunctionBreakpoint` Subclass

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/ui/breakpoints/MethodBreakpoint.java
+++ b/java/debugger/impl/src/com/intellij/debugger/ui/breakpoints/MethodBreakpoint.java
@@ -278,55 +278,63 @@ public class MethodBreakpoint extends BreakpointWithHighlighter<JavaMethodBreakp
     }
   }
 
-  private void createRequestForPreparedClassOriginal(@NotNull DebugProcessImpl debugProcess, @NotNull ReferenceType classType) {
+  /**
+   * Return `true` if the method has the same name and signature as the breakpoint.
+   */
+  protected boolean isMethodMatch(@NotNull Method method, @NotNull DebugProcessImpl debugProcess) {
     try {
-      boolean hasMethod = false;
-      for (Method method : classType.allMethods()) {
-        String signature = method.signature();
-        String name = method.name();
+      String name = getMethodName();
+      return
+        name != null && name.equals(method.name()) &&
+        mySignature != null && mySignature.getName(debugProcess).equals(method.signature());
+    }
+    catch (EvaluateException e) {
+      LOG.debug("Should not happen. mySignature is a JVMRawText and it doesn't throw", e);
+      return false;
+    }
+  }
 
-        if (getMethodName().equals(name) && mySignature.getName(debugProcess).equals(signature)) {
-          hasMethod = true;
-          break;
-        }
-      }
-
-      if (!hasMethod) {
-        debugProcess.getRequestsManager().setInvalid(
-          this, JavaDebuggerBundle.message("error.invalid.breakpoint.method.not.found", classType.name())
-        );
-        return;
-      }
-
-      RequestManagerImpl requestManager = debugProcess.getRequestsManager();
-      if (isWatchEntry()) {
-        MethodEntryRequest entryRequest = findRequest(debugProcess, MethodEntryRequest.class, this);
-        if (entryRequest == null) {
-          entryRequest = requestManager.createMethodEntryRequest(this);
-        }
-        else {
-          entryRequest.disable();
-        }
-        //entryRequest.addClassFilter(myClassQualifiedName);
-        // use addClassFilter(ReferenceType) in order to stop on subclasses also!
-        entryRequest.addClassFilter(classType);
-        debugProcess.getRequestsManager().enableRequest(entryRequest);
-      }
-      if (isWatchExit()) {
-        MethodExitRequest exitRequest = findRequest(debugProcess, MethodExitRequest.class, this);
-        if (exitRequest == null) {
-          exitRequest = requestManager.createMethodExitRequest(this);
-        }
-        else {
-          exitRequest.disable();
-        }
-        //exitRequest.addClassFilter(myClassQualifiedName);
-        exitRequest.addClassFilter(classType);
-        debugProcess.getRequestsManager().enableRequest(exitRequest);
+  private void createRequestForPreparedClassOriginal(@NotNull DebugProcessImpl debugProcess, @NotNull ReferenceType classType) {
+    boolean hasMethod = false;
+    for (Method method : classType.allMethods()) {
+      if (isMethodMatch(method, debugProcess)) {
+        hasMethod = true;
+        break;
       }
     }
-    catch (Exception e) {
-      LOG.debug(e);
+
+    if (!hasMethod) {
+      debugProcess.getRequestsManager().setInvalid(
+        this, JavaDebuggerBundle.message("error.invalid.breakpoint.method.not.found", classType.name())
+      );
+      return;
+    }
+
+    RequestManagerImpl requestManager = debugProcess.getRequestsManager();
+    if (isWatchEntry()) {
+      MethodEntryRequest entryRequest = findRequest(debugProcess, MethodEntryRequest.class, this);
+      if (entryRequest == null) {
+        entryRequest = requestManager.createMethodEntryRequest(this);
+      }
+      else {
+        entryRequest.disable();
+      }
+      //entryRequest.addClassFilter(myClassQualifiedName);
+      // use addClassFilter(ReferenceType) in order to stop on subclasses also!
+      entryRequest.addClassFilter(classType);
+      debugProcess.getRequestsManager().enableRequest(entryRequest);
+    }
+    if (isWatchExit()) {
+      MethodExitRequest exitRequest = findRequest(debugProcess, MethodExitRequest.class, this);
+      if (exitRequest == null) {
+        exitRequest = requestManager.createMethodExitRequest(this);
+      }
+      else {
+        exitRequest.disable();
+      }
+      //exitRequest.addClassFilter(myClassQualifiedName);
+      exitRequest.addClassFilter(classType);
+      debugProcess.getRequestsManager().enableRequest(exitRequest);
     }
   }
 
@@ -417,7 +425,7 @@ public class MethodBreakpoint extends BreakpointWithHighlighter<JavaMethodBreakp
     return super.evaluateCondition(context, event);
   }
 
-  public boolean matchesEvent(@NotNull final LocatableEvent event, final DebugProcessImpl process) throws EvaluateException {
+  public boolean matchesEvent(@NotNull final LocatableEvent event, final DebugProcessImpl process) {
     if (isEmulated()) {
       return true;
     }
@@ -425,7 +433,7 @@ public class MethodBreakpoint extends BreakpointWithHighlighter<JavaMethodBreakp
       return false;
     }
     final Method method = event.location().method();
-    return method != null && method.name().equals(getMethodName()) && method.signature().equals(mySignature.getName(process));
+    return isMethodMatch(method, process);
   }
 
   @Nullable
@@ -531,7 +539,7 @@ public class MethodBreakpoint extends BreakpointWithHighlighter<JavaMethodBreakp
   }
 
   @Nullable
-  private String getMethodName() {
+  protected String getMethodName() {
     return getProperties().myMethodName;
   }
 

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/breakpoints/KotlinFunctionBreakpoint.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/breakpoints/KotlinFunctionBreakpoint.kt
@@ -31,13 +31,11 @@ import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.asJava.elements.KtLightMethod
 import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.asJava.toLightElements
-import org.jetbrains.kotlin.idea.base.facet.platform.platform
 import org.jetbrains.kotlin.idea.base.psi.isExpectDeclaration
 import org.jetbrains.kotlin.idea.debugger.core.KotlinDebuggerCoreBundle.message
 import org.jetbrains.kotlin.idea.debugger.core.KotlinDebuggerLegacyFacade
 import org.jetbrains.kotlin.idea.util.application.isDispatchThread
 import org.jetbrains.kotlin.idea.util.application.isUnitTestMode
-import org.jetbrains.kotlin.platform.jvm.isJvm
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
@@ -46,7 +44,7 @@ interface SourcePositionRefiner {
     fun refineSourcePosition(sourcePosition: SourcePosition): SourcePosition
 }
 
-class KotlinFunctionBreakpoint(
+open class KotlinFunctionBreakpoint(
     project: Project,
     breakpoint: XBreakpoint<*>
 ) : MethodBreakpoint(project, breakpoint), SourcePositionRefiner {

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/breakpoints/KotlinFunctionBreakpointType.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/breakpoints/KotlinFunctionBreakpointType.kt
@@ -6,19 +6,26 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import com.intellij.xdebugger.breakpoints.XBreakpoint
+import org.jetbrains.annotations.Nls
+import org.jetbrains.annotations.NotNull
 import org.jetbrains.java.debugger.breakpoints.properties.JavaMethodBreakpointProperties
+import org.jetbrains.kotlin.asJava.LightClassGenerationSupport
 import org.jetbrains.kotlin.idea.base.facet.platform.platform
 import org.jetbrains.kotlin.idea.debugger.breakpoints.KotlinBreakpointType
 import org.jetbrains.kotlin.idea.debugger.core.KotlinDebuggerCoreBundle.message
 import org.jetbrains.kotlin.idea.debugger.core.breakpoints.ApplicabilityResult.Companion.maybe
+import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName
 import org.jetbrains.kotlin.platform.isCommon
 import org.jetbrains.kotlin.platform.jvm.isJvm
 import org.jetbrains.kotlin.psi.*
 
-class KotlinFunctionBreakpointType :
-    JavaMethodBreakpointType("kotlin-function", message("function.breakpoint.tab.title")),
-    KotlinBreakpointType
-{
+open class KotlinFunctionBreakpointType protected constructor(@NotNull id: String, @Nls @NotNull message: String) :
+    JavaMethodBreakpointType(id, message),
+    KotlinBreakpointType {
+
+    @Suppress("unused") // Used by plugin XML
+    constructor() : this("kotlin-function", message("function.breakpoint.tab.title"))
+
     override fun getPriority() = 120
 
     override fun createJavaBreakpoint(project: Project, breakpoint: XBreakpoint<JavaMethodBreakpointProperties>) =
@@ -32,25 +39,45 @@ class KotlinFunctionBreakpointType :
         val platform = psiFile.platform
         return platform.isCommon() || platform.isJvm()
     }
+
+    protected open fun isFunctionBreakpointApplicable(file: VirtualFile, line: Int, project: Project): Boolean =
+        isBreakpointApplicable(file, line, project) { element ->
+            when (element) {
+                is KtConstructor<*> ->
+                    ApplicabilityResult.DEFINITELY_YES
+
+                is KtFunction ->
+                    maybe(
+                        !KtPsiUtil.isLocal(element)
+                                && !element.isInlineOnly()
+                                && !element.isComposable()
+                    )
+
+                is KtPropertyAccessor ->
+                    maybe(element.hasBody() && !KtPsiUtil.isLocal(element.property))
+
+                is KtClass ->
+                    maybe(
+                        element !is KtEnumEntry
+                                && !element.isAnnotation()
+                                && !element.isInterface()
+                                && element.hasPrimaryConstructor()
+                    )
+
+                else ->
+                    ApplicabilityResult.UNKNOWN
+            }
+        }
 }
 
-fun isFunctionBreakpointApplicable(file: VirtualFile, line: Int, project: Project): Boolean =
-    isBreakpointApplicable(file, line, project) { element ->
-        when (element) {
-            is KtConstructor<*> ->
-                ApplicabilityResult.DEFINITELY_YES
-            is KtFunction ->
-                maybe(!KtPsiUtil.isLocal(element) && !element.isInlineOnly())
-            is KtPropertyAccessor ->
-                maybe(element.hasBody() && !KtPsiUtil.isLocal(element.property))
-            is KtClass ->
-                maybe(
-                    element !is KtEnumEntry
-                            && !element.isAnnotation()
-                            && !element.isInterface()
-                            && element.hasPrimaryConstructor()
-                )
-            else ->
-                ApplicabilityResult.UNKNOWN
-        }
-    }
+private const val COMPOSABLE_FQDN = "androidx.compose.runtime.Composable"
+
+/**
+ * Don't allow method breakpoints on Composable functions because we can't match their signature.
+ *
+ * This will be handled by the Compose plugin.
+ */
+fun KtFunction.isComposable() = annotationEntries.any { it.getType() == COMPOSABLE_FQDN }
+
+private fun KtAnnotationEntry.getType() =
+    LightClassGenerationSupport.getInstance(project).analyzeAnnotation(this)?.type?.getKotlinTypeFqName(false)


### PR DESCRIPTION
1. Change KotlinFunctionBreakpointType to not support @Composable methods and open it for subclasses to extend.
2. Make KotlinFunctionBreakpoint and open class, so we can subclass it with ComposeFunctionBreakpoint.
1. Extend MethodBreakpoint to allow a derived class to check for a method signature match.

https://youtrack.jetbrains.com/issue/IDEA-322802/Composable-Kotlin-Method-Breakpoints-Dont-Break