### PR TITLE
[kotlin] K2 J2K: Port ConvertToIsArrayOfCallFix to a JK conversion

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -60,10 +60,6 @@ private val errorsFixingDiagnosticBasedPostProcessingGroup = DiagnosticBasedPost
         Errors.NO_EXPLICIT_VISIBILITY_IN_API_MODE,
         Errors.NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING,
     ),
-    diagnosticBasedProcessing(
-        ConvertToIsArrayOfCallFix,
-        Errors.CANNOT_CHECK_FOR_ERASED,
-    ),
     fixTypeMismatchDiagnosticBasedProcessing
 )
 

--- a/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
+++ b/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/ConversionsRunner.kt
@@ -64,7 +64,8 @@ internal object ConversionsRunner {
         FunctionalInterfacesConversion(context),
         FilterImportsConversion(context),
         AddElementsInfoConversion(context),
-        EnumSyntheticValuesMethodConversion(context)
+        EnumSyntheticValuesMethodConversion(context),
+        IsArrayOfCallConversion(context)
     )
 
 

--- a/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/conversions/IsArrayOfCallConversion.kt
+++ b/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/conversions/IsArrayOfCallConversion.kt
@@ -1,0 +1,47 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.nj2k.conversions
+
+import org.jetbrains.kotlin.j2k.Nullability
+import org.jetbrains.kotlin.nj2k.NewJ2kConverterContext
+import org.jetbrains.kotlin.nj2k.RecursiveApplicableConversionBase
+import org.jetbrains.kotlin.nj2k.identifier
+import org.jetbrains.kotlin.nj2k.symbols.JKFieldSymbol
+import org.jetbrains.kotlin.nj2k.tree.*
+import org.jetbrains.kotlin.nj2k.types.*
+import org.jetbrains.kotlin.nj2k.unboxFieldReference
+
+internal class IsArrayOfCallConversion(override val context: NewJ2kConverterContext) :
+    RecursiveApplicableConversionBase(context) {
+
+    override fun applyToElement(element: JKTreeElement): JKTreeElement {
+        if (element !is JKIsExpression) return recurse(element)
+        if (!element.type.type.isArrayType()) return recurse(element)
+        val operand = element.expression
+        val operandType = operand.calculateType(typeFactory) ?: return recurse(element)
+        val type = element::type.detached().type
+
+        val isArrayOfExpression = JKQualifiedExpression(
+            operand.detached(element), JKCallExpressionImpl(
+                symbolProvider.provideMethodSymbol("kotlin.isArrayOf"),
+                JKArgumentList(), JKTypeArgumentList(type.arrayInnerType()!!)
+            )
+        )
+        val replacement = if (operandType.isArrayType()) {
+            isArrayOfExpression
+        } else {
+            JKBinaryExpression(
+                JKIsExpression(
+                    JKFieldAccessExpression(operand.identifier!! as JKFieldSymbol),
+                    JKClassType(
+                        symbolProvider.provideClassSymbol("kotlin.Array"),
+                        listOf(JKStarProjectionTypeImpl),
+                        Nullability.NotNull
+                    ).asTypeElement()
+                ),
+                isArrayOfExpression,
+                JKKtOperatorImpl(JKOperatorToken.ANDAND, typeFactory.types.boolean)
+            )
+        }
+        return recurse(replacement)
+    }
+}


### PR DESCRIPTION
Context from the spreadsheet:
"KTIJ-26655. Looks like ConvertToIsArrayOfCallFix can be just ported to a JK conversion"

NB: The test `CheckForInstanceOfErasedArrayType` still fails, but I thought I'd put up a PR to get feedback before I dig deeper. The test fails because the parameters are still treated as non-nullable. Should this step remain as a postprocessing, since it seems like nullability analysis needs to happen first?

Contents of the failed test:
```
class J {
    fun testObject(obj: Any): Boolean {
        return obj is Array<*> && obj.isArrayOf<String>()
    }

    fun testArray(array: Array<Any?>): Boolean {
        return array.isArrayOf<String>()
    }
}
```
Expected output:
```
class J {
    fun testObject(obj: Any?): Boolean {
        return obj is Array<*> && obj.isArrayOf<String>()
    }

    fun testArray(array: Array<Any?>?): Boolean {
        return array?.isArrayOf<String>() == true
    }
}
```

cc @darthorimar  @abelkov @jocelynluizzi13