### PR TITLE
Allow GrMethodWrapper objects to be used as keys

### DIFF
--- a/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/synthetic/GrLightMethodBuilder.java
+++ b/plugins/groovy/groovy-psi/src/org/jetbrains/plugins/groovy/lang/psi/impl/synthetic/GrLightMethodBuilder.java
@@ -575,7 +575,7 @@ public class GrLightMethodBuilder extends LightElement implements GrMethod, Orig
     return myConstructor == builder.myConstructor &&
            Objects.equals(myName, builder.myName) &&
            Objects.equals(myMethodKind, builder.myMethodKind) &&
-           Objects.equals(myReturnType, builder.myReturnType) &&
+           Objects.equals(getReturnType(), builder.getReturnType()) &&
            Objects.equals(myModifierList, builder.myModifierList) &&
            Objects.equals(myParameterList, builder.myParameterList) &&
            Arrays.equals(myTypeParameterList.getTypeParameters(), builder.myTypeParameterList.getTypeParameters()) &&
@@ -591,7 +591,7 @@ public class GrLightMethodBuilder extends LightElement implements GrMethod, Orig
       myConstructor,
       myName,
       myMethodKind,
-      myReturnType,
+      getReturnType(),
       myModifierList,
       myParameterList,
       Arrays.hashCode(myTypeParameterList.getTypeParameters()),


### PR DESCRIPTION
Hashing data structures require their keys' hashCode() to be unchanging while the object is used as a key.  GrMethodWrapper lazily computes its return type, which means that the underlying myReturnType field in the GrLightMethodBuilder which is used in the hashCode() (and equality) can change.  Convert the direct use of the private field to a use of the overridden accessor.

This had visible effects because GrMethodWrapper objects are used as keys in the BoundedLocalCache used by the IconDeferrer implementation.