### PR TITLE
Include java executable check during JDK validation

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/LocalGradleExecutionAware.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/LocalGradleExecutionAware.kt
@@ -117,12 +117,12 @@ class LocalGradleExecutionAware : GradleExecutionAware {
     }
     checkForWslJdkOnWindows(homePath, projectSettings.externalProjectPath, task)
     if (!JdkUtil.checkForJdk(homePath)) {
-      if (JdkUtil.checkForJre(homePath)) {
-        LOG.warn("Gradle JVM ($gradleJvm) is JRE instead JDK: $sdkInfo")
-        throw jdkConfigurationException("gradle.jvm.is.jre")
-      }
       LOG.warn("Invalid Gradle JVM ($gradleJvm) home path: $sdkInfo")
       throw jdkConfigurationException("gradle.jvm.is.invalid")
+    }
+    if (!JdkUtil.checkForJre(homePath)) {
+      LOG.warn("Gradle JVM ($gradleJvm) is JRE instead JDK: $sdkInfo")
+      throw jdkConfigurationException("gradle.jvm.is.jre")
     }
     return sdkInfo
   }


### PR DESCRIPTION
The `LocalGradleExecutionAware` validates the user-specified Gradle JDK when triggering sync. However, in case the "bin/java" or "bin/java.exe" isn't present Gradle will throw the below exception without the IDE to be able to properly suggest a quick fix.

```
Gradle sync failed in 51 ms. The supplied javaHome seems to be invalid. I cannot find the Java executable. Tried location: C:\Program Files\Android\Android Studio\jbr\bin\java.exe
```

NOTE: There are different reasons when users may end up in this scenario for example antivirus software removing those executables in Windows, but also other cases like this popular issue in [flutter](https://github.com/flutter/flutter/issues/106674) 

#### Current behaviour
<img width="938" alt="Exception" src="https://github.com/JetBrains/intellij-community/assets/18151158/a3be1be4-ea55-4499-9fbe-d31a29815ea8">
