### PR TITLE
Fix identifier highlight in injected languages.

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/IdentifierHighlighterPassFactory.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/IdentifierHighlighterPassFactory.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.impl.NonBlockingReadActionImpl;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
@@ -23,7 +24,7 @@ public final class IdentifierHighlighterPassFactory {
   public IdentifierHighlighterPass createHighlightingPass(@NotNull PsiFile file,
                                                           @NotNull Editor editor,
                                                           @NotNull TextRange visibleRange) {
-    if (!editor.isOneLineMode() &&
+    if ((!editor.isOneLineMode() || !((EditorEx) editor).isEmbeddedIntoDialogWrapper()) &&
         CodeInsightSettings.getInstance().HIGHLIGHT_IDENTIFIER_UNDER_CARET &&
         !DumbService.isDumb(file.getProject()) &&
         isEnabled() &&


### PR DESCRIPTION
Identifier highlighting was disabled for single-line editors, which accounts for injected languages inside single-line Java string literals. According to git blame, the original intention of this was to disable identifier highlighting in dialog editors, so I switched the check to explicitly check that.

My use case is that I'm developing a plugin which makes use of a `MultiHostInjector` for a DSL spread across multiple Java string literals. It would significantly improve UX if identifier highlighting was possible in this use case. I could not find any clean workaround which doesn't involve modifying IntelliJ in this way. Besides, I consider this a bug and it's nice to get it fixed :)

Before the fix:
![image](https://github.com/JetBrains/intellij-community/assets/13084089/b2532256-2566-4903-a9da-ae0d5b7e5aed)

After the fix:
![image](https://github.com/JetBrains/intellij-community/assets/13084089/d9c022f9-ffd2-41d0-adc8-9b3e79a37965)

