### PR TITLE
KTIJ-26064 Use configure in init script

### DIFF
--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/KotlinGradleCoroutineDebugProjectResolver.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/KotlinGradleCoroutineDebugProjectResolver.kt
@@ -28,7 +28,7 @@ class KotlinGradleCoroutineDebugProjectResolver : AbstractProjectResolverExtensi
             gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
                 taskGraph.allTasks.each { Task task ->
                     if (task instanceof Test || task instanceof JavaExec) {
-                        task.doFirst { Task forkedTask ->
+                        task.configure { JavaForkOptions forkedTask ->
                             def kotlinxCoroutinesCoreJar = forkedTask.classpath.find { it.name.startsWith("kotlinx-coroutines-core") }
                             if (kotlinxCoroutinesCoreJar) {
                                 def results = (kotlinxCoroutinesCoreJar.getName() =~ /kotlinx-coroutines-core(\-jvm)?-(\d[\w\.\-]+)\.jar${'$'}/).findAll()


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/KTIJ-26064/Debugger-does-not-work-with-Gradle-Configuration-Cache-and-custom-JavaExec-tasks-UnsupportedOperationException

Changing the jvm args during execution phase isn't supported with config cache (and a bad practice). Instead, the configuration phase is used now, with works with the config cache.