### PR TITLE
 Add support for building libsqliteij.so on loongarch64 and riscv64

### DIFF
--- a/platform/sqlite/make.sh
+++ b/platform/sqlite/make.sh
@@ -26,8 +26,8 @@ if [ "$OS" == "mac" ]; then
 elif [ "$OS" == "linux" ]; then
   libFilename="libsqliteij.so"
 
-  # cannot compile for aarch64 and loongarch64 - unable to find library -lgcc, so, use dock cross
-  if [ "$ARCH" == "aarch64" ] || [ "$ARCH" = "loongarch64" ]; then
+  # cannot compile for aarch64, loongarch64 and riscv64 - unable to find library -lgcc, so, use dock cross
+  if [ "$ARCH" == "aarch64" ] || [ "$ARCH" = "loongarch64" ] || [ "$ARCH" = "riscv64" ]; then
     linkFlags+=" -shared"
   else
     cFlags+=" --target=$ARCH-unknown-linux-gnu --sysroot=target/linux-$ARCH"

--- a/platform/sqlite/make.sh
+++ b/platform/sqlite/make.sh
@@ -26,8 +26,8 @@ if [ "$OS" == "mac" ]; then
 elif [ "$OS" == "linux" ]; then
   libFilename="libsqliteij.so"
 
-  # cannot compile arm - unable to find library -lgcc, so, use dock cross
-  if [ "$ARCH" == "aarch64" ]; then
+  # cannot compile for aarch64 and loongarch64 - unable to find library -lgcc, so, use dock cross
+  if [ "$ARCH" == "aarch64" ] || [ "$ARCH" = "loongarch64" ]; then
     linkFlags+=" -shared"
   else
     cFlags+=" --target=$ARCH-unknown-linux-gnu --sysroot=target/linux-$ARCH"


### PR DESCRIPTION
Now Goland 2023.2 works on loongarch64 and riscv64
![Screenshot_20230803_015538](https://github.com/JetBrains/intellij-community/assets/24467495/ac925e5f-e961-4280-be83-9ffa01eb5e7d)
