### PR TITLE
FIxed bug of generating bad native py module skeletons

### DIFF
--- a/python/helpers/generator3/module_redeclarator.py
+++ b/python/helpers/generator3/module_redeclarator.py
@@ -529,7 +529,7 @@ class ModuleRedeclarator(object):
             if p_name != "__new__" and type(descriptor).__name__.startswith('classmethod'):
                 # 'classmethod_descriptor' in Python 2.x and 3.x, 'classmethod' in Jython
                 deco = "classmethod"
-            elif type(p_func).__name__.startswith('staticmethod'):
+            elif type(descriptor).__name__.startswith('staticmethod'):
                 deco = "staticmethod"
         if p_name == "__new__":
             deco = "staticmethod"


### PR DESCRIPTION
I recently developed a native python module and found pycharm faield to generate the good sketelon for it. 
However, it can handle classmethod well.
I addressed the problem and found its an issue in module_redecalarator.py.
So I created the pull request here. the code here has the same bug as pycharm, hope pycharm is using code from here.
