### PR TITLE
#IDEA-346366 - Files .md is not displayed if preview mode is selected…

### DIFF
--- a/plugins/markdown/core/src/org/intellij/plugins/markdown/ui/preview/MarkdownPreviewFileEditor.java
+++ b/plugins/markdown/core/src/org/intellij/plugins/markdown/ui/preview/MarkdownPreviewFileEditor.java
@@ -76,7 +76,7 @@ public final class MarkdownPreviewFileEditor extends UserDataHolderBase implemen
     myHtmlPanelWrapper = new JPanel(new BorderLayout());
     myHtmlPanelWrapper.addComponentListener(new AttachPanelOnVisibilityChangeListener());
 
-    //    attachHtmlPanel();
+    attachHtmlPanel();
 
     final var messageBusConnection = myProject.getMessageBus().connect(this);
     final var settingsChangedListener = new MyUpdatePanelOnSettingsChangedListener();


### PR DESCRIPTION
Fix for issue [IDEA-346366](https://youtrack.jetbrains.com/issue/IDEA-346366/Files-.md-is-not-displayed-if-preview-mode-is-selected-by-default)