### PR TITLE
 Fix NewJavaToKotlinConverter adds  against all non-annotated types assuming them as nullable.

### DIFF
--- a/plugins/kotlin/j2k/new/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
+++ b/plugins/kotlin/j2k/new/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
@@ -2,6 +2,7 @@
 
 package org.jetbrains.kotlin.nj2k
 
+import org.jetbrains.kotlin.j2k.ConverterSettings
 import org.jetbrains.kotlin.nj2k.conversions.*
 import org.jetbrains.kotlin.nj2k.tree.JKLambdaExpression
 import org.jetbrains.kotlin.nj2k.tree.JKParameter
@@ -10,7 +11,10 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 import java.util.*
 
 object ConversionsRunner {
-    private fun createConversions(context: NewJ2kConverterContext) = listOf(
+    private fun createConversions(
+        settings: ConverterSettings,
+        context: NewJ2kConverterContext
+    ) = listOf(
         ParenthesizeBinaryExpressionIfNeededConversion(context),
         NonCodeElementsConversion(context),
         JavaModifiersConversion(context),
@@ -26,7 +30,7 @@ object ConversionsRunner {
         ArrayInitializerConversion(context),
         JavaStatementConversion(context),
         EnumFieldAccessConversion(context),
-        NullabilityAnnotationsConversion(context),
+        NullabilityAnnotationsConversion(settings, context),
         DefaultArgumentsConversion(context),
         ConstructorConversion(context),
         MoveConstructorsAfterFieldsConversion(context),
@@ -69,11 +73,12 @@ object ConversionsRunner {
 
     fun doApply(
         trees: List<JKTreeRoot>,
+        settings: ConverterSettings,
         context: NewJ2kConverterContext,
         updateProgress: (conversionIndex: Int, conversionCount: Int, fileIndex: Int, String) -> Unit
     ) {
 
-        val conversions = createConversions(context)
+        val conversions = createConversions(settings, context)
         for ((conversionIndex, conversion) in conversions.withIndex()) {
 
             val treeSequence = trees.asSequence().onEachIndexed { index, _ ->

--- a/plugins/kotlin/j2k/new/src/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverter.kt
+++ b/plugins/kotlin/j2k/new/src/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverter.kt
@@ -131,7 +131,7 @@ class NewJavaToKotlinConverter(
             externalCodeProcessing,
             languageVersion.supportsFeature(LanguageFeature.FunctionalInterfaceConversion)
         )
-        ConversionsRunner.doApply(asts.mapNotNull { it.second }, context) { conversionIndex, conversionCount, i, desc ->
+        ConversionsRunner.doApply(asts.mapNotNull { it.second }, settings, context) { conversionIndex, conversionCount, i, desc ->
             processor.updateState(
                 J2KConversionPhase.RUN_CONVERSIONS.phaseNumber,
                 conversionIndex,
@@ -177,6 +177,7 @@ class NewJavaToKotlinConverter(
             if (imports.isEmpty()) return
 
             val psiFactory = KtPsiFactory(project)
+
             @Suppress("DEPRECATION") // unclear how to replace this
             val importPsi = psiFactory.createImportDirectives(
                 imports.map { ImportPath(it, isAllUnder = false) }

--- a/plugins/kotlin/j2k/new/src/org/jetbrains/kotlin/nj2k/printing/JKPrinter.kt
+++ b/plugins/kotlin/j2k/new/src/org/jetbrains/kotlin/nj2k/printing/JKPrinter.kt
@@ -152,7 +152,7 @@ internal class JKPrinter(
                     && owner?.safeAs<JKLambdaExpression>()?.functionalType?.type != type
                     || type.nullability == Nullability.Nullable)
         ) {
-            this.print("?")
+            //this.print("?")
         }
     }
 


### PR DESCRIPTION
Resolves: https://youtrack.jetbrains.com/issue/IDEA-324140/NewJavaToKotlinConverter-adds-against-all-non-annotated-types-assuming-them-as-nullable.