### PR TITLE
 Don't dynamically remove the proxy.password on instantiated -- it will never be remembered

### DIFF
--- a/platform/platform-api/src/com/intellij/util/net/HttpConfigurable.java
+++ b/platform/platform-api/src/com/intellij/util/net/HttpConfigurable.java
@@ -109,9 +109,6 @@ public class HttpConfigurable implements PersistentStateComponent<HttpConfigurab
 
     HttpConfigurable state = new HttpConfigurable();
     XmlSerializerUtil.copyBean(this, state);
-    if (!KEEP_PROXY_PASSWORD) {
-      removeSecure("proxy.password");
-    }
     correctPasswords(state);
     return state;
   }
@@ -146,9 +143,6 @@ public class HttpConfigurable implements PersistentStateComponent<HttpConfigurab
   @Override
   public void loadState(@NotNull HttpConfigurable state) {
     XmlSerializerUtil.copyBean(state, this);
-    if (!KEEP_PROXY_PASSWORD) {
-      removeSecure("proxy.password");
-    }
     correctPasswords(this);
   }
 


### PR DESCRIPTION

There's a state problem with the keep password. The remember my password checkbox only works in-memory. The moment you restart it clears the proxy password even though it's persisted. The moment the IDE is started the proxy password is removed.

![image (13)](https://github.com/JetBrains/intellij-community/assets/326857/15f23d57-69f2-4318-93a9-81e31dad44c1)

Related to: https://youtrack.jetbrains.com/issue/IDEA-140044/Proxy-authentication-is-requested-although-remember-password-is-checked#focus=Comments-27-7331020.0-0