### PR TITLE
[kotlin] K2 J2K: Port JavaMapForEachInspection to BuiltinMembersConversion

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -99,7 +99,6 @@ private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
     RemoveExplicitPropertyTypeProcessing(),
     RemoveRedundantNullabilityProcessing(),
     inspectionBasedProcessing(FoldInitializerAndIfToElvisInspection(), writeActionNeeded = false),
-    inspectionBasedProcessing(JavaMapForEachInspection()),
     inspectionBasedProcessing(IfThenToSafeAccessInspection(inlineWithPrompt = false), writeActionNeeded = false) {
         it.shouldBeTransformed()
     },

--- a/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
+++ b/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
@@ -380,6 +380,19 @@ private class ConversionsHolder(private val symbolProvider: JKSymbolProvider, pr
         Method("java.util.Collections.emptyList") convertTo Method("kotlin.collections.emptyList") withReplaceType REPLACE_WITH_QUALIFIER,
         Method("java.util.Collections.emptySet") convertTo Method("kotlin.collections.emptySet") withReplaceType REPLACE_WITH_QUALIFIER,
         Method("java.util.Collections.emptyMap") convertTo Method("kotlin.collections.emptyMap") withReplaceType REPLACE_WITH_QUALIFIER,
+        Method("java.util.Map.forEach") convertTo Method("kotlin.collections.Map.forEach") withArgumentsProvider { arguments ->
+            val argument = arguments.arguments.single()::value.detached()
+            if (argument is JKLambdaExpression) {
+                val statement = argument.statement.detached(argument)
+                JKArgumentList(
+                    JKLambdaExpression(
+                        statement,
+                        argument.parameters.map { it.detached(argument) }).withFormattingFrom(argument)
+                )
+            } else {
+                JKArgumentList(argument)
+            }
+        }
     )
 
     private val enumConversions: List<Conversion> = listOf(


### PR DESCRIPTION
NB: The test `testJava8MapForEachWithFullJdk` still fails, but I thought I'd put up a PR to get feedback before I dig deeper and/or start moving tests around.

I was able to switch the expression to use the more Kotlin-y curly braces (i.e. from `map.forEach((key, value) -> foo(key, value))` to `map.forEach { key: String?, value: String? -> foo(key, value) }`), but *not* to use the destructuring (i.e. `key: String?, value: String?` vs. `(key: String?, value: String?)`).

If I understand correctly, I *think* that change might be impossible without 2 refactorings to JKTree classes:
1. Add a JKTree class that's analogous to `KtDestructuringDeclaration`
2. Modify `JKParameter` to also have a `JKDestructuringDeclaration` property (or something similar)

Is there another way to do this that I'm missing?

```
internal class Test {
    fun test(map: HashMap<String?, String?>) {
        map.forEach { key: String?, value: String? -> foo(key, value) }
    }

    fun foo(key: String?, value: String?) {
    }
}
```
@darthorimar @abelkov @jocelynluizzi13 
