### PR TITLE
Update pydevd_console_output.py

### DIFF
--- a/python/helpers/pydev/_pydevd_bundle/pydevd_console_output.py
+++ b/python/helpers/pydev/_pydevd_bundle/pydevd_console_output.py
@@ -9,11 +9,11 @@ class ConsoleOutputHook:
         self.original_out = out
         self.is_error = is_stderr
 
-    def write(self, str):
-        if len(str) > MAX_STRING_LENGTH:
-            self._write_long_string(str)
+    def write(self, string):
+        if len(string) > MAX_STRING_LENGTH:
+            self._write_long_string(string)
         else:
-            self._write_short_string(str)
+            self._write_short_string(string)
 
     def flush(self):
         pass
@@ -24,15 +24,15 @@ class ConsoleOutputHook:
             return getattr(self.original_out, item)
         raise AttributeError("%s has no attribute %s" % (self.original_out, item))
 
-    def _write_long_string(self, str):
-        str_len, chunk_size = len(str), len(str) // MAX_STRING_LENGTH
+    def _write_long_string(self, string):
+        str_len, chunk_size = len(string), len(string) // MAX_STRING_LENGTH
         for i in range(0, str_len, chunk_size):
-            self._write_short_string(str[i:i + chunk_size])
+            self._write_short_string(string[i:i + chunk_size])
 
-    def _write_short_string(self, str):
+    def _write_short_string(self, string):
         if self.is_error:
-            cmd = self.dbg.cmd_factory.make_io_message(str, WRITE_ERR)
+            cmd = self.dbg.cmd_factory.make_io_message(string, WRITE_ERR)
         else:
-            cmd = self.dbg.cmd_factory.make_io_message(str, WRITE_OUT)
+            cmd = self.dbg.cmd_factory.make_io_message(string, WRITE_OUT)
 
         self.dbg.writer.add_command(cmd)


### PR DESCRIPTION
Renaming usage of `str` keyword (reserved by Python) to `string` for easier understanding of code. Interestingly, I found the warning via PyCharm itself :) 

As always, a big thanks to the JetBrains tea