### PR TITLE
Keep Balloon open when hovered, even if it has no buttons

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/BalloonImpl.java
+++ b/platform/platform-impl/src/com/intellij/ui/BalloonImpl.java
@@ -166,7 +166,7 @@ public final class BalloonImpl implements Balloon, IdeTooltip.Ui, ScreenAreaCons
           }
         }
 
-        if (myEnableButtons && id == MouseEvent.MOUSE_MOVED) {
+        if (id == MouseEvent.MOUSE_MOVED) {
           final boolean moveChanged = insideBalloon != myLastMoveWasInsideBalloon;
           myLastMoveWasInsideBalloon = insideBalloon;
           if (moveChanged) {


### PR DESCRIPTION
Removes a condition so the code that keeps the Balloon visible when hovered is always executed.

This is the expected behavior for floating UI components, so the user can keep it open if they are reading (or deciding whether to interact with) the contents.

Previously, this was conditioned to the Balloon being created with a close button (adding other buttons manually, or using a text with clickable links wouldn't trigger this behavior either).