### PR TITLE
IDEA-333730: Persist compiler plugins model in data nodes

### DIFF
--- a/plugins/kotlin/compiler-plugins/allopen/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/allopen/gradleJava/AllOpenProjectResolverExtension.kt
+++ b/plugins/kotlin/compiler-plugins/allopen/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/allopen/gradleJava/AllOpenProjectResolverExtension.kt
@@ -2,13 +2,13 @@
 
 package org.jetbrains.kotlin.idea.compilerPlugin.allopen.gradleJava
 
-import com.intellij.openapi.util.Key
+import com.intellij.openapi.externalSystem.model.Key
 import org.jetbrains.kotlin.idea.gradleTooling.model.allopen.AllOpenModel
 import org.jetbrains.kotlin.idea.gradleJava.compilerPlugin.AnnotationBasedPluginProjectResolverExtension
 
 class AllOpenProjectResolverExtension : AnnotationBasedPluginProjectResolverExtension<AllOpenModel>() {
     companion object {
-        val KEY = Key<AllOpenModel>("AllOpenModel")
+        val KEY = Key.create(AllOpenModel::class.java, 1)
     }
 
     override val modelClass get() = AllOpenModel::class.java

--- a/plugins/kotlin/compiler-plugins/assignment/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/assignment/gradleJava/AssignmentProjectResolverExtension.kt
+++ b/plugins/kotlin/compiler-plugins/assignment/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/assignment/gradleJava/AssignmentProjectResolverExtension.kt
@@ -5,13 +5,13 @@
 
 package org.jetbrains.kotlin.idea.compilerPlugin.assignment.gradleJava
 
-import com.intellij.openapi.util.Key
+import com.intellij.openapi.externalSystem.model.Key
 import org.jetbrains.kotlin.idea.gradleJava.compilerPlugin.AnnotationBasedPluginProjectResolverExtension
 import org.jetbrains.kotlin.idea.gradleTooling.model.assignment.AssignmentModel
 
 class AssignmentProjectResolverExtension : AnnotationBasedPluginProjectResolverExtension<AssignmentModel>() {
     companion object {
-        val KEY = Key<AssignmentModel>("AssignmentModel")
+        val KEY = Key.create(AssignmentModel::class.java, 1)
     }
 
     override val modelClass get() = AssignmentModel::class.java

--- a/plugins/kotlin/compiler-plugins/compiler-plugin-support/gradle/src/org/jetbrains/kotlin/idea/gradleJava/compilerPlugin/AbstractCompilerPluginGradleImportHandler.kt
+++ b/plugins/kotlin/compiler-plugins/compiler-plugin-support/gradle/src/org/jetbrains/kotlin/idea/gradleJava/compilerPlugin/AbstractCompilerPluginGradleImportHandler.kt
@@ -3,10 +3,10 @@
 package org.jetbrains.kotlin.idea.gradleJava.compilerPlugin
 
 import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.Key
 import com.intellij.openapi.externalSystem.model.ProjectKeys
 import com.intellij.openapi.externalSystem.model.project.ModuleData
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
-import com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.idea.compilerPlugin.CompilerPluginSetup.PluginOption
 import org.jetbrains.kotlin.idea.gradleTooling.model.annotation.AnnotationBasedPluginModel
 import org.jetbrains.kotlin.idea.compilerPlugin.CompilerPluginSetup
@@ -57,7 +57,8 @@ abstract class AbstractCompilerPluginGradleImportHandler<T> : GradleProjectImpor
     protected open fun getOptions(model: T): List<PluginOption> = emptyList()
 
     private fun getPluginSetupByModule(moduleNode: DataNode<ModuleData>): CompilerPluginSetup? {
-        val model = moduleNode.getCopyableUserData(modelKey)?.takeIf { isEnabled(it) } ?: return null
+        val modelNode = ExternalSystemApiUtil.find(moduleNode, modelKey)?: return null
+        val model = modelNode.data.takeIf { isEnabled(it) } ?: return null
         val options = getOptions(model)
 
         // For now we can't use plugins from Gradle cause they're shaded and may have an incompatible version.

--- a/plugins/kotlin/compiler-plugins/compiler-plugin-support/gradle/src/org/jetbrains/kotlin/idea/gradleJava/compilerPlugin/AnnotationBasedPluginProjectResolverExtension.kt
+++ b/plugins/kotlin/compiler-plugins/compiler-plugin-support/gradle/src/org/jetbrains/kotlin/idea/gradleJava/compilerPlugin/AnnotationBasedPluginProjectResolverExtension.kt
@@ -4,8 +4,8 @@ package org.jetbrains.kotlin.idea.gradleJava.compilerPlugin
 
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.Key
 import com.intellij.openapi.externalSystem.model.project.ModuleData
-import com.intellij.openapi.util.Key
 import org.gradle.tooling.model.idea.IdeaModule
 import org.jetbrains.kotlin.idea.gradleTooling.model.annotation.AnnotationBasedPluginModel
 import org.jetbrains.plugins.gradle.service.project.AbstractProjectResolverExtension
@@ -34,7 +34,7 @@ abstract class AnnotationBasedPluginProjectResolverExtension<T : AnnotationBased
             @Suppress("UNCHECKED_CAST")
             val refurbishedModel = Class.forName(className).constructors.single().newInstance(*args) as T
 
-            ideModule.putCopyableUserData(userDataKey, refurbishedModel)
+            ideModule.createChild(userDataKey, refurbishedModel)
         }
 
         super.populateModuleExtraModels(gradleModule, ideModule)

--- a/plugins/kotlin/compiler-plugins/noarg/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/noarg/gradleJava/NoArgProjectResolverExtension.kt
+++ b/plugins/kotlin/compiler-plugins/noarg/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/noarg/gradleJava/NoArgProjectResolverExtension.kt
@@ -2,13 +2,13 @@
 
 package org.jetbrains.kotlin.idea.compilerPlugin.noarg.gradleJava
 
-import com.intellij.openapi.util.Key
+import com.intellij.openapi.externalSystem.model.Key
 import org.jetbrains.kotlin.idea.gradleJava.compilerPlugin.AnnotationBasedPluginProjectResolverExtension
 import org.jetbrains.kotlin.idea.gradleTooling.model.noarg.NoArgModel
 
 class NoArgProjectResolverExtension : AnnotationBasedPluginProjectResolverExtension<NoArgModel>() {
     companion object {
-        val KEY = Key<NoArgModel>("NoArgModel")
+        val KEY = Key.create(NoArgModel::class.java, 1)
     }
 
     override val modelClass get() = NoArgModel::class.java

--- a/plugins/kotlin/compiler-plugins/sam-with-receiver/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/samWithReceiver/gradleJava/SamWithReceiverProjectResolverExtension.kt
+++ b/plugins/kotlin/compiler-plugins/sam-with-receiver/gradle/src/org/jetbrains/kotlin/idea/compilerPlugin/samWithReceiver/gradleJava/SamWithReceiverProjectResolverExtension.kt
@@ -2,13 +2,13 @@
 
 package org.jetbrains.kotlin.idea.compilerPlugin.samWithReceiver.gradleJava
 
-import com.intellij.openapi.util.Key
+import com.intellij.openapi.externalSystem.model.Key
 import org.jetbrains.kotlin.idea.gradleJava.compilerPlugin.AnnotationBasedPluginProjectResolverExtension
 import org.jetbrains.kotlin.idea.gradleTooling.model.samWithReceiver.SamWithReceiverModel
 
 class SamWithReceiverProjectResolverExtension : AnnotationBasedPluginProjectResolverExtension<SamWithReceiverModel>() {
     companion object {
-        val KEY = Key<SamWithReceiverModel>("SamWithReceiverModel")
+        val KEY = Key.create(SamWithReceiverModel::class.java, 1)
     }
 
     override val modelClass get() = SamWithReceiverModel::class.java


### PR DESCRIPTION
... to allow data importers to always produce the same result, even if data nodes are retrieved from cache.

Also, variant switching in Android Studio relies on this. It restores data nodes from the cache, to avoid invoking full Gradle sync.