### PR TITLE
Don't show messages about optimised variables from inline blocks

### DIFF
--- a/plugins/kotlin/jvm-debugger/coroutines/src/org/jetbrains/kotlin/idea/debugger/coroutine/KotlinVariableNameFinder.kt
+++ b/plugins/kotlin/jvm-debugger/coroutines/src/org/jetbrains/kotlin/idea/debugger/coroutine/KotlinVariableNameFinder.kt
@@ -64,7 +64,7 @@ internal class KotlinVariableNameFinder(val debugProcess: DebugProcessImpl) {
             var stopTraversal = false
 
             override fun visitBlockExpression(expression: KtBlockExpression) {
-                if (isInlined(expression) || expression in blocksToVisit) {
+                if (expression in blocksToVisit) {
                     expression.acceptChildren(this)
                 }
             }

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesInSuspendInline.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesInSuspendInline.out
@@ -14,11 +14,9 @@ CoroutinePreflightFrame invokeSuspend (optimisedVariablesInSuspendInline.kt:14)
 optimisedVariablesInSuspendInline.kt:17
 CoroutinePreflightFrame invokeSuspend (optimisedVariablesInSuspendInline.kt:17)
     JavaValue[local] a: java.lang.String = a (optimisedVariablesInSuspendInline.kt:9)
-    DummyMessageValueNode = 'b' was optimised out
 optimisedVariablesInSuspendInline.kt:19
 CoroutinePreflightFrame invokeSuspend (optimisedVariablesInSuspendInline.kt:19)
     DummyMessageValueNode = 'a' was optimised out
-    DummyMessageValueNode = 'b' was optimised out
 Disconnected from the target VM
 
 Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesWithLambdas.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesWithLambdas.out
@@ -88,7 +88,6 @@ CoroutinePreflightFrame foo (optimisedVariablesWithLambdas.kt:58)
     JavaValue[local] j: java.lang.String = j (optimisedVariablesWithLambdas.kt:56)
     DummyMessageValueNode = 'b' was optimised out
     DummyMessageValueNode = 'g' was optimised out
-    DummyMessageValueNode = 'i' was optimised out
     DummyMessageValueNode = 'param1' was optimised out
     DummyMessageValueNode = 'param2' was optimised out
     DummyMessageValueNode = 'param3' was optimised out
@@ -100,9 +99,6 @@ CoroutinePreflightFrame foo (optimisedVariablesWithLambdas.kt:70)
     JavaValue[local] result = null
     DummyMessageValueNode = 'a' was optimised out
     DummyMessageValueNode = 'b' was optimised out
-    DummyMessageValueNode = 'g' was optimised out
-    DummyMessageValueNode = 'i' was optimised out
-    DummyMessageValueNode = 'j' was optimised out
     DummyMessageValueNode = 'param1' was optimised out
     DummyMessageValueNode = 'param2' was optimised out
     DummyMessageValueNode = 'param3' was optimised out
@@ -111,9 +107,6 @@ CoroutinePreflightFrame foo (optimisedVariablesWithLambdas.kt:72)
     JavaValue[local] result = null
     DummyMessageValueNode = 'a' was optimised out
     DummyMessageValueNode = 'b' was optimised out
-    DummyMessageValueNode = 'g' was optimised out
-    DummyMessageValueNode = 'i' was optimised out
-    DummyMessageValueNode = 'j' was optimised out
     DummyMessageValueNode = 'param1' was optimised out
     DummyMessageValueNode = 'param2' was optimised out
     DummyMessageValueNode = 'param3' was optimised out

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesWithWhen.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/optimisedVariablesWithWhen.out
@@ -42,7 +42,6 @@ CoroutinePreflightFrame foo (optimisedVariablesWithWhen.kt:32)
     JavaValue[local] f: java.lang.String = f (optimisedVariablesWithWhen.kt:28)
     JavaValue[local] g: java.lang.String = g (optimisedVariablesWithWhen.kt:30)
     DummyMessageValueNode = 'c' was optimised out
-    DummyMessageValueNode = 'e' was optimised out
 optimisedVariablesWithWhen.kt:36
 KotlinStackFrame (optimisedVariablesWithWhen.kt:36)
     JavaValue[local] h: java.lang.String = h (optimisedVariablesWithWhen.kt:34)
@@ -54,7 +53,6 @@ CoroutinePreflightFrame foo (optimisedVariablesWithWhen.kt:42)
     JavaValue[local] a: java.lang.String = a (optimisedVariablesWithWhen.kt:9)
     JavaValue[local] i: java.lang.String = i (optimisedVariablesWithWhen.kt:40)
     DummyMessageValueNode = 'c' was optimised out
-    DummyMessageValueNode = 'e' was optimised out
     DummyMessageValueNode = 'g' was optimised out
 optimisedVariablesWithWhen.kt:47
 CoroutinePreflightFrame foo (optimisedVariablesWithWhen.kt:47)
@@ -62,10 +60,8 @@ CoroutinePreflightFrame foo (optimisedVariablesWithWhen.kt:47)
     JavaValue[local] b: java.lang.String = b (optimisedVariablesWithWhen.kt:11)
     JavaValue[local] a: java.lang.String = a (optimisedVariablesWithWhen.kt:9)
     DummyMessageValueNode = 'c' was optimised out
-    DummyMessageValueNode = 'e' was optimised out
     DummyMessageValueNode = 'f' was optimised out
     DummyMessageValueNode = 'g' was optimised out
-    DummyMessageValueNode = 'i' was optimised out
 optimisedVariablesWithWhen.kt:55
 CoroutinePreflightFrame foo$foo (optimisedVariablesWithWhen.kt:55)
     JavaValue[local] result = null
@@ -86,7 +82,6 @@ CoroutinePreflightFrame foo (optimisedVariablesWithWhen.kt:66)
     JavaValue[local] a: java.lang.String = a (optimisedVariablesWithWhen.kt:9)
     DummyMessageValueNode = 'b' was optimised out
     DummyMessageValueNode = 'c' was optimised out
-    DummyMessageValueNode = 'e' was optimised out
 optimisedVariablesWithWhen.kt:72
 CoroutinePreflightFrame foo (optimisedVariablesWithWhen.kt:72)
     JavaValue[local] result = null

--- a/plugins/kotlin/jvm-debugger/test/testData/variables/spilledCapturedVariables.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/variables/spilledCapturedVariables.out
@@ -12,12 +12,9 @@ spilledCapturedVariables.kt:19
 CoroutinePreflightFrame invokeSuspend (spilledCapturedVariables.kt:19)
     JavaValue[local] y: int = 1 (spilledCapturedVariables.kt:12)
     JavaValue[local] x: int = 1 (spilledCapturedVariables.kt:10)
-    DummyMessageValueNode = 'z' was optimised out
 spilledCapturedVariables.kt:22
 CoroutinePreflightFrame invokeSuspend (spilledCapturedVariables.kt:22)
     JavaValue[local] x: int = 1 (spilledCapturedVariables.kt:10)
-    DummyMessageValueNode = 'y' was optimised out
-    DummyMessageValueNode = 'z' was optimised out
 Disconnected from the target VM
 
 Process finished with exit code 0


### PR DESCRIPTION
Related issue: https://youtrack.jetbrains.com/issue/IDEA-331620/Kotlin-debugger-out-of-scope-variables-are-shown-as-optimised-out