### PR TITLE
HelpTooltip: null title => null title supplier

### DIFF
--- a/platform/platform-api/src/com/intellij/ide/HelpTooltip.java
+++ b/platform/platform-api/src/com/intellij/ide/HelpTooltip.java
@@ -117,7 +117,7 @@ public class HelpTooltip {
   private static final String TOOLTIP_PROPERTY = "JComponent.helpTooltip";
   private static final String TOOLTIP_DISABLED_PROPERTY = "JComponent.helpTooltipDisabled";
 
-  private @Nullable Supplier<@TooltipTitle String> title;
+  private @Nullable Supplier<@NotNull @TooltipTitle String> title;
   private @NlsSafe String shortcut;
   private @Tooltip String description;
   private ActionLink link;
@@ -201,7 +201,7 @@ public class HelpTooltip {
    * @return {@code this}
    */
   public HelpTooltip setTitle(@Nullable @TooltipTitle String title) {
-    this.title = () -> title;
+    this.title = title != null ? () -> title : null;
     return this;
   }
 


### PR DESCRIPTION
This ensures that calling setTitle(null) does not affect tooltip equality comparisons. This is minor follow-up to commit e289bf0253 and IDEA-336264.

This change is useful for integrating IntelliJ 2023.3 into Android Studio because it fixes some test failures related to tooltip equality. Cherry-picking to branch 233 would be appreciated if possible. Thanks! cc @juliabeliaeva 