### PR TITLE
IDEA-334617: Suggest installing Azure plugin for users who have Azure CLI installed

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
@@ -15,6 +15,7 @@ import kotlin.io.path.isRegularFile
 
 internal class EnvironmentDependencyCollector : DependencyCollector {
   private val ALLOWED_EXECUTABLES: List<String> = listOf(
+    "az",
     "docker",
     "kubectl",
     "podman",

--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
@@ -49,7 +49,7 @@ object EnvironmentScanner {
 
   fun hasToolInLocalPath(pathNames: List<Path>, executableWithoutExt: String): Boolean {
     val baseNames = if (SystemInfo.isWindows) {
-      sequenceOf(".bat", ".com", ".exe")
+      sequenceOf(".bat", ".com", ".exe", ".cmd")
         .map { exeSuffix -> executableWithoutExt + exeSuffix }
     }
     else {


### PR DESCRIPTION
### Changes
- Add `az` to the `ALLOWED_EXECUTABLES` in `EnvironmentDependencyCollector`, so that IDEA could detect azure cli installation and recommend Azure plugins

### Todo
Register executable dependencySupport in Azure Toolkit for IntelliJ and Azure Toolkit for Rider
- https://github.com/JetBrains/azure-tools-for-intellij/pull/721
- https://github.com/microsoft/azure-tools-for-java/pull/7933