### PR TITLE
The getPlugins scripts can now accept the --shallow argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and build numbers for older releases of IntelliJ IDEA can be found on the page o
 
 These Git operations can also be done through the [IntelliJ IDEA user interface](https://www.jetbrains.com/help/idea/using-git-integration.html).
 
-_**Speed Tip:**_ If the complete repository history isn't needed then using a shallow clone (`git clone --depth 1`) will save significant time.
+_**Speed Tip:**_ If the complete repository history isn't needed, then using a shallow clone (`git clone --depth 1`) will save significant time.
 
 _**On Windows:**_ Two git options are required to check out sources on Windows. Since it's a common source of Git issues on Windows anyway, those options could be set globally (execute those commands before cloning any of intellij-community/android repositories):
 
@@ -22,7 +22,8 @@ _**On Windows:**_ Two git options are required to check out sources on Windows. 
 * `git config --global core.autocrlf input`
 
 IntelliJ IDEA Community Edition requires additional Android modules from separate Git repositories. To clone these repositories,
-run one of the `getPlugins` scripts located in the `<IDEA_HOME>` directory. These scripts clone their respective *master* branches. Make sure you are inside the `<IDEA_HOME>` directory when running those scripts, so the modules get cloned inside the `<IDEA_HOME>` directory.
+run one of the `getPlugins` scripts located in the `<IDEA_HOME>` directory. Use the `--shallow` argument if the complete repository history isn't needed. 
+These scripts clone their respective *master* branches. Make sure you are inside the `<IDEA_HOME>` directory when running those scripts, so the modules get cloned inside the `<IDEA_HOME>` directory.
 * `getPlugins.sh` for Linux or macOS.
 * `getPlugins.bat` for Windows.
 

--- a/getPlugins.bat
+++ b/getPlugins.bat
@@ -1,1 +1,8 @@
-call git clone git://git.jetbrains.org/idea/android.git android
+@echo off
+
+:ParseArgs
+if "%~1" == "--shallow" (
+    call git clone git://git.jetbrains.org/idea/android.git android --depth 1
+) else (
+    call git clone git://git.jetbrains.org/idea/android.git android
+)

--- a/getPlugins.sh
+++ b/getPlugins.sh
@@ -1,1 +1,7 @@
-git clone git://git.jetbrains.org/idea/android.git android
+#!/bin/bash
+
+if [ "$1" == "--shallow" ]; then
+    git clone git://git.jetbrains.org/idea/android.git android --depth 1
+else
+    git clone git://git.jetbrains.org/idea/android.git android
+fi


### PR DESCRIPTION
When the full repo history of the Android modules is not needed, getPlugins can now be ran with the --shallow argument.