### PR TITLE
(🐞) PyTypeProvider: add new method `getAnnotaionType`

### DIFF
--- a/python/python-psi-api/src/com/jetbrains/python/psi/impl/PyTypeProvider.java
+++ b/python/python-psi-api/src/com/jetbrains/python/psi/impl/PyTypeProvider.java
@@ -72,4 +72,7 @@ public interface PyTypeProvider {
   @Nullable Ref<@Nullable PyCallableType> prepareCalleeTypeForCall(@Nullable PyType type,
                                                                    @NotNull PyCallExpression call,
                                                                    @NotNull TypeEvalContext context);
+
+  @Nullable Ref<@Nullable PyCallableType> getAnnotationType(@NotNull PyExpression typeHint,
+                                                            @NotNull TypeEvalContext context);
 }

--- a/python/python-psi-api/src/com/jetbrains/python/psi/types/PyTypeProviderBase.java
+++ b/python/python-psi-api/src/com/jetbrains/python/psi/types/PyTypeProviderBase.java
@@ -90,6 +90,13 @@ public class PyTypeProviderBase implements PyTypeProvider {
     return null;
   }
 
+
+  @Override
+  public @Nullable Ref<@Nullable PyType> getAnnotationType(@NotNull PyExpression typeHint,
+                                                          @NotNull TypeEvalContext context) {
+    return null;
+  }
+
   protected void registerSelfReturnType(@NotNull String classQualifiedName, @NotNull Collection<String> methods) {
     registerReturnType(classQualifiedName, methods, mySelfTypeCallback);
   }

--- a/python/python-psi-impl/src/com/jetbrains/python/codeInsight/typing/PyTypingTypeProvider.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/codeInsight/typing/PyTypingTypeProvider.java
@@ -776,6 +776,12 @@ public class PyTypingTypeProvider extends PyTypeProviderWithCustomContext<PyTypi
       context.getTypeAliasStack().add(alias);
     }
     try {
+      for (final PyTypeProvider provider : PyTypeProvider.EP_NAME.getExtensionList()) {
+        result = provider.getAnnotationType(typeHint, context.getTypeContext());
+        if (result != null) {
+          return result;
+        }
+      }
       final Ref<PyType> typeFromParenthesizedExpression = getTypeFromParenthesizedExpression(resolved, context);
       if (typeFromParenthesizedExpression != null) {
         return typeFromParenthesizedExpression;


### PR DESCRIPTION
[youtrack](https://youtrack.jetbrains.com/issue/PY-65388/PyTypingTypeProvidergetParameterType-getReturnType-doesnt-return-null)