### PR TITLE
Enhance CompilerManager#compileJavaCode with the ability to listen to diagnostics and outputs

### DIFF
--- a/java/compiler/openapi/src/com/intellij/openapi/compiler/CompilerManager.java
+++ b/java/compiler/openapi/src/com/intellij/openapi/compiler/CompilerManager.java
@@ -14,10 +14,12 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.tools.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * A "root" class in compiler subsystem - allows one to register a custom compiler or a compilation task, register/unregister a compilation listener
@@ -276,6 +278,23 @@ public abstract class CompilerManager {
                                                           Collection<? extends File> sourcePath,
                                                           Collection<? extends File> files,
                                                           File outputDir) throws IOException, CompilationException;
+
+  /**
+   * Compiles java files with given parameters and provides a way to listen to diagnostics reported and class objects created during the
+   * compilation. Listeners will be invoked regardless of the compilation result (success/failure).
+   *
+   * @return {@code true} if compilation succeeds, {@code false} otherwise
+   */
+  public abstract boolean compileJavaCode(List<String> options,
+                                          Collection<? extends File> platformCp,
+                                          Collection<? extends File> classpath,
+                                          Collection<? extends File> upgradeModulePath,
+                                          Collection<? extends File> modulePath,
+                                          Collection<? extends File> sourcePath,
+                                          Collection<? extends File> files,
+                                          File outputDir,
+                                          DiagnosticListener<? super JavaFileObject> diagnosticListener,
+                                          Consumer<? super ClassObject> outputListener) throws IOException;
 
   @Nullable
   public abstract File getJavacCompilerWorkingDir();


### PR DESCRIPTION
The existing method signature has 2 limitations:
1) There is no way to listen to diagnostics reported during a successful compilation, unless compilation fails with `CompilationException` which provides access to messages.
2) There is no way to access files generated during a failed compilation. `CompilationException` provides access to messages only. This could pose a problem if, for example, an annotation processor generated some files even though the compilation failed.

Also, the existing signature is confusing because the return type is a collection of `ClassObject`, i.e., a compiled file. But a returned collection can also include another kind of compiler output -- source files generated by annotation processors.