### PR TITLE
Feature: JUnit patcher supports excluding module dependency

### DIFF
--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcherTest.kt
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/execution/MavenJUnitPatcherTest.kt
@@ -25,6 +25,8 @@ import org.intellij.lang.annotations.Language
 import org.jetbrains.idea.maven.project.MavenProjectSettings
 import org.junit.Test
 import java.io.File
+import java.nio.file.Paths
+import kotlin.io.path.name
 
 class MavenJUnitPatcherTest : MavenMultiVersionImportingTestCase() {
   override fun runInDispatchThread() = true
@@ -34,6 +36,84 @@ class MavenJUnitPatcherTest : MavenMultiVersionImportingTestCase() {
     MavenProjectSettings.getInstance(project).testRunningSettings.isPassArgLine = true
     MavenProjectSettings.getInstance(project).testRunningSettings.isPassEnvironmentVariables = true
     MavenProjectSettings.getInstance(project).testRunningSettings.isPassSystemProperties = true
+  }
+
+  @Test
+  @Throws(CantRunException::class)
+  fun ExcludeProjectDependencyInClassPathElement() {
+    val m = createModulePom("m", """
+      <groupId>test</groupId>
+      <artifactId>m</artifactId>
+      <version>1</version>
+      <dependencies>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.0</version>
+        </dependency>
+        <dependency>
+          <groupId>test</groupId>
+          <artifactId>dep</artifactId>
+          <version>1</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.16</version>
+            <configuration>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>test:dep</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      """.trimIndent())
+
+    val dep = createModulePom("dep", """
+      <groupId>test</groupId>
+      <artifactId>dep</artifactId>
+      <version>1</version>
+      <dependencies>
+      </dependencies>
+      
+      """.trimIndent())
+
+    createProjectSubDirs("m/src/main/java",
+                         "m/target/classes",
+                         "dep/src/main/java",
+                         "dep/target/classes")
+
+    importProjects(m, dep)
+    assertModules("m", "dep")
+    assertModuleModuleDeps("m", "dep")
+
+    val module = getModule("m")
+
+    val mavenJUnitPatcher = MavenJUnitPatcher()
+    val javaParameters = JavaParameters()
+
+    val pathTransformer = { path: String ->
+      val nioPath = Paths.get(path)
+
+      if (nioPath.name.endsWith(".jar")) {
+        nioPath.name
+      }
+      else {
+        nioPath.subpath(nioPath.nameCount - 3, nioPath.nameCount).toString()
+      }
+    }
+
+    javaParameters.configureByModule(module, JavaParameters.CLASSES_AND_TESTS, IdeaTestUtil.getMockJdk18())
+    assertEquals(listOf("dep/target/classes", "junit-4.0.jar", "m/target/classes"),
+                 javaParameters.classPath.getPathList().map(pathTransformer).sorted())
+
+    mavenJUnitPatcher.patchJavaParameters(module, javaParameters)
+    assertEquals(listOf("junit-4.0.jar", "m/target/classes"),
+                 javaParameters.classPath.getPathList().map(pathTransformer).sorted())
   }
 
   @Test


### PR DESCRIPTION
In the previous version, when I used classpathDependencyExclude with MavenId configured as a Module Dependency, the JUnit plugin did not exclude this dependency's path (e.g., module-dependency/target/classes). For more details, please refer to the test case in the PR.

I have attempted a fix and would greatly appreciate it if you could perform a code review on my code.