### PR TITLE
fix JBCefScrollbarsHelper.java

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/jcef/JBCefScrollbarsHelper.java
+++ b/platform/platform-api/src/com/intellij/ui/jcef/JBCefScrollbarsHelper.java
@@ -233,7 +233,7 @@ public final class JBCefScrollbarsHelper {
     Color color = ObjectUtils.notNull(colorsScheme.getColor(key), key.getDefaultColor());
     double alpha = ObjectUtils.notNull(getScrollbarAlpha(key), color.getAlpha()) / 255.0;
 
-    return String.format(Locale.ROOT, "rgba(%d, %d, %d, %f)", color.getRed(), color.getBlue(), color.getBlue(), alpha);
+    return String.format(Locale.ROOT, "rgba(%d, %d, %d, %f)", color.getRed(), color.getBlue(), color.getGreen(), alpha);
   }
 
   private static @NotNull String readResource(@NotNull String path) {

--- a/platform/platform-api/src/com/intellij/ui/jcef/JBCefScrollbarsHelper.java
+++ b/platform/platform-api/src/com/intellij/ui/jcef/JBCefScrollbarsHelper.java
@@ -233,7 +233,7 @@ public final class JBCefScrollbarsHelper {
     Color color = ObjectUtils.notNull(colorsScheme.getColor(key), key.getDefaultColor());
     double alpha = ObjectUtils.notNull(getScrollbarAlpha(key), color.getAlpha()) / 255.0;
 
-    return String.format(Locale.ROOT, "rgba(%d, %d, %d, %f)", color.getRed(), color.getBlue(), color.getGreen(), alpha);
+    return String.format(Locale.ROOT, "rgba(%d, %d, %d, %f)", color.getRed(), color.getGreen(), color.getBlue(), alpha);
   }
 
   private static @NotNull String readResource(@NotNull String path) {


### PR DESCRIPTION
I got this issue in my plugin: https://github.com/mallowigi/material-theme-issues/issues/369

After investigating a bit I found out that the Markdown Preview doesn't render the scrollbars well, but only for some of the themes.

Then I found out this possible typo. I don't know if this is the fix for my issue but I suspect it is