### PR TITLE
Don't add orphaned labels to LocalHistory RevisionData

### DIFF
--- a/platform/lvcs-impl/src/com/intellij/history/integration/ui/models/RevisionData.kt
+++ b/platform/lvcs-impl/src/com/intellij/history/integration/ui/models/RevisionData.kt
@@ -40,8 +40,10 @@ private fun mergeLabelsWithRevisions(revisions: List<Revision>): List<RevisionIt
   val result = mutableListOf<RevisionItem>()
 
   for (revision in revisions.asReversed()) {
-    if (revision.isLabel && !result.isEmpty()) {
-      result.last().labels.addFirst(revision)
+    if (revision.isLabel) {
+      if (!result.isEmpty()) {
+        result.last().labels.addFirst(revision)
+      }
     }
     else {
       result.add(RevisionItem(revision))


### PR DESCRIPTION
If the list of local history revisions is prefixed by one or more labels, simply drop them to avoid spurious revisions showing up in the Local History Dialog.

Addresses IDEA-343512