### PR TITLE
Collaboration wrong focus TokenLoginDialog and GitLab wrong isDefault condition

### DIFF
--- a/platform/collaboration-tools/src/com/intellij/collaboration/auth/ui/login/TokenLoginDialog.kt
+++ b/platform/collaboration-tools/src/com/intellij/collaboration/auth/ui/login/TokenLoginDialog.kt
@@ -64,8 +64,12 @@ class TokenLoginDialog(
     return null
   }
 
-  override fun getPreferredFocusedComponent(): JComponent? {
-    val focusManager = IdeFocusManager.findInstanceByComponent(contentPanel)
-    return focusManager.getFocusTargetFor(contentPanel)
-  }
+  /**
+   * This change the focus to the first focusable component in the dialog, while the focus should be on the Password text field
+   * when this code is running the focus is on the server text field even though the password text field request focus.
+   */
+  //override fun getPreferredFocusedComponent(): JComponent? {
+  //  val focusManager = IdeFocusManager.findInstanceByComponent(contentPanel)
+  //  return focusManager.getFocusTargetFor(contentPanel)
+  //}
 }

--- a/platform/collaboration-tools/src/com/intellij/collaboration/auth/ui/login/TokenLoginInputPanelFactory.kt
+++ b/platform/collaboration-tools/src/com/intellij/collaboration/auth/ui/login/TokenLoginInputPanelFactory.kt
@@ -6,7 +6,6 @@ import com.intellij.collaboration.ui.SingleValueModel
 import com.intellij.collaboration.util.URIUtil
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.util.NlsContexts
-import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.ui.AnimatedIcon
 import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.components.fields.ExtendableTextComponent
@@ -64,7 +63,7 @@ class TokenLoginInputPanelFactory(
           }
       }
       row(CollaborationToolsBundle.message("login.field.token")) {
-        val tokenField = passwordField()
+        passwordField()
           .bindText(model::token)
           .align(AlignX.FILL)
           .resizableColumn()
@@ -80,12 +79,10 @@ class TokenLoginInputPanelFactory(
           .apply {
             onReset { component.text = "" }
           }
-          .component
 
         if (model is LoginTokenGenerator) {
           button(CollaborationToolsBundle.message("login.token.generate")) {
             model.generateToken(serverTextField.text)
-            IdeFocusManager.findInstanceByComponent(tokenField).requestFocus(tokenField, false)
           }.enabledIf(TokenGeneratorPredicate(model, serverTextField))
         }
       }

--- a/plugins/gitlab/src/org/jetbrains/plugins/gitlab/api/GitLabServerPath.kt
+++ b/plugins/gitlab/src/org/jetbrains/plugins/gitlab/api/GitLabServerPath.kt
@@ -34,8 +34,13 @@ class GitLabServerPath : ServerPath {
   val restApiUri: URI
     get() = toURI().resolveRelative("api/v4/")
 
+  /**
+   * I think the first part of this condition was wrong and always false - since the default String uri is always https://gitlab.com and so it's
+   *  never start with gitlab.com
+   *
+   */
   val isDefault: Boolean
-    get() = uri.startsWith("gitlab.com", true) || uri.contains("/gitlab.com", true)
+    get() = uri.startsWith("https://gitlab.com", true) || uri.contains("/gitlab.com", true)
 
   fun toURL(): URL = URL("$uri/")
 


### PR DESCRIPTION
### Summary:
This Pull Request addresses two minor issues within the collaboration module and the GitLab plugin.

### Details:

##### Issue 1:
When users click the "Log In" button, the focus is incorrectly set to the server instead of the token, as illustrated in the attached screenshot.

![image](https://github.com/JetBrains/intellij-community/assets/3816566/72a54107-3296-48fd-a572-ab7ab626c6fe)

##### Issue 2:
There seems to be an incorrect condition checking whether the GitLab server is the default one.

