### PR TITLE
KTIJ-28155: Remove 'Kt' suffix for test class name

### DIFF
--- a/java/java-impl/src/com/intellij/testIntegration/createTest/CreateTestDialog.java
+++ b/java/java-impl/src/com/intellij/testIntegration/createTest/CreateTestDialog.java
@@ -104,7 +104,12 @@ public class CreateTestDialog extends DialogWrapper {
     JavaCodeStyleSettings customSettings = JavaCodeStyleSettings.getInstance(targetClass.getContainingFile());
     String prefix = customSettings.TEST_NAME_PREFIX;
     String suffix = customSettings.TEST_NAME_SUFFIX;
-    return prefix + targetClass.getName() + suffix;
+    return prefix + adjustForKotlin(targetClass.getName()) + suffix;
+  }
+
+  private static String adjustForKotlin(String targetClassName) {
+    // From JVM's perspective, Kotlin classes have the trailing "Kt". Users usually don't want to use it in their test names.
+    return StringUtil.trimEnd(targetClassName, "Kt");
   }
 
   private boolean isSuperclassSelectedManually() {

--- a/platform/lang-impl/src/com/intellij/testIntegration/GotoTestOrCodeHandler.java
+++ b/platform/lang-impl/src/com/intellij/testIntegration/GotoTestOrCodeHandler.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.pom.Navigatable;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -114,12 +115,18 @@ public class GotoTestOrCodeHandler extends GotoTargetHandler {
   @Override
   protected String getChooserTitle(@NotNull PsiElement sourceElement, String name, int length, boolean finished) {
     String suffix = finished ? "" : " so far";
+    name = adjustForKotlin(name);
     if (TestFinderHelper.isTest(sourceElement)) {
       return CodeInsightBundle.message("goto.test.chooserTitle.subject", name, length, suffix);
     }
     else {
       return CodeInsightBundle.message("goto.test.chooserTitle.test", name, length, suffix);
     }
+  }
+
+  private static String adjustForKotlin(String name) {
+    // From JVM's perspective, Kotlin classes have the trailing "Kt". Users usually don't want to use it in their test names.
+    return StringUtil.trimEnd(name, "Kt");
   }
 
   @NotNull


### PR DESCRIPTION
I realize it's a bit hacky solution, and to fix it properly, it would require some serious refactoring.
If you think the solution is good enough, that's fine. If not, I'm glad to follow your hints.

# Testing

<img width="461" alt="Screenshot 2023-12-13 at 21 49 27" src="https://github.com/JetBrains/intellij-community/assets/3110813/8c7cef3f-6da5-45ac-a0e7-fd71a2030ca0">
<img width="615" alt="Screenshot 2023-12-13 at 21 49 34" src="https://github.com/JetBrains/intellij-community/assets/3110813/16cbba18-7bf8-4a80-97a4-5f8a2f1d915d">
