### PR TITLE
KTIJ-26360 False positive "Redundant 'asSequence' call"

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/ConvertCallChainIntoSequenceInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/collections/ConvertCallChainIntoSequenceInspection.kt
@@ -23,7 +23,9 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.*
 import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+import org.jetbrains.kotlin.types.KotlinType
 
 class ConvertCallChainIntoSequenceInspection : AbstractKotlinInspection() {
 
@@ -129,9 +131,6 @@ private fun KtQualifiedExpression.findCallChain(): CallChain? {
     if (calls.isEmpty()) return null
 
     val lastCall = calls.last()
-    val receiverType = lastCall.receiverType(context)
-    if (receiverType?.isIterable() != true) return null
-
     val firstCall = calls.first()
     val qualified = firstCall.getQualifiedExpressionForSelector() ?: firstCall.getQualifiedExpressionForReceiver() ?: return null
     return CallChain(qualified, lastCall, calls.size)
@@ -157,12 +156,17 @@ private fun KtQualifiedExpression.collectCallExpression(context: BindingContext)
     val transformationCalls = calls
         .asSequence()
         .dropWhile { !it.isTransformationOrTermination(context) }
+        .dropWhile { !it.receiverType(context).isIterable() && !it.returnType(context).isIterable() }
         .takeWhile { it.isTransformationOrTermination(context) && !it.hasReturn() }
         .toList()
-        .dropLastWhile { it.isLazyTermination(context) }
+        .dropLastWhile { it.isLazyTermination(context) || it.isTermination(context) && !it.returnType(context).isIterable() }
     if (transformationCalls.size < 2) return emptyList()
 
     return transformationCalls
+}
+
+private fun KtCallExpression.returnType(context: BindingContext): KotlinType? {
+    return getResolvedCall(context)?.resultingDescriptor?.returnType
 }
 
 private fun KtCallExpression.hasReturn(): Boolean = valueArguments.any { arg ->

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -1451,6 +1451,26 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
                     runTest("testData/inspectionsLocal/collections/convertCallChainIntoSequence/flatten2.kt");
                 }
 
+                @TestMetadata("groupBy.kt")
+                public void testGroupBy() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy.kt");
+                }
+
+                @TestMetadata("groupBy2.kt")
+                public void testGroupBy2() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy2.kt");
+                }
+
+                @TestMetadata("groupBy3.kt")
+                public void testGroupBy3() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy3.kt");
+                }
+
+                @TestMetadata("groupBy4.kt")
+                public void testGroupBy4() throws Exception {
+                    runTest("testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy4.kt");
+                }
+
                 @TestMetadata("implicitReceiver.kt")
                 public void testImplicitReceiver() throws Exception {
                     runTest("testData/inspectionsLocal/collections/convertCallChainIntoSequence/implicitReceiver.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy.kt
@@ -1,0 +1,10 @@
+// WITH_STDLIB
+
+fun test(list: List<String>): List<String> {
+    return list
+        .groupBy { it.length }
+        .filter<caret> { it.value.size > 1 }
+        .map { entry -> entry.value.joinToString() }
+        .map { it + it }
+        .map { it + it + it }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy.kt.after
@@ -1,0 +1,12 @@
+// WITH_STDLIB
+
+fun test(list: List<String>): List<String> {
+    return list
+        .groupBy { it.length }
+        .asSequence()
+        .filter { it.value.size > 1 }
+        .map { entry -> entry.value.joinToString() }
+        .map { it + it }
+        .map { it + it + it }
+        .toList()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy2.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+// WITH_STDLIB
+fun test(list: List<String>): Map<Int, List<String>> {
+    return list
+        .groupBy { it.length }
+        .filter<caret> { it.value.size > 1 }
+        .filter { it.value.size > 2 }
+        .filter { it.value.size > 3 }
+        .filter { it.value.size > 4 }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy3.kt
@@ -1,0 +1,13 @@
+// WITH_STDLIB
+
+fun test(list: List<String>): List<String> {
+    return list
+        .filter<caret> { it.length > 1 }
+        .filter { it.length > 2 }
+        .filter { it.length > 3 }
+        .groupBy { it.length }
+        .filter { it.value.size > 4 }
+        .filter { it.value.size > 5 }
+        .filter { it.value.size > 6 }
+        .map { it.value.joinToString() }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy3.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy3.kt.after
@@ -1,0 +1,15 @@
+// WITH_STDLIB
+
+fun test(list: List<String>): List<String> {
+    return list
+        .asSequence()
+        .filter { it.length > 1 }
+        .filter { it.length > 2 }
+        .filter { it.length > 3 }
+        .groupBy { it.length }
+        .filter { it.value.size > 4 }
+        .filter { it.value.size > 5 }
+        .filter { it.value.size > 6 }
+        .map { it.value.joinToString() }
+        .toList()
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy4.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy4.kt
@@ -1,0 +1,12 @@
+// WITH_STDLIB
+
+fun test(list: List<String>): Map<Int, List<String>> {
+    return list
+        .filter<caret> { it.length > 1 }
+        .filter { it.length > 2 }
+        .filter { it.length > 3 }
+        .groupBy { it.length }
+        .filter { it.value.size > 4 }
+        .filter { it.value.size > 5 }
+        .filter { it.value.size > 6 }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy4.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy4.kt.after
@@ -1,0 +1,13 @@
+// WITH_STDLIB
+
+fun test(list: List<String>): Map<Int, List<String>> {
+    return list
+        .asSequence()
+        .filter { it.length > 1 }
+        .filter { it.length > 2 }
+        .filter { it.length > 3 }
+        .groupBy { it.length }
+        .filter { it.value.size > 4 }
+        .filter { it.value.size > 5 }
+        .filter { it.value.size > 6 }
+}

--- a/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
+++ b/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
@@ -783,6 +783,26 @@ public abstract class Fe10BindingLocalInspectionTestGenerated extends AbstractFe
                 runTest("../idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/flatten2.kt");
             }
 
+            @TestMetadata("groupBy.kt")
+            public void testGroupBy() throws Exception {
+                runTest("../idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy.kt");
+            }
+
+            @TestMetadata("groupBy2.kt")
+            public void testGroupBy2() throws Exception {
+                runTest("../idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy2.kt");
+            }
+
+            @TestMetadata("groupBy3.kt")
+            public void testGroupBy3() throws Exception {
+                runTest("../idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy3.kt");
+            }
+
+            @TestMetadata("groupBy4.kt")
+            public void testGroupBy4() throws Exception {
+                runTest("../idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/groupBy4.kt");
+            }
+
             @TestMetadata("implicitReceiver.kt")
             public void testImplicitReceiver() throws Exception {
                 runTest("../idea/tests/testData/inspectionsLocal/collections/convertCallChainIntoSequence/implicitReceiver.kt");


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-26360

False positive `Call chain on a collection could be converted into 'Sequence' to improve performance`.
<img width="525" alt="スクリーンショット 2023-07-25 19 42 37" src="https://github.com/JetBrains/intellij-community/assets/1121855/8d9848b2-0d49-4fa5-a299-6ec80e89c574">
