### PR TITLE
CertificateManager: set default SSLSocketFactory

### DIFF
--- a/platform/platform-api/src/com/intellij/util/net/ssl/CertificateManager.kt
+++ b/platform/platform-api/src/com/intellij/util/net/ssl/CertificateManager.kt
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import javax.crypto.BadPaddingException
+import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.KeyManager
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
@@ -90,6 +91,7 @@ class CertificateManager(coroutineScope: CoroutineScope) : PersistentStateCompon
       // Don't do this: protocol created this way will ignore SSL tunnels. See IDEA-115708.
       // Protocol.registerProtocol("https", CertificateManager.createDefault().createProtocol());
       SSLContext.setDefault(sslContext)
+      HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory) // in case a previous value was already cached
       LOG.info("Default SSL context initialized")
     }
   }


### PR DESCRIPTION
The problem:

  If an HTTPS connection is created before CertificateManager.<init>
  calls SSLContext.setDefault(sslContext), then HttpsURLConnection
  will cache the wrong value for its field `defaultSSLSocketFactory`,
  and thus all future HTTPS connections will use the wrong
  SSLSocketFactory by default. This can lead to issues such as
  https://issuetracker.google.com/319147212.

The solution:

  Explicitly call setDefaultSSLSocketFactory() to ensure any
  previously cached value is overwritten.

---

Issue link: https://issuetracker.google.com/319147212

Let me know what you think. Also, concerned that this initialization code
happens within `coroutineScope.launch` and thus has no guarantees of
finishing before the IDE starts making HTTPS requests. Let me know if you
would like to YouTrack issue filed for further discussion. Thanks!