### PR TITLE
DependencyArtifactsPolicyModel

### DIFF
--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/internal/DependencyArtifactPolicyModel.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/internal/DependencyArtifactPolicyModel.java
@@ -1,0 +1,8 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.model.internal;
+
+public interface DependencyArtifactPolicyModel {
+  boolean isDownloadSources();
+
+  boolean isDownloadJavadoc();
+}

--- a/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/internal/ParentDependencyArtifactPolicyParameter.java
+++ b/plugins/gradle/tooling-extension-api/src/org/jetbrains/plugins/gradle/model/internal/ParentDependencyArtifactPolicyParameter.java
@@ -1,0 +1,29 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.model.internal;
+
+import org.gradle.api.Action;
+
+public interface ParentDependencyArtifactPolicyParameter {
+  boolean isDownloadSources();
+
+  void setDownloadSources(boolean downloadSources);
+
+  boolean isDownloadJavadoc();
+
+  void setDownloadJavadoc(boolean downloadJavadoc);
+
+  class Initializer implements Action<ParentDependencyArtifactPolicyParameter> {
+
+    private final DependencyArtifactPolicyModel model;
+
+    public Initializer(DependencyArtifactPolicyModel model) {
+      this.model = model;
+    }
+
+    @Override
+    public void execute(ParentDependencyArtifactPolicyParameter parameter) {
+      parameter.setDownloadSources(model.isDownloadSources());
+      parameter.setDownloadJavadoc(model.isDownloadJavadoc());
+    }
+  }
+}

--- a/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/sourceSetModel/GradleSourceSetModelBuilder.groovy
+++ b/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/sourceSetModel/GradleSourceSetModelBuilder.groovy
@@ -232,9 +232,6 @@ class GradleSourceSetModelBuilder extends AbstractModelBuilderService {
     def ideaResourceDirs = null
     def ideaTestSourceDirs = null
     def ideaTestResourceDirs = null
-    final downloadSources = GradleDependencyArtifactPolicyUtil.shouldDownloadSources(project)
-    final downloadJavadoc = GradleDependencyArtifactPolicyUtil.shouldDownloadJavadoc(project)
-    GradleDependencyArtifactPolicyUtil.setPolicy(project, downloadSources, downloadJavadoc)
 
     def testSourceSets = []
 

--- a/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/util/GradleDependencyArtifactPolicyUtil.java
+++ b/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/util/GradleDependencyArtifactPolicyUtil.java
@@ -9,8 +9,8 @@ import org.jetbrains.annotations.Nullable;
 
 public final class GradleDependencyArtifactPolicyUtil {
 
-  private static final String DOWNLOAD_SOURCES_FORCE_PROPERTY_NAME = "idea.gradle.download.sources.force";
-  private static final String DOWNLOAD_SOURCES_PROPERTY_NAME = "idea.gradle.download.sources";
+  public static final String DOWNLOAD_SOURCES_FORCE_PROPERTY_NAME = "idea.gradle.download.sources.force";
+  public static final String DOWNLOAD_SOURCES_PROPERTY_NAME = "idea.gradle.download.sources";
 
   public static boolean shouldDownloadSources(@NotNull Project project) {
     // this is necessary for the explicit 'Download sources' action, and also to ensure that sources can be disabled for the headless idea

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/DependencyArtifactPolicyModelBuilder.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/DependencyArtifactPolicyModelBuilder.java
@@ -1,0 +1,80 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.tooling.builder;
+
+import org.gradle.api.Project;
+import org.gradle.plugins.ide.idea.IdeaPlugin;
+import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
+import org.jetbrains.plugins.gradle.model.internal.DependencyArtifactPolicyModel;
+import org.jetbrains.plugins.gradle.model.internal.ParentDependencyArtifactPolicyParameter;
+import org.jetbrains.plugins.gradle.tooling.internal.DependencyArtifactPolicyModelImpl;
+
+import static com.intellij.gradle.toolingExtension.impl.util.GradleDependencyArtifactPolicyUtil.DOWNLOAD_SOURCES_FORCE_PROPERTY_NAME;
+import static com.intellij.gradle.toolingExtension.impl.util.GradleDependencyArtifactPolicyUtil.DOWNLOAD_SOURCES_PROPERTY_NAME;
+
+public class DependencyArtifactPolicyModelBuilder implements ParameterizedToolingModelBuilder<ParentDependencyArtifactPolicyParameter> {
+  @Override
+  public boolean canBuild(String modelName) {
+    return DependencyArtifactPolicyModel.class.getName().equals(modelName);
+  }
+
+  @Override
+  public Class<ParentDependencyArtifactPolicyParameter> getParameterType() {
+    return ParentDependencyArtifactPolicyParameter.class;
+  }
+
+  @Override
+  public Object buildAll(String modelName, Project project) {
+    return buildAll(modelName, null, project);
+  }
+
+  @Override
+  public Object buildAll(String modelName, ParentDependencyArtifactPolicyParameter parameter, Project project) {
+    DependencyArtifactPolicyModel policy = build(project, parameter);
+    IdeaPlugin ideaPlugin = findIdeaPluginFor(project);
+    if (ideaPlugin != null) {
+      ideaPlugin.getModel().getModule().setDownloadSources(policy.isDownloadSources());
+      ideaPlugin.getModel().getModule().setDownloadJavadoc(policy.isDownloadJavadoc());
+    }
+    return policy;
+  }
+
+  private DependencyArtifactPolicyModel build(Project project, ParentDependencyArtifactPolicyParameter parentPolicy) {
+    boolean downloadSources = shouldDownloadSources(project, parentPolicy);
+    boolean downloadJavadoc = shouldDownloadJavadocs(project, parentPolicy);
+    return new DependencyArtifactPolicyModelImpl(downloadSources, downloadJavadoc);
+  }
+
+  private boolean shouldDownloadSources(Project project, ParentDependencyArtifactPolicyParameter parentPolicy) {
+    // this is necessary for the explicit 'Download sources' action, and also to ensure that sources can be disabled for the headless idea
+    // regardless of user settings
+    String forcePropertyValue = System.getProperty(DOWNLOAD_SOURCES_FORCE_PROPERTY_NAME);
+    if (forcePropertyValue != null) {
+      return Boolean.parseBoolean(forcePropertyValue);
+    }
+
+    IdeaPlugin ideaPlugin = findIdeaPluginFor(project);
+    if (ideaPlugin != null) {
+      return ideaPlugin.getModel().getModule().isDownloadSources();
+    }
+    if (parentPolicy != null) {
+      return parentPolicy.isDownloadSources();
+    }
+    // default IDE policy
+    return Boolean.parseBoolean(System.getProperty(DOWNLOAD_SOURCES_PROPERTY_NAME, "false"));
+  }
+
+  private boolean shouldDownloadJavadocs(Project project, ParentDependencyArtifactPolicyParameter parentPolicy) {
+    IdeaPlugin ideaPlugin = findIdeaPluginFor(project);
+    if (ideaPlugin != null) {
+      return ideaPlugin.getModel().getModule().isDownloadJavadoc();
+    }
+    if (parentPolicy != null) {
+      return parentPolicy.isDownloadJavadoc();
+    }
+    return false;
+  }
+
+  private IdeaPlugin findIdeaPluginFor(Project project) {
+    return project.getPlugins().findPlugin(IdeaPlugin.class);
+  }
+}

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/DependencyArtifactPolicyModelImpl.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/DependencyArtifactPolicyModelImpl.java
@@ -1,0 +1,28 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.tooling.internal;
+
+import org.jetbrains.plugins.gradle.model.internal.DependencyArtifactPolicyModel;
+
+import java.io.Serializable;
+
+public class DependencyArtifactPolicyModelImpl implements DependencyArtifactPolicyModel, Serializable {
+
+  private final boolean downloadSources;
+
+  private final boolean downloadJavadoc;
+
+  public DependencyArtifactPolicyModelImpl(boolean downloadSources, boolean downloadJavadoc) {
+    this.downloadSources = downloadSources;
+    this.downloadJavadoc = downloadJavadoc;
+  }
+
+  @Override
+  public boolean isDownloadSources() {
+    return downloadSources;
+  }
+
+  @Override
+  public boolean isDownloadJavadoc() {
+    return downloadJavadoc;
+  }
+}


### PR DESCRIPTION
This PR is eliminating cross-project access violation during resolving policy for downloading sources and javadocs.

Previously, `downloadSources/Javadocs` flags for each project was calculated in "bottom to top" manner:
each project either had it's own configured value or did [recursive lookup](https://github.com/JetBrains/intellij-community/blob/21eb657aa0414fce13777ce159458be6c8daf59d/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/util/GradleDependencyArtifactPolicyUtil.java#L55) in it's parents. This violates Gradle Isolated Projects constraints.

This PR reverts an order of the calculation to "top to bottom":
each project has a model that contains `downloadSources/Javadocs` flags, which is calculated with respect to same flags of parent project. The calculation of that model have a side-effect: calculated value is setting to `IdeaModule` of project.