### PR TITLE
[kotlin] K2 J2K: Remove NON_FINAL_MEMBER_IN_FINAL_CLASS and NON_FINAL_MEMBER_IN_OBJECT Postprocessings

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -41,10 +41,6 @@ private val errorsFixingDiagnosticBasedPostProcessingGroup = DiagnosticBasedPost
         Errors.UNSAFE_INFIX_CALL,
         Errors.UNSAFE_OPERATOR_CALL
     ),
-    diagnosticBasedProcessing(
-        RemoveModifierFixBase.createRemoveModifierFromListOwnerPsiBasedFactory(KtTokens.OPEN_KEYWORD),
-        Errors.NON_FINAL_MEMBER_IN_FINAL_CLASS, Errors.NON_FINAL_MEMBER_IN_OBJECT
-    ),
     exposedVisibilityDiagnosticBasedProcessing(
         ChangeVisibilityOnExposureFactory,
         Errors.EXPOSED_FUNCTION_RETURN_TYPE,


### PR DESCRIPTION
Both `NON_FINAL_MEMBER_IN_FINAL_CLASS` and `NON_FINAL_MEMBER_IN_OBJECT` have no affected tests since `open` modifiers are handled in earlier parts of the code with the porting of other post-processing steps. Removing them from post-processing for completeness and speed of code

@abelkov @darthorimar @ermattt