### PR TITLE
Revise SSH URL checker to allow '@' and ':' in path

### DIFF
--- a/platform/dvcs-impl/src/com/intellij/dvcs/ui/CloneDvcsValidationUtils.java
+++ b/platform/dvcs-impl/src/com/intellij/dvcs/ui/CloneDvcsValidationUtils.java
@@ -22,8 +22,9 @@ public final class CloneDvcsValidationUtils {
   static {
     // TODO make real URL pattern
     @NonNls final String ch = "[\\p{ASCII}&&[\\p{Graph}]&&[^@:/]]";
+    @NonNls final String ch2 = "[\\p{ASCII}&&[\\p{Graph}]&&[^/]]";
     @NonNls final String host = ch + "+(?:\\." + ch + "+)*";
-    @NonNls final String path = "/?" + ch + "+(?:/" + ch + "+)*/?";
+    @NonNls final String path = "/?" + ch2 + "+(?:/" + ch2 + "+)*/?";
     @NonNls final String all = "(?:" + ch + "+@)?" + host + ":" + path;
     SSH_URL_PATTERN = Pattern.compile(all);
   }


### PR DESCRIPTION
RFC 3986 allows '@' and ':' characters in the path component of a URL, but SSH_URL_PATTERN did not. This revises SSH_URL_PATTERN to allow these characters, so that Intellij supports URLs of the following form:

user_at_example_dot_com@example.com:/home/user@example.com/project

See also https://youtrack.jetbrains.com/issue/IDEA-326235.