### PR TITLE
[java,doc] Allow nested markup in inline return tag

### DIFF
--- a/java/java-frontback-psi-impl/src/com/intellij/lang/java/parser/BasicJavaDocParser.java
+++ b/java/java-frontback-psi-impl/src/com/intellij/lang/java/parser/BasicJavaDocParser.java
@@ -33,7 +33,8 @@ public final class BasicJavaDocParser {
   private static final String LINK_TAG = "@link";
   private static final String LINK_PLAIN_TAG = "@linkplain";
   private static final String PARAM_TAG = "@param";
-  private static final String RETURN_TAG = "@return";
+  private static final String CODE_TAG = "@code";
+  private static final String LITERAL_TAG = "@literal";
   private static final String VALUE_TAG = "@value";
   private static final String SNIPPET_TAG = "@snippet";
   private static final Set<String> REFERENCE_TAGS = ContainerUtil.immutableSet("@throws", "@exception", "@provides", "@uses");
@@ -96,7 +97,9 @@ public final class BasicJavaDocParser {
       if (braceScope > 0) {
         setBraceScope(builder, braceScope + 1);
         builder.remapCurrentToken(JavaDocTokenType.DOC_COMMENT_DATA);
-        if (!RETURN_TAG.equals(tagName)) {
+        // Some inline tags can contain arbitrary other markup, process it as such
+        boolean isLiteralTag = CODE_TAG.equals(tagName) || LITERAL_TAG.equals(tagName) || SNIPPET_TAG.equals(tagName);
+        if (isLiteralTag) {
           builder.advanceLexer();
           return;
         }

--- a/java/java-frontback-psi-impl/src/com/intellij/lang/java/parser/BasicJavaDocParser.java
+++ b/java/java-frontback-psi-impl/src/com/intellij/lang/java/parser/BasicJavaDocParser.java
@@ -33,6 +33,7 @@ public final class BasicJavaDocParser {
   private static final String LINK_TAG = "@link";
   private static final String LINK_PLAIN_TAG = "@linkplain";
   private static final String PARAM_TAG = "@param";
+  private static final String RETURN_TAG = "@return";
   private static final String VALUE_TAG = "@value";
   private static final String SNIPPET_TAG = "@snippet";
   private static final Set<String> REFERENCE_TAGS = ContainerUtil.immutableSet("@throws", "@exception", "@provides", "@uses");
@@ -88,14 +89,17 @@ public final class BasicJavaDocParser {
                                     @Nullable String tagName,
                                     boolean isInline,
                                     @NotNull AbstractBasicJavaDocElementTypeFactory.JavaDocElementTypeContainer javaDocElementTypeContainer) {
+    int initialBraceScope = getBraceScope(builder);
     IElementType tokenType = getTokenType(builder);
     if (tokenType == JavaDocTokenType.DOC_INLINE_TAG_START) {
       int braceScope = getBraceScope(builder);
       if (braceScope > 0) {
         setBraceScope(builder, braceScope + 1);
         builder.remapCurrentToken(JavaDocTokenType.DOC_COMMENT_DATA);
-        builder.advanceLexer();
-        return;
+        if (!RETURN_TAG.equals(tagName)) {
+          builder.advanceLexer();
+          return;
+        }
       }
 
       PsiBuilder.Marker tag = builder.mark();
@@ -125,7 +129,7 @@ public final class BasicJavaDocParser {
         if (tokenType == JavaDocTokenType.DOC_INLINE_TAG_END) {
           braceScope = getBraceScope(builder);
           if (braceScope > 0) setBraceScope(builder, --braceScope);
-          if (braceScope == 0) break;
+          if (braceScope == initialBraceScope) break;
         }
       }
 


### PR DESCRIPTION
## Fixed Youtrack issues
https://youtrack.jetbrains.com/issue/IDEA-300185/Support-code-tags-inside-inline-return  
https://youtrack.jetbrains.com/issue/IDEA-329877/Javadoc-does-not-render-correctly-for-inline-return  
Maybe more

## Before
Previously IntelliJ did not parse nested markup in inline tags, resulting in the following display for a simple method doc comment.
```java
    /**
     * {@return {@code something cody} in here !}
     *
     * @param args my args
     * @throws IOException if things happen
     */
    public static void main(String[] args) throws IOException {}
```
<img width="231" alt="grafik" src="https://github.com/JetBrains/intellij-community/assets/20284688/afdf4b1a-c946-4863-97cb-ffd07217796f">

## After
<img width="229" alt="grafik" src="https://github.com/JetBrains/intellij-community/assets/20284688/128b09f7-65e0-4efc-bf45-b86a99faab0e">
<img width="234" alt="grafik" src="https://github.com/JetBrains/intellij-community/assets/20284688/166d274a-85e6-4587-aa4a-5647feaf1731">


## Threats to validity
The javadoc parsing code seems incredibly complicated for what it does, so I might have missed some intricacies. As my changes are quite limited in scope though, that should be okay to review.

## Alternative approaches and future work
My first commit only fixes inline return tags. My second commit allows nested content everywhere except literal tags, which prettifies the display somewhat in other cases (e.g. `{@link Test {@code foo} bar}`). The standard resolves such text and the spec says
> Escape sequences cannot be used in inline tags that contain literal text; this includes `{@code}`, `{@literal}`, `{@snippet}`, and user-defined tags.

The last part, user-defined tags, I did not model. They will also have their markup parsed recursively. I do not know how to detect them in a future-proof way in IntelliJ.
