### PR TITLE
KTIJ-26565 "Suspicious callable reference as the only lambda element" quickfix leads to red code (unresolved reference due to receiver type mismatch)

### DIFF
--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -15633,6 +15633,26 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/explicitThisReceiver.kt");
         }
 
+        @TestMetadata("hasExplicitType.kt")
+        public void testHasExplicitType() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType.kt");
+        }
+
+        @TestMetadata("hasExplicitType2.kt")
+        public void testHasExplicitType2() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType2.kt");
+        }
+
+        @TestMetadata("hasExplicitType3.kt")
+        public void testHasExplicitType3() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType3.kt");
+        }
+
+        @TestMetadata("hasExplicitType4.kt")
+        public void testHasExplicitType4() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType4.kt");
+        }
+
         @TestMetadata("implicitThisReceiver.kt")
         public void testImplicitThisReceiver() throws Exception {
             runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/implicitThisReceiver.kt");
@@ -15716,6 +15736,21 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         @TestMetadata("parameterOuter.kt")
         public void testParameterOuter() throws Exception {
             runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/parameterOuter.kt");
+        }
+
+        @TestMetadata("usedAsParameter.kt")
+        public void testUsedAsParameter() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsParameter.kt");
+        }
+
+        @TestMetadata("usedAsReceiver.kt")
+        public void testUsedAsReceiver() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsReceiver.kt");
+        }
+
+        @TestMetadata("usedAsReturn.kt")
+        public void testUsedAsReturn() throws Exception {
+            runTest("testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsReturn.kt");
         }
 
         @TestMetadata("variableReceiver.kt")

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+import kotlin.reflect.KFunction0
+
+val foo: List<KFunction0<String>> = listOf(1, 2, 3).map { it::toString <caret>}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType2.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType2.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+import kotlin.reflect.KFunction0
+
+fun foo(): List<KFunction0<String>> = listOf(1, 2, 3).map { it::toString <caret>}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType3.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType3.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+import kotlin.reflect.KFunction0
+
+fun List<Int>.test() {
+    val foo: List<KFunction0<String>> = map { it::toString <caret>}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType4.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/hasExplicitType4.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+import kotlin.reflect.KFunction0
+
+fun String.test() {
+    val x: () -> KFunction0<String> = { ::toString <caret>}
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/normal.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/normal.kt
@@ -1,5 +1,5 @@
 // WITH_STDLIB
 
 fun foo() {
-    listOf(1,2,3).map {<caret> Int::toString }
+    val x = listOf(1,2,3).map {<caret> Int::toString }
 }

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/normal.kt.after
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/normal.kt.after
@@ -1,5 +1,5 @@
 // WITH_STDLIB
 
 fun foo() {
-    listOf(1,2,3).map(Int::toString)
+    val x = listOf(1,2,3).map(Int::toString)
 }

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsParameter.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsParameter.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+import kotlin.reflect.KFunction0
+
+fun test() {
+    foo(listOf(1, 2, 3).map { it::toString <caret>})
+}
+
+fun foo(list: List<KFunction0<String>>) {
+    list.forEach { it.invoke() }
+}
+

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsReceiver.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsReceiver.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+import kotlin.reflect.KFunction0
+
+fun test() {
+    listOf(1, 2, 3).map { it::toString <caret>}.foo()
+}
+
+fun List<KFunction0<String>>.foo() {
+    forEach { it.invoke() }
+}
+

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsReturn.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/suspiciousCallableReferenceInLambda/usedAsReturn.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+import kotlin.reflect.KFunction0
+
+fun foo(): List<KFunction0<String>> {
+    return listOf(1, 2, 3).map { it::toString <caret>}
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-26565