### PR TITLE
Remove slash to adjust path candidate of `/Home` to `Home`

### DIFF
--- a/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderMac.java
+++ b/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderMac.java
@@ -52,7 +52,7 @@ public class JavaHomeFinderMac extends JavaHomeFinderBasic {
   @NotNull
   @Override
   protected List<Path> listPossibleJdkHomesFromInstallRoot(@NotNull Path path) {
-    return Arrays.asList(path, path.resolve("/Home"), path.resolve("Contents/Home"));
+    return Arrays.asList(path, path.resolve("Home"), path.resolve("Contents/Home"));
   }
 
   @Override


### PR DESCRIPTION
# Changes

Remove the slash to modify the path candidate to `{path}/Home` instead of `/Home`.

# Related code

In this lines it test for a subdirectory `Home`:
https://github.com/JetBrains/intellij-community/blob/4ac697da854eaf6778cbfa93bf474b85831146ea/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderMac.java#L63-L66

# Compare

before:
- for each path ( e.q. `/Users/muescha/.asdf/installs/java/openjdk-21.0.1`) it created a candidate path with `/Home`:

```
[
   /Users/muescha/.asdf/installs/java/openjdk-21.0.1,
   /Home,
   /Users/muescha/.asdf/installs/java/openjdk-21.0.1/Contents/Home
]
```

after:

```
[
   /Users/muescha/.asdf/installs/java/openjdk-21.0.1,
   /Users/muescha/.asdf/installs/java/openjdk-21.0.1/Home,
   /Users/muescha/.asdf/installs/java/openjdk-21.0.1/Contents/Home
]
```

# History

`/Home` is introduced in 163b96c