### PR TITLE
KTIJ-26237: Don't ever return duplicates of classes

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
@@ -167,7 +167,7 @@ public class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
       }
     }
 
-    return result == null ? Collections.emptyList() : result;
+    return result == null ? Collections.emptyList() : new ArrayList<>(result);
   }
 
   private static Predicate<PsiClass> getFilterFromFinders(@NotNull GlobalSearchScope scope, @NotNull List<? extends PsiElementFinder> finders) {
@@ -273,7 +273,7 @@ public class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
     for (PsiElementFinder finder : finders) {
       PsiClass[] classes = finder.getClasses(psiPackage, scope);
       if (classes.length == 0) continue;
-      if (result == null) result = new LinkedHashSet<>(classes.length);
+      if (result == null) result = new HashSet<>(classes.length);
       filterClassesAndAppend(finder, classesFilter, classes, result);
     }
 

--- a/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
@@ -162,7 +162,7 @@ public class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
     for (PsiElementFinder finder : finders) {
       PsiClass[] finderClasses = finder.findClasses(qualifiedName, scope);
       if (finderClasses.length != 0) {
-        if (result == null) result = new LinkedHashSet<>(finderClasses.length);
+        if (result == null) result = new HashSet<>(finderClasses.length);
         filterClassesAndAppend(finder, classesFilter, finderClasses, result);
       }
     }

--- a/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/JavaPsiFacadeImpl.java
@@ -158,11 +158,11 @@ public class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
     List<PsiElementFinder> finders = filteredFinders();
     Predicate<PsiClass> classesFilter = getFilterFromFinders(scope, finders);
 
-    List<PsiClass> result = null;
+    Set<PsiClass> result = null;
     for (PsiElementFinder finder : finders) {
       PsiClass[] finderClasses = finder.findClasses(qualifiedName, scope);
       if (finderClasses.length != 0) {
-        if (result == null) result = new ArrayList<>(finderClasses.length);
+        if (result == null) result = new LinkedHashSet<>(finderClasses.length);
         filterClassesAndAppend(finder, classesFilter, finderClasses, result);
       }
     }
@@ -269,11 +269,11 @@ public class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
     List<PsiElementFinder> finders = filteredFinders();
     Predicate<PsiClass> classesFilter = getFilterFromFinders(scope, finders);
 
-    List<PsiClass> result = null;
+    Set<PsiClass> result = null;
     for (PsiElementFinder finder : finders) {
       PsiClass[] classes = finder.getClasses(psiPackage, scope);
       if (classes.length == 0) continue;
-      if (result == null) result = new ArrayList<>(classes.length);
+      if (result == null) result = new LinkedHashSet<>(classes.length);
       filterClassesAndAppend(finder, classesFilter, classes, result);
     }
 
@@ -283,7 +283,7 @@ public class JavaPsiFacadeImpl extends JavaPsiFacadeEx {
   private static void filterClassesAndAppend(PsiElementFinder finder,
                                              @Nullable Predicate<? super PsiClass> classesFilter,
                                              PsiClass @NotNull [] classes,
-                                             @NotNull List<? super PsiClass> result) {
+                                             @NotNull Collection<? super PsiClass> result) {
     for (PsiClass psiClass : classes) {
       if (psiClass == null) {
         LOG.error("Finder " + finder + " returned null PsiClass");

--- a/java/java-tests/testSrc/com/intellij/psi/impl/JavaPsiFacadeImplTest.kt
+++ b/java/java-tests/testSrc/com/intellij/psi/impl/JavaPsiFacadeImplTest.kt
@@ -1,0 +1,62 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.psi.impl
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElementFinder
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.impl.file.PsiPackageImpl
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.DisposableRule
+import com.intellij.testFramework.EdtRule
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RunsInEdt
+import com.intellij.testFramework.assertions.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when` as whenever
+
+@RunWith(JUnit4::class)
+class JavaPsiFacadeImplTest {
+  @get:Rule val projectRule = ProjectRule()
+  @get:Rule val disposableRule = DisposableRule()
+  @get:Rule val edtRule = EdtRule()
+
+  private val project by lazy { projectRule.project }
+  @RunsInEdt
+  @Test
+  fun noDuplicates() {
+    val dupePkg = "com.example.duplicates"
+    val psiClass: PsiClass = mock()
+    val pkg: PsiPackage by lazy { PsiPackageImpl(PsiManager.getInstance(project), dupePkg) }
+    val facadeImpl by lazy { JavaPsiFacadeImpl(project) }
+
+    val psiClassName = "$dupePkg.ReturnedClass"
+    whenever(psiClass.name).thenReturn(psiClassName)
+    // Make sure we get dupes from multiple finders.
+    PsiElementFinder.EP.getPoint(project).registerExtension(DupeReturner(pkg, psiClass), disposableRule.disposable)
+    PsiElementFinder.EP.getPoint(project).registerExtension(DupeReturner(pkg, psiClass), disposableRule.disposable)
+
+    val scope = GlobalSearchScope.allScope(project)
+
+    val classes = facadeImpl.getClasses(pkg, scope)
+    assertThat(classes).containsExactly(psiClass)
+  }
+
+  private class DupeReturner(private val pkg: PsiPackage, private val cls: PsiClass) : PsiElementFinder() {
+    override fun findClass(qualifiedName: String, scope: GlobalSearchScope): PsiClass? =
+      cls.takeIf { qualifiedName == it.name }
+
+    override fun findClasses(qualifiedName: String, scope: GlobalSearchScope): Array<PsiClass> =
+      if(qualifiedName == cls.name) arrayOf(cls, cls, cls) else arrayOf()
+
+    override fun getClasses(psiPackage: PsiPackage, scope: GlobalSearchScope): Array<PsiClass> =
+      if (psiPackage == pkg) arrayOf(cls, cls, cls) else arrayOf()
+
+    override fun getClassNames(psiPackage: PsiPackage, scope: GlobalSearchScope): Set<String> =
+      if (psiPackage == pkg) setOf(checkNotNull(cls.name)) else setOf()
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/psi/impl/JavaPsiFacadeImplTest.kt
+++ b/java/java-tests/testSrc/com/intellij/psi/impl/JavaPsiFacadeImplTest.kt
@@ -31,8 +31,8 @@ class JavaPsiFacadeImplTest {
   fun noDuplicates() {
     val dupePkg = "com.example.duplicates"
     val psiClass: PsiClass = mock()
-    val pkg: PsiPackage by lazy { PsiPackageImpl(PsiManager.getInstance(project), dupePkg) }
-    val facadeImpl by lazy { JavaPsiFacadeImpl(project) }
+    val pkg: PsiPackage = PsiPackageImpl(PsiManager.getInstance(project), dupePkg)
+    val facadeImpl = JavaPsiFacadeImpl(project)
 
     val psiClassName = "$dupePkg.ReturnedClass"
     whenever(psiClass.name).thenReturn(psiClassName)

--- a/java/java-tests/testSrc/com/intellij/psi/impl/JavaPsiFacadeImplTest.kt
+++ b/java/java-tests/testSrc/com/intellij/psi/impl/JavaPsiFacadeImplTest.kt
@@ -26,23 +26,22 @@ class JavaPsiFacadeImplTest {
   @get:Rule val edtRule = EdtRule()
 
   private val project by lazy { projectRule.project }
+
   @RunsInEdt
   @Test
   fun noDuplicates() {
     val dupePkg = "com.example.duplicates"
     val psiClass: PsiClass = mock()
+    whenever(psiClass.name).thenReturn("$dupePkg.ReturnedClass")
     val pkg: PsiPackage = PsiPackageImpl(PsiManager.getInstance(project), dupePkg)
-    val facadeImpl = JavaPsiFacadeImpl(project)
 
-    val psiClassName = "$dupePkg.ReturnedClass"
-    whenever(psiClass.name).thenReturn(psiClassName)
     // Make sure we get dupes from multiple finders.
     PsiElementFinder.EP.getPoint(project).registerExtension(DupeReturner(pkg, psiClass), disposableRule.disposable)
     PsiElementFinder.EP.getPoint(project).registerExtension(DupeReturner(pkg, psiClass), disposableRule.disposable)
-
     val scope = GlobalSearchScope.allScope(project)
 
-    val classes = facadeImpl.getClasses(pkg, scope)
+    val classes = JavaPsiFacadeImpl(project).getClasses(pkg, scope)
+
     assertThat(classes).containsExactly(psiClass)
   }
 

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/quickDoc/PackageQuickDocTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/editor/quickDoc/PackageQuickDocTest.kt
@@ -1,0 +1,29 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.editor.quickDoc
+
+import com.intellij.codeInsight.javadoc.JavaDocInfoGenerator
+import com.intellij.psi.PsiPackage
+import org.jetbrains.kotlin.idea.test.KotlinLightCodeInsightFixtureTestCase
+import org.junit.Assert
+
+class PackageQuickDocTest: KotlinLightCodeInsightFixtureTestCase() {
+    fun testNoDuplicates() {
+        val psiFile = myFixture.addFileToProject(
+            "com/example/nodupes/Fantastic.kt", """
+            package com.example.nod<caret>upes
+            class Fantastic
+        """.trimIndent()
+        )
+        myFixture.configureFromExistingVirtualFile(psiFile.virtualFile)
+
+        val psiPackage = myFixture.elementAtCaret as PsiPackage
+
+        val stringBuilder = StringBuilder()
+        JavaDocInfoGenerator(myFixture.project, psiPackage).generateDocInfoCore(stringBuilder, false)
+        val html = stringBuilder.toString()
+
+        val hrefPattern = Regex(Regex.escape("psi_element://com.example.nodupes.Fantastic"))
+        val numMatches = hrefPattern.findAll(html).count()
+        Assert.assertEquals(1, numMatches)
+    }
+}


### PR DESCRIPTION
This change ensures that `getClassNames` and `findClassesWithoutJvmFacade` never return duplicates, even if multiple `PsiElementFinder`s find the same `PsiClass`es.