### PR TITLE
fix BooleanParameterInspection considering all methods as public in interfaces

### DIFF
--- a/java/java-analysis-impl/src/com/siyeh/ig/abstraction/BooleanParameterInspection.java
+++ b/java/java-analysis-impl/src/com/siyeh/ig/abstraction/BooleanParameterInspection.java
@@ -70,10 +70,7 @@ public class BooleanParameterInspection extends BaseInspection {
     public void visitMethod(@NotNull PsiMethod method) {
       super.visitMethod(method);
       if (!method.hasModifierProperty(PsiModifier.PUBLIC)) {
-        final PsiClass aClass = method.getContainingClass();
-        if (aClass == null || !aClass.isInterface()) {
-          return;
-        }
+        return;
       }
       if (PropertyUtilBase.isSimplePropertySetter(method) || LibraryUtil.isOverrideOfLibraryMethod(method)) {
         return;

--- a/java/java-tests/testSrc/com/siyeh/ig/abstraction/BooleanParameterInspectionTest.java
+++ b/java/java-tests/testSrc/com/siyeh/ig/abstraction/BooleanParameterInspectionTest.java
@@ -55,6 +55,18 @@ public class BooleanParameterInspectionTest extends LightJavaInspectionTestCase 
            "}");
   }
 
+  public void testInterfaceMethods() {
+    doTest(
+      """
+          interface I {
+            private boolean check(boolean b) { return !b; }
+            private static boolean check2(boolean b) { return !b; }
+            boolean /*'public' method 'check3()' with 'boolean' parameter*/check3/**/(boolean b);
+          }
+          """
+    );
+  }
+
   @Override
   protected LocalInspectionTool getInspection() {
     return new BooleanParameterInspection();


### PR DESCRIPTION
The inspection previously checked if the `public` modifier is absent, in which case it considered the method to be public if the enclosing class is an interface. However, this ignores `private` methods.

As a fix, I propose to cover the cases of `private` and `protected` methods more explicitly to make the intentions clear.

I also added a testcase that failed without the changes but succeeds now.