### PR TITLE
terminal: bash nounset mode unbound variable error fixes

### DIFF
--- a/plugins/terminal/resources/shell-integrations/bash/command-block-support.bash
+++ b/plugins/terminal/resources/shell-integrations/bash/command-block-support.bash
@@ -1,6 +1,6 @@
 # Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 
-[ -z "$INTELLIJ_TERMINAL_COMMAND_BLOCKS" ] && return
+[ -z "${INTELLIJ_TERMINAL_COMMAND_BLOCKS-}" ] && return
 
 __jetbrains_intellij_encode_slow() {
   local out=''
@@ -48,7 +48,7 @@ __jetbrains_intellij_configure_prompt() {
 }
 
 __jetbrains_intellij_debug_log() {
-  if [ -n "$JETBRAINS_INTELLIJ_TERMINAL_DEBUG_LOG_LEVEL" ]; then
+  if [ -n "${JETBRAINS_INTELLIJ_TERMINAL_DEBUG_LOG_LEVEL-}" ]; then
     builtin printf "$1\n"
   fi
 }
@@ -71,7 +71,7 @@ __jetbrains_intellij_command_started() {
 __jetbrains_intellij_initialized=""
 
 __jetbrains_intellij_command_terminated() {
-  if [ ! -z $__JETBRAINS_INTELLIJ_GENERATOR_COMMAND ]
+  if [ -n "${__JETBRAINS_INTELLIJ_GENERATOR_COMMAND-}" ]
   then
     unset __JETBRAINS_INTELLIJ_GENERATOR_COMMAND
     return 0


### PR DESCRIPTION
More of the kind fixed in 60fbf3911, for #1415.

bashrc workaround
```bash
INTELLIJ_TERMINAL_COMMAND_BLOCKS=""
```