### PR TITLE
IDEA-346717: Decompiler fails to decompile switch statements containing static calls

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
@@ -424,7 +424,7 @@ public final class SwitchHelper {
       @Override
       public SwitchOnStringCandidate recognize(@NotNull SwitchStatement firstSwitch,
                                                @NotNull InvocationExprent switchSelector) {
-        if (switchSelector.getInstance().type != Exprent.EXPRENT_VAR) return null;
+        if (switchSelector.getInstance() == null || switchSelector.getInstance().type != Exprent.EXPRENT_VAR) return null;
         if (!switchSelector.isInstanceCall(ClassNameConstants.JAVA_LANG_STRING, "hashCode", 0)) return null;
 
         Set<Object> realCaseValueHashCodes = findRealCaseValuesHashCodes(firstSwitch);


### PR DESCRIPTION
[IDEA-346717](https://youtrack.jetbrains.com/issue/IDEA-346717/Decompiler-fails-to-decompile-switch-statements-containing-static-method-calls)

When a switch statement contains a static call like **switch(Cls.foo())**, the decompiler throws java.lang.NullPointerException.

The field **instance** in InvocationExprent is null when the method call is static (InvocationExprent.java:121):
```
else if (opcode == CodeConstants.opc_invokestatic) {
  isStatic = true;
}
else {
  instance = stack.pop();
}
```

However, the decompiler does not check whether **instance** is null before getting its field **type** (SwitchHelper.java:427):
```
if (switchSelector.getInstance().type != Exprent.EXPRENT_VAR) return null;
```

To fix this,  it is neccessary to check whether switchSelector.getInstance() is null first.