### PR TITLE
Fix Javadoc syntax for `{@code}` and `{@link}`

### DIFF
--- a/java/compiler/openapi/src/com/intellij/openapi/compiler/CompileScope.java
+++ b/java/compiler/openapi/src/com/intellij/openapi/compiler/CompileScope.java
@@ -70,7 +70,7 @@ public interface CompileScope extends ExportableUserDataHolder {
   }
 
   /**
-   * @return similar to {getAffectedModules}, but is more precise about which kinds of source roots are affected: production and/or tests
+   * @return similar to {@link #getAffectedModules}, but is more precise about which kinds of source roots are affected: production and/or tests
    */
   default Collection<ModuleSourceSet> getAffectedSourceSets() {
     List<ModuleSourceSet> sets = new SmartList<>();

--- a/platform/analysis-impl/src/com/intellij/codeInsight/quickfix/UnresolvedReferenceQuickFixUpdater.java
+++ b/platform/analysis-impl/src/com/intellij/codeInsight/quickfix/UnresolvedReferenceQuickFixUpdater.java
@@ -51,7 +51,7 @@ public interface UnresolvedReferenceQuickFixUpdater {
   void waitQuickFixesSynchronously(@NotNull PsiFile file, @NotNull Editor editor, @NotNull List<? extends HighlightInfo> infos);
 
   /**
-   * Start background computation of quick fixes for unresolved references in the {code file} at the current caret offset
+   * Start background computation of quick fixes for unresolved references in the {@code file} at the current caret offset
    */
   void startComputingNextQuickFixes(@NotNull PsiFile file, @NotNull Editor editor, @NotNull ProperTextRange visibleRange);
 }

--- a/platform/lang-impl/src/com/intellij/ide/actions/BigPopupUI.java
+++ b/platform/lang-impl/src/com/intellij/ide/actions/BigPopupUI.java
@@ -60,7 +60,7 @@ public abstract class BigPopupUI extends BorderLayoutPanel implements Disposable
   protected abstract ListCellRenderer<Object> createCellRenderer();
 
   /**
-   * todo make the method abstract after {@link #createTopLeftPanel()} and {link {@link #createSettingsPanel()}} are removed
+   * todo make the method abstract after {@link #createTopLeftPanel()} and {@link #createSettingsPanel()} are removed
    */
   @NotNull
   protected JComponent createHeader() {

--- a/platform/platform-impl/src/com/intellij/ui/popup/util/PopupImplUtil.java
+++ b/platform/platform-impl/src/com/intellij/ui/popup/util/PopupImplUtil.java
@@ -71,7 +71,7 @@ public final class PopupImplUtil {
     return null;
   }
 
-  /** @deprecated Use @{@link PopupUtil#setPopupToggleComponent}, but in the most cases it is not needed any more */
+  /** @deprecated Use {@link PopupUtil#setPopupToggleComponent}, but in the most cases it is not needed any more */
   @Deprecated(forRemoval = true)
   public static void setPopupToggleButton(@NotNull JBPopup jbPopup, @Nullable Component toggleButton) {
     PopupUtil.setPopupToggleComponent(jbPopup, toggleButton);

--- a/platform/util/base/src/com/intellij/openapi/util/NlsSafe.java
+++ b/platform/util/base/src/com/intellij/openapi/util/NlsSafe.java
@@ -16,7 +16,7 @@ import java.lang.annotation.*;
  *   <li>URL</li>
  *   <li>Programming language or framework name</li>
  * </ul>
- * Avoid using NlsSafe just to suppress the "hardcoded string" inspection warning. Use @{@link NonNls} 
+ * Avoid using NlsSafe just to suppress the "hardcoded string" inspection warning. Use {@link NonNls}
  * if something is not intended to be displayed to the user: internal identifier, XML tag attribute, 
  * substring to be searched in the external process output, etc.
  * <p>

--- a/platform/util/src/com/intellij/util/io/SimpleStringPersistentEnumerator.java
+++ b/platform/util/src/com/intellij/util/io/SimpleStringPersistentEnumerator.java
@@ -28,7 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <li>Always has synchronized state between disk and memory state</li>
  * <li>Could have >1 id for same value
  * (i.e. it violates general {@link DataEnumerator} contract -- this is to keep backward-compatible behavior)</li>
- * <li>Uses CopyOnWrite for updating state, so {@link #valueOf(int)}/@{@link #enumerate(String)} are wait-free
+ * <li>Uses CopyOnWrite for updating state, so {@link #valueOf(int)}/{@link #enumerate(String)} are wait-free
  * for already existing value/id</li>
  * </ul>
  */

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ignore/psi/IgnoreTokenType.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ignore/psi/IgnoreTokenType.java
@@ -40,7 +40,7 @@ public class IgnoreTokenType extends IElementType {
   private final String debugName;
 
   /**
-   * Builds a new instance of @{link IgnoreTokenType}.
+   * Builds a new instance of {@link IgnoreTokenType}.
    */
   public IgnoreTokenType(@NotNull @NonNls String debugName) {
     super(debugName, IgnoreLanguage.INSTANCE);

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ignore/reference/IgnoreReferenceContributor.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/ignore/reference/IgnoreReferenceContributor.java
@@ -57,7 +57,7 @@ public class IgnoreReferenceContributor extends PsiReferenceContributor {
     }
 
     /**
-     * Returns references for given @{link PsiElement}.
+     * Returns references for given {@link PsiElement}.
      *
      * @param psiElement        current element
      * @param processingContext context

--- a/plugins/devkit/devkit-core/src/module/PluginModuleBuilder.java
+++ b/plugins/devkit/devkit-core/src/module/PluginModuleBuilder.java
@@ -35,7 +35,7 @@ import static java.awt.GridBagConstraints.CENTER;
 import static java.awt.GridBagConstraints.HORIZONTAL;
 
 /**
- * @deprecated Completely replaced with @{link {@link IdePluginModuleBuilder}.
+ * @deprecated Completely replaced with {@link IdePluginModuleBuilder}.
  */
 @Deprecated(forRemoval = true)
 public class PluginModuleBuilder extends JavaModuleBuilder {

--- a/plugins/textmate/core/src/org/jetbrains/plugins/textmate/bundles/BundleFactory.java
+++ b/plugins/textmate/core/src/org/jetbrains/plugins/textmate/bundles/BundleFactory.java
@@ -22,7 +22,7 @@ public class BundleFactory {
 
   /**
    * Create bundle object from directory.
-   * Return {code}null{code} if bundle type can't be defined or
+   * Return {@code null} if bundle type can't be defined or
    * if IO exception occurred while reading directory.
    *
    * @return Bundle object or null


### PR DESCRIPTION
Incorrect usages of Javadoc syntax `{@code}` and `{@link}` in various Java classes have been fixed. Details – in the commit message.