### PR TITLE
KTIJ-24134 False positive 'Remove unnecessary parentheses from function call with lambda' inspection is displayed together with 'no value for parameter' error

### DIFF
--- a/plugins/kotlin/code-insight/inspections-shared/src/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/RemoveEmptyParenthesesFromLambdaCallInspection.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/src/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/RemoveEmptyParenthesesFromLambdaCallInspection.kt
@@ -4,12 +4,15 @@ package org.jetbrains.kotlin.idea.codeInsight.inspections.shared
 import com.intellij.codeInspection.CleanupLocalInspectionTool
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.analysis.api.calls.KtSuccessCallInfo
 import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
 import org.jetbrains.kotlin.idea.codeinsight.api.applicable.inspections.AbstractKotlinApplicableInspection
 import org.jetbrains.kotlin.idea.codeinsight.api.applicators.KotlinApplicabilityRange
 import org.jetbrains.kotlin.idea.codeinsights.impl.base.RemoveEmptyParenthesesFromLambdaCallUtils.canRemoveByPsi
 import org.jetbrains.kotlin.idea.codeinsights.impl.base.RemoveEmptyParenthesesFromLambdaCallUtils.removeArgumentList
 import org.jetbrains.kotlin.idea.codeinsights.impl.base.applicators.ApplicabilityRanges
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 
 class RemoveEmptyParenthesesFromLambdaCallInspection : AbstractKotlinApplicableInspection<KtValueArgumentList>(KtValueArgumentList::class),
@@ -22,6 +25,10 @@ class RemoveEmptyParenthesesFromLambdaCallInspection : AbstractKotlinApplicableI
     override fun getApplicabilityRange(): KotlinApplicabilityRange<KtValueArgumentList> = ApplicabilityRanges.SELF
 
     override fun isApplicableByPsi(element: KtValueArgumentList): Boolean = canRemoveByPsi(element)
+
+    context(KtAnalysisSession)
+    override fun isApplicableByAnalyze(element: KtValueArgumentList): Boolean =
+        (element.parent as? KtCallExpression)?.resolveCall() is KtSuccessCallInfo
 
     override fun apply(element: KtValueArgumentList, project: Project, editor: Editor?) {
         removeArgumentList(element)

--- a/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
@@ -912,6 +912,11 @@ public abstract class SharedK1LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/nextLine.kt");
         }
 
+        @TestMetadata("noValueForParameter.kt")
+        public void testNoValueForParameter() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/noValueForParameter.kt");
+        }
+
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("../testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/simple.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
@@ -912,6 +912,11 @@ public abstract class SharedK2LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/nextLine.kt");
         }
 
+        @TestMetadata("noValueForParameter.kt")
+        public void testNoValueForParameter() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/noValueForParameter.kt");
+        }
+
         @TestMetadata("simple.kt")
         public void testSimple() throws Exception {
             runTest("../testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/simple.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/noValueForParameter.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyParenthesesFromLambdaCall/noValueForParameter.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+// DISABLE-ERRORS
+fun test() {
+    foo(<caret>) { 1 }
+}
+
+fun foo(i: Int, f: () -> Int) {
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24134