### PR TITLE
IDEA-299661 Run console input is reset with every output

### DIFF
--- a/platform/lang-impl/src/com/intellij/execution/impl/ConsoleTokenUtil.java
+++ b/platform/lang-impl/src/com/intellij/execution/impl/ConsoleTokenUtil.java
@@ -174,7 +174,7 @@ final class ConsoleTokenUtil {
       ConsoleViewContentType tokenType = getTokenType(marker);
       if (tokenType != null) {
         if (tokenType != ConsoleViewContentType.USER_INPUT || marker.getUserData(USER_INPUT_SENT) == Boolean.TRUE) {
-          break;
+          continue;
         }
         marker.putUserData(USER_INPUT_SENT, true);
         textToSend.insert(0, marker.getDocument().getText(marker.getTextRange()));


### PR DESCRIPTION
Breaking this loop effectively discards all `ConsoleViewContentType.USER_INPUT` tokens buffered before any other type of token, which prevents interleaving of `System.out` / `System.in` and does not align with the behavior of typical terminals. In order to discover all user input, we simply keep iterating.

[YouTrack Issue](https://youtrack.jetbrains.com/issue/IDEA-299661)