### PR TITLE
Fix hex color writing consistency

### DIFF
--- a/platform/core-api/src/com/intellij/openapi/editor/markup/AttributesFlyweight.java
+++ b/platform/core-api/src/com/intellij/openapi/editor/markup/AttributesFlyweight.java
@@ -153,7 +153,7 @@ public final class AttributesFlyweight {
 
   private static void writeColor(@NotNull Element element, @NotNull String fieldName, Color color) {
     if (color != null) {
-      String string = Integer.toString(color.getRGB() & 0xFFFFFF, 16);
+      String string = String.format("%06x", 0xFFFFFF & color.getRGB());
       JDOMExternalizerUtil.writeField(element, fieldName, string);
     }
   }

--- a/platform/editor-ui-ex/src/com/intellij/openapi/editor/colors/impl/AbstractColorsScheme.java
+++ b/platform/editor-ui-ex/src/com/intellij/openapi/editor/colors/impl/AbstractColorsScheme.java
@@ -753,9 +753,9 @@ public abstract class AbstractColorsScheme extends EditorFontCacheImpl implement
 
     String rgb = "";
     if (color != NULL_COLOR_MARKER) {
-      rgb = Integer.toString(0xFFFFFF & color.getRGB(), 16);
+      rgb = String.format("%06x", 0xFFFFFF & color.getRGB());
       int alpha = 0xFF & color.getAlpha();
-      if (alpha != 0xFF) rgb += Integer.toString(alpha, 16);
+      if (alpha != 0xFF) rgb += String.format("%02x", alpha);
     }
     JdomKt.addOptionTag(colorElements, key.getExternalName(), rgb);
   }


### PR DESCRIPTION
Fix that color is always written as a hexadecimal of size 6(8). 
Especially necessary for something like Color(0, 0, 11, 179), which used to be written as "bb3"