### PR TITLE
IDEA-287090 update plugin parent classloader when optional dependency is loaded dynamically

### DIFF
--- a/platform/core-impl/src/com/intellij/ide/plugins/cl/PluginClassLoader.kt
+++ b/platform/core-impl/src/com/intellij/ide/plugins/cl/PluginClassLoader.kt
@@ -62,7 +62,8 @@ private val parentListCacheIdCounter = AtomicInteger()
 
 @ApiStatus.Internal
 class PluginClassLoader(classPath: ClassPath,
-                        private val parents: Array<IdeaPluginDescriptorImpl>,
+                        @Volatile
+                        private var parents: Array<IdeaPluginDescriptorImpl>,
                         private val pluginDescriptor: PluginDescriptor,
                         private val coreLoader: ClassLoader,
                         resolveScopeManager: ResolveScopeManager?,
@@ -479,6 +480,20 @@ ${if (exception == null) "" else exception.message}""")
            "packagePrefix=$packagePrefix, " +
            "state=${if (state == PluginAwareClassLoader.ACTIVE) "active" else "unload in progress"}" +
            ")"
+  }
+
+  fun addParent(pluginDescriptor: IdeaPluginDescriptorImpl) {
+    val parents = this.parents
+    if (pluginDescriptor !in parents) {
+      this.parents = parents + pluginDescriptor
+    }
+  }
+
+  fun removeParent(pluginDescriptor: IdeaPluginDescriptorImpl) {
+    val parents = this.parents
+    if (pluginDescriptor in parents) {
+      this.parents = parents.filter { it != pluginDescriptor }.toTypedArray()
+    }
   }
 
   @Suppress("FunctionName")

--- a/platform/platform-impl/src/com/intellij/ide/plugins/DynamicPlugins.kt
+++ b/platform/platform-impl/src/com/intellij/ide/plugins/DynamicPlugins.kt
@@ -644,6 +644,8 @@ object DynamicPlugins {
           classLoaders.add(classLoader)
           classLoader.state = PluginAwareClassLoader.UNLOAD_IN_PROGRESS
         }
+
+        classLoader.removeParent(dependencyPlugin)
       }
       true
     }
@@ -867,6 +869,7 @@ object DynamicPlugins {
           listenerCallbacks = listenerCallbacks,
         )
 
+        updateOptionalPluginClassLoaderDependencies(pluginDescriptor, pluginSet)
         clearPluginClassLoaderParentListCache(pluginSet)
         clearCachedValues()
 
@@ -1366,6 +1369,13 @@ private fun setClassLoaderState(pluginDescriptor: IdeaPluginDescriptorImpl, stat
   (pluginDescriptor.pluginClassLoader as? PluginClassLoader)?.state = state
   for (dependency in pluginDescriptor.pluginDependencies) {
     dependency.subDescriptor?.let { setClassLoaderState(it, state) }
+  }
+}
+
+private fun updateOptionalPluginClassLoaderDependencies(loadedPlugin: IdeaPluginDescriptorImpl, pluginSet: PluginSet) {
+  processOptionalDependenciesOnPlugin(loadedPlugin, pluginSet, true) { mainDescriptor, subDescriptor ->
+    (subDescriptor.pluginClassLoader as? PluginClassLoader)?.addParent(loadedPlugin)
+    true
   }
 }
 


### PR DESCRIPTION
This is a fix for https://youtrack.jetbrains.com/issue/IDEA-287090

When an optional plugin dependency `optionalPlugin` of plugin `mainPlugin` is loaded dynamically at runtime, then the features of `mainPlugin` using `optionalPlugin` were enabled, but the Java classpath of `mainPlugin` did not include the classes of `optionalPlugin`. 
Further details have been documented in the YouTrack issue above.

The bug is a major nuisance for plugins, which make use of optional dependencies.

This PR changes the `parents` property of `PluginClassLoader` to be mutable to allow changing it when an optional dependency is loaded.
I can't tell if that's how you'd like it, but IMHO it should be safe because it's volatile and only updated in a WriteAction, AFAIK.

The test only validates the handling with old-style plugins, because AFAIK the new-style module approach is already handling this case, i.e. the module depending on `optionalPlugin` is loaded when `optionalPlugin` is loaded and unloaded again when `optionalPlugin` is removed again.
I don't have any experience with the new-style module descriptors, so I may have misunderstood the code.

Thank you for your consideration!