### PR TITLE
IDEA-310560 - Hide the border of the right toolbar when it is empty (New UI)

### DIFF
--- a/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowRightToolbar.kt
+++ b/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowRightToolbar.kt
@@ -4,7 +4,10 @@ package com.intellij.toolWindow
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.impl.AbstractDroppableStripe
 import com.intellij.ui.UIBundle
-import com.intellij.util.ui.JBUI
+import com.intellij.ui.border.CustomLineBorder
+import com.intellij.util.ui.JBInsets
+import java.awt.Component
+import java.awt.Insets
 import javax.swing.border.Border
 
 internal class ToolWindowRightToolbar(paneId: String, isPrimary: Boolean) : ToolWindowToolbar(isPrimary, ToolWindowAnchor.RIGHT) {
@@ -24,5 +27,11 @@ internal class ToolWindowRightToolbar(paneId: String, isPrimary: Boolean) : Tool
     }
   }
 
-  override fun createBorder(): Border = JBUI.Borders.customLineLeft(getBorderColor())
+  override fun createBorder(): Border {
+    return object : CustomLineBorder(getBorderColor(), JBInsets(0, 1, 0, 0)) {
+      override fun getBorderInsets(c: Component?): Insets {
+        return if (hasButtons()) super.getBorderInsets(c) else JBInsets.emptyInsets()
+      }
+    }
+  }
 }


### PR DESCRIPTION
Hello.
There is a problem with the New UI toolbar that has been bothering me for a while.
When the right toolbar is empty (i.e. has no attached buttons), it will stil have a 1 pixel border and, accordingly, will push the text editor's scrollbar away from the right edge of the screen.

![image](https://github.com/JetBrains/intellij-community/assets/8329446/a4231069-b4da-48e6-829c-2bd85ca39176)

This is important because the scroll bar is very thin and it's hard to find it without looking.
When there is no border (and the text editor window is in fullscreen mode), to get to the scroll bar horizontally you just blindly throw the mouse cursor to the rightmost pixel of the screen (the OS won't let you go any further if there is no 2nd monitor), and it will still be clickable just fine. Currently, the user has to make a consious effort to find the tiny scroll bar. It can be really exhausting when you scroll a lot (which is almost always the case).

I don't really know how common this issue is for other people, but I always rely on this behaviour in almost any program I use (and keep the right toolbar empty where possible). Any web browser I've tried supports it, and VS Code and Jetbrains' IDEs with the Old UI don't have that problem. Unfortunately, there are still programs that lack this 'feature'. I think on Linux sometimes it even depends on which desktop environment I use.

Surprisingly I've found only [one issue about it on Youtrack](https://youtrack.jetbrains.com/issue/IDEA-310560/New-UI-Cant-select-vertical-scrollbar-from-edge-of-screen). Someone is already assigned to it, but it's been a year, and I wanted to somehow nudge this task as it's really really important problem (at least, for me). If this basic solution is not adequate, I would be curious to know which one is (just for self improvement; not that I would be able to fix it or anything).