### PR TITLE
Fix azure cli may not be detected in windows through EnvironmentDependencyCollector

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
@@ -53,7 +53,7 @@ object EnvironmentScanner {
 
   fun hasToolInLocalPath(pathNames: List<Path>, executableWithoutExt: String): Boolean {
     val baseNames = if (SystemInfo.isWindows) {
-      sequenceOf(".bat", ".com", ".exe")
+      sequenceOf(".bat", ".cmd", ".com", ".exe")
         .map { exeSuffix -> executableWithoutExt + exeSuffix }
     }
     else {


### PR DESCRIPTION
### Changes
Add `.cmd` to the possible extension name list in `EnvironmentDependencyCollector`. As in windows, azure cli may only have extension name `.cmd`