### PR TITLE
[kotlin] J2K: K2 Port SimplifyAssertNotNullInspection to JKTree processing

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -115,7 +115,6 @@ private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
         it.getExplicitLabelComment() == null
     },
     DestructureForLoopParameterProcessing(),
-    inspectionBasedProcessing(SimplifyAssertNotNullInspection()),
     LiftReturnInspectionBasedProcessing(),
     LiftAssignmentInspectionBasedProcessing(),
     intentionBasedProcessing(RemoveEmptyPrimaryConstructorIntention()),

--- a/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/conversions/JavaStatementConversion.kt
+++ b/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/conversions/JavaStatementConversion.kt
@@ -1,13 +1,13 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
-
 package org.jetbrains.kotlin.nj2k.conversions
 
 import org.jetbrains.kotlin.j2k.Nullability.NotNull
-import org.jetbrains.kotlin.nj2k.NewJ2kConverterContext
+import org.jetbrains.kotlin.nj2k.*
 import org.jetbrains.kotlin.nj2k.RecursiveConversion
 import org.jetbrains.kotlin.nj2k.kotlinAssert
 import org.jetbrains.kotlin.nj2k.tree.*
 import org.jetbrains.kotlin.nj2k.types.JKJavaDisjunctionType
+import org.jetbrains.kotlin.nj2k.types.isNull
 import org.jetbrains.kotlin.nj2k.types.updateNullability
 import org.jetbrains.kotlin.nj2k.useExpression
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
@@ -25,7 +25,7 @@ internal class JavaStatementConversion(context: NewJ2kConverterContext) : Recurs
         )
     }
 
-    private fun convertAssert(element: JKJavaAssertStatement): JKExpressionStatement {
+    private fun convertAssert(element: JKJavaAssertStatement): JKStatement {
         var assertion = element::condition.detached()
         if (assertion is JKParenthesizedExpression) {
             // drop awkward parentheses around the first argument
@@ -34,7 +34,59 @@ internal class JavaStatementConversion(context: NewJ2kConverterContext) : Recurs
         val messageExpression =
             if (element.description is JKStubExpression) null
             else JKLambdaExpression(JKExpressionStatement(element::description.detached()))
+        // If this is a null assertion like `assert s1 != null`, replace it with `checkNotNull(s1)
+        val expressionComparedToNull = assertion.singleExpressionComparedToNull()
+        if (expressionComparedToNull != null && assertion is JKBinaryExpression && assertion.operator.token.text == "!=") {
+            val referencedVariable = if (expressionComparedToNull is JKFieldAccessExpression)
+                expressionComparedToNull.identifier.target else null
+            val checkNotNullSymbol = symbolProvider.provideMethodSymbol("kotlin.checkNotNull")
+            return if (referencedVariable is JKLocalVariable && element.occursImmediatelyAfterDeclarationInBlock(referencedVariable)) {
+                // If the assertion occurs immediately after the variable declaration, merge them by wrapping the initializer in checkNotNull
+                val initializerType = referencedVariable.initializer.calculateType(typeFactory)
+                referencedVariable.initializer = JKCallExpressionImpl(
+                    checkNotNullSymbol,
+                    listOfNotNull(referencedVariable.initializer.copyTreeAndDetach(), messageExpression?.copyTree()).toArgumentList(),
+                    expressionType = initializerType?.updateNullability(NotNull)
+                )
+                // effectively delete the original statement, since the assertion was merged into the variable declaration above
+                JKEmptyStatement()
+            } else {
+                // Otherwise, leave the variable declaration untouched and do an inplace replacement of the assertion
+                JKExpressionStatement(
+                    JKCallExpressionImpl(
+                        checkNotNullSymbol,
+                        listOfNotNull(
+                            expressionComparedToNull.detached(assertion),
+                            messageExpression?.copyTree()
+                        ).toArgumentList()
+                    )
+                ).withFormattingFrom(element)
+            }
+        }
         return JKExpressionStatement(kotlinAssert(assertion, messageExpression, typeFactory))
+    }
+
+    private fun JKStatement.occursImmediatelyAfterDeclarationInBlock(declaration: JKDeclaration): Boolean {
+        val parent = this.parent.safeAs<JKBlockImpl>() ?: return false
+        if (parent != declaration.parent?.parent) return false
+        val statements = parent.statements
+        val declarationIndex =
+            statements.indexOfFirst { it is JKDeclarationStatement && it.declaredStatements.singleOrNull() == declaration }
+        if (declarationIndex < 0 || declarationIndex == statements.lastIndex) return false
+        val expressionIndex = statements.indexOf(this)
+        if (expressionIndex < declarationIndex) return false
+        if (declarationIndex + 1 == expressionIndex) return true
+        return statements.subList(declarationIndex + 1, expressionIndex).all { it.isEmpty() }
+    }
+
+    private fun JKExpression.singleExpressionComparedToNull(): JKExpression? {
+        if (this !is JKBinaryExpression) return null
+        val left = left
+        val right = right
+        val leftIsNull = left is JKLiteralExpression && left.isNull()
+        val rightIsNull = right is JKLiteralExpression && right.isNull()
+        if (leftIsNull == rightIsNull) return null
+        return if (leftIsNull) right else left
     }
 
     private fun convertSynchronized(element: JKJavaSynchronizedStatement): JKExpressionStatement {

--- a/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/assertStatement/assertNotNull.java
+++ b/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/assertStatement/assertNotNull.java
@@ -1,11 +1,24 @@
 abstract class C {
+    String mMemberVariable;
+
     void foo() {
         String s1 = f();
         assert s1 != null;
 
         String s2 = g();
         assert s2 != null : "g should not return null";
+        String doNotMergeDueToPossibleSideEffects = g();
+        assert s2.hashCode() == 42;
         int h = s2.hashCode();
+
+        String s3 = "sss";
+        assert s3.hashCode() != null;
+
+        assert doNotMergeDueToPossibleSideEffects != null;
+        assert mMemberVariable != null;
+
+        String doNotTouchDifferentAssert = f();
+        assert doNotTouchDifferentAssert == null;
     }
 
     abstract String f();

--- a/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/assertStatement/assertNotNull.kt
+++ b/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/assertStatement/assertNotNull.kt
@@ -1,8 +1,19 @@
 internal abstract class C {
+    var mMemberVariable: String? = null
+
     fun foo() {
         val s1 = f()!!
         val s2 = g() ?: error("g should not return null")
+        val doNotMergeDueToPossibleSideEffects = g()
+        assert(s2.hashCode() == 42)
         val h = s2.hashCode()
+
+        val s3 = "sss"
+        assert(s3.hashCode() != null)
+        assert(doNotMergeDueToPossibleSideEffects != null)
+        assert(mMemberVariable != null)
+        val doNotTouchDifferentAssert = f()
+        assert(doNotTouchDifferentAssert == null)
     }
 
     abstract fun f(): String?

--- a/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/assertStatement/assertNotNull.kt
+++ b/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/assertStatement/assertNotNull.kt
@@ -2,16 +2,18 @@ internal abstract class C {
     var mMemberVariable: String? = null
 
     fun foo() {
-        val s1 = f()!!
-        val s2 = g() ?: error("g should not return null")
+        val s1 = checkNotNull(f())
+        val s2 = checkNotNull(g()) { "g should not return null" }
         val doNotMergeDueToPossibleSideEffects = g()
         assert(s2.hashCode() == 42)
         val h = s2.hashCode()
 
         val s3 = "sss"
-        assert(s3.hashCode() != null)
-        assert(doNotMergeDueToPossibleSideEffects != null)
-        assert(mMemberVariable != null)
+        checkNotNull(s3.hashCode())
+
+        checkNotNull(doNotMergeDueToPossibleSideEffects)
+        checkNotNull(mMemberVariable)
+
         val doNotTouchDifferentAssert = f()
         assert(doNotTouchDifferentAssert == null)
     }

--- a/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/nullability/notNullCast.kt
+++ b/plugins/kotlin/j2k/k1.new/tests/testData/newJ2k/nullability/notNullCast.kt
@@ -8,14 +8,14 @@ class Passenger {
     }
 
     fun test1() {
-        val pass = provideNullable(1)!!
+        val pass = checkNotNull(provideNullable(1))
         accept1(pass as PassChild)
     }
 
     fun test2() {
         val pass = provideNullable(1)
         if (1 == 2) {
-            assert(pass != null)
+            checkNotNull(pass)
             accept2(pass as PassChild?)
         }
         accept2(pass as PassChild?)


### PR DESCRIPTION
Context from spreadsheet:
"Try to move to conversions.JavaStatementConversion#convertAssert"

There are no functional changes in the first commit--I just expanded the tests here to include cases covered by the [inspection's tests](https://github.com/JetBrains/intellij-community/tree/45d0890f92f15bd9bf7c181a939affff166da55e/plugins/kotlin/idea/tests/testData/inspectionsLocal/simplifyAssertNotNull).

The second commit contains the actual porting plus--as the tests indicate--two changes in behavior compared to the original inspection:
1. Better preservation of the original spacing 
2. Replacing `assert` with `checkNotNull` instead of `!!` (more on this choice below)

I actually feel pretty strongly that it's preferable to replace `assert(s != null)` with `checkNotNull(s)` rather than `s!!`, though I may be missing some important details. My reasoning is that `assert` and `checkNotNull` are both strong indications that a previous author wanted to make a condition very explicit, whereas `!!` feels more like a stopgap that crops up when converting Java code with wonky nullability. From that perspective, `checkNotNull` feels like a more natural replacement. (Admittedly I'm also biased in favor of the `checkNotNull` approach because adding JKTree support for `!!` expressions would be more work.)

@abelkov @darthorimar @jocelynluizzi13 