### PR TITLE
IDEA-338696: Resolve GRADLE_USER_HOME environment variable defined on macOS

### DIFF
--- a/plugins/gradle/java/testSources/importing/GradleFindUsagesTest.java
+++ b/plugins/gradle/java/testSources/importing/GradleFindUsagesTest.java
@@ -11,10 +11,10 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.usageView.UsageInfo;
-import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.wrapper.PathAssembler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.gradle.service.execution.GradleUserHomeUtil;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -45,7 +45,7 @@ public class GradleFindUsagesTest extends GradleImportingTestCase {
   @Override
   protected void collectAllowedRoots(List<String> roots, PathAssembler.LocalDistribution distribution) {
     super.collectAllowedRoots(roots, distribution);
-    File gradleUserHomeDir = new BuildLayoutParameters().getGradleUserHomeDir();
+    File gradleUserHomeDir = GradleUserHomeUtil.gradleUserHomeDir();
     File generatedGradleJarsDir = new File(gradleUserHomeDir, "caches/" + gradleVersion + "/generated-gradle-jars");
     roots.add(generatedGradleJarsDir.getPath());
     File gradleDistLibDir = new File(distribution.getDistributionDir(), "gradle-" + gradleVersion + "/lib");

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/GradleDaemonStartupIssueChecker.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/GradleDaemonStartupIssueChecker.kt
@@ -14,12 +14,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.pom.Navigatable
 import com.intellij.util.PlatformUtils
 import com.intellij.util.text.nullize
-import org.gradle.initialization.BuildLayoutParameters
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.annotations.Nls
 import org.jetbrains.plugins.gradle.execution.GradleConsoleFilter
 import org.jetbrains.plugins.gradle.issue.quickfix.GradleSettingsQuickFix
 import org.jetbrains.plugins.gradle.service.execution.GradleExecutionErrorHandler.getRootCauseAndLocation
+import org.jetbrains.plugins.gradle.service.execution.gradleUserHomeDir
 import org.jetbrains.plugins.gradle.settings.GradleSystemSettings
 import org.jetbrains.plugins.gradle.util.GradleBundle
 import java.nio.file.Paths
@@ -52,7 +52,7 @@ class GradleDaemonStartupIssueChecker : GradleIssueChecker {
       quickFixes.add(openFileQuickFix)
     }
 
-    val gradleUserHomeDir = issueData.buildEnvironment?.gradle?.gradleUserHome ?: BuildLayoutParameters().gradleUserHomeDir
+    val gradleUserHomeDir = issueData.buildEnvironment?.gradle?.gradleUserHome ?: gradleUserHomeDir()
     val commonGradleProperties = Paths.get(gradleUserHomeDir.path, "gradle.properties")
     if (commonGradleProperties.isRegularFile()) {
       val openFileQuickFix = OpenFileQuickFix(commonGradleProperties, "org.gradle.jvmargs")

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/GradleOutOfMemoryIssueChecker.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/GradleOutOfMemoryIssueChecker.kt
@@ -9,10 +9,10 @@ import com.intellij.build.issue.quickfix.OpenFileQuickFix
 import com.intellij.openapi.project.Project
 import com.intellij.pom.Navigatable
 import com.intellij.util.PlatformUtils
-import org.gradle.initialization.BuildLayoutParameters
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.plugins.gradle.issue.quickfix.GradleSettingsQuickFix
 import org.jetbrains.plugins.gradle.service.execution.GradleExecutionErrorHandler.getRootCauseAndLocation
+import org.jetbrains.plugins.gradle.service.execution.gradleUserHomeDir
 import org.jetbrains.plugins.gradle.settings.GradleSystemSettings
 import org.jetbrains.plugins.gradle.util.GradleBundle
 import java.nio.file.Paths
@@ -40,7 +40,7 @@ class GradleOutOfMemoryIssueChecker : GradleIssueChecker {
       quickFixes.add(openFileQuickFix)
     }
 
-    val gradleUserHomeDir = issueData.buildEnvironment?.gradle?.gradleUserHome ?: BuildLayoutParameters().gradleUserHomeDir
+    val gradleUserHomeDir = issueData.buildEnvironment?.gradle?.gradleUserHome ?: gradleUserHomeDir()
     val commonGradleProperties = Paths.get(gradleUserHomeDir.path, "gradle.properties")
     if (commonGradleProperties.isRegularFile()) {
       val openFileQuickFix = OpenFileQuickFix(commonGradleProperties, "org.gradle.jvmargs")

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleUserHomeUtil.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleUserHomeUtil.kt
@@ -1,0 +1,20 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+@file:JvmName("GradleUserHomeUtil")
+
+package org.jetbrains.plugins.gradle.service.execution
+
+import com.intellij.openapi.externalSystem.util.environment.Environment
+import org.gradle.internal.FileUtils
+import org.gradle.internal.SystemProperties
+import java.io.File
+
+private val DEFAULT_GRADLE_USER_HOME = File(SystemProperties.getInstance().userHome + "/.gradle")
+
+fun gradleUserHomeDir(): File {
+  var gradleUserHome = Environment.getProperty("gradle.user.home")
+  if (gradleUserHome == null) {
+    gradleUserHome = Environment.getVariable("GRADLE_USER_HOME")
+  }
+
+  return FileUtils.canonicalize(File(gradleUserHome ?: DEFAULT_GRADLE_USER_HOME.absolutePath))
+}

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/LocalBuildLayoutParameters.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/LocalBuildLayoutParameters.kt
@@ -97,7 +97,7 @@ internal open class LocalBuildLayoutParameters(private val project: Project,
     return getGradleSettings().serviceDirectoryPath ?: defaultGradleUserHome()
   }
 
-  private fun defaultGradleUserHome() = org.gradle.initialization.BuildLayoutParameters().gradleUserHomeDir.path
+  private fun defaultGradleUserHome() = gradleUserHomeDir().path
 
   companion object {
     private val log = logger<LocalGradleExecutionAware>()

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/DefaultProjectResolverContext.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/DefaultProjectResolverContext.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.externalSystem.model.task.event.ExternalSystemBuildE
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.util.UserDataHolderBase;
 import com.intellij.util.containers.CollectionFactory;
-import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.tooling.CancellationTokenSource;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
@@ -21,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.model.Build;
 import org.jetbrains.plugins.gradle.model.ProjectImportAction;
+import org.jetbrains.plugins.gradle.service.execution.GradleUserHomeUtil;
 import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings;
 
 import java.io.File;
@@ -142,7 +142,7 @@ public class DefaultProjectResolverContext extends UserDataHolderBase implements
   public File getGradleUserHome() {
     if (myGradleUserHome == null) {
       String serviceDirectory = mySettings == null ? null : mySettings.getServiceDirectory();
-      myGradleUserHome = serviceDirectory != null ? new File(serviceDirectory) : new BuildLayoutParameters().getGradleUserHomeDir();
+      myGradleUserHome = serviceDirectory != null ? new File(serviceDirectory) : GradleUserHomeUtil.gradleUserHomeDir();
     }
     return myGradleUserHome;
   }

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleAutoImportAware.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleAutoImportAware.java
@@ -16,10 +16,10 @@ import com.intellij.openapi.roots.CompilerProjectExtension;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.SmartList;
-import org.gradle.initialization.BuildLayoutParameters;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.model.data.BuildScriptClasspathData;
+import org.jetbrains.plugins.gradle.service.execution.GradleUserHomeUtil;
 import org.jetbrains.plugins.gradle.settings.DistributionType;
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
 import org.jetbrains.plugins.gradle.settings.GradleSettings;
@@ -119,7 +119,7 @@ public class GradleAutoImportAware implements ExternalSystemAutoImportAware {
     public List<File> collectSettingsFiles(@NotNull Project project, @NotNull GradleProjectSettings projectSettings) {
       String gradleUserHome = ObjectUtils.chooseNotNull(
         GradleSettings.getInstance(project).getServiceDirectoryPath(),
-        new BuildLayoutParameters().getGradleUserHomeDir().getPath()
+        GradleUserHomeUtil.gradleUserHomeDir().getPath()
       );
       String externalProjectPath = projectSettings.getExternalProjectPath();
 

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleImportingTestCase.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleImportingTestCase.java
@@ -41,7 +41,6 @@ import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.lang.JavaVersion;
 import org.gradle.StartParameter;
-import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.util.GradleVersion;
 import org.gradle.wrapper.GradleWrapperMain;
 import org.gradle.wrapper.PathAssembler;
@@ -55,6 +54,7 @@ import org.jetbrains.plugins.gradle.frameworkSupport.settingsScript.GroovyDslGra
 import org.jetbrains.plugins.gradle.jvmcompat.GradleJvmSupportMatrix;
 import org.jetbrains.plugins.gradle.service.execution.GradleExternalTaskConfigurationType;
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
+import org.jetbrains.plugins.gradle.service.execution.GradleUserHomeUtil;
 import org.jetbrains.plugins.gradle.settings.DistributionType;
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
 import org.jetbrains.plugins.gradle.settings.GradleSettings;
@@ -163,7 +163,7 @@ public abstract class GradleImportingTestCase extends JavaExternalSystemImportin
 
   protected Path getGradleUserHome() {
     String serviceDirectory = GradleSettings.getInstance(myProject).getServiceDirectoryPath();
-    return serviceDirectory != null ? Path.of(serviceDirectory) : new BuildLayoutParameters().getGradleUserHomeDir().toPath();
+    return serviceDirectory != null ? Path.of(serviceDirectory) : GradleUserHomeUtil.gradleUserHomeDir().toPath();
   }
 
   /**
@@ -297,7 +297,7 @@ public abstract class GradleImportingTestCase extends JavaExternalSystemImportin
     roots.add(myJdkHome);
     roots.addAll(collectRootsInside(myJdkHome));
     roots.add(PathManager.getConfigPath());
-    String gradleHomeEnv = System.getenv("GRADLE_USER_HOME");
+    String gradleHomeEnv = Environment.getVariable("GRADLE_USER_HOME");
     if (gradleHomeEnv != null) roots.add(gradleHomeEnv);
     String javaHome = Environment.getVariable("JAVA_HOME");
     if (javaHome != null) roots.add(javaHome);


### PR DESCRIPTION
Following the original documentation https://www.jetbrains.com/help/idea/gradle-settings.html, users should be able to override their `GRADLE_USER_HOME` environment variable and this should be taken into consideration for the Gradle Daemon configuration.

The reason is because platform relies on Gradle implementation of `BuildLayoutParameters.findGradleUserHomeDir()` which uses `System` class causing on macOS to not be able to obtain the defined environment variable. For this reason will be required to move this logic into the platform directly and use `Environment` class, being this aligned with https://github.com/JetBrains/intellij-community/commit/474b49db890e986170ce91655a80d65ea36c63ce change about `JAVA_HOME`.

#### Overview 
<img width="731" alt="Platform issue" src="https://github.com/JetBrains/intellij-community/assets/18151158/8806050b-1761-4f8a-a565-c7b73bd752fd">