### PR TITLE
fix: forward mouseClicked() to correct delegate method (IDEA-333538)

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/hints/presentation/ScaleAwarePresentationFactory.kt
+++ b/platform/lang-impl/src/com/intellij/codeInsight/hints/presentation/ScaleAwarePresentationFactory.kt
@@ -125,7 +125,7 @@ abstract class ScaledDelegatedPresentation : BasePresentation() {
   }
 
   override fun mouseClicked(event: MouseEvent, translated: Point) {
-    delegate.mouseExited()
+    delegate.mouseClicked(event, translated)
   }
 
   override fun mouseMoved(event: MouseEvent, translated: Point) {


### PR DESCRIPTION
Fixes the issue reported in https://youtrack.jetbrains.com/issue/IDEA-333538/ScaledDelegatedPresentation-does-not-forward-mouse-clicks