### PR TITLE
Rename RegistryKey about Kotlin not configured notification

### DIFF
--- a/plugins/kotlin/jvm/resources/META-INF/jvm-k1.xml
+++ b/plugins/kotlin/jvm/resources/META-INF/jvm-k1.xml
@@ -96,6 +96,10 @@
                    description="Enable bytecode instrumentation for Kotlin classes"
                    defaultValue="false"
                    restartRequired="false"/>
+
+      <registryKey key="kotlin.not.configured.show.notification"
+                   defaultValue="true"
+                   description="Show notification about Kotlin missing configuration"/>
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.uast">

--- a/plugins/kotlin/project-configuration/src/org/jetbrains/kotlin/idea/configuration/KotlinSetupEnvironmentNotificationProvider.kt
+++ b/plugins/kotlin/project-configuration/src/org/jetbrains/kotlin/idea/configuration/KotlinSetupEnvironmentNotificationProvider.kt
@@ -41,7 +41,7 @@ import javax.swing.JComponent
 // Code is partially copied from com.intellij.codeInsight.daemon.impl.SetupSDKNotificationProvider
 class KotlinSetupEnvironmentNotificationProvider : EditorNotificationProvider {
     override fun collectNotificationData(project: Project, file: VirtualFile): Function<in FileEditor, out JComponent?>? {
-        if (!Registry.`is`("unknown.sdk.show.editor.actions")) {
+        if (!Registry.`is`("kotlin.not.configured.show.notification")) {
             return null
         }
 


### PR DESCRIPTION
The `unknown.sdk.show.editor.actions` RegistryKey is already in use for `UnknownSdkEditorNotification`. For this reason a dedicated key was created for the `KotlinSetupEnvironmentNotificationProvider` to allow disabling them separately since those are not related