### PR TITLE
Fix comment in CommonCodeStyleSettings.java

### DIFF
--- a/platform/code-style-api/src/com/intellij/psi/codeStyle/CommonCodeStyleSettings.java
+++ b/platform/code-style-api/src/com/intellij/psi/codeStyle/CommonCodeStyleSettings.java
@@ -586,7 +586,7 @@ public class CommonCodeStyleSettings implements CommentStyleSettings {
   /**
    * "try( Resource r = r() )"
    * or
-   * "catch(Resource r = r())"
+   * "try(Resource r = r())"
    */
   public boolean SPACE_WITHIN_TRY_PARENTHESES = false;
 


### PR DESCRIPTION
Comment fixed for `SPACE_WITHIN_TRY_PARENTHESES` within `CommonCodeStyleSettings.java`