### PR TITLE
IDEA-333389 Dependency Analyzer does not request focus while its window is inactive

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/DependencyAnalyzerManager.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/DependencyAnalyzerManager.kt
@@ -23,9 +23,7 @@ class DependencyAnalyzerManager(private val project: Project) {
         }
       }
     }
-    if (file.getViews().isEmpty()) {
-      fileEditorManager.openFile(file, true)
-    }
+    fileEditorManager.openFile(file, true, true)
     return requireNotNull(file.getViews().firstOrNull()) {
       "DependencyAnalyzerView should be created during file open"
     }


### PR DESCRIPTION
IDEA YouTrack issue created: [IDEA-333389](https://youtrack.jetbrains.com/issue/IDEA-333389)