### PR TITLE
Gradle Sync cleanup: Move dependency resolver test to same package as the tested class

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/GradleDependencyResolver.java
+++ b/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/GradleDependencyResolver.java
@@ -454,7 +454,7 @@ public final class GradleDependencyResolver {
    * @return best match, null otherwise
    */
   @VisibleForTesting
-  public static @Nullable File chooseAuxiliaryArtifactFile(@NotNull File main, @NotNull Set<File> auxiliaries) {
+  static @Nullable File chooseAuxiliaryArtifactFile(@NotNull File main, @NotNull Set<File> auxiliaries) {
     Iterator<File> auxiliariesIterator = auxiliaries.iterator();
     if (!auxiliariesIterator.hasNext()) {
       return null;

--- a/plugins/gradle/tooling-extension-impl/testSources/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/GradleDependencyResolverTest.kt
+++ b/plugins/gradle/tooling-extension-impl/testSources/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/GradleDependencyResolverTest.kt
@@ -1,7 +1,6 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
-package org.jetbrains.plugins.gradle.tooling.util.resolve
+package com.intellij.gradle.toolingExtension.impl.model.dependencyModel
 
-import com.intellij.gradle.toolingExtension.impl.model.dependencyModel.GradleDependencyResolver
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir


### PR DESCRIPTION
[Gradle|Sync] cleanup: moved dependency resolver test to dependencyModel package
* This is a follow-up to commit c4be347449156b43b1fb10b7b1b671ea4538525a that moved the resolver class itself, and allows reducing the visibility of method `chooseAuxiliaryArtifactFile` to package private again.

@HackerMadCat , please review.