### PR TITLE
IDEA-332969 - Fix source attachments when a dependency has several matching source jars

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/StringUtils.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/util/StringUtils.java
@@ -49,4 +49,32 @@ public final class StringUtils {
       }
     }
   }
+
+  /**
+   * Same functionality as `com.intellij.openapi.util.text.StringUtil#commonPrefixLength`
+   */
+  public static int commonPrefixLength(CharSequence s1, CharSequence s2) {
+    int maxCommonLength = Math.min(s1.length(), s2.length());
+    for (int i = 0; i < maxCommonLength; ++i) {
+      if (s1.charAt(i) != s2.charAt(i)) {
+        return i;
+      }
+    }
+    return maxCommonLength;
+  }
+
+  /**
+   * Same functionality as `com.intellij.openapi.util.text.StringUtil#commonSuffixLength`
+   */
+  public static int commonSuffixLength(CharSequence s1, CharSequence s2) {
+    int s1Length = s1.length();
+    int s2Length = s2.length();
+    int maxCommonLength = Math.min(s1Length, s2Length);
+    for (int i = 0; i < maxCommonLength; ++i) {
+      if (s1.charAt(s1Length - 1 - i) != s2.charAt(s2Length - 1 - i)) {
+        return i;
+      }
+    }
+    return maxCommonLength;
+  }
 }

--- a/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/util/StringUtilsTest.kt
+++ b/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/util/StringUtilsTest.kt
@@ -1,0 +1,102 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.tooling.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * @see StringUtils
+ * @author Denes Daniel
+ */
+class StringUtilsTest {
+
+  private fun <T> assertCommutative(function: (T, T) -> Int, in1: T, in2: T, expected: Int) {
+    assertThat(function(in1, in2)).isEqualTo(expected)
+    assertThat(function(in2, in1)).isEqualTo(expected)
+  }
+
+  @Test
+  fun `common prefix length test`() {
+    assertCommutative(StringUtils::commonPrefixLength, "", "", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "", "a", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "", "X", 0)
+
+    assertCommutative(StringUtils::commonPrefixLength, "a", "a", 1)
+    assertCommutative(StringUtils::commonPrefixLength, "a", "A", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "a", "x", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "x", "X", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "X", "X", 1)
+
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "a", 1)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "A", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "ab", 2)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "aB", 1)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "AB", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "Ab", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "abc", 3)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "abC", 2)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "aBC", 1)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "ABC", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "ABc", 0)
+    assertCommutative(StringUtils::commonPrefixLength, "abc", "Abc", 0)
+
+    assertCommutative(StringUtils::commonPrefixLength, "11111", "11111", 5)
+    assertCommutative(StringUtils::commonPrefixLength, "11111", "11110", 4)
+    assertCommutative(StringUtils::commonPrefixLength, "11111", "11101", 3)
+    assertCommutative(StringUtils::commonPrefixLength, "11111", "11011", 2)
+    assertCommutative(StringUtils::commonPrefixLength, "11111", "10111", 1)
+    assertCommutative(StringUtils::commonPrefixLength, "11111", "01111", 0)
+
+    assertCommutative(StringUtils::commonPrefixLength, "foo-bar-1.0.jar", "foo", 3)
+    assertCommutative(StringUtils::commonPrefixLength, "foo-bar-1.0.jar", "foo.bar", 3)
+    assertCommutative(StringUtils::commonPrefixLength, "foo-bar-1.0.jar", "foo-ton", 4)
+    assertCommutative(StringUtils::commonPrefixLength, "foo-bar-1.0.jar", "foo-baz", 6)
+    assertCommutative(StringUtils::commonPrefixLength, "foo-bar-1.0.jar", "foo-bar", 7)
+    assertCommutative(StringUtils::commonPrefixLength, "foo-bar-1.0.jar", "foo-bar.testing", 7)
+    assertCommutative(StringUtils::commonPrefixLength, "foo-bar-1.0.jar", "foo-bar-testing", 8)
+  }
+
+  @Test
+  fun `common suffix length test`() {
+    assertCommutative(StringUtils::commonSuffixLength, "", "", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "", "a", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "", "X", 0)
+
+    assertCommutative(StringUtils::commonSuffixLength, "a", "a", 1)
+    assertCommutative(StringUtils::commonSuffixLength, "a", "A", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "a", "x", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "x", "X", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "X", "X", 1)
+
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "c", 1)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "C", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "bc", 2)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "Bc", 1)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "BC", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "bC", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "abc", 3)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "Abc", 2)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "ABc", 1)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "ABC", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "aBC", 0)
+    assertCommutative(StringUtils::commonSuffixLength, "abc", "abC", 0)
+
+    assertCommutative(StringUtils::commonSuffixLength, "11111", "11111", 5)
+    assertCommutative(StringUtils::commonSuffixLength, "11111", "01111", 4)
+    assertCommutative(StringUtils::commonSuffixLength, "11111", "10111", 3)
+    assertCommutative(StringUtils::commonSuffixLength, "11111", "11011", 2)
+    assertCommutative(StringUtils::commonSuffixLength, "11111", "11101", 1)
+    assertCommutative(StringUtils::commonSuffixLength, "11111", "11110", 0)
+
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar.jar", "foo-bar-testing.jar", 4)
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar-1.0.jar", "foo-bar-testing-1.0.jar", 8)
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar-sources.jar", "foo-bar-testing-sources.jar", 12)
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar-1.0-sources.jar", "foo-bar-testing-1.0-sources.jar", 16)
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar.src.jar", "foo-bar-testing.src.jar", 8)
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar-1.0.src.jar", "foo-bar-testing-1.0.src.jar", 12)
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar-sources.src.jar", "foo-bar-testing-sources.src.jar", 16)
+    assertCommutative(StringUtils::commonSuffixLength, "foo-bar-1.0-sources.src.jar", "foo-bar-testing-1.0-sources.src.jar", 20)
+  }
+}

--- a/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImplTest.kt
+++ b/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/util/resolve/DependencyResolverImplTest.kt
@@ -1,0 +1,86 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.tooling.util.resolve
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+import java.util.stream.Stream
+
+/**
+ * @see DependencyResolverImpl
+ * @author Denes Daniel
+ */
+class DependencyResolverImplTest {
+
+  @field:TempDir
+  lateinit var tempDir: File
+
+  private fun testFile(name: String) = File(tempDir, name)
+
+  @Test
+  fun `choose auxiliary artifact file when there is none to choose from`() {
+    val main = testFile("foo-bar.jar")
+    assertThat(DependencyResolverImpl.chooseAuxiliaryArtifactFile(main, setOf())).isNull()
+  }
+
+  @Test
+  fun `choose auxiliary artifact file when there is only one to choose from`() {
+    val main = testFile("foo-bar.jar")
+    val valid1 = testFile("foo-bar.src.jar")
+    val valid2 = testFile("foo-bar-sources.jar")
+    val valid3 = testFile("foo-bar-sources.src.jar")
+    val nonsense = testFile("nonsense")
+    assertThat(DependencyResolverImpl.chooseAuxiliaryArtifactFile(main, setOf(valid1))).isSameAs(valid1)
+    assertThat(DependencyResolverImpl.chooseAuxiliaryArtifactFile(main, setOf(valid2))).isSameAs(valid2)
+    assertThat(DependencyResolverImpl.chooseAuxiliaryArtifactFile(main, setOf(valid3))).isSameAs(valid3)
+    assertThat(DependencyResolverImpl.chooseAuxiliaryArtifactFile(main, setOf(nonsense))).isSameAs(nonsense)
+  }
+
+  data class ChooseAuxiliaryTestCase(val main: String, val auxiliaries: Set<String>, val correctAuxiliary: String = main) {
+    fun mapAuxiliaries(transform: (IndexedValue<String>) -> String): ChooseAuxiliaryTestCase {
+      val auxiliariesMap = auxiliaries.withIndex().associate { it.value to transform(it) }
+      return ChooseAuxiliaryTestCase(main, auxiliariesMap.values.toSet(), auxiliariesMap.getValue(correctAuxiliary))
+    }
+    fun mapMainAndAuxiliaries(transform: (String) -> String) = ChooseAuxiliaryTestCase(
+      transform(main), auxiliaries.map(transform).toSet(), transform(correctAuxiliary))
+    fun appendSuffixes(mainSuffix: String, auxiliarySuffix: String) = ChooseAuxiliaryTestCase(
+      main + mainSuffix, auxiliaries.map { it + auxiliarySuffix }.toSet(), correctAuxiliary + auxiliarySuffix)
+  }
+
+  @ParameterizedTest
+  @MethodSource("chooseAuxiliaryTestCases")
+  fun `choose auxiliary artifact file when there are multiple to choose from`(testCase: ChooseAuxiliaryTestCase) {
+    val main = testFile(testCase.main)
+    val auxiliaries = testCase.auxiliaries.map(::testFile).toSet()
+    val correctAuxiliary = testFile(testCase.correctAuxiliary)
+    assertThat(DependencyResolverImpl.chooseAuxiliaryArtifactFile(main, auxiliaries)).isEqualTo(correctAuxiliary)
+  }
+
+  companion object {
+    @JvmStatic
+    fun chooseAuxiliaryTestCases(): Stream<ChooseAuxiliaryTestCase> {
+      return listOf(
+        ChooseAuxiliaryTestCase("net-soap", setOf("net", "net-soap", "net-soap-jaxb")),
+        ChooseAuxiliaryTestCase("net-soap", setOf("net-soap", "net-soap-jaxb", "net")),
+        ChooseAuxiliaryTestCase("net-soap", setOf("net-soap-jaxb", "net", "net-soap"))
+      ).flatMap { input -> listOf(
+        input,
+        input.mapAuxiliaries { "${it.value}-x${"%02d".format(it.index + 1)}" })
+      }.flatMap { input -> listOf(
+        input,
+        input.mapMainAndAuxiliaries { "${it}-1.2" },
+        input.mapMainAndAuxiliaries { "${it}-3.x-3.4.5" })
+      }.flatMap { input -> listOf(
+        input,
+        input.mapMainAndAuxiliaries { it.replace('-', '.') })
+      }.flatMap { input -> listOf(
+        input.appendSuffixes(".jar", ".src.jar"),
+        input.appendSuffixes(".jar", "-sources.jar"),
+        input.appendSuffixes(".jar", "-sources.src.jar"))
+      }.stream()
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IDEA-332969

> The issue happens when we're trying to import a Gradle project into IntelliJ, where one of the dependencies has multiple JARs. So, a single dependency coordinate (e.g. `foo:bar:1.2.3`) resolves to multiple code JARs, which is possible with an Ivy repository. In this case, IntelliJ only attaches a single source JAR, even if all code JARs have matching source JARs.