### PR TITLE
Fixed SVG Icon preview in the Gutter

### DIFF
--- a/java/java-impl/src/com/intellij/psi/util/ProjectIconsAccessor.java
+++ b/java/java-impl/src/com/intellij/psi/util/ProjectIconsAccessor.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference;
 import com.intellij.ui.scale.JBUIScale;
+import com.intellij.util.SVGLoader;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -159,6 +160,10 @@ public final class ProjectIconsAccessor {
   private static Icon createOrFindBetterIcon(VirtualFile file, boolean useIconLoader) throws IOException {
     if (useIconLoader) {
       return IconLoader.findIcon(new File(file.getPath()).toURI().toURL());
+    }
+    if (StringUtil.equalsIgnoreCase(file.getExtension(), "svg")) {
+      var svg = SVGLoader.load(file.getInputStream(), 1.0f);
+      return new ImageIcon(svg);
     }
     return new ImageIcon(file.contentsToByteArray());
   }


### PR DESCRIPTION
Continuation of the change applied by `Aleksey Pivovarov 12/04/2018, 17:25 ui: support svg icons in editor gutter preview`
in scope of the `14b800ee91f81e6f3dead5a489c1d0255e890c9d`.
SVG images cannot be loaded directly from the file bytearray.

**before**
<img width="668" alt="Screenshot 2023-04-09 at 17 10 33" src="https://user-images.githubusercontent.com/2292510/230781315-1a87df31-0dc6-487c-ade6-e8d8fb120a29.png">

----

**after**
<img width="679" alt="Screenshot 2023-04-09 at 17 12 29" src="https://user-images.githubusercontent.com/2292510/230781328-b464afdf-49c0-4aea-a45e-69bf935c17c3.png">
<img width="1003" alt="Screenshot 2023-04-09 at 17 14 33" src="https://user-images.githubusercontent.com/2292510/230781331-fd435109-7101-4a20-b6df-2f1fe97050ba.png">

closed previous PR by mistake -> https://github.com/JetBrains/intellij-community/pull/2392