### PR TITLE
Fix handling of line and column in ClassSource and CompositeTestSource.

### DIFF
--- a/platform/platform-tests/testSrc/com/intellij/openapi/editor/DocumentUtilTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/editor/DocumentUtilTest.java
@@ -18,4 +18,15 @@ public class DocumentUtilTest {
     assertEquals(" \t ", DocumentUtil.getIndent(doc, doc.getLineStartOffset(1) + 2).toString());
     assertEquals("", DocumentUtil.getIndent(doc, doc.getLineStartOffset(2)).toString());
   }
+
+  @Test
+  public void calculateOffsetIsZeroBased() {
+    final Document doc = new DocumentImpl("""
+                                            line1
+                                            line2
+                                            """);
+
+    int offset = DocumentUtil.calculateOffset(doc, 0, 0, 0);
+    assertEquals(0, offset);
+  }
 }

--- a/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestExecutionListener.java
+++ b/plugins/junit5_rt/src/com/intellij/junit5/JUnit5TestExecutionListener.java
@@ -25,6 +25,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static com.intellij.rt.execution.TestListenerProtocol.CLASS_CONFIGURATION;
 
@@ -344,20 +345,38 @@ public class JUnit5TestExecutionListener implements TestExecutionListener {
 
   private static String getMetaInfo(TestIdentifier root) {
     return root.getSource()
-      .map(testSource -> {
-        if (testSource instanceof MethodSource) {
-          //noinspection SpellCheckingInspection
-          return " metainfo='" + ((MethodSource)testSource).getMethodParameterTypes() + "'";
-        }
-        if (testSource instanceof ClassSource) {
-          //noinspection SpellCheckingInspection
-          return ((ClassSource)testSource).getPosition()
-            .map(position -> " metainfo='" + position.getLine() + ":" + position.getColumn() + "'")
-            .orElse(NO_LOCATION_HINT);
-        }
-        return NO_LOCATION_HINT;
-      })
+      .flatMap(JUnit5TestExecutionListener::doGetMetaInfo)
       .orElse(NO_LOCATION_HINT);
+  }
+
+  private static Optional<String> doGetMetaInfo(TestSource testSource) {
+    if (testSource instanceof CompositeTestSource) {
+      return ((CompositeTestSource)testSource).getSources()
+        .stream()
+        .map(JUnit5TestExecutionListener::doGetMetaInfo)
+        .flatMap(JUnit5TestExecutionListener::streamOptional)
+        .findFirst();
+    }
+    if (testSource instanceof MethodSource) {
+      //noinspection SpellCheckingInspection
+      return Optional.of(" metainfo='" + ((MethodSource)testSource).getMethodParameterTypes() + "'");
+    }
+    if (testSource instanceof ClassSource) {
+      //noinspection SpellCheckingInspection
+      return ((ClassSource)testSource).getPosition()
+        .map(position -> " metainfo='"
+                         + oneBasedToZeroBased(position.getLine()) + ":"
+                         + oneBasedToZeroBased(position.getColumn().orElse(1)) + "'");
+    }
+    return Optional.empty();
+  }
+
+  private static <T> Stream<T> streamOptional(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<T> optional) {
+    return optional.map(Stream::of).orElseGet(Stream::empty);
+  }
+
+  private static Integer oneBasedToZeroBased(Integer integer) {
+    return integer - 1;
   }
 
   static String getLocationHintValue(TestSource testSource, TestSource parentSource) {


### PR DESCRIPTION
# Description of the issue

I work with a proprietary test library that uses JUnit 5 and sets a `ClassSource` on each `DynamicTest` it creates. But IntelliJ doesn't currently handle tests with an associated `ClassSource` correctly. Instead it fails in one of two ways:
1. If there is a line but no column set on the `ClassSource`, clicking the test's name in the `Run` window simply redirects to the top of the class declaration, instead of the correct line.
2. If there is a column set, IntelliJ fails to read the test results and displays the raw output from `JUnit5TestExecutionListener` (see second screenshot below).

This is because `JUnit5TestExecutionListener` prints the column of the `ClassSource`'s `FilePosition` without unwrapping in from the enclosing `Optional`, resulting in lines that contain output like `metainfo='123:Optional.empty'` in the first case, or `metainfo='123:Optional[456]'` in the second.

The first scenario (no column) fails because `JavaTestLocator` simply ignores the line and column if they can't be parsed into ints. The reason for the more obvious failure in the second case is that the message parser looks for an unescaped `]` to determine the end of a parseable event (`ServiceMessagesParser` line 62). It therefore stops parsing at the `]` in `Optional[456]`, instead of at the end of the test event. This second failure mode logs this:

```
2023-10-08 15:04:56,600 [  92063] SEVERE - #c.i.e.t.s.ServiceMessageUtil - Failed to parse service message
Details: ##teamcity[testStarted id='|[engine:junit-jupiter|]/|[class:com.mikaelfrancoeur.MyTest|]/|[test-factory:bootstrap()|]/|[dynamic-test:#1|]' name='it passes' nodeId='|[engine:junit-jupiter|]/|[class:com.mikaelfrancoeur.MyTest|]/|[test-factory:bootstrap()|]/|[dynamic-test:#1|]' parentNodeId='|[engine:junit-jupiter|]/|[class:com.mikaelfrancoeur.MyTest|]/|[test-factory:bootstrap()|]' locationHint='java:suite://com.mikaelfrancoeur.MyTest' metainfo='11:Optional[456]
testFramework:JUnit
java.text.ParseException: Error while parsing TeamCity service message: Value should end with "'". Valid service message has a form of "##teamcity[messageName name1='escaped_value' name2='escaped_value']" where escaped_value uses substitutions: '->|', [->|[, ]->|], |->||, newline->|n
	at jetbrains.buildServer.messages.serviceMessages.MapSerializerUtil.stringToProperties(MapSerializerUtil.java:134)
	at jetbrains.buildServer.messages.serviceMessages.ServiceMessage.parseAttributes(ServiceMessage.java:237)
	at jetbrains.buildServer.messages.serviceMessages.ServiceMessage.init(ServiceMessage.java:371)
	at jetbrains.buildServer.messages.serviceMessages.ServiceMessagesParser.doParse(ServiceMessagesParser.java:136)
	at jetbrains.buildServer.messages.serviceMessages.ServiceMessagesParser.parse(ServiceMessagesParser.java:54)
	at com.intellij.execution.testframework.sm.ServiceMessageUtil.parse(ServiceMessageUtil.java:33)
        ...
```
## Demonstration of the issue

When the test has a `ClassSource` with no column, the tree displays correctly but you can't click it to navigate to the test sources:

![image](https://github.com/JetBrains/intellij-community/assets/22927506/ed5ceeef-7cef-48f9-a43a-0335434e735e)

When the test has a `ClassSource` with a column:

![image](https://github.com/JetBrains/intellij-community/assets/22927506/fb97a47c-8630-4612-8d57-b000ee8488ab)

# Description of the solution

I solved this by adding unwrapping the `getColumn()` optional with `.orElse(1)` (`JUnit5TestExecutionListener` line 369). I also added a test to cover this and used the opportunity to add coverage to the other `TestSource` subclasses for which location data is emitted by `JUnit5TestExecutionListener` (`FileSource`, `MethodSource`, and `CompositeTestSource`). This revealed an other issue: the `metainfo` of `CompositeTestSource` wasn't being emitted, even though its `locationHint` was being emitted, so I added support for this as well (`JUnit5TestExecutionListener` line 346).

Fixing this also surfaced another bug. JUnit treats its line and column numbers as 1-based (see the `line > 0` and `column > 0` preconditions in `org.junit.platform.engine.support.descriptor.FilePosition`). This is coherent with the `FileUrlProvider` used to handle line numbers for instances of `FileSource` (URIs starting in `file:`). But `JavaTestLocator`, used by IntelliJ for test URIs starting in `java:`, uses the 0-based `OpenFileDescriptor`. This meant that clicking on a test node in the `Run` window would bring you to the line after the test. I fixed this by subtracting 1 from the line and column when the text string is emitted (`JUnit5TestExecutionListener` line 368), to avoid impacting other code paths, since things like breakpoint also used the 0-based behaviour. The method in `DocumentUtil` that was responsible for this 0-based logic wasn't directly tested, so I added a unit test to further document the 0-based behaviour.

# Results

IntelliJ community, test using a `ClassSource` with a column, after this patch (for the "before" version, see above):

![image](https://github.com/JetBrains/intellij-community/assets/22927506/2d5c8981-b0ea-4820-8877-252eb9687165)

Moreover, you can now click on a test node that's using either or a `ClassSource` or an applicable `TestSource` wrapped in `CompositeTestSource`, and it will take you to the correct line. In this case, you can click `it passes`. The contextual menu is also accessible for test nodes, with options to run/debug a certain test.

-----

I'll be happy to address any comments on this PR. N.B. the new test will fail when run from IntelliJ, unless you rename `JUnit5TestExecutionListener` to something like `JUnit5TestExecutionListener2` to avoid java using the bundled class instead.