### PR TITLE
IDEA-288455 - Add registry option for ignoring force push warning

### DIFF
--- a/platform/dvcs-impl/src/com/intellij/dvcs/push/ui/ForcePushAction.kt
+++ b/platform/dvcs-impl/src/com/intellij/dvcs/push/ui/ForcePushAction.kt
@@ -8,11 +8,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.showOkCancelDialog
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.xml.util.XmlStringUtil
 
 private class ForcePushAction : PushActionBase() {
   override fun actionPerformed(project: Project, ui: VcsPushUi) {
-    if (confirmForcePush(project, ui)) {
+    if (Registry.`is`("vcs.non.modal.force.push.warning", false) || confirmForcePush(project, ui)) {
       ui.push(true)
     }
   }

--- a/platform/util/resources/misc/registry.properties
+++ b/platform/util/resources/misc/registry.properties
@@ -821,6 +821,8 @@ vcs.unversioned.files.max.intree.description=Maximum number of unversioned and i
   If there are more unversioned or ignored files, they are substituted with a link which opens a dialog.
 vcs.code.author.inlay.hints=false
 vcs.code.author.inlay.hints.description=Show inlay hints with code author (based on vcs annotations) for classes, methods
+vcs.non.modal.force.push.warning=false
+vcs.non.modal.force.push.warning.description=Show warning dialog when pushing with force
 
 vcs.code.analysis.before.checkin.show.only.new.threshold=-1
 vcs.code.analysis.before.checkin.show.only.new.threshold.description=Show only newly introduced warnings and errors in results \


### PR DESCRIPTION
This change addresses https://youtrack.jetbrains.com/issue/IDEA-288455

It is not a full fix, just a registry option to achieve the same result. 