### PR TITLE
Add getText for getting the text for the remove unused variable fix

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/RemoveUnusedVariableFix.java
+++ b/java/java-impl/src/com/intellij/codeInsight/daemon/impl/quickfix/RemoveUnusedVariableFix.java
@@ -34,9 +34,14 @@ public class RemoveUnusedVariableFix extends PsiBasedModCommandAction<PsiVariabl
     return QuickFixBundle.message("remove.unused.element.family", JavaElementKind.VARIABLE.object());
   }
 
+  @NotNull
+  protected String getText(@NotNull PsiVariable variable) {
+    return CommonQuickFixBundle.message("fix.remove.title.x", JavaElementKind.fromElement(variable).object(), variable.getName());
+  }
+
   @Override
   protected @Nullable Presentation getPresentation(@NotNull ActionContext context, @NotNull PsiVariable variable) {
-    String message = CommonQuickFixBundle.message("fix.remove.title.x", JavaElementKind.fromElement(variable).object(), variable.getName());
+    String message = getText(variable);
     return Presentation.of(message);
   }
 


### PR DESCRIPTION
A bit late, but we've realized that we are extending the non public `RemoveUnusedVariableFix` in the MapStruct IntelliJ plugin (https://github.com/mapstruct/mapstruct-idea/blob/553a9f9655dc164f9697dc56dedc2d015969224e/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java#L120).

We have managed to find a way to make this work both on 2023.3 and prior versions. However, one thing that we are still missing is the custom text that we are providing.

We can't just add

```java
protected @Nullable Presentation getPresentation(@NotNull ActionContext context, @NotNull PsiVariable variable) {
  //...
}
```

since it won't compile on older IntelliJ versions.

If you agree to accept this PR then we would be able to keep using `RemoveUnusedVariableFix` on all versions. If not then we will need to look for an alternative.

The reason why we are using it is due to the fact that the fix is removing a static variable (which is identical to what `RemoveUnusedVariableFix` does).