### PR TITLE
IDEA-342913 [Inlays/Fix]: Fix implementation of mouseMoved method in the ContainerInlayPresentation.

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/hints/presentation/ContainerInlayPresentation.kt
+++ b/platform/lang-impl/src/com/intellij/codeInsight/hints/presentation/ContainerInlayPresentation.kt
@@ -56,7 +56,7 @@ class ContainerInlayPresentation(
 
   override fun mouseMoved(event: MouseEvent, translated: Point) {
     handleMouse(translated) { point ->
-      presentation.mouseClicked(event, point)
+      presentation.mouseMoved(event, point)
     }
   }
 


### PR DESCRIPTION
Resolves: [IDEA-342913](https://youtrack.jetbrains.com/issue/IDEA-342913/)