### PR TITLE
IDEA-328234 vcs: add icon & description to "Copy Revision Number" in annotations

### DIFF
--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/actions/CopyRevisionNumberFromAnnotateAction.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/actions/CopyRevisionNumberFromAnnotateAction.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.openapi.vcs.actions;
 
+import com.intellij.idea.ActionsBundle;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ide.CopyPasteManager;
@@ -8,6 +9,7 @@ import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.vcs.VcsBundle;
 import com.intellij.openapi.vcs.annotate.FileAnnotation;
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
+import com.intellij.util.PlatformIcons;
 import com.intellij.util.ui.TextTransferable;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,7 +20,9 @@ public class CopyRevisionNumberFromAnnotateAction extends DumbAwareAction {
   private final FileAnnotation myAnnotation;
 
   public CopyRevisionNumberFromAnnotateAction(FileAnnotation annotation) {
-    super(VcsBundle.messagePointer("copy.revision.number.action"));
+    super(VcsBundle.messagePointer("copy.revision.number.action"),
+          ActionsBundle.messagePointer("action.Vcs.CopyRevisionNumberAction.description"),
+          PlatformIcons.COPY_ICON);
     myAnnotation = annotation;
   }
 


### PR DESCRIPTION
Improvement for `CopyRevisionNumberFromAnnotateAction`. Details are in the commit message.

Comparison screenshot, before and after, both in Old and New UIs:

![CopyRevisionNumberFromAnnotateAction before and after](https://github.com/JetBrains/intellij-community/assets/624072/4bd34a93-45f2-4ef1-9517-fe720dd5726e)

For reference, here's how `CopyRevisionNumberAction` looks like  in the context menu of commits in the "Log" tab:

![IntelliJ IDEA CopyRevisionNumberAction demonstration of description and icon](https://github.com/JetBrains/intellij-community/assets/624072/e6afaf51-cd29-4cd0-9be4-363b3c7b98eb)


