### PR TITLE
Add Arena#ofAuto and Arena#global to list of ignored AutoCloseable producers

### DIFF
--- a/java/java-impl/src/com/siyeh/ig/resources/AutoCloseableResourceInspection.java
+++ b/java/java-impl/src/com/siyeh/ig/resources/AutoCloseableResourceInspection.java
@@ -76,6 +76,8 @@ public final class AutoCloseableResourceInspection extends ResourceInspection {
       .add("org.hibernate.Session", "close")
       .add("java.io.PrintWriter", "printf")
       .add("java.io.PrintStream", "printf")
+      .add("java.lang.foreign.Arena", "ofAuto")
+      .add("java.lang.foreign.Arena", "global")
       .finishDefault();
   }
 


### PR DESCRIPTION
Both methods return implementations that will throw UOEs when calling `close()`.
IntelliJ should therefore not warn when those methods are used without TWR. (It might make sense to instead warn if used *with* TWR?)

Java 22: https://cr.openjdk.org/~mcimadamore/jdk/FFM_22_PR/javadoc/java.base/java/lang/foreign/Arena.html
Java 21 (Preview): https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/foreign/Arena.html