### PR TITLE
Prefer external bundling for Gradle source downloads

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/downloadSources.gradle
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/init/downloadSources.gradle
@@ -56,7 +56,11 @@ gradle.projectsEvaluated {
 
 afterProject {
   if (it.name == rootProject.name) {
+    def objects = it.objects
     Configuration configuration = it.configurations.create('downloadSources_' + UUID.randomUUID())
+    configuration.attributes {
+      attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+    }
     configuration.transitive = false
     it.dependencies.add(configuration.name, Properties.dependencyNotation)
     def lazyArtifacts = configuration.incoming.files


### PR DESCRIPTION
For a component that publishes a normal `runtimeElements` alongside a `shadowRuntimeElements` (for example: https://repo.maven.apache.org/maven2/xyz/jpenilla/reflection-remapper/0.1.0/reflection-remapper-0.1.0.module), the "Download Sources" button would previously fail with a confusing variant selection error. By specifying the bundling attribute Gradle can select the standard variant and download the sources.

Another way to address this would be to stop appending `:sources` to the coordinates, and use variant selection alone to tell Gradle we want sources. But that would be a much larger change, and in my experience it does not always work with some published components having strange metadata but perfectly fine `-sources.jar`s. So it would probably want a fallback to the current behavior as well.