### PR TITLE
[kotlin] J2K: Port "move lambda outside parentheses" processing to printing phase

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -82,7 +82,6 @@ private val removeRedundantElementsProcessingGroup = InspectionLikeProcessingGro
 )
 
 private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
-    MoveLambdaOutsideParenthesesProcessing(),
     intentionBasedProcessing(ConvertToStringTemplateIntention(), writeActionNeeded = false) {
         ConvertToStringTemplateIntention.Holder.shouldSuggestToConvert(it)
     },

--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -82,6 +82,7 @@ private val removeRedundantElementsProcessingGroup = InspectionLikeProcessingGro
 )
 
 private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
+    MoveLambdaOutsideParenthesesProcessing(),
     intentionBasedProcessing(ConvertToStringTemplateIntention(), writeActionNeeded = false) {
         ConvertToStringTemplateIntention.Holder.shouldSuggestToConvert(it)
     },

--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/inspectionLikeProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/inspectionLikeProcessings.kt
@@ -303,18 +303,6 @@ internal class LiftAssignmentInspectionBasedProcessing : InspectionLikeProcessin
     }
 }
 
-internal class MoveLambdaOutsideParenthesesProcessing : InspectionLikeProcessingForElement<KtCallExpression>(KtCallExpression::class.java) {
-    private val inspection = MoveLambdaOutsideParenthesesInspection()
-
-    override fun isApplicableTo(element: KtCallExpression, settings: ConverterSettings?): Boolean =
-        isInspectionEnabledInCurrentProfile(inspection, element.project) &&
-                element.canMoveLambdaOutsideParentheses()
-
-    override fun apply(element: KtCallExpression) {
-        element.moveFunctionLiteralOutsideParentheses()
-    }
-}
-
 // Don't destructure regular variables, it will lose the original variable name and may hurt code readability
 internal class DestructureForLoopParameterProcessing : InspectionLikeProcessingForElement<KtParameter>(KtParameter::class.java) {
     override fun isApplicableTo(element: KtParameter, settings: ConverterSettings?): Boolean =

--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/inspectionLikeProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/inspectionLikeProcessings.kt
@@ -303,6 +303,18 @@ internal class LiftAssignmentInspectionBasedProcessing : InspectionLikeProcessin
     }
 }
 
+internal class MoveLambdaOutsideParenthesesProcessing : InspectionLikeProcessingForElement<KtCallExpression>(KtCallExpression::class.java) {
+    private val inspection = MoveLambdaOutsideParenthesesInspection()
+
+    override fun isApplicableTo(element: KtCallExpression, settings: ConverterSettings?): Boolean =
+        isInspectionEnabledInCurrentProfile(inspection, element.project) &&
+                element.canMoveLambdaOutsideParentheses()
+
+    override fun apply(element: KtCallExpression) {
+        element.moveFunctionLiteralOutsideParentheses()
+    }
+}
+
 // Don't destructure regular variables, it will lose the original variable name and may hurt code readability
 internal class DestructureForLoopParameterProcessing : InspectionLikeProcessingForElement<KtParameter>(KtParameter::class.java) {
     override fun isApplicableTo(element: KtParameter, settings: ConverterSettings?): Boolean =

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/ArrayInitializerConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/ArrayInitializerConversion.kt
@@ -23,7 +23,8 @@ class ArrayInitializerConversion(context: NewJ2kConverterContext) : RecursiveCon
                     ArrayFqNames.PRIMITIVE_TYPE_TO_ARRAY[PrimitiveType.valueOf(primitiveArrayType.jvmPrimitiveType.name)]!!.asString()
                 else
                     ArrayFqNames.ARRAY_OF_FUNCTION.asString()
-            val arguments = element.initializer.also { element.initializer = emptyList() }.toArgumentList(element.hasTrailingComma)
+            val arguments = element.initializer.also { element.initializer = emptyList() }.toArgumentList()
+            arguments.hasTrailingComma = element.hasTrailingComma
             val typeArguments =
                 if (primitiveArrayType == null) JKTypeArgumentList(element::type.detached())
                 else JKTypeArgumentList()
@@ -63,15 +64,12 @@ class ArrayInitializerConversion(context: NewJ2kConverterContext) : RecursiveCon
             val arrayType = dimensions.drop(1).fold(type) { currentType, _ ->
                 JKJavaArrayType(currentType)
             }
-
-            val argList = JKArgumentList(
-                dimensions[0],
-                JKLambdaExpression(JKExpressionStatement(buildArrayInitializer(dimensions.subList(1, dimensions.size), type)))
-            )
-
             return JKNewExpression(
                 symbolProvider.provideClassSymbol("kotlin.Array"),
-                argList,
+                JKArgumentList(
+                    dimensions[0],
+                    JKLambdaExpression(JKExpressionStatement(buildArrayInitializer(dimensions.subList(1, dimensions.size), type)))
+                ),
                 JKTypeArgumentList(arrayType),
                 canExtractLastArgumentIfLambda = true
             )

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
@@ -190,7 +190,7 @@ class BuiltinMembersConversion(context: NewJ2kConverterContext) : RecursiveConve
     }
 
     private fun Conversion.createBuilder(): ResultBuilder = when (to) {
-        is Method -> MethodBuilder(to.fqName, to.parameterTypesFqNames, argumentsProvider ?: { it })
+        is Method -> MethodBuilder(to.fqName, to.parameterTypesFqNames, argumentsProvider ?: { it }, to.canExtractLastArgumentIfLambda)
         is Field -> FieldBuilder(to.fqName)
         is ExtensionMethod -> ExtensionMethodBuilder(to.fqName)
         is CustomExpression -> CustomExpressionBuilder(to.expressionBuilder)
@@ -367,12 +367,22 @@ private class ConversionsHolder(private val symbolProvider: JKSymbolProvider, pr
     )
 
     private val collectionConversions: List<Conversion> = listOf(
+        Method("java.util.Iterable.forEach") convertTo Method("kotlin.collections.Iterable.forEach", canExtractLastArgumentIfLambda = true),
+
         Method("java.util.Map.entrySet") convertTo Field("kotlin.collections.Map.entries"),
         Method("java.util.Map.keySet") convertTo Field("kotlin.collections.Map.keys"),
         Method("java.util.Map.size") convertTo Field("kotlin.collections.Map.size"),
         Method("java.util.Map.values") convertTo Field("kotlin.collections.Map.values"),
+        Method("java.util.Map.compute") convertTo Method("kotlin.collections.Map.compute", canExtractLastArgumentIfLambda = true),
+        Method("java.util.Map.computeIfAbsent") convertTo Method("kotlin.collections.Map.computeIfAbsent", canExtractLastArgumentIfLambda = true),
+        Method("java.util.Map.computeIfPresent") convertTo Method("kotlin.collections.Map.computeIfPresent", canExtractLastArgumentIfLambda = true),
+        Method("java.util.Map.forEach") convertTo Method("kotlin.collections.Map.forEach", canExtractLastArgumentIfLambda = true),
+        Method("java.util.Map.merge") convertTo Method("kotlin.collections.Map.merge", canExtractLastArgumentIfLambda = true),
+        Method("java.util.Map.replaceAll") convertTo Method("kotlin.collections.Map.replaceAll", canExtractLastArgumentIfLambda = true),
+
         Method("java.util.Collection.size") convertTo Field("kotlin.collections.Collection.size"),
         Method("java.util.Collection.remove") convertTo Method("kotlin.collections.MutableCollection.remove"),
+        Method("java.util.Collection.removeIf") convertTo Method("kotlin.collections.MutableCollection.removeIf", canExtractLastArgumentIfLambda = true),
         Method("java.util.Collection.toArray") convertTo Method("kotlin.collections.toTypedArray") withByArgumentsFilter { it.isEmpty() },
         Method("java.util.Collection.toArray") convertTo Method("kotlin.collections.toTypedArray") withByArgumentsFilter {
             it.singleOrNull()?.let { parameter ->
@@ -381,6 +391,7 @@ private class ConversionsHolder(private val symbolProvider: JKSymbolProvider, pr
         } withArgumentsProvider { JKArgumentList() },
 
         Method("java.util.List.remove") convertTo Method("kotlin.collections.MutableCollection.removeAt"),
+        Method("java.util.List.replaceAll") convertTo Method("kotlin.collections.MutableCollection.replaceAll", canExtractLastArgumentIfLambda = true),
         Method("java.util.Map.Entry.getKey") convertTo Field("kotlin.collections.Map.Entry.key"),
         Method("java.util.Map.Entry.getValue") convertTo Field("kotlin.collections.Map.Entry.value"),
 

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/JavaStatementConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/JavaStatementConversion.kt
@@ -24,6 +24,19 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
         )
     }
 
+    private fun JKStatement.occursImmediatelyAfterDeclarationInBlock(declaration: JKDeclaration): Boolean {
+        val parent = this.parent.safeAs<JKBlockImpl>() ?: return false
+        if (parent != declaration.parent?.parent) return false
+        val statements = parent.statements
+        val declarationIndex =
+            statements.indexOfFirst { it is JKDeclarationStatement && it.declaredStatements.singleOrNull() == declaration }
+        if (declarationIndex < 0 || declarationIndex == statements.lastIndex) return false
+        val expressionIndex = statements.indexOf(this)
+        if (expressionIndex < declarationIndex) return false
+        if (declarationIndex + 1 == expressionIndex) return true
+        return statements.subList(declarationIndex + 1, expressionIndex).all { it.isEmpty() }
+    }
+
     // If this is a null assertion like `assert s1 != null`, replace it with `checkNotNull(s1),
     // otherwise convert it to a regular Kotlin assert statement
     private fun convertAssert(element: JKJavaAssertStatement): JKStatement {
@@ -44,11 +57,13 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
         if (referencedVariable != null && element.occursImmediatelyAfterDeclarationInBlock(referencedVariable)) {
             // If the assertion occurs immediately after the variable declaration, merge them by wrapping the initializer in checkNotNull
             val initializerType = referencedVariable.initializer.calculateType(typeFactory)
+
             val arguments = listOfNotNull(referencedVariable.initializer.copyTreeAndDetach(), messageExpression).toArgumentList()
             referencedVariable.initializer = JKCallExpressionImpl(
                 checkNotNullSymbol,
                 arguments,
-                expressionType = initializerType?.updateNullability(NotNull)
+                expressionType = initializerType?.updateNullability(NotNull),
+                canExtractLastArgumentIfLambda = true
             )
 
             // effectively delete the original statement, since the assertion was merged into the variable declaration above
@@ -58,21 +73,9 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
         // Otherwise, leave the variable declaration untouched and do an inplace replacement of the assertion
         return JKCallExpressionImpl(
             checkNotNullSymbol,
-            arguments = listOfNotNull(expressionComparedToNull.detached(assertion), messageExpression).toArgumentList()
+            arguments = listOfNotNull(expressionComparedToNull.detached(assertion), messageExpression).toArgumentList(),
+            canExtractLastArgumentIfLambda = true
         ).asStatement().withFormattingFrom(element)
-    }
-
-    private fun JKStatement.occursImmediatelyAfterDeclarationInBlock(declaration: JKDeclaration): Boolean {
-        val parent = this.parent.safeAs<JKBlockImpl>() ?: return false
-        if (parent != declaration.parent?.parent) return false
-        val statements = parent.statements
-        val declarationIndex =
-            statements.indexOfFirst { it is JKDeclarationStatement && it.declaredStatements.singleOrNull() == declaration }
-        if (declarationIndex < 0 || declarationIndex == statements.lastIndex) return false
-        val expressionIndex = statements.indexOf(this)
-        if (expressionIndex < declarationIndex) return false
-        if (declarationIndex + 1 == expressionIndex) return true
-        return statements.subList(declarationIndex + 1, expressionIndex).all { it.isEmpty() }
     }
 
     private fun JKExpression.expressionComparedToNull(): JKExpression? {
@@ -93,7 +96,8 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
         return JKExpressionStatement(
             JKCallExpressionImpl(
                 symbolProvider.provideMethodSymbol("kotlin.synchronized"),
-                JKArgumentList(element.lockExpression, lambdaBody)
+                JKArgumentList(element.lockExpression, lambdaBody),
+                canExtractLastArgumentIfLambda = true
             ).withFormattingFrom(element)
         )
     }

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/TypeMappingConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/TypeMappingConversion.kt
@@ -37,7 +37,8 @@ class TypeMappingConversion(
                         element::arguments.detached(),
                         element::typeArgumentList.detached().fixTypeArguments(newClassSymbol),
                         element::classBody.detached(),
-                        element.isAnonymousClass
+                        element.isAnonymousClass,
+                        canExtractLastArgumentIfLambda = element.canExtractLastArgumentIfLambda
                     ).withPsiAndFormattingFrom(element)
                 )
             }

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/expressions.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/expressions.kt
@@ -120,7 +120,8 @@ fun useExpression(
 fun kotlinAssert(assertion: JKExpression, message: JKExpression?, symbolProvider: JKSymbolProvider): JKCallExpressionImpl =
     JKCallExpressionImpl(
         symbolProvider.provideMethodSymbol("kotlin.assert"),
-        listOfNotNull(assertion, message).toArgumentList(), canExtractLastArgumentIfLambda = true
+        listOfNotNull(assertion, message).toArgumentList(),
+        canExtractLastArgumentIfLambda = true
     )
 
 fun jvmAnnotation(name: String, symbolProvider: JKSymbolProvider): JKAnnotation =
@@ -306,8 +307,8 @@ fun JKExpression.asLiteralTextWithPrefix(): String? = when {
 
 fun JKClass.primaryConstructor(): JKKtPrimaryConstructor? = classBody.declarations.firstIsInstanceOrNull()
 
-fun List<JKExpression>.toArgumentList(hasTrailingComma: Boolean = false): JKArgumentList =
-    JKArgumentList(map { JKArgumentImpl(it) }, hasTrailingComma = hasTrailingComma)
+fun List<JKExpression>.toArgumentList(): JKArgumentList =
+    JKArgumentList(map { JKArgumentImpl(it) })
 
 fun JKExpression.asStatement(): JKExpressionStatement =
     JKExpressionStatement(this)

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
@@ -195,6 +195,12 @@ class JKDelegationConstructorCall(
     override fun accept(visitor: JKVisitor) = visitor.visitDelegationConstructorCall(this)
 }
 
+/**
+ * @param canExtractLastArgumentIfLambda - Useful during the printing phase for rendering lambda arguments when the method's full signature
+ * can't be determined (e.g. when a node is created midway through conversion for a reference to a Kotlin method like `map`). If
+ * `canExtractLastArgumentIfLambda` isn't set, the printing phase will still try to determine whether the last argument should be printed
+ * outside parentheses
+ */
 class JKCallExpressionImpl(
     override var identifier: JKMethodSymbol,
     arguments: JKArgumentList = JKArgumentList(),
@@ -207,6 +213,12 @@ class JKCallExpressionImpl(
     override fun accept(visitor: JKVisitor) = visitor.visitCallExpressionImpl(this)
 }
 
+/**
+ * @param canExtractLastArgumentIfLambda - Useful during the printing phase for rendering lambda arguments when the method's full signature
+ * can't be determined (e.g. when a node is created midway through conversion for a reference to an `Array` constructor). If
+ * `canExtractLastArgumentIfLambda` isn't set, the printing phase will still try to determine whether the last argument should be printed
+ * outside parentheses
+ */
 class JKNewExpression(
     val classSymbol: JKClassSymbol,
     arguments: JKArgumentList,

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
@@ -200,6 +200,7 @@ class JKCallExpressionImpl(
     arguments: JKArgumentList = JKArgumentList(),
     typeArgumentList: JKTypeArgumentList = JKTypeArgumentList(),
     override val expressionType: JKType? = null,
+    val canExtractLastArgumentIfLambda: Boolean = false
 ) : JKCallExpression() {
     override var typeArgumentList by child(typeArgumentList)
     override var arguments by child(arguments)
@@ -213,6 +214,7 @@ class JKNewExpression(
     classBody: JKClassBody = JKClassBody(),
     val isAnonymousClass: Boolean = false,
     override val expressionType: JKType? = null,
+    val canExtractLastArgumentIfLambda: Boolean = false
 ) : JKExpression() {
     var typeArgumentList by child(typeArgumentList)
     var arguments by child(arguments)

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/assertStatement/withStringDetail.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/assertStatement/withStringDetail.java
@@ -1,3 +1,2 @@
-// IGNORE_K2
 //statement
 assert true : "string details";

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/assignmentExpression/expressionAssignmentWithParentheses.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/assignmentExpression/expressionAssignmentWithParentheses.kt
@@ -7,8 +7,7 @@ internal object Test {
         var d = true
         val e = true
 
-        if (e.let { d = d and it; d }.also { (c) = it }.let { b = b or it; b }
-                .also { a = it });
+        if (e.let { d = d and it; d }.also { (c) = it }.let { b = b or it; b }.also { a = it });
         while ((((((b.also { a = it }))))));
         do {
         } while (((b.let { (a) = (a) xor it; (a) })))

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/blocks/Blocks.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/blocks/Blocks.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 //method
 void bar(int a) {}
 void foo() {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/blocks/nestedBlocks.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/blocks/nestedBlocks.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class Foo {
     void x() {
         {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/forWithBlockAndDoubleUpdate.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/forWithBlockAndDoubleUpdate.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 //statement
 int j = 0;
 for (int i = 0; i < 0; j++, i++) {int i = 1; i++;}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/nameConflict1.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/nameConflict1.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class A {
     void foo() {
         for (int i = 1; i < 1000; i *= 2) {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/nameConflict2.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/nameConflict2.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class A {
     void foo() {
         for (int i = 1, j = 0; i < 1000; i *= 2, j++) {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/nameConflict3.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/for/nameConflict3.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class A {
     int i = 1;
 

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/issues/kt-19358.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/issues/kt-19358.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 public class TestAssignmentInCondition {
     private int i;
 

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.java
@@ -1,4 +1,5 @@
 // IGNORE_K2
+
 import kotlin.jvm.functions.Function0;
 import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
@@ -13,7 +14,36 @@ public class Java8Class {
     public void foo2(Function2<Integer, Integer, String> r) {
     }
 
+    public void bar(Function0<String> f) {
+        // It seems we can't resolve overloaded methods, so this lambda stays inside the parentheses
+        bar(f, (i) -> "default g");
+    }
+
+    public void bar(Function0<String> f, Function1<Integer, String> g) {
+    }
+
+    public doNotTouch(Function0<String> f, String s) {
+    }
+
     public void helper() {
+    }
+
+    public void vararg(String key, Function0<String>... functions) {
+    }
+
+    public static void runnableFun(Runnable r) {}
+
+    class Base {
+        Base(String name, Function0<String> f) {
+        }
+    }
+
+    class Child extends Base {
+        Child() {
+            super("Child", () -> {
+                return "a child class";
+            })
+        }
     }
 
     public void foo() {
@@ -39,6 +69,21 @@ public class Java8Class {
         foo2((Integer i, Integer j) -> {
             helper();
             return "42";
+        });
+
+        bar(() -> "f", (i) -> "g");
+
+        assert "s" != null : "that's strange";
+
+        Base base = new Base("Base", () -> "base");
+
+        vararg("first", () -> "f");
+
+        runnableFun(new Runnable() {
+            @Override
+            public void run() {
+                "hello"
+            }
         });
 
         Function2<Integer, Integer, String> f = (Integer i, Integer k) -> {
@@ -86,5 +131,9 @@ public class Java8Class {
 
             return "43";
         });
+
+        doNotTouch(() -> {
+            return "first arg";
+        }, "last arg");
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.java
@@ -1,5 +1,6 @@
 // IGNORE_K2
 
+import java.util.*;
 import kotlin.jvm.functions.Function0;
 import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
@@ -135,5 +136,23 @@ public class Java8Class {
         doNotTouch(() -> {
             return "first arg";
         }, "last arg");
+    }
+
+    void moreTests(
+            Map<String, String> m1,
+            Map<String, String> m2,
+            Map<String, String> m3,
+            Map<String, String> m4
+    ) {
+        m1.compute("m1", (k, v) -> v);
+        m2.computeIfAbsent("m2", (k) -> "value");
+        m3.computeIfPresent("m1", (k, v) -> v);
+        m4.merge("", "", (k, v) -> v);
+        m4.merge("", "", String::concat);
+
+        String [][] ss = new String[5][5];
+
+        String s = "test";
+        s.trim();
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
@@ -53,7 +53,7 @@ class Java8Class {
 
         checkNotNull("s") { "that's strange" }
 
-        val base: Base = Base("Base") { "base" }
+        val base = Base("Base") { "base" }
 
         vararg("first", { "f" })
 

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
@@ -8,8 +8,22 @@ class Java8Class {
     fun foo2(r: Function2<Int?, Int?, String?>?) {
     }
 
+    @JvmOverloads
+    fun bar(f: Function0<String?>?, g: Function1<Int?, String?>? = { i: Int? -> "default g" }) {
+    }
+
+    fun doNotTouch(f: Function0<String?>?, s: String?) {
+    }
+
     fun helper() {
     }
+
+    fun vararg(key: String?, vararg functions: Function0<String?>?) {
+    }
+
+    internal open inner class Base(name: String?, f: Function0<String?>?)
+
+    internal inner class Child : Base("Child", { "a child class" })
 
     fun foo() {
         foo0 { "42" }
@@ -34,6 +48,16 @@ class Java8Class {
             helper()
             "42"
         }
+
+        bar({ "f" }, { i: Int? -> "g" })
+
+        checkNotNull("s") { "that's strange" }
+
+        val base: Base = Base("Base") { "base" }
+
+        vararg("first", { "f" })
+
+        runnableFun { "hello" }
 
         val f: Function2<Int, Int, String> = label@{ i: Int, k: Int? ->
             helper()
@@ -76,5 +100,11 @@ class Java8Class {
             }
             "43"
         }
+
+        doNotTouch({ "first arg" }, "last arg")
+    }
+
+    companion object {
+        fun runnableFun(r: Runnable?) {}
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
@@ -104,6 +104,24 @@ class Java8Class {
         doNotTouch({ "first arg" }, "last arg")
     }
 
+    fun moreTests(
+        m1: MutableMap<String?, String?>,
+        m2: MutableMap<String?, String?>,
+        m3: MutableMap<String?, String?>,
+        m4: MutableMap<String?, String>
+    ) {
+        m1.compute("m1") { k: String?, v: String? -> v }
+        m2.computeIfAbsent("m2") { k: String? -> "value" }
+        m3.computeIfPresent("m1") { k: String?, v: String? -> v }
+        m4.merge("", "") { k: String?, v: String? -> v }
+        m4.merge("", "") { obj: String, str: String -> obj + str }
+
+        val ss = Array(5) { arrayOfNulls<String>(5) }
+
+        val s = "test"
+        s.trim { it <= ' ' }
+    }
+
     companion object {
         fun runnableFun(r: Runnable?) {}
     }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/lambda/lambdas.kt
@@ -49,7 +49,7 @@ class Java8Class {
             "42"
         }
 
-        bar({ "f" }, { i: Int? -> "g" })
+        bar({ "f" }) { i: Int? -> "g" }
 
         checkNotNull("s") { "that's strange" }
 

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/mutableCollections/MutableMap.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/mutableCollections/MutableMap.kt
@@ -2,7 +2,7 @@ class J {
     fun foo(
         m1: MutableMap<String?, String?>,
         m2: MutableMap<String?, String?>,
-        m3: MutableMap<String?, String>,
+        m3: MutableMap<String?, String?>,
         m4: MutableMap<String?, String?>,
         m5: MutableMap<String?, String?>,
         m6: MutableMap<String?, String?>,

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/synchronizedStatement/singleLineExample.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/synchronizedStatement/singleLineExample.java
@@ -1,3 +1,2 @@
-// IGNORE_K2
 //statement
 synchronized (s) { doSomething(s); }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/tryWithResource/WithCatch.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/tryWithResource/WithCatch.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 import java.io.*;
 
 public class C {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/tryWithResource/WithCatchAndFinally.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/tryWithResource/WithCatchAndFinally.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 import java.io.*;
 
 public class C {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/tryWithResource/WithReturnAtEnd.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/tryWithResource/WithReturnAtEnd.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 import java.io.*;
 
 public class C {


### PR DESCRIPTION
I'm not sure whether it's possible to port this postprocessing step earlier for 2 reasons:
1. When trying to resolve a method call expressions via `JKSymbol::target`, the returned method definition node has the right name and return type, but not necessarily the right parameters--i.e. it's oblivious to overloaded methods. For example, resolving a call like `checkNotNull(x, "oops")` returns the `KtNamedFunction` node for `checkNotNull` with only one parameter. The same is true when resolving local functions, like the call to `bar` with 2 args in the test below (`bar(f, (i) -> "default g")`).
2. When trying to resolve a constructor call expression via `JKSymbol::target`, we get the whole class definition rather than the constructor definition with matching parameters. With some extra work I could implement very basic resolution for constructors in classes without overloading or inheritance (like in the test below where we call `new Base("Base", () -> "base")`), but that's hardly a replacement for the postprocessing step that currently handles everything.

Is there another way to do symbol resolution on JKTree nodes that I'm missing?

@abelkov @darthorimar @jocelynluizzi13