### PR TITLE
KTIJ-22247: Fix wrong indent because of trailing comma after closing brace

### DIFF
--- a/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/formatter/lineIndent/KotlinLangLineIndentProvider.kt
+++ b/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/formatter/lineIndent/KotlinLangLineIndentProvider.kt
@@ -286,8 +286,12 @@ abstract class KotlinLangLineIndentProvider : JavaLikeLangLineIndentProvider() {
                 return createIndentCalculator(defaultIndent, 0)
             }
 
-            if (after.afterIgnoringWhiteSpaceOrComment().isAt(Comma)) {
-                return createIndentCalculator(createAlignMultilineIndent(leftBrace), leftBrace.startOffset)
+            val hasCommaAfterClosingBrace = after.afterIgnoringWhiteSpaceOrComment().isAt(Comma)
+            if (hasCommaAfterClosingBrace) {
+                val isEmptyBlock = before.isAt(BlockOpeningBrace) && after.isAt(BlockClosingBrace)
+                if (!isEmptyBlock) {
+                    return createIndentCalculator(createAlignMultilineIndent(leftBrace), leftBrace.startOffset)
+                }
             }
 
             val beforeLeftBrace = leftBrace.copyAnd { it.moveBeforeIgnoringWhiteSpaceOrComment() }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/AbstractEnterHandlerTest.kt
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/AbstractEnterHandlerTest.kt
@@ -48,6 +48,17 @@ abstract class AbstractEnterHandlerTest : KotlinLightPlatformCodeInsightTestCase
             "// IGNORE_INV_FORMATTER"
         ) != null
 
+        val normalIndentSizePrefix = "// NORMAL_INDENT_SIZE:"
+        val normalIndentSize =
+            InTextDirectivesUtils
+                .findStringWithPrefixes(
+                    originalFileText,
+                    normalIndentSizePrefix
+                )
+                ?.replace(normalIndentSizePrefix, "")
+                ?.trim()
+                ?.toInt()
+
         Assert.assertFalse(
             "Only one option of 'WITHOUT_CUSTOM_LINE_INDENT_PROVIDER' and 'IGNORE_FORMATTER' is available at the same time",
             withoutCustomLineIndentProvider && ignoreFormatter
@@ -61,6 +72,13 @@ abstract class AbstractEnterHandlerTest : KotlinLightPlatformCodeInsightTestCase
                     configurator.configureSettings()
                 } else {
                     configurator.configureInvertedSettings()
+                }
+                if (normalIndentSize != null) {
+                    val kotlinSettings = it.getCommonSettings(KotlinLanguage.INSTANCE)
+                    if (kotlinSettings.indentOptions == null) {
+                        kotlinSettings.initIndentOptions()
+                    }
+                    kotlinSettings.indentOptions?.INDENT_SIZE = normalIndentSize
                 }
             },
             body = {

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/EnterHandlerTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/formatter/EnterHandlerTestGenerated.java
@@ -734,54 +734,111 @@ public abstract class EnterHandlerTestGenerated extends AbstractEnterHandlerTest
 
         @RunWith(JUnit3RunnerWithInners.class)
         @TestMetadata("testData/editor/enterHandler/emptyBraces")
-        public static class EmptyBraces extends AbstractEnterHandlerTest {
-            private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doNewlineTest, this, testDataFilePath);
+        public abstract static class EmptyBraces extends AbstractEnterHandlerTest {
+            @RunWith(JUnit3RunnerWithInners.class)
+            @TestMetadata("testData/editor/enterHandler/emptyBraces/trailingComma")
+            public static class TrailingComma extends AbstractEnterHandlerTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doNewlineTest, this, testDataFilePath);
+                }
+
+                @TestMetadata("DifferentNormalIndentLambdaAsArgument.after.kt")
+                public void testDifferentNormalIndentLambdaAsArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/DifferentNormalIndentLambdaAsArgument.after.kt");
+                }
+
+                @TestMetadata("IfAsArgument.after.kt")
+                public void testIfAsArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/IfAsArgument.after.kt");
+                }
+
+                @TestMetadata("IfAsNamedArgument.after.kt")
+                public void testIfAsNamedArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/IfAsNamedArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsConstructorArgument.after.kt")
+                public void testLambdaAsConstructorArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsConstructorArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsFunctionArgument.after.kt")
+                public void testLambdaAsFunctionArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsFunctionArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsNamedConstructorArgument.after.kt")
+                public void testLambdaAsNamedConstructorArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedConstructorArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsNamedFunctionArgument.after.kt")
+                public void testLambdaAsNamedFunctionArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedFunctionArgument.after.kt");
+                }
+
+                @TestMetadata("WhenAsArgument.after.kt")
+                public void testWhenAsArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsArgument.after.kt");
+                }
+
+                @TestMetadata("WhenAsNamedArgument.after.kt")
+                public void testWhenAsNamedArgument() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsNamedArgument.after.kt");
+                }
             }
 
-            @TestMetadata("ClassWithConstructor.after.kt")
-            public void testClassWithConstructor() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/ClassWithConstructor.after.kt");
-            }
+            @RunWith(JUnit3RunnerWithInners.class)
+            @TestMetadata("testData/editor/enterHandler/emptyBraces")
+            public static class Uncategorized extends AbstractEnterHandlerTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doNewlineTest, this, testDataFilePath);
+                }
 
-            @TestMetadata("ClassWithConstructor2.after.kt")
-            public void testClassWithConstructor2() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/ClassWithConstructor2.after.kt");
-            }
+                @TestMetadata("ClassWithConstructor.after.kt")
+                public void testClassWithConstructor() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/ClassWithConstructor.after.kt");
+                }
 
-            @TestMetadata("ClassWithoutConstructor.after.kt")
-            public void testClassWithoutConstructor() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/ClassWithoutConstructor.after.kt");
-            }
+                @TestMetadata("ClassWithConstructor2.after.kt")
+                public void testClassWithConstructor2() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/ClassWithConstructor2.after.kt");
+                }
 
-            @TestMetadata("FunctionBlock.after.kt")
-            public void testFunctionBlock() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/FunctionBlock.after.kt");
-            }
+                @TestMetadata("ClassWithoutConstructor.after.kt")
+                public void testClassWithoutConstructor() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/ClassWithoutConstructor.after.kt");
+                }
 
-            @TestMetadata("FunctionBlock2.after.kt")
-            public void testFunctionBlock2() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/FunctionBlock2.after.kt");
-            }
+                @TestMetadata("FunctionBlock.after.kt")
+                public void testFunctionBlock() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/FunctionBlock.after.kt");
+                }
 
-            @TestMetadata("FunctionBody3.after.kt")
-            public void testFunctionBody3() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/FunctionBody3.after.kt");
-            }
+                @TestMetadata("FunctionBlock2.after.kt")
+                public void testFunctionBlock2() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/FunctionBlock2.after.kt");
+                }
 
-            @TestMetadata("FunctionBody4.after.kt")
-            public void testFunctionBody4() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/FunctionBody4.after.kt");
-            }
+                @TestMetadata("FunctionBody3.after.kt")
+                public void testFunctionBody3() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/FunctionBody3.after.kt");
+                }
 
-            @TestMetadata("FunctionBodyInsideClass.after.kt")
-            public void testFunctionBodyInsideClass() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass.after.kt");
-            }
+                @TestMetadata("FunctionBody4.after.kt")
+                public void testFunctionBody4() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/FunctionBody4.after.kt");
+                }
 
-            @TestMetadata("FunctionBodyInsideClass2.after.kt")
-            public void testFunctionBodyInsideClass2() throws Exception {
-                runTest("testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass2.after.kt");
+                @TestMetadata("FunctionBodyInsideClass.after.kt")
+                public void testFunctionBodyInsideClass() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass.after.kt");
+                }
+
+                @TestMetadata("FunctionBodyInsideClass2.after.kt")
+                public void testFunctionBodyInsideClass2() throws Exception {
+                    runTest("testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass2.after.kt");
+                }
             }
         }
 

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/DifferentNormalIndentLambdaAsArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/DifferentNormalIndentLambdaAsArgument.after.kt
@@ -1,0 +1,13 @@
+fun main() {
+  foo(
+    a = {
+      <caret>
+    },
+  )
+}
+
+fun foo(a: () -> Unit) {
+
+}
+
+// NORMAL_INDENT_SIZE: 2

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/DifferentNormalIndentLambdaAsArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/DifferentNormalIndentLambdaAsArgument.kt
@@ -1,0 +1,11 @@
+fun main() {
+  foo(
+    a = {<caret>},
+  )
+}
+
+fun foo(a: () -> Unit) {
+
+}
+
+// NORMAL_INDENT_SIZE: 2

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsArgument.after.kt
@@ -1,0 +1,11 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        if (true) {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsArgument.kt
@@ -1,0 +1,9 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        if (true) {<caret>},
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsNamedArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsNamedArgument.after.kt
@@ -1,0 +1,11 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        lambda = if (true) {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsNamedArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsNamedArgument.kt
@@ -1,0 +1,9 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        lambda = if (true) {<caret>},
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsConstructorArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsConstructorArgument.after.kt
@@ -1,0 +1,11 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsConstructorArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsConstructorArgument.kt
@@ -1,0 +1,9 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        {<caret>},
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsFunctionArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsFunctionArgument.after.kt
@@ -1,0 +1,11 @@
+fun test(lambda: () -> Unit) {
+
+}
+
+fun a() {
+    test(
+        {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsFunctionArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsFunctionArgument.kt
@@ -1,0 +1,9 @@
+fun test(lambda: () -> Unit) {
+
+}
+
+fun a() {
+    test(
+        {<caret>},
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedConstructorArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedConstructorArgument.after.kt
@@ -1,0 +1,11 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        lambda = {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedConstructorArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedConstructorArgument.kt
@@ -1,0 +1,9 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        lambda = {<caret>},
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedFunctionArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedFunctionArgument.after.kt
@@ -1,0 +1,11 @@
+fun test(lambda: () -> Unit) {
+
+}
+
+fun a() {
+    test(
+        lambda = {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedFunctionArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedFunctionArgument.kt
@@ -1,0 +1,9 @@
+fun test(lambda: () -> Unit) {
+
+}
+
+fun a() {
+    test(
+        lambda = {<caret>},
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsArgument.after.kt
@@ -1,0 +1,11 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        when {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsArgument.kt
@@ -1,0 +1,9 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        when {<caret>},
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsNamedArgument.after.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsNamedArgument.after.kt
@@ -1,0 +1,11 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        lambda = when {
+            <caret>
+        },
+    )
+}

--- a/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsNamedArgument.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsNamedArgument.kt
@@ -1,0 +1,9 @@
+data class Test(
+    val lambda: () -> Unit,
+)
+
+fun a() {
+    Test(
+        lambda = when {<caret>},
+    )
+}

--- a/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceTypingIndentationTestGenerated.java
+++ b/plugins/kotlin/performance-tests/test/org/jetbrains/kotlin/idea/perf/synthetic/PerformanceTypingIndentationTestGenerated.java
@@ -734,54 +734,111 @@ public abstract class PerformanceTypingIndentationTestGenerated extends Abstract
 
         @RunWith(JUnit3RunnerWithInners.class)
         @TestMetadata("../idea/tests/testData/editor/enterHandler/emptyBraces")
-        public static class EmptyBraces extends AbstractPerformanceTypingIndentationTest {
-            private void runTest(String testDataFilePath) throws Exception {
-                KotlinTestUtils.runTest(this::doNewlineTest, this, testDataFilePath);
+        public abstract static class EmptyBraces extends AbstractPerformanceTypingIndentationTest {
+            @RunWith(JUnit3RunnerWithInners.class)
+            @TestMetadata("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma")
+            public static class TrailingComma extends AbstractPerformanceTypingIndentationTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doNewlineTest, this, testDataFilePath);
+                }
+
+                @TestMetadata("DifferentNormalIndentLambdaAsArgument.after.kt")
+                public void testDifferentNormalIndentLambdaAsArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/DifferentNormalIndentLambdaAsArgument.after.kt");
+                }
+
+                @TestMetadata("IfAsArgument.after.kt")
+                public void testIfAsArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsArgument.after.kt");
+                }
+
+                @TestMetadata("IfAsNamedArgument.after.kt")
+                public void testIfAsNamedArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/IfAsNamedArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsConstructorArgument.after.kt")
+                public void testLambdaAsConstructorArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsConstructorArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsFunctionArgument.after.kt")
+                public void testLambdaAsFunctionArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsFunctionArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsNamedConstructorArgument.after.kt")
+                public void testLambdaAsNamedConstructorArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedConstructorArgument.after.kt");
+                }
+
+                @TestMetadata("LambdaAsNamedFunctionArgument.after.kt")
+                public void testLambdaAsNamedFunctionArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/LambdaAsNamedFunctionArgument.after.kt");
+                }
+
+                @TestMetadata("WhenAsArgument.after.kt")
+                public void testWhenAsArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsArgument.after.kt");
+                }
+
+                @TestMetadata("WhenAsNamedArgument.after.kt")
+                public void testWhenAsNamedArgument() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/trailingComma/WhenAsNamedArgument.after.kt");
+                }
             }
 
-            @TestMetadata("ClassWithConstructor.after.kt")
-            public void testClassWithConstructor() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/ClassWithConstructor.after.kt");
-            }
+            @RunWith(JUnit3RunnerWithInners.class)
+            @TestMetadata("../idea/tests/testData/editor/enterHandler/emptyBraces")
+            public static class Uncategorized extends AbstractPerformanceTypingIndentationTest {
+                private void runTest(String testDataFilePath) throws Exception {
+                    KotlinTestUtils.runTest(this::doNewlineTest, this, testDataFilePath);
+                }
 
-            @TestMetadata("ClassWithConstructor2.after.kt")
-            public void testClassWithConstructor2() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/ClassWithConstructor2.after.kt");
-            }
+                @TestMetadata("ClassWithConstructor.after.kt")
+                public void testClassWithConstructor() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/ClassWithConstructor.after.kt");
+                }
 
-            @TestMetadata("ClassWithoutConstructor.after.kt")
-            public void testClassWithoutConstructor() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/ClassWithoutConstructor.after.kt");
-            }
+                @TestMetadata("ClassWithConstructor2.after.kt")
+                public void testClassWithConstructor2() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/ClassWithConstructor2.after.kt");
+                }
 
-            @TestMetadata("FunctionBlock.after.kt")
-            public void testFunctionBlock() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBlock.after.kt");
-            }
+                @TestMetadata("ClassWithoutConstructor.after.kt")
+                public void testClassWithoutConstructor() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/ClassWithoutConstructor.after.kt");
+                }
 
-            @TestMetadata("FunctionBlock2.after.kt")
-            public void testFunctionBlock2() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBlock2.after.kt");
-            }
+                @TestMetadata("FunctionBlock.after.kt")
+                public void testFunctionBlock() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBlock.after.kt");
+                }
 
-            @TestMetadata("FunctionBody3.after.kt")
-            public void testFunctionBody3() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBody3.after.kt");
-            }
+                @TestMetadata("FunctionBlock2.after.kt")
+                public void testFunctionBlock2() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBlock2.after.kt");
+                }
 
-            @TestMetadata("FunctionBody4.after.kt")
-            public void testFunctionBody4() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBody4.after.kt");
-            }
+                @TestMetadata("FunctionBody3.after.kt")
+                public void testFunctionBody3() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBody3.after.kt");
+                }
 
-            @TestMetadata("FunctionBodyInsideClass.after.kt")
-            public void testFunctionBodyInsideClass() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass.after.kt");
-            }
+                @TestMetadata("FunctionBody4.after.kt")
+                public void testFunctionBody4() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBody4.after.kt");
+                }
 
-            @TestMetadata("FunctionBodyInsideClass2.after.kt")
-            public void testFunctionBodyInsideClass2() throws Exception {
-                runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass2.after.kt");
+                @TestMetadata("FunctionBodyInsideClass.after.kt")
+                public void testFunctionBodyInsideClass() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass.after.kt");
+                }
+
+                @TestMetadata("FunctionBodyInsideClass2.after.kt")
+                public void testFunctionBodyInsideClass2() throws Exception {
+                    runTest("../idea/tests/testData/editor/enterHandler/emptyBraces/FunctionBodyInsideClass2.after.kt");
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes following issues (both issues have same root cause):
https://youtrack.jetbrains.com/issue/KTIJ-22247/Trailing-comma-adds-wrong-indentation-in-when-statement
https://youtrack.jetbrains.com/issue/KTIJ-23252/Smart-enter-Wrong-new-line-indentation-inside-lambda-named-parameter-with-trailing-comma

What's changed:
- Added special case in `KotlinLangLineIdentProvider` for block braces with empty body to not be alined multiline.
- Added new test directive `// NORMAL_INDENT_SIZE: {INDENT_SIZE}` which allows to set arbitrary normal indent for specific enter handler test. Required for KTIJ-23252. Used in [DifferentNormalIndentLambdaAsArgument.after.kt](https://github.com/JetBrains/intellij-community/compare/master...IlyaGulya:intellij-community:KTIJ-22247-trailing-comma-breaks-indentation-on-enter-inside-empty-block-braces?expand=1#diff-1af6064b12604a6044f6159d6080390ced864a24dd39e42e2386b45188cb0a35) test.