### PR TITLE
Improve docstring on `@ApiStatus.Internal` annotated `RunManager#isTemplate`

### DIFF
--- a/platform/execution/src/com/intellij/execution/RunManager.kt
+++ b/platform/execution/src/com/intellij/execution/RunManager.kt
@@ -245,8 +245,17 @@ abstract class RunManager {
 
   abstract fun setTemporaryConfiguration(tempConfiguration: RunnerAndConfigurationSettings?)
 
-  // due to historical reasons findSettings() searches by name in addition to instance and this behavior is bad for isTemplate,
-  // so, client cannot for now use `findSettings()?.isTemplate() ?: false`.
+  /**
+   * Returns true if the provided configuration settings object represents a template used to create other configurations
+   * of the same type.
+   *
+   * Plugins should use `RunManager#findSettings()?.isTemplate() ?: false`.
+   * 
+   * Due to historical reasons, `findSettings()` searches by name in addition to instance and this behavior is bad for `isTemplate`,
+   * so, for now, the client uses this instead.
+   * 
+   * @return `true` if the configuration is a template, `false` otherwise.
+   */
   @ApiStatus.Internal
   abstract fun isTemplate(configuration: RunConfiguration): Boolean
 }


### PR DESCRIPTION
Previous comment lines did not make it obvious that `findSettings()?.isTemplate() ?: false` is the intended syntax for plugins to use. 