### PR TITLE
On Windows, inline environment variable values case-insensitively

### DIFF
--- a/platform/util/src/com/intellij/util/EnvironmentUtil.java
+++ b/platform/util/src/com/intellij/util/EnvironmentUtil.java
@@ -540,7 +540,10 @@ public final class EnvironmentUtil {
   private static final Pattern pattern = Pattern.compile("\\$(.*?)\\$");
 
   public static void inlineParentOccurrences(@NotNull Map<String, String> envs, @NotNull Map<String, String> parentEnv) {
-    LinkedHashMap<String, String> lookup = new LinkedHashMap<>(envs);
+    // On Windows, names of environment variables are case-insensitive. On UNIX, names are case-sensitive.
+    Comparator<String> keyComparator = SystemInfoRt.isWindows ? String.CASE_INSENSITIVE_ORDER : Comparator.naturalOrder();
+    Map<String, String> lookup = new TreeMap<>(keyComparator);
+    lookup.putAll(envs);
     lookup.putAll(parentEnv);
     for (Map.Entry<String, String> entry : envs.entrySet()) {
       String key = entry.getKey();

--- a/platform/util/testSrc/com/intellij/util/EnvironmentUtilTest.java
+++ b/platform/util/testSrc/com/intellij/util/EnvironmentUtilTest.java
@@ -110,6 +110,16 @@ public class EnvironmentUtilTest {
     assertEquals("/hey", list.get(2));
   }
 
+  @Test
+  public void testWindowsCaseInsensitive() {
+    assumeWindows();
+
+    List<String> list = substitute("FIRST=$foo$;SECOND=$FOO$;THIRD=$fOo$", "FOo=/hey");
+    assertEquals("/hey", list.get(0));
+    assertEquals("/hey", list.get(1));
+    assertEquals("/hey", list.get(2));
+  }
+
   private static List<String> substitute(String environment, String parent) {
     Map<String, String> env = EnvVariablesTable.parseEnvsFromText(environment);
     Map<String, String> parentEnv = EnvVariablesTable.parseEnvsFromText(parent);


### PR DESCRIPTION
On Windows, when inlining environment variable values,`$PATH$` and `$Path` should both refer to the same value.
On macOS and Linux, names of environment variables are case-sensitive and must be treated as before.

On Windows, this prints `second`:
```bat
set myVALUE=first
set MYvalue=second
echo %myvalue%
```