### PR TITLE
Fix the error thrown when clicking "Analyze Dependencies..." in the Gradle panel with Quarkus.

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/dependencyGraphModel/GradleDependencyReportTask.java
+++ b/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/dependencyGraphModel/GradleDependencyReportTask.java
@@ -44,7 +44,7 @@ public class GradleDependencyReportTask extends DefaultTask {
 
   @TaskAction
   public void generate() throws IOException {
-    Collection<Configuration> configurations = getSelectedConfigurations();
+    Collection<Configuration> configurations = new ArrayList<>(getSelectedConfigurations());
     GradleDependencyReportGenerator generator = new GradleDependencyReportGenerator();
     List<DependencyScopeNode> graph = new ArrayList<>();
     for (Configuration configuration : configurations) {


### PR DESCRIPTION
When using Quarkus in a Gradle environment and clicking the "Analyze Dependencies..." button in the Gradle panel, IDEA throws an error:
```
Execution failed for task ':GradleDependencyReportTask'.
> java.util.ConcurrentModificationException (no error message)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
BUILD FAILED in 391ms
1 actionable task: 1 executed
```

A potentially related issue [IDEA-309245 IDEA Gradle Quarkus projects cannot "show Dependencies"](https://youtrack.jetbrains.com/issue/IDEA-309245/IDEA-Gradle-Quarkus-projects-cannot-show-Dependencies) was observed， In my local environment using IntelliJ IDEA 2024.1 Beta
，and pressing Ctrl-Alt-Shift-U to "show dependencies" also produced the error mentioned above. However, it's not entirely the same as the error description in [IDEA-309245](https://youtrack.jetbrains.com/issue/IDEA-309245/IDEA-Gradle-Quarkus-projects-cannot-show-Dependencies)，and I am uncertain if it's the same issue.
```
IntelliJ IDEA 2024.1 Beta (Ultimate Edition)
Build #IU-241.14494.17, built on March 6, 2024
```