### PR TITLE
Restore support for pyAddSdkProvider extension point.

### DIFF
--- a/python/src/META-INF/python-core-common.xml
+++ b/python/src/META-INF/python-core-common.xml
@@ -718,11 +718,9 @@
                    implementationClass="com.jetbrains.python.inspections.PyExpressionCodeFragmentVisitorFilter"/>
 
     <!-- Pipenv -->
-    <pyAddSdkProvider implementation="com.jetbrains.python.sdk.pipenv.PyAddPipEnvSdkProvider"/>
     <pythonFlavorProvider implementation="com.jetbrains.python.sdk.pipenv.PyPipEnvSdkFlavorProvider"/>
 
     <!-- Poetry -->
-    <pyAddSdkProvider implementation="com.jetbrains.python.sdk.poetry.PyAddPoetrySdkProvider"/>
     <pythonFlavorProvider implementation="com.jetbrains.python.sdk.poetry.PyPoetrySdkFlavorProvider"/>
 
     <!-- SDK Flavors -->


### PR DESCRIPTION
This PR addresses the following YouTrack issue: https://youtrack.jetbrains.com/issue/PY-61600/Regression-in-support-for-the-pyAddSdkProvider-extension-point-starting-with-Pycharm-CE-version-2022.2x

In PyCharm releases after 2021.1.4, support for the  pyAddSdkProvider was removed as part of a code refactoring. Plugins depending on this extension point now fail silently.  This PR restores that functionality by moving the missing code to the new com.jetbrains.python.sdk.add.target.PyAddTargetBasedSdkPanel from the class which it replaced com.jetbrains.python.sdk.add.PyAddSdkDialog. 

Note pyAddSdkProvider is a documented extension point. See https://plugins.jetbrains.com/docs/intellij/extension-point-list.html . It is not marked deprecated or experimental.