### PR TITLE
KTIJ-26366 False positive "Redundant empty class body" caused by local class followed by anything with parentheses

### DIFF
--- a/plugins/kotlin/code-insight/inspections-shared/src/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/RemoveEmptyClassBodyInspection.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/src/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/RemoveEmptyClassBodyInspection.kt
@@ -4,7 +4,12 @@ package org.jetbrains.kotlin.idea.codeInsight.inspections.shared
 import com.intellij.codeInspection.CleanupLocalInspectionTool
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.nextLeafs
+import com.intellij.psi.util.prevLeafs
 import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
 import org.jetbrains.kotlin.idea.codeinsight.api.classic.inspections.AbstractApplicabilityBasedInspection
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -43,6 +48,12 @@ class RemoveEmptyClassBodyInspection : AbstractApplicabilityBasedInspection<KtCl
                 val isLastChild = element == children.lastOrNull()
                 val isLastEnumEntry = element == children.lastOrNull { it is KtEnumEntry }
                 if (isLastChild || !isLastEnumEntry) return
+            }
+
+            is KtClass -> {
+                if (!element.isLocal) return
+                if (element.nextLeafs.firstOrNull { it !is PsiWhiteSpace && it !is PsiComment }?.elementType != KtTokens.LPAR) return
+                if (next.prevLeafs.firstOrNull { it !is PsiWhiteSpace && it !is PsiComment }?.elementType == KtTokens.RPAR) return
             }
 
             else -> return

--- a/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
@@ -877,6 +877,31 @@ public abstract class SharedK1LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/removeEmptyClassBody/lastEnumEntry3.kt");
         }
 
+        @TestMetadata("localClass.kt")
+        public void testLocalClass() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass.kt");
+        }
+
+        @TestMetadata("localClass2.kt")
+        public void testLocalClass2() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass2.kt");
+        }
+
+        @TestMetadata("localClass3.kt")
+        public void testLocalClass3() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass3.kt");
+        }
+
+        @TestMetadata("localClass4.kt")
+        public void testLocalClass4() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass4.kt");
+        }
+
+        @TestMetadata("localClass5.kt")
+        public void testLocalClass5() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass5.kt");
+        }
+
         @TestMetadata("nestedAnonymous.kt")
         public void testNestedAnonymous() throws Exception {
             runTest("../testData/inspectionsLocal/removeEmptyClassBody/nestedAnonymous.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
@@ -500,6 +500,31 @@ public abstract class SharedK1LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/redundantSemicolon/ifElse.kt");
         }
 
+        @TestMetadata("localClass.kt")
+        public void testLocalClass() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass.kt");
+        }
+
+        @TestMetadata("localClass2.kt")
+        public void testLocalClass2() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass2.kt");
+        }
+
+        @TestMetadata("localClass3.kt")
+        public void testLocalClass3() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass3.kt");
+        }
+
+        @TestMetadata("localClass4.kt")
+        public void testLocalClass4() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass4.kt");
+        }
+
+        @TestMetadata("localClass5.kt")
+        public void testLocalClass5() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass5.kt");
+        }
+
         @TestMetadata("startOfLine.kt")
         public void testStartOfLine() throws Exception {
             runTest("../testData/inspectionsLocal/redundantSemicolon/startOfLine.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
@@ -500,6 +500,31 @@ public abstract class SharedK2LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/redundantSemicolon/ifElse.kt");
         }
 
+        @TestMetadata("localClass.kt")
+        public void testLocalClass() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass.kt");
+        }
+
+        @TestMetadata("localClass2.kt")
+        public void testLocalClass2() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass2.kt");
+        }
+
+        @TestMetadata("localClass3.kt")
+        public void testLocalClass3() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass3.kt");
+        }
+
+        @TestMetadata("localClass4.kt")
+        public void testLocalClass4() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass4.kt");
+        }
+
+        @TestMetadata("localClass5.kt")
+        public void testLocalClass5() throws Exception {
+            runTest("../testData/inspectionsLocal/redundantSemicolon/localClass5.kt");
+        }
+
         @TestMetadata("startOfLine.kt")
         public void testStartOfLine() throws Exception {
             runTest("../testData/inspectionsLocal/redundantSemicolon/startOfLine.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
@@ -877,6 +877,31 @@ public abstract class SharedK2LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/removeEmptyClassBody/lastEnumEntry3.kt");
         }
 
+        @TestMetadata("localClass.kt")
+        public void testLocalClass() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass.kt");
+        }
+
+        @TestMetadata("localClass2.kt")
+        public void testLocalClass2() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass2.kt");
+        }
+
+        @TestMetadata("localClass3.kt")
+        public void testLocalClass3() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass3.kt");
+        }
+
+        @TestMetadata("localClass4.kt")
+        public void testLocalClass4() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass4.kt");
+        }
+
+        @TestMetadata("localClass5.kt")
+        public void testLocalClass5() throws Exception {
+            runTest("../testData/inspectionsLocal/removeEmptyClassBody/localClass5.kt");
+        }
+
         @TestMetadata("nestedAnonymous.kt")
         public void testNestedAnonymous() throws Exception {
             runTest("../testData/inspectionsLocal/removeEmptyClassBody/nestedAnonymous.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass.kt
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar;<caret>
+
+    val x = (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass.kt.after
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar
+
+    val x = (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass2.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass2.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+fun test(foo: Any) {
+    class Bar;<caret>
+
+    (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass3.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass3.kt
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar();<caret>
+
+    (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass3.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass3.kt.after
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar()
+
+    (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass4.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass4.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+interface Baz
+
+fun test4(foo: Any) {
+    class Bar: Baz;<caret>
+
+    (foo as? String)?.length
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass5.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass5.kt
@@ -1,0 +1,7 @@
+open class Baz
+
+fun test5(foo: Any) {
+    class Bar: Baz();<caret>
+
+    (foo as? String)?.length
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass5.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/redundantSemicolon/localClass5.kt.after
@@ -1,0 +1,7 @@
+open class Baz
+
+fun test5(foo: Any) {
+    class Bar: Baz()
+
+    (foo as? String)?.length
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass.kt
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar {<caret>}
+
+    val x = (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass.kt.after
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar
+
+    val x = (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass2.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass2.kt
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar {<caret>}
+
+    (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass2.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass2.kt.after
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar;
+
+    (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass3.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass3.kt
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar() {<caret>}
+
+    (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass3.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass3.kt.after
@@ -1,0 +1,5 @@
+fun test(foo: Any) {
+    class Bar()
+
+    (foo as? String)
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass4.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass4.kt
@@ -1,0 +1,7 @@
+interface Baz
+
+fun test4(foo: Any) {
+    class Bar: Baz {<caret>}
+
+    (foo as? String)?.length
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass4.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass4.kt.after
@@ -1,0 +1,7 @@
+interface Baz
+
+fun test4(foo: Any) {
+    class Bar: Baz;
+
+    (foo as? String)?.length
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass5.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass5.kt
@@ -1,0 +1,7 @@
+open class Baz
+
+fun test5(foo: Any) {
+    class Bar: Baz() /* comment */ {<caret>}
+
+    (foo as? String)?.length
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass5.kt.after
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/removeEmptyClassBody/localClass5.kt.after
@@ -1,0 +1,7 @@
+open class Baz
+
+fun test5(foo: Any) {
+    class Bar: Baz() /* comment */
+
+    (foo as? String)?.length
+}

--- a/plugins/kotlin/code-insight/utils/src/org/jetbrains/kotlin/idea/codeinsight/utils/RedundantSemicolonUtils.kt
+++ b/plugins/kotlin/code-insight/utils/src/org/jetbrains/kotlin/idea/codeinsight/utils/RedundantSemicolonUtils.kt
@@ -4,6 +4,9 @@ package org.jetbrains.kotlin.idea.codeinsight.utils
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.nextLeafs
+import com.intellij.psi.util.prevLeafs
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.util.match
 import org.jetbrains.kotlin.idea.util.isLineBreak
@@ -83,6 +86,12 @@ private fun isSemicolonRequired(semicolon: PsiElement): Boolean {
         // enum; class Foo
         return true
     }
+
+    if (prevSibling is KtClass &&
+        prevSibling.isLocal &&
+        semicolon.nextLeafs.firstOrNull { it !is PsiWhiteSpace && it !is PsiComment }.elementType == KtTokens.LPAR &&
+        semicolon.prevLeafs.firstOrNull { it !is PsiWhiteSpace && it !is PsiComment }.elementType != KtTokens.RPAR
+    ) return true
 
     if (nextSibling is KtPrefixExpression && nextSibling.operationToken == KtTokens.EXCL) {
         val typeElement = semicolon.prevLeaf()?.getStrictParentOfType<KtTypeReference>()?.typeElement


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-26366
https://youtrack.jetbrains.com/issue/KTIJ-26378