### PR TITLE
IDEA-323242 ExternalAnnotationsRepositoryResolver cause roots changed events

### DIFF
--- a/java/idea-ui/testSrc/com/intellij/jarRepository/ExternalAnnotationsRepositoryResolverTest.kt
+++ b/java/idea-ui/testSrc/com/intellij/jarRepository/ExternalAnnotationsRepositoryResolverTest.kt
@@ -145,4 +145,29 @@ class ExternalAnnotationsRepositoryResolverTest: LibraryTest() {
       .endsWith("myGroup/myArtifact/1.0-an1/myArtifact-1.0-an1-annotations.zip!/")
   }
 
+  @Test fun `test RootSetChanged should not be triggered resolving same artifact`() {
+    val resolver = ExternalAnnotationsRepositoryResolver()
+    val library = createLibrary()
+    var libraryRootsChangedCounter = 0
+    library.rootProvider.addRootSetChangedListener {
+      libraryRootsChangedCounter++
+    }
+
+    RemoteRepositoriesConfiguration.getInstance(myProject).repositories = listOf(myMavenRepoDescription)
+
+    MavenRepoFixture(myMavenRepo).apply {
+      addAnnotationsArtifact(artifact = "myArtifact", version = "1.0")
+      generateMavenMetadata("myGroup", "myArtifact")
+    }
+
+    resolver.resolve(myProject, library, "myGroup:myArtifact:1.0")
+
+    val modifiableModel = library.modifiableModel
+    modifiableModel.addRoot("file:///fake.source", OrderRootType.SOURCES)
+    runWriteAction { modifiableModel.commit() }
+
+    resolver.resolve(myProject, library, "myGroup:myArtifact:1.0")
+
+    assertEquals(2, libraryRootsChangedCounter)
+  }
 }

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/LibraryModifiableModelBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/LibraryModifiableModelBridgeImpl.kt
@@ -170,8 +170,8 @@ internal class LibraryModifiableModelBridgeImpl(
   private fun LibraryEntity.hasEqualProperties(another: LibraryEntity): Boolean {
     if (this.tableId != another.tableId) return false
     if (this.name != another.name) return false
-    if (this.roots != another.roots) return false
-    if (this.excludedRoots != another.excludedRoots) return false
+    if (this.roots.toSet() != another.roots.toSet()) return false
+    if (this.excludedRoots.toSet() != another.excludedRoots.toSet()) return false
     return true
   }
 


### PR DESCRIPTION
A project that is using a library from [this list](https://github.com/JetBrains/intellij-community/blob/fc2da486cdbf8a52b9a68aa90b45d5e2be2580d8/java/java-impl/src/extensions/predefinedExternalAnnotations.json) IDEA will try to fetch external annotations, causing  the `ExternalAnnotationsRepositoryResolver` to trigger unnecessary `rootsChanged` event for  `ProjectTopics.PROJECT_ROOTS` given to the following things: 

- ExternalAnnotationsRepositoryResolver updateLibrary with same annotation roots
<img width="1002" alt="ExternalAnnotationsRepositoryResolver updateLibrary with same annotation roots" src="https://github.com/JetBrains/intellij-community/assets/18151158/9b1ceb4b-9092-4905-adf5-124a0e45611d">

- LibraryModifiableModelBridgeImpl isChanged takes in consideration roots order
<img width="1850" alt="LibraryModifiableModelBridgeImpl isChanged takes in consideration roots order " src="https://github.com/JetBrains/intellij-community/assets/18151158/b632aa22-8b0a-4702-92ca-a8a99d886179">
