### PR TITLE
[kotlin] Drop inline suffixes from spilled variables

### DIFF
--- a/plugins/kotlin/jvm-debugger/coroutines/src/org/jetbrains/kotlin/idea/debugger/coroutine/proxy/ContinuationHolder.kt
+++ b/plugins/kotlin/jvm-debugger/coroutines/src/org/jetbrains/kotlin/idea/debugger/coroutine/proxy/ContinuationHolder.kt
@@ -5,6 +5,7 @@ package org.jetbrains.kotlin.idea.debugger.coroutine.proxy
 import com.intellij.debugger.engine.JavaValue
 import com.sun.jdi.ObjectReference
 import com.sun.jdi.VMDisconnectedException
+import org.jetbrains.kotlin.idea.debugger.base.util.dropInlineSuffix
 import org.jetbrains.kotlin.idea.debugger.coroutine.data.*
 import org.jetbrains.kotlin.idea.debugger.coroutine.proxy.mirror.*
 import org.jetbrains.kotlin.idea.debugger.coroutine.util.isAbstractCoroutine
@@ -121,7 +122,7 @@ fun FieldVariable.toJavaValue(continuation: ObjectReference, context: DefaultExe
         context,
         continuation,
         fieldName,
-        variableName
+        dropInlineSuffix(variableName)
     )
     return JavaValue.create(
         null,

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinVariablePrintingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK1CodeKotlinVariablePrintingTestGenerated.java
@@ -62,4 +62,9 @@ public class K2IdeK1CodeKotlinVariablePrintingTestGenerated extends AbstractK2Id
     public void testReentrantInlineFunctions() throws Exception {
         runTest("../testData/variables/reentrantInlineFunctions.kt");
     }
+
+    @TestMetadata("spilledCapturedVariables.kt")
+    public void testSpilledCapturedVariables() throws Exception {
+        runTest("../testData/variables/spilledCapturedVariables.kt");
+    }
 }

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK2CodeKotlinVariablePrintingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK2CodeKotlinVariablePrintingTestGenerated.java
@@ -62,4 +62,9 @@ public class K2IdeK2CodeKotlinVariablePrintingTestGenerated extends AbstractK2Id
     public void testReentrantInlineFunctions() throws Exception {
         runTest("../testData/variables/reentrantInlineFunctions.kt");
     }
+
+    @TestMetadata("spilledCapturedVariables.kt")
+    public void testSpilledCapturedVariables() throws Exception {
+        runTest("../testData/variables/spilledCapturedVariables.kt");
+    }
 }

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinVariablePrintingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinVariablePrintingTestGenerated.java
@@ -62,4 +62,9 @@ public class K1IdeK2CodeKotlinVariablePrintingTestGenerated extends AbstractK1Id
     public void testReentrantInlineFunctions() throws Exception {
         runTest("testData/variables/reentrantInlineFunctions.kt");
     }
+
+    @TestMetadata("spilledCapturedVariables.kt")
+    public void testSpilledCapturedVariables() throws Exception {
+        runTest("testData/variables/spilledCapturedVariables.kt");
+    }
 }

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinVariablePrintingTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/KotlinVariablePrintingTestGenerated.java
@@ -62,4 +62,9 @@ public class KotlinVariablePrintingTestGenerated extends AbstractKotlinVariableP
     public void testReentrantInlineFunctions() throws Exception {
         runTest("testData/variables/reentrantInlineFunctions.kt");
     }
+
+    @TestMetadata("spilledCapturedVariables.kt")
+    public void testSpilledCapturedVariables() throws Exception {
+        runTest("testData/variables/spilledCapturedVariables.kt");
+    }
 }

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesInSuspendInline.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesInSuspendInline.out
@@ -14,7 +14,6 @@ CoroutinePreflightFrame invokeSuspend (optimisedVariablesInSuspendInline.kt:14)
 optimisedVariablesInSuspendInline.kt:17
 CoroutinePreflightFrame invokeSuspend (optimisedVariablesInSuspendInline.kt:17)
     JavaValue[local] a: java.lang.String = a (optimisedVariablesInSuspendInline.kt:9)
-    JavaValue[continuation] a$iv = a
     DummyMessageValueNode = 'b' was optimised out
 optimisedVariablesInSuspendInline.kt:19
 CoroutinePreflightFrame invokeSuspend (optimisedVariablesInSuspendInline.kt:19)

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/spilledCapturedVariables.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/spilledCapturedVariables.kt
@@ -1,0 +1,33 @@
+package spilledCapturedVariables
+
+// ATTACH_LIBRARY: maven(org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2)
+// SHOW_KOTLIN_VARIABLES
+
+import kotlinx.coroutines.runBlocking
+
+class A {
+    suspend inline fun foo() {
+        val x = 1
+        inlineBlock {
+            val y = 1
+            inlineBlock {
+                val z = 1
+                //Breakpoint!
+                suspendUse(z)
+            }
+            //Breakpoint!
+            suspendUse(y)
+        }
+        //Breakpoint!
+        suspendUse(x)
+    }
+}
+
+fun main() = runBlocking {
+    A().foo()
+}
+
+suspend fun suspendUse(value: Any) {
+}
+
+inline fun inlineBlock(block: () -> Unit) = block()

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/spilledCapturedVariables.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/spilledCapturedVariables.out
@@ -1,0 +1,23 @@
+LineBreakpoint created at spilledCapturedVariables.kt:16
+LineBreakpoint created at spilledCapturedVariables.kt:19
+LineBreakpoint created at spilledCapturedVariables.kt:22
+Run Java
+Connected to the target VM
+spilledCapturedVariables.kt:16
+CoroutinePreflightFrame invokeSuspend (spilledCapturedVariables.kt:16)
+    JavaValue[local] x: int = 1 (spilledCapturedVariables.kt:10)
+    JavaValue[local] y: int = 1 (spilledCapturedVariables.kt:12)
+    JavaValue[local] z: int = 1 (spilledCapturedVariables.kt:14)
+spilledCapturedVariables.kt:19
+CoroutinePreflightFrame invokeSuspend (spilledCapturedVariables.kt:19)
+    JavaValue[local] y: int = 1 (spilledCapturedVariables.kt:12)
+    JavaValue[local] x: int = 1 (spilledCapturedVariables.kt:10)
+    DummyMessageValueNode = 'z' was optimised out
+spilledCapturedVariables.kt:22
+CoroutinePreflightFrame invokeSuspend (spilledCapturedVariables.kt:22)
+    JavaValue[local] x: int = 1 (spilledCapturedVariables.kt:10)
+    DummyMessageValueNode = 'y' was optimised out
+    DummyMessageValueNode = 'z' was optimised out
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/KTIJ-26894/Debugger-Spilled-variables-duplicate-existing-ones-in-coroutine-frames