### PR TITLE
IDEA-347543 - Fix Incorrect File Selection in Merge Conflict Window Directory Tree by Preserving Expanded State

### DIFF
--- a/platform/platform-api/src/com/intellij/util/ui/tree/TreeUtil.java
+++ b/platform/platform-api/src/com/intellij/util/ui/tree/TreeUtil.java
@@ -21,6 +21,7 @@ import com.intellij.ui.tree.DelegatingEdtBgtTreeVisitor;
 import com.intellij.ui.tree.TreeVisitor;
 import com.intellij.ui.treeStructure.CachingTreePath;
 import com.intellij.ui.treeStructure.Tree;
+import com.intellij.ui.treeStructure.treetable.TreeTableTree;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.Range;
 import com.intellij.util.concurrency.EdtScheduledExecutorService;
@@ -68,6 +69,34 @@ public final class TreeUtil {
   private static final Key<Function<TreePath, Navigatable>> NAVIGATABLE_PROVIDER = Key.create("TreeUtil: convert TreePath to Navigatable");
 
   private TreeUtil() {}
+
+  public static @NotNull List<TreePath> findPaths(@Nullable TreeTableTree tree,
+                                                  @NotNull List<String> pathsToSearch) {
+    List<TreePath> treePaths = new ArrayList<>();
+    if (tree != null) {
+      TreePath root = tree.getPathForRow(0);
+      if (root != null) {
+        findPaths(tree, root, pathsToSearch, treePaths);
+      }
+    }
+    return treePaths;
+  }
+
+  private static void findPaths(@NotNull TreeTableTree tree,
+                                @NotNull TreePath path,
+                                @NotNull List<String> pathsToSearch,
+                                @NotNull List<TreePath> treePaths) {
+    if (pathsToSearch.contains(path.toString())) {
+      treePaths.add(path);
+    }
+
+    for (int i = 0; i < tree.getModel().getChildCount(path.getLastPathComponent()); i++) {
+      Object childNode = tree.getModel().getChild(path.getLastPathComponent(), i);
+      TreePath childNodePath = path.pathByAddingChild(childNode);
+
+      findPaths(tree, childNodePath, pathsToSearch, treePaths);
+    }
+  }
 
   /**
    * @return a navigatable object that corresponds to the specified path,  or {@code null} otherwise

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/merge/MultipleFileMergeDialog.kt
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/merge/MultipleFileMergeDialog.kt
@@ -373,8 +373,17 @@ open class MultipleFileMergeDialog(
       doCancelAction()
     }
     else {
+      val expandedPathsStr = TreeUtil.collectExpandedPaths(table.tree)
+        .map { it.toString() }
+
       var selIndex = table.selectionModel.minSelectionIndex
       updateTree()
+
+      TreeUtil.collapseAll(table.tree, true, -1)
+
+      val previouslyExpandedTreeNodes = TreeUtil.findPaths(table.tree, expandedPathsStr)
+      TreeUtil.restoreExpandedPaths(table.tree, previouslyExpandedTreeNodes)
+
       if (selIndex >= table.rowCount) {
         selIndex = table.rowCount - 1
       }


### PR DESCRIPTION
### Problem:

When users collapse directories in the Merge Conflict window pop up and a refresh occurs (triggered by updateModelFromFiles(), for example when I open the file for merge and close it immediately), the previously selected file could be reselected incorrectly. 

This issue stems from `table.selectionModel.minSelectionIndex` not accounting for the visibility (expanded/collapsed state) of files in the directory tree. Consequently, when the updateTree() function expands all directories during a refresh, the indices of files change, leading to a mismatch between the intended and actual selections.

Here is the visualization of the problem:
https://imgur.com/gallery/sjJe84Y

### Solution:
To address this issue, I implemented a strategy to preserve the user's context in the directory tree across updates. The solution involves the following steps:

1. Save Expanded Paths
2. After `updateTree()` function is invoked, collapse the entire tree.
3. Restore expanded paths

This approach ensures that the directory tree's structure post-update remains identical to its state prior to the update. Consequently, the index saved in `selIndex` remains consistent. 