### PR TITLE
[kotlin] J2K: Add more test cases for handling lambdas in argument lists

### DIFF
--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.java
@@ -1,4 +1,5 @@
 // IGNORE_K2
+
 import kotlin.jvm.functions.Function0;
 import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
@@ -13,7 +14,33 @@ public class Java8Class {
     public void foo2(Function2<Integer, Integer, String> r) {
     }
 
+    public bar(Function0<String> f) {
+        bar(f, (i) -> "default g")
+    }
+
+    public bar(Function0<String> f, Function1<Integer, String> g) {
+    }
+
+    public doNotTouch(Function0<String> f, String s) {
+    }
+
     public void helper() {
+    }
+
+    public void vararg(String key, Function0<String>... functions) {
+    }
+
+    class Base {
+        Base(String name, Function0<String> f) {
+        }
+    }
+
+    class Child extends Base {
+        Child() {
+            super("Child", () -> {
+                return "a child class";
+            })
+        }
     }
 
     public void foo() {
@@ -40,6 +67,10 @@ public class Java8Class {
             helper();
             return "42";
         });
+
+        bar(() -> "f", (i) -> "g");
+
+        vararg("first", () -> "f");
 
         Function2<Integer, Integer, String> f = (Integer i, Integer k) -> {
             helper();
@@ -86,5 +117,9 @@ public class Java8Class {
 
             return "43";
         });
+
+        doNotTouch(() -> {
+            return "first arg";
+        }, "last arg");
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
@@ -8,8 +8,25 @@ class Java8Class {
     fun foo2(r: Function2<Int?, Int?, String?>?) {
     }
 
+    fun bar(f: Function0<String?>?) {
+        bar(f) { i -> "default g" }
+    }
+
+    fun bar(f: Function0<String?>?, g: Function1<Int?, String?>?) {
+    }
+
+    fun doNotTouch(f: Function0<String?>?, s: String?) {
+    }
+
     fun helper() {
     }
+
+    fun vararg(key: String?, vararg functions: Function0<String?>?) {
+    }
+
+    internal open inner class Base(name: String?, f: Function0<String?>?)
+
+    internal inner class Child : Base("Child", { "a child class" })
 
     fun foo() {
         foo0 { "42" }
@@ -34,6 +51,10 @@ class Java8Class {
             helper()
             "42"
         }
+
+        bar({ "f" }, { i -> "g" })
+
+        vararg("first", { "f" })
 
         val f: Function2<Int, Int, String> = label@{ i: Int, k: Int? ->
             helper()
@@ -76,5 +97,7 @@ class Java8Class {
             }
             "43"
         }
+
+        doNotTouch({ "first arg" }, "last arg")
     }
 }


### PR DESCRIPTION
Adding more tests before porting the postprocessing `MoveLambdaOutsideParenthesesProcessing` to a JKTree processing. The existing tests were already pretty comprehensive, so there wasn't much to add from the tests for `MoveLambdaOutsideParenthesesInspection`.

@abelkov @darthorimar @jocelynluizzi13