### PR TITLE
IDEA-336443 - Handle scheme- and authority-relative link URLs in external documentation

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
@@ -53,6 +53,25 @@ public class JavaDocExternalFilter extends AbstractExternalFilter {
           if (href.startsWith("#")) {
             return root + href;
           }
+          else if (href.startsWith("//")) {
+            Url rootUrl = Urls.parse(root, false);
+            if (rootUrl == null) return null;
+            String scheme = rootUrl.getScheme();
+            if (scheme == null) return null;
+            String[] parts = href.substring(2).split("/", 2);
+            if (parts.length != 2) return null;
+            Url relativeUrl = Urls.newUrl(scheme, parts[0], parts[1]);
+            return relativeUrl.toString();
+          }
+          else if (href.startsWith("/")) {
+            Url rootUrl = Urls.parse(root, false);
+            if (rootUrl == null) return null;
+            String scheme = rootUrl.getScheme();
+            String authority = rootUrl.getAuthority();
+            if (scheme == null || authority == null) return null;
+            Url relativeUrl = Urls.newUrl(scheme, authority, href);
+            return relativeUrl.toString();
+          }
           else {
             String nakedRoot = ourHtmlFileSuffix.matcher(root).replaceAll("/");
             return doAnnihilate(nakedRoot + href);

--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
@@ -55,20 +55,20 @@ public class JavaDocExternalFilter extends AbstractExternalFilter {
           }
           else if (href.startsWith("//")) {
             Url rootUrl = Urls.parse(root, false);
-            if (rootUrl == null) return null;
+            if (rootUrl == null) return href;
             String scheme = rootUrl.getScheme();
-            if (scheme == null) return null;
+            if (scheme == null) return href;
             String[] parts = href.substring(2).split("/", 2);
-            if (parts.length != 2) return null;
+            if (parts.length != 2) return href;
             Url relativeUrl = Urls.newUrl(scheme, parts[0], parts[1]);
             return relativeUrl.toString();
           }
           else if (href.startsWith("/")) {
             Url rootUrl = Urls.parse(root, false);
-            if (rootUrl == null) return null;
+            if (rootUrl == null) return href;
             String scheme = rootUrl.getScheme();
             String authority = rootUrl.getAuthority();
-            if (scheme == null || authority == null) return null;
+            if (scheme == null || authority == null) return href;
             Url relativeUrl = Urls.newUrl(scheme, authority, href);
             return relativeUrl.toString();
           }

--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
@@ -14,7 +14,6 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.util.Url;
-import com.intellij.util.UrlImpl;
 import com.intellij.util.Urls;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -23,7 +22,6 @@ import org.jetbrains.builtInWebServer.BuiltInServerOptions;
 import org.jetbrains.builtInWebServer.WebServerPathToFileManager;
 
 import java.io.InputStreamReader;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
This change addresses https://youtrack.jetbrains.com/issue/IDEA-336443

When the `href` attribute of an anchor tag starts with a single forward
slash ('/'), this means the link should be relative to the authority
(host + port) of the current page. Similarly, when the `href` attribute
of an anchor tag starts with two forward slashes ('//'), the link should
be relative to the scheme (e.g. https://) of the current page.