### PR TITLE
IDEA-326697 Add git with ssh support to the settings repository plugin

### DIFF
--- a/plugins/settings-repository/intellij.settingsRepository.iml
+++ b/plugins/settings-repository/intellij.settingsRepository.iml
@@ -17,9 +17,6 @@
             <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/org.eclipse.jgit/6.5.0.202303070854-r-custom-4/org.eclipse.jgit-6.5.0.202303070854-r-custom-4.jar">
               <sha256sum>d9b12a3323f6447a7ca8de3d781166224f11c3505fe43dc0a9dfb1f33eb3cf04</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13.jar">
-              <sha256sum>4c0fda2b1d317750d7ea324e36c70b2bc48310c0aaae67b98df0915d696d7111</sha256sum>
-            </artifact>
           </verification>
           <exclude>
             <dependency maven-id="org.slf4j:slf4j-api" />
@@ -30,20 +27,59 @@
         </ANNOTATIONS>
         <CLASSES>
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/org.eclipse.jgit/6.5.0.202303070854-r-custom-4/org.eclipse.jgit-6.5.0.202303070854-r-custom-4.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13.jar!/" />
         </CLASSES>
         <JAVADOC>
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/org.eclipse.jgit/6.5.0.202303070854-r-custom-4/org.eclipse.jgit-6.5.0.202303070854-r-custom-4-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13-javadoc.jar!/" />
         </JAVADOC>
         <SOURCES>
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/org.eclipse.jgit/6.5.0.202303070854-r-custom-4/org.eclipse.jgit-6.5.0.202303070854-r-custom-4-sources.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" exported="">
+      <library name="eclipse.jgit.ssh.jsch" type="repository">
+        <properties maven-id="org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:6.5.0.202303070854-r">
+          <verification>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/eclipse/jgit/org.eclipse.jgit.ssh.jsch/6.5.0.202303070854-r/org.eclipse.jgit.ssh.jsch-6.5.0.202303070854-r.jar">
+              <sha256sum>8ab7b5fefc2a42c5156c678148f415ce35ae8d93a8e3127b5426241e965606f6</sha256sum>
+            </artifact>
+          </verification>
+          <exclude>
+            <dependency maven-id="org.eclipse.jgit:org.eclipse.jgit" />
+            <dependency maven-id="org.slf4j:slf4j-api" />
+          </exclude>
+        </properties>
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jgit/org.eclipse.jgit.ssh.jsch/6.5.0.202303070854-r/org.eclipse.jgit.ssh.jsch-6.5.0.202303070854-r.jar!/" />
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jgit/org.eclipse.jgit.ssh.jsch/6.5.0.202303070854-r/org.eclipse.jgit.ssh.jsch-6.5.0.202303070854-r-javadoc.jar!/" />
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/eclipse/jgit/org.eclipse.jgit.ssh.jsch/6.5.0.202303070854-r/org.eclipse.jgit.ssh.jsch-6.5.0.202303070854-r-sources.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" exported="">
+      <library name="JavaEWAH" type="repository">
+        <properties maven-id="com.googlecode.javaewah:JavaEWAH:1.1.13">
+          <verification>
+            <artifact url="file://$MAVEN_REPOSITORY$/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13.jar">
+              <sha256sum>4c0fda2b1d317750d7ea324e36c70b2bc48310c0aaae67b98df0915d696d7111</sha256sum>
+            </artifact>
+          </verification>
+        </properties>
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13.jar!/" />
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13-javadoc.jar!/" />
+        </JAVADOC>
+        <SOURCES>
           <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
-    <orderEntry type="module" module-name="intellij.platform.vcs.impl" />
-    <orderEntry type="module" module-name="intellij.platform.projectModel.impl" />
     <orderEntry type="module-library" exported="">
       <library name="JSch" type="repository">
         <properties maven-id="com.jcraft:jsch:0.1.55">
@@ -56,12 +92,36 @@
         <CLASSES>
           <root url="jar://$MAVEN_REPOSITORY$/com/jcraft/jsch/0.1.55/jsch-0.1.55.jar!/" />
         </CLASSES>
-        <JAVADOC />
+        <JAVADOC>
+          <root url="jar://$MAVEN_REPOSITORY$/com/jcraft/jsch/0.1.55/jsch-0.1.55-javadoc.jar!/" />
+        </JAVADOC>
         <SOURCES>
           <root url="jar://$MAVEN_REPOSITORY$/com/jcraft/jsch/0.1.55/jsch-0.1.55-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
+    <orderEntry type="module-library" exported="">
+      <library name="jzlib" type="repository">
+        <properties maven-id="com.jcraft:jzlib:1.1.3">
+          <verification>
+            <artifact url="file://$MAVEN_REPOSITORY$/com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar">
+              <sha256sum>89b1360f407381bf61fde411019d8cbd009ebb10cff715f3669017a031027560</sha256sum>
+            </artifact>
+          </verification>
+        </properties>
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://$MAVEN_REPOSITORY$/com/jcraft/jzlib/1.1.3/jzlib-1.1.3-javadoc.jar!/" />
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://$MAVEN_REPOSITORY$/com/jcraft/jzlib/1.1.3/jzlib-1.1.3-sources.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module" module-name="intellij.platform.vcs.impl" />
+    <orderEntry type="module" module-name="intellij.platform.projectModel.impl" />
     <orderEntry type="library" name="kotlin-stdlib" level="project" />
     <orderEntry type="library" name="Slf4j" level="project" />
     <orderEntry type="library" name="slf4j-jdk14" level="project" />

--- a/plugins/settings-repository/src/git/GitEx.kt
+++ b/plugins/settings-repository/src/git/GitEx.kt
@@ -23,6 +23,8 @@ import org.eclipse.jgit.transport.CredentialsProvider
 import org.eclipse.jgit.transport.FetchResult
 import org.eclipse.jgit.transport.RemoteConfig
 import org.eclipse.jgit.transport.Transport
+import org.eclipse.jgit.transport.SshSessionFactory
+import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory
 import org.eclipse.jgit.treewalk.FileTreeIterator
 import org.eclipse.jgit.treewalk.TreeWalk
 import org.jetbrains.annotations.NonNls
@@ -55,9 +57,18 @@ private fun isAuthFailedMessage(message: String): Boolean {
          message.contains(": reject HostKey:") /* JSch */
 }
 
+private fun ensureSshSessionFactory() {
+  var instance = SshSessionFactory.getInstance()
+  if (instance == null) {
+    instance = JschConfigSessionFactory()
+    SshSessionFactory.setInstance(instance)
+  }
+}
+
 fun Repository.fetch(remoteConfig: RemoteConfig,
                      credentialsProvider: CredentialsProvider? = null,
                      progressMonitor: ProgressMonitor? = null): FetchResult? {
+  ensureSshSessionFactory()
   try {
     Transport.open(this, remoteConfig).use { transport ->
       transport.credentialsProvider = credentialsProvider


### PR DESCRIPTION
On upgrading jgit from 5.x to 6.5, ssh support was removed. This change adds ssh support back to the settings repository plugin by using the `eclipse.jgit.ssh.jsch`.

I manually added a code for registering `JschConfigSessionFactory` to `SshSessionFactory` in `GitEx.kt` because I couldn't find a way to do it automatically.