### PR TITLE
[KTIJ-4113] - Enabling align when multiline option for chained methods

### DIFF
--- a/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt
+++ b/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinCommonBlock.kt
@@ -183,16 +183,88 @@ abstract class KotlinCommonBlock(
     // enforce indent to children when there's a line break before the dot in any call in the chain (meaning that
     // the call chain following that call is indented)
     private fun createIndentForQualifierExpression(enforceIndentToChildren: Boolean): Indent {
+        var spaces = 0
         val indentType = if (settings.kotlinCustomSettings.CONTINUATION_INDENT_FOR_CHAINED_CALLS) {
             if (enforceIndentToChildren) Indent.Type.CONTINUATION else Indent.Type.CONTINUATION_WITHOUT_FIRST
+        } else if (settings.kotlinCommonSettings.ALIGN_MULTILINE_CHAINED_METHODS) {
+            node.qualifierReceiver()?.let {
+                spaces = calculateQualifierIndentSpaces(it)
+                Indent.Type.SPACES
+            } ?: Indent.Type.NORMAL
         } else {
             Indent.Type.NORMAL
         }
 
         return Indent.getIndent(
-            indentType, false,
+            indentType, spaces, false,
             enforceIndentToChildren,
         )
+    }
+
+    private fun calculateQualifierIndentSpaces(qualifierNode: ASTNode): Int {
+        var spaces: Int = qualifierNode.children().first().countNodeSpaces()
+        val siblings = node.siblings(false).filterNot { f -> f.elementType == PROPERTY }
+
+        if(siblings.count() > 0 && siblings.first().elementType == LPAR) {
+            spaces += node.parents()
+                .filter{ f -> f.elementType == PROPERTY}
+                .first()
+                .children()
+                .sumSpacesFromNode()
+                .plus(1)
+        } else if (siblings.count() == 0) {
+            val parentSiblings = node.parents().first().siblings(false)
+            if (parentSiblings.none { e -> e.elementType == ARROW }) {
+                spaces += parentSiblings.sumSpacesFromNode()
+            }
+        }
+
+        spaces += siblings.sumSpacesFromNode()
+
+        val parent = node.parents().first()
+        val parentSiblings = parent.siblings(false)
+        if (parentSiblings.all { p -> p.elementType == WHITE_SPACE
+                    || p.elementType == EQ
+                    || p.elementType == IDENTIFIER
+                    || p.elementType == VAL_KEYWORD
+                    || p.elementType == VAR_KEYWORD } ) {
+            when (parent.elementType) {
+                FUN -> spaces += parentSiblings.sumSpacesFromNode()
+            }
+        }
+
+        return spaces
+    }
+
+    private fun ASTNode.countNodeSpaces(): Int {
+        val safeAccessShift = if(this.siblings().first().elementType == SAFE_ACCESS ) { 1 } else { 0 }
+        return when (this.elementType) {
+            SAFE_ACCESS_EXPRESSION ,
+            DOT_QUALIFIED_EXPRESSION -> this.text.split(DOT.value).first().length
+
+            PARENTHESIZED -> {
+                val secondDotIndex = this.text.indexOf(DOT.value, node.text.indexOf(DOT.value).plus(1))
+                if (secondDotIndex > -1) {
+                    this.text.substring(0, secondDotIndex.plus(1)).length
+                } else {
+                    this.textLength
+                } + safeAccessShift
+            }
+
+            else -> this.textLength + safeAccessShift
+        }
+    }
+
+    private fun Sequence<ASTNode>.sumSpacesFromNode(): Int {
+        return this.filterNot { f -> f.elementType == LBRACE }
+            .filterNot { f -> f.elementType == LBRACKET }
+            .filterNot { f -> f.elementType == LPAR }
+            .filterNot { f -> f.elementType == DANGLING_NEWLINE }
+            .filterNot { f -> f.elementType == DOT_QUALIFIED_EXPRESSION }
+            .filterNot { f -> f.elementType == SAFE_ACCESS_EXPRESSION }
+            .filterNot { f -> (f.text.any { l -> l == '\n' }) }
+            .map { s -> s.countNodeSpaces() }
+            .sum()
     }
 
     private fun List<ASTBlock>.wrapToBlock(

--- a/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt
+++ b/plugins/kotlin/formatter/src/org/jetbrains/kotlin/idea/formatter/KotlinLanguageCodeStyleSettingsProvider.kt
@@ -141,7 +141,7 @@ class KotlinLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvide
             }
             SettingsType.WRAPPING_AND_BRACES_SETTINGS -> {
                 consumer.showStandardOptions(
-                    // "ALIGN_MULTILINE_CHAINED_METHODS",
+                    "ALIGN_MULTILINE_CHAINED_METHODS",
                     "RIGHT_MARGIN",
                     "WRAP_ON_TYPING",
                     "KEEP_FIRST_COLUMN_COMMENT",

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/FormatterTestGenerated.java
@@ -38,6 +38,11 @@ public abstract class FormatterTestGenerated extends AbstractFormatterTest {
                 runTest("testData/formatter/callChain/CallChainWrapping2.after.kt");
             }
 
+            @TestMetadata("CallChainWrappingAlignMultiline.after.kt")
+            public void testCallChainWrappingAlignMultiline() throws Exception {
+                runTest("testData/formatter/callChain/CallChainWrappingAlignMultiline.after.kt");
+            }
+
             @TestMetadata("CallChainWrappingChopDown.after.kt")
             public void testCallChainWrappingChopDown() throws Exception {
                 runTest("testData/formatter/callChain/CallChainWrappingChopDown.after.kt");
@@ -111,6 +116,11 @@ public abstract class FormatterTestGenerated extends AbstractFormatterTest {
             @TestMetadata("NotCallChain.after.kt")
             public void testNotCallChain() throws Exception {
                 runTest("testData/formatter/callChain/NotCallChain.after.kt");
+            }
+
+            @TestMetadata("SafeCallChainWrappingAlignMultiline.after.kt")
+            public void testSafeCallChainWrappingAlignMultiline() throws Exception {
+                runTest("testData/formatter/callChain/SafeCallChainWrappingAlignMultiline.after.kt");
             }
         }
 

--- a/plugins/kotlin/idea/tests/testData/formatter/callChain/CallChainWrappingAlignMultiline.after.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/callChain/CallChainWrappingAlignMultiline.after.kt
@@ -1,0 +1,121 @@
+val x = foo.bar()
+           .baz()
+           .quux()
+
+val x2 = foo().bar()
+              .baz()
+              .quux()
+
+val x3 = ((foo().bar())).baz()
+                        .quux()
+
+val x4 = (foo().bar()
+               .baz()).quux()
+
+val x5 = (foo()).bar()
+                .baz()
+                .quux()
+
+val x6 = foo!!.bar()
+              .baz()!!
+              .quux()!!
+
+val x7 = foo!!.bar()
+              .baz()!!
+              .quux()!!
+
+val x8 = foo!!!!!!!!.bar()
+                    .baz()!!
+                    .quux()!!
+
+val x9 = ((b!!)!!!!)!!.f
+
+val x10 = a()!!.a()
+
+val x11 = a()!!!!.a()
+
+val x12 = a()!!.a()!!
+               .a()
+
+val x13 = a()!!!!.a()
+                 .a()
+
+val x14 = a().a()
+
+val x15 = (a()).a()
+
+val x16 = (a()).a()
+               .a()
+
+val x17 = (a().a()).a()
+
+val x18 = (a().a()).a()
+                   .a()
+
+val x18 = (a().a()
+              .a()).a()
+                   .a()
+
+val x19 = (a().a()
+              .a()).a()
+
+val x20 = foo!!.foo.baz()!!
+               .quux()!!.foo.foo.foo.baz().foo.baz()
+               .baz()
+
+val y = xyzzy(
+    foo.bar()
+       .baz()
+       .quux()
+)
+
+fun foo() {
+    foo.bar()
+       .baz()
+       .quux()
+
+    z = foo.bar()
+           .baz()
+           .quux()
+
+    z += foo.bar()
+            .baz()
+            .quux()
+
+    return foo.bar()
+              .baz()
+              .quux()
+}
+
+fun top() = "".plus("")
+              .plus("")
+
+class C {
+    fun member() = "".plus("")
+                     .plus("")
+}
+
+fun foo() {
+    fun local() = "".plus("")
+                    .plus("")
+
+    val anonymous = fun() = "".plus("")
+                               .plus("")
+}
+
+override fun foo(bar: baz) {
+    outter.call {
+        val inner = a.a(it)
+        val xyz = col.map { b -> b.baz(inner) }
+                     .map { c ->
+                         inner.foo(c)
+                              .bar(c)
+                     }
+        inner.foo(xyz)
+             .bar()
+    }
+}
+
+// SET_INT: METHOD_CALL_CHAIN_WRAP = 2
+// SET_FALSE: WRAP_FIRST_METHOD_IN_CALL_CHAIN
+// SET_TRUE: ALIGN_MULTILINE_CHAINED_METHODS

--- a/plugins/kotlin/idea/tests/testData/formatter/callChain/CallChainWrappingAlignMultiline.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/callChain/CallChainWrappingAlignMultiline.kt
@@ -1,0 +1,74 @@
+val x = foo.bar().baz().quux()
+
+val x2 = foo().bar().baz().quux()
+
+val x3 = ((foo().bar())).baz().quux()
+
+val x4 = (foo().bar().baz()).quux()
+
+val x5 = (foo()).bar().baz().quux()
+
+val x6 = foo!!.bar().baz()!!.quux()!!
+
+val x7 = foo!!.bar().baz()!!.quux()!!
+
+val x8 = foo!!!!!!!!.bar().baz()!!.quux()!!
+
+val x9 = ((b!!)!!!!)!!.f
+
+val x10 = a()!!.a()
+
+val x11 = a()!!!!.a()
+
+val x12 = a()!!.a()!!.a()
+
+val x13 = a()!!!!.a().a()
+
+val x14 = a().a()
+
+val x15 = (a()).a()
+
+val x16 = (a()).a().a()
+
+val x17 = (a().a()).a()
+
+val x18 = (a().a()).a().a()
+
+val x18 = (a().a().a()).a().a()
+
+val x19 = (a().a().a()).a()
+
+val x20 = foo!!.foo.baz()!!.quux()!!.foo.foo.foo.baz().foo.baz().baz()
+
+val y = xyzzy(foo.bar().baz().quux())
+
+fun foo() {
+    foo.bar().baz().quux()
+
+    z = foo.bar().baz().quux()
+
+    z += foo.bar().baz().quux()
+
+    return foo.bar().baz().quux()
+}
+
+fun top() = "".plus("").plus("")
+class C {
+    fun member() = "".plus("").plus("")
+}
+fun foo() {
+    fun local() = "".plus("").plus("")
+    val anonymous = fun() = "".plus("").plus("")
+}
+
+override fun foo(bar: baz) {
+    outter.call {
+        val inner = a.a(it)
+        val xyz = col.map { b -> b.baz(inner) }.map { c -> inner.foo(c).bar(c) }
+        inner.foo(xyz).bar()
+    }
+}
+
+// SET_INT: METHOD_CALL_CHAIN_WRAP = 2
+// SET_FALSE: WRAP_FIRST_METHOD_IN_CALL_CHAIN
+// SET_TRUE: ALIGN_MULTILINE_CHAINED_METHODS

--- a/plugins/kotlin/idea/tests/testData/formatter/callChain/SafeCallChainWrappingAlignMultiline.after.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/callChain/SafeCallChainWrappingAlignMultiline.after.kt
@@ -1,0 +1,187 @@
+val x1 = foo?.bar()
+             .baz()
+             .quux()
+
+val x2 = foo?.bar()
+             ?.baz()
+             .quux()
+
+val x3 = foo?.bar()
+             ?.baz()
+             ?.quux()
+
+val x4 = foo.bar()
+            ?.baz()
+            ?.quux()
+
+val x5 = foo.bar()
+            .baz()
+            ?.quux()
+
+val x6 = foo()?.bar()
+               .baz()
+               .quux()
+
+val x7 = foo()?.bar()
+               ?.baz()
+               .quux()
+
+val x8 = foo()?.bar()
+               ?.baz()
+               ?.quux()
+
+val x9 = foo().bar()
+              ?.baz()
+              ?.quux()
+
+val x10 = foo().bar()
+               .baz()
+               ?.quux()
+
+val x11 = ((foo()?.bar()))?.baz()
+                           ?.quux()
+
+val x12 = ((foo()?.bar())).baz()
+                          ?.quux()
+
+val x13 = ((foo().bar())).baz()
+                         ?.quux()
+
+val x14 = (foo()?.bar()
+                 ?.baz())?.quux()
+
+val x15 = (foo()?.bar()
+                 .baz())?.quux()
+
+val x16 = (foo().bar()
+                ?.baz())?.quux()
+
+val x17 = (foo())?.bar()
+                  ?.baz()
+                  ?.quux()
+
+val x18 = (foo()).bar()
+                 ?.baz()
+                 ?.quux()
+
+val x19 = (foo())?.bar()
+                  .baz()
+                  ?.quux()
+
+val x20 = (foo()).bar()
+                 .baz()
+                 ?.quux()
+
+val x21 = foo!!.bar()
+               ?.baz()!!
+               .quux()!!
+
+val x22 = foo!!.bar()
+               ?.baz()!!
+               .quux()!!
+
+val x23 = foo!!!!!!!!.bar()
+                     ?.baz()!!
+                     .quux()!!
+
+val x24 = a()!!!!.a()
+                 ?.a()
+
+val x25 = a()?.a()
+
+val x26 = (a())?.a()
+
+val x27 = (a())?.a()
+                ?.a()
+
+val x28 = (a()).a()
+               ?.a()
+
+val x29 = (a()?.a())?.a()
+
+val x30 = (a().a())?.a()
+
+val x31 = (a()?.a())?.a()
+                     ?.a()
+
+val x32 = (a()?.a()).a()
+                    ?.a()
+
+val x33 = (a().a()).a()
+                   ?.a()
+
+val x34 = (a()?.a()
+               ?.a())?.a()
+                      ?.a()
+
+val x35 = (a()?.a()
+               ?.a())?.a()
+
+val x36 = foo!!.foo?.baz()!!
+               .quux()!!.foo?.foo?.foo?.baz()?.foo?.baz()
+               ?.baz()
+
+val y = xyzzy(
+    foo?.bar()
+        ?.baz()
+        ?.quux()
+)
+
+fun foo() {
+    foo?.bar()
+        ?.baz()
+        ?.quux()
+
+    foo.bar()
+       ?.baz()
+       ?.quux()
+
+    foo.bar()
+       .baz()
+       ?.quux()
+
+    z = foo?.bar()
+            ?.baz()
+            ?.quux()
+
+    z = foo.bar()
+           ?.baz()
+           ?.quux()
+
+    z = foo.bar()
+           .baz()
+           ?.quux()
+
+    z += foo?.bar()
+             ?.baz()
+             ?.quux()
+
+    z += foo.bar()
+            ?.baz()
+            ?.quux()
+
+    z += foo.bar()
+            .baz()
+            ?.quux()
+
+    return foo?.bar()
+               ?.baz()
+               ?.quux()
+}
+
+override fun foo(bar: baz) {
+    outter?.call {
+        val inner = a?.a(it)
+        val xyz = col?.map { b -> b.baz(inner) }
+                      ?.map { c ->
+                          inner?.foo(c)
+                                ?.bar(c)
+                      }
+        inner?.foo(xyz)
+              ?.bar()
+    }
+}
+
+// SET_INT: METHOD_CALL_CHAIN_WRAP = 2
+// SET_FALSE: WRAP_FIRST_METHOD_IN_CALL_CHAIN
+// SET_TRUE: ALIGN_MULTILINE_CHAINED_METHODS

--- a/plugins/kotlin/idea/tests/testData/formatter/callChain/SafeCallChainWrappingAlignMultiline.kt
+++ b/plugins/kotlin/idea/tests/testData/formatter/callChain/SafeCallChainWrappingAlignMultiline.kt
@@ -1,0 +1,107 @@
+val x1 = foo?.bar().baz().quux()
+
+val x2 = foo?.bar()?.baz().quux()
+
+val x3 = foo?.bar()?.baz()?.quux()
+
+val x4 = foo.bar()?.baz()?.quux()
+
+val x5 = foo.bar().baz()?.quux()
+
+val x6 = foo()?.bar().baz().quux()
+
+val x7 = foo()?.bar()?.baz().quux()
+
+val x8 = foo()?.bar()?.baz()?.quux()
+
+val x9 = foo().bar()?.baz()?.quux()
+
+val x10 = foo().bar().baz()?.quux()
+
+val x11 = ((foo()?.bar()))?.baz()?.quux()
+
+val x12 = ((foo()?.bar())).baz()?.quux()
+
+val x13 = ((foo().bar())).baz()?.quux()
+
+val x14 = (foo()?.bar()?.baz())?.quux()
+
+val x15 = (foo()?.bar().baz())?.quux()
+
+val x16 = (foo().bar()?.baz())?.quux()
+
+val x17 = (foo())?.bar()?.baz()?.quux()
+
+val x18 = (foo()).bar()?.baz()?.quux()
+
+val x19 = (foo())?.bar().baz()?.quux()
+
+val x20 = (foo()).bar().baz()?.quux()
+
+val x21 = foo!!.bar()?.baz()!!.quux()!!
+
+val x22 = foo!!.bar()?.baz()!!.quux()!!
+
+val x23 = foo!!!!!!!!.bar()?.baz()!!.quux()!!
+
+val x24 = a()!!!!.a()?.a()
+
+val x25 = a()?.a()
+
+val x26 = (a())?.a()
+
+val x27 = (a())?.a()?.a()
+
+val x28 = (a()).a()?.a()
+
+val x29 = (a()?.a())?.a()
+
+val x30 = (a().a())?.a()
+
+val x31 = (a()?.a())?.a()?.a()
+
+val x32 = (a()?.a()).a()?.a()
+
+val x33 = (a().a()).a()?.a()
+
+val x34 = (a()?.a()?.a())?.a()?.a()
+
+val x35 = (a()?.a()?.a())?.a()
+
+val x36 = foo!!.foo?.baz()!!.quux()!!.foo?.foo?.foo?.baz()?.foo?.baz()?.baz()
+
+val y = xyzzy(foo?.bar()?.baz()?.quux())
+
+fun foo() {
+    foo?.bar()?.baz()?.quux()
+
+    foo.bar()?.baz()?.quux()
+
+    foo.bar().baz()?.quux()
+
+    z = foo?.bar()?.baz()?.quux()
+
+    z = foo.bar()?.baz()?.quux()
+
+    z = foo.bar().baz()?.quux()
+
+    z += foo?.bar()?.baz()?.quux()
+
+    z += foo.bar()?.baz()?.quux()
+
+    z += foo.bar().baz()?.quux()
+
+    return foo?.bar()?.baz()?.quux()
+}
+
+override fun foo(bar: baz) {
+    outter?.call {
+        val inner = a?.a(it)
+        val xyz = col?.map { b -> b.baz(inner) }?.map { c -> inner?.foo(c)?.bar(c) }
+        inner?.foo(xyz)?.bar()
+    }
+}
+
+// SET_INT: METHOD_CALL_CHAIN_WRAP = 2
+// SET_FALSE: WRAP_FIRST_METHOD_IN_CALL_CHAIN
+// SET_TRUE: ALIGN_MULTILINE_CHAINED_METHODS


### PR DESCRIPTION
This PR makes the option 'Align when multiline' available for chained method calls that are wrapped.
Continuation indent still takes precedence and the option being anabled will only work when continuation indent is disabled.