### PR TITLE
IDEA-304758 - Add support for Nushell when loading environment

### DIFF
--- a/platform/util/src/com/intellij/util/EnvironmentUtil.java
+++ b/platform/util/src/com/intellij/util/EnvironmentUtil.java
@@ -264,10 +264,23 @@ public final class EnvironmentUtil {
         }
         readerCmd.append(SHELL_SOURCE_COMMAND).append(" \"").append(file).append("\" && ");
       }
-
-      readerCmd.append("'").append(reader).append("' > '").append(envDataFile.toAbsolutePath()).append("'");
-
       List<String> command = getShellProcessCommand();
+      boolean isNushell = command.get(0).endsWith("/nu");
+
+      if (isNushell) {
+        readerCmd.append("^");
+      }
+
+      readerCmd.append("'").append(reader);
+
+      if (isNushell) {
+        readerCmd.append("' | save '");
+      } else {
+        readerCmd.append("' > '");
+      }
+
+      readerCmd.append(envDataFile.toAbsolutePath()).append("'");
+
       int idx = command.indexOf(SHELL_COMMAND_ARGUMENT);
       if (idx >= 0) {
         // if there is already a command append command to the end


### PR DESCRIPTION
This fixes https://youtrack.jetbrains.com/issue/IDEA-304758, by adjusting the script when the shell is Nushell to `| save <path>`. Also escaped paths requires a `^` in nushell, otherwise it just outputs the path as a string.

I tested the change with Nushell and Bash. For every other shell, the generated script is exactly the same as before.