### PR TITLE
KTIJ-25742 "Redundant argument-based 'let' call" changes semantics with side effect and unused 'let' parameter

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLetInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantLetInspection.kt
@@ -100,10 +100,15 @@ class ComplexRedundantLetInspection : RedundantLetInspection() {
                 false
             } else {
                 val references = lambdaExpression.functionLiteral.valueParameterReferences(bodyExpression)
-                val destructuringDeclaration = lambdaExpression.functionLiteral.valueParameters.firstOrNull()?.destructuringDeclaration
-                references.isEmpty() || (references.singleOrNull()?.takeIf { expression ->
-                    expression.parents.takeWhile { it != lambdaExpression.functionLiteral }.find { it is KtFunction } == null
-                } != null && destructuringDeclaration == null)
+                if (references.isEmpty()) {
+                    val receiver = element.getQualifiedExpressionForSelector()?.receiverExpression
+                    receiver?.anyDescendantOfType<KtCallElement>() != true
+                } else {
+                    val destructuringDeclaration = lambdaExpression.functionLiteral.valueParameters.firstOrNull()?.destructuringDeclaration
+                    references.singleOrNull()?.takeIf { expression ->
+                        expression.parents.takeWhile { it != lambdaExpression.functionLiteral }.find { it is KtFunction } == null
+                    } != null && destructuringDeclaration == null
+                }
             }
         else ->
             false

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -3151,6 +3151,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/complexRedundantLet/plusNullable.kt");
         }
 
+        @TestMetadata("receiverHasSideEffectAndLetParamIsUnused.kt")
+        public void testReceiverHasSideEffectAndLetParamIsUnused() throws Exception {
+            runTest("testData/inspectionsLocal/complexRedundantLet/receiverHasSideEffectAndLetParamIsUnused.kt");
+        }
+
         @TestMetadata("receiverWithLambda.kt")
         public void testReceiverWithLambda() throws Exception {
             runTest("testData/inspectionsLocal/complexRedundantLet/receiverWithLambda.kt");

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/complexRedundantLet/receiverHasSideEffectAndLetParamIsUnused.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/complexRedundantLet/receiverHasSideEffectAndLetParamIsUnused.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+// WITH_STDLIB
+
+fun Int.foo(): Int {
+    println("side effect")
+    return this
+}
+
+fun main() {
+    42.foo().let<caret> {
+        println("")
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-25742