### PR TITLE
Obey accept protocol in KotlinUSimpleReferenceExpression

### DIFF
--- a/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/expressions/KotlinUSimpleReferenceExpression.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/expressions/KotlinUSimpleReferenceExpression.kt
@@ -55,7 +55,7 @@ class KotlinUSimpleReferenceExpression(
         }
 
     override fun accept(visitor: UastVisitor) {
-        visitor.visitSimpleNameReferenceExpression(this)
+        if (visitor.visitSimpleNameReferenceExpression(this)) return
 
         if (sourcePsi.parent.destructuringDeclarationInitializer != true) {
             visitAccessorCalls(visitor)


### PR DESCRIPTION
Do not visit synthetic method calls if the visitor returns true on visiting the expression itself.  Should fix IDEA-338071.