### PR TITLE
Expose onGradleJvmChange on GradleSettingsListener

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/config/DelegatingGradleSettingsListenerAdapter.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/config/DelegatingGradleSettingsListenerAdapter.java
@@ -45,6 +45,10 @@ public class DelegatingGradleSettingsListenerAdapter extends DelegatingExternalS
   }
 
   @Override
+  public void onGradleJvmChange(@Nullable String oldGradleJvm, @Nullable String newGradleJvm, @NotNull String linkedProjectPath) {
+  }
+
+  @Override
   public void onGradleVmOptionsChange(@Nullable String oldOptions, @Nullable String newOptions) {
   }
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/config/GradleSettingsListenerAdapter.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/config/GradleSettingsListenerAdapter.java
@@ -24,6 +24,10 @@ public abstract class GradleSettingsListenerAdapter implements ExternalSystemSet
   }
 
   @Override
+  public void onGradleJvmChange(@Nullable String oldGradleJvm, @Nullable String newGradleJvm, @NotNull String linkedProjectPath) {
+  }
+
+  @Override
   public void onGradleVmOptionsChange(@Nullable String oldOptions, @Nullable String newOptions) {
   }
 

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/settings/GradleSettings.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/settings/GradleSettings.java
@@ -143,6 +143,9 @@ public class GradleSettings extends AbstractExternalSystemSettings<GradleSetting
     if (!Objects.equals(old.getGradleHome(), current.getGradleHome())) {
       getPublisher().onGradleHomeChange(old.getGradleHome(), current.getGradleHome(), current.getExternalProjectPath());
     }
+    if (!Objects.equals(old.getGradleJvm(), current.getGradleJvm())) {
+      getPublisher().onGradleJvmChange(old.getGradleJvm(), current.getGradleJvm(), current.getExternalProjectPath());
+    }
     if (old.getDistributionType() != current.getDistributionType()) {
       getPublisher().onGradleDistributionTypeChange(current.getDistributionType(), current.getExternalProjectPath());
     }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/settings/GradleSettingsListener.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/settings/GradleSettingsListener.java
@@ -48,6 +48,14 @@ public interface GradleSettingsListener extends ExternalSystemSettingsListener<G
   void onServiceDirectoryPathChange(@Nullable String oldPath, @Nullable String newPath);
 
   /**
+   * Is expected to be called when gradle JVM is changed by end-user.
+   *
+   * @param oldGradleJvm  old gradleJvm (if any)
+   * @param newGradleJvm  new gradleJvm (if any)
+   */
+  void onGradleJvmChange(@Nullable String oldGradleJvm, @Nullable String newGradleJvm, @NotNull String linkedProjectPath);
+
+  /**
    * Is expected to be called when gradle JVM options are changed by end-user.
    *
    * @param oldOptions  old options (if any)

--- a/plugins/package-search/gradle/src/com/jetbrains/packagesearch/intellij/plugin/gradle/ExternalProjectSignalProvider.kt
+++ b/plugins/package-search/gradle/src/com/jetbrains/packagesearch/intellij/plugin/gradle/ExternalProjectSignalProvider.kt
@@ -73,6 +73,10 @@ internal class GradleModuleLinkSignalProvider : FlowModuleChangesSignalProvider 
                     trySend()
                 }
 
+                override fun onGradleJvmChange(oldGradleJvm: String?, newGradleJvm: String?, linkedProjectPath: String) {
+                    trySend()
+                }
+
                 override fun onGradleVmOptionsChange(oldOptions: String?, newOptions: String?) {
                     trySend()
                 }


### PR DESCRIPTION
Allow to detect when the Gradle JDK configuration has changed by the user allowing for example to display notification requesting Gradle sync