### PR TITLE
[kotlin] J2K: Port replace guard clause with function call inspection postprocessing to jk tree phase

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -117,7 +117,6 @@ private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
     LiftAssignmentInspectionBasedProcessing(),
     MayBeConstantInspectionBasedProcessing(),
     RemoveForExpressionLoopParameterTypeProcessing(),
-    inspectionBasedProcessing(ReplaceGuardClauseWithFunctionCallInspection()),
     intentionBasedProcessing(ConvertToRawStringTemplateIntention(), additionalChecker = ::shouldConvertToRawString),
     intentionBasedProcessing(IndentRawStringIntention()),
     intentionBasedProcessing(JoinDeclarationAndAssignmentIntention()),

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/JavaStatementConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/JavaStatementConversion.kt
@@ -5,9 +5,7 @@ import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
 import org.jetbrains.kotlin.j2k.Nullability.NotNull
 import org.jetbrains.kotlin.nj2k.*
 import org.jetbrains.kotlin.nj2k.tree.*
-import org.jetbrains.kotlin.nj2k.types.JKJavaDisjunctionType
-import org.jetbrains.kotlin.nj2k.types.isNull
-import org.jetbrains.kotlin.nj2k.types.updateNullability
+import org.jetbrains.kotlin.nj2k.types.*
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConversion(context) {
@@ -19,6 +17,7 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
                 is JKJavaAssertStatement -> convertAssert(element)
                 is JKJavaSynchronizedStatement -> convertSynchronized(element)
                 is JKJavaTryStatement -> convertTry(element)
+                is JKIfElseStatement -> convertGuardStatement(element)
                 else -> element
             }
         )
@@ -36,7 +35,7 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
             if (element.description is JKStubExpression) null
             else JKLambdaExpression(JKExpressionStatement(element::description.detached()))
 
-        val expressionComparedToNull = assertion.expressionComparedToNull()
+        val expressionComparedToNull = assertion.expressionComparedToNull(isNegated = true)
             ?: return kotlinAssert(assertion, messageExpression, symbolProvider).asStatement().withFormattingFrom(element)
         val referencedVariable = (expressionComparedToNull as? JKFieldAccessExpression)?.identifier?.target as? JKLocalVariable
         val checkNotNullSymbol = symbolProvider.provideMethodSymbol("kotlin.checkNotNull")
@@ -75,9 +74,10 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
         return statements.subList(declarationIndex + 1, expressionIndex).all { it.isEmpty() }
     }
 
-    private fun JKExpression.expressionComparedToNull(): JKExpression? {
+    private fun JKExpression.expressionComparedToNull(isNegated: Boolean = false): JKExpression? {
         if (this !is JKBinaryExpression) return null
-        if (operator.token.text != "!=") return null
+        if (isNegated && operator.token.text != "!=") return null
+        if (!isNegated && operator.token.text != "==") return null
 
         val left = left
         val right = right
@@ -167,4 +167,80 @@ class JavaStatementConversion(context: NewJ2kConverterContext) : RecursiveConver
                 tryStatement.catchSections.flatMap(::convertCatchSection)
             )
         ).withFormattingFrom(tryStatement)
+
+    /**
+     * Replaces some if-then-throw statements with calls to `require` or `check`. For example, a statement like
+     * `if (enabled) throw new IllegalArgumentException("must be enabled")` would become `requireNotNull(s1) { "must be enabled" }`. This
+     * conversion is analogous to `ReplaceGuardClauseWithFunctionCallInspection`.
+     */
+    private fun convertGuardStatement(ifElseStatement: JKIfElseStatement): JKStatement {
+        val thenExpression = ifElseStatement.thenBranch.statements.singleOrNull() ?: return ifElseStatement
+        if (thenExpression !is JKExpressionStatement) return ifElseStatement
+
+        val thrownExpression = thenExpression.expression.safeAs<JKThrowExpression>()?.exception ?: return ifElseStatement
+        if (thrownExpression !is JKNewExpression || thrownExpression.arguments.arguments.size > 1) {
+            return ifElseStatement
+        }
+
+        val expressionComparedToNull = ifElseStatement.condition.expressionComparedToNull()
+        val exceptionName = thrownExpression.identifier?.name
+        val correspondingMethodName = when (exceptionName) {
+            "IllegalArgumentException" -> if (expressionComparedToNull != null) "kotlin.requireNotNull" else "kotlin.require"
+            "IllegalStateException" -> if (expressionComparedToNull != null) "kotlin.checkNotNull" else "kotlin.check"
+            else -> return ifElseStatement
+        }
+        val exceptionArgument = thrownExpression.arguments.arguments.firstOrNull()
+        if (exceptionArgument != null && exceptionArgument.value.calculateType(typeFactory)?.isStringType() != true) {
+            return ifElseStatement
+        }
+
+        val messageExpression = if (exceptionArgument == null) null else
+            JKLambdaExpression(JKExpressionStatement(exceptionArgument::value.detached()))
+        val methodCallSymbol = symbolProvider.provideMethodSymbol(correspondingMethodName)
+
+        val originalCondition = ifElseStatement::condition.detached()
+        val negatedCondition = if (originalCondition is JKPrefixExpression && originalCondition.operator.token.text == "!") {
+            val conditionExpression = originalCondition::expression.detached()
+            if (conditionExpression is JKParenthesizedExpression) {
+                // now that the `!` prefix has been removed, clean up any superfluous parentheses
+                conditionExpression::expression.detached()
+            } else {
+                conditionExpression
+            }
+        } else {
+            JKPrefixExpression(
+                originalCondition.parenthesizeIfCompoundExpression(),
+                JKKtOperatorImpl(JKOperatorToken.EXCL, typeFactory.types.boolean)
+            )
+        }.withFormattingFrom(originalCondition)
+
+        val newCallExpression = if (expressionComparedToNull != null && ifElseStatement.elseBranch.isEmpty()) {
+            JKCallExpressionImpl(
+                methodCallSymbol,
+                listOfNotNull(
+                    expressionComparedToNull.detached(ifElseStatement.condition),
+                    messageExpression
+                ).toArgumentList()
+            )
+        } else {
+            JKCallExpressionImpl(
+                methodCallSymbol,
+                listOfNotNull(negatedCondition, messageExpression).toArgumentList()
+            )
+        }.asStatement()
+
+        val elseBranch = ifElseStatement::elseBranch.detached()
+        return if (elseBranch.isEmpty()) {
+            newCallExpression
+        } else {
+            val statements = if (elseBranch is JKBlockStatement) {
+                // any newlines that should follow the else block will be attached to the new parent block statement
+                elseBranch.statements.last().lineBreaksAfter = 0
+                listOf(newCallExpression) + elseBranch.statements.map { it.detached(elseBranch.block) }
+            } else {
+                listOf(newCallExpression, elseBranch)
+            }
+            JKBlockStatementWithoutBrackets(statements).withFormattingFrom(ifElseStatement)
+        }.withFormattingFrom(ifElseStatement)
+    }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/GuardClause.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/GuardClause.java
@@ -1,8 +1,69 @@
 // IGNORE_K2
 public class Test {
-    void test(String s) {
-        if (s == null) {
+    void testRequire(String s1, boolean b1, boolean b2) {
+        if (s1 == null) {
             throw new IllegalArgumentException("s should not be null");
+        }
+
+        if (!b1) {
+            throw new IllegalArgumentException();
+        } else {
+            System.out.println("never mind");
+        }
+        // comment above b2
+        if (b2) {
+            throw new IllegalArgumentException();
+        }
+
+        if (!b1 && b2) throw new IllegalArgumentException();
+        else {
+            System.out.println(1);
+            System.out.println(2);
+        }
+
+        if (s1.length() < 3) {
+            throw new IllegalArgumentException();
+        } else if (s1.length() == 4) {
+            System.out.println(1);
+        } else {
+            System.out.println(2);
+        }
+    }
+
+    void testCheck(boolean b, String notNullString) {
+        if (b) throw new IllegalStateException();
+
+        // comment above notNullString
+        if (notNullString == null) {
+            throw new IllegalStateException()
+        }
+    }
+
+    void testDoubles(double x, double y) {
+        if (!(x < y)) {
+            throw new IllegalStateException()
+        }
+        if (y < 2*x) {
+            throw new IllegalStateException()
+        }
+    }
+
+    void doNotTouch(boolean b, String s1) {
+        try {
+            System.out.println("hello!");
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        if (b) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        if (s1.length() < 5) {
+            System.out.println("Some other side effect");
+            throw new IllegalStateException("oops");
         }
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/GuardClause.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/GuardClause.kt
@@ -1,5 +1,52 @@
 class Test {
-    fun test(s: String?) {
-        requireNotNull(s) { "s should not be null" }
+    fun testRequire(s1: String?, b1: Boolean, b2: Boolean) {
+        requireNotNull(s1) { "s should not be null" }
+
+        require(b1)
+        println("never mind")
+        // comment above b2
+        require(!b2)
+
+        require(!(!b1 && b2))
+        println(1)
+        println(2)
+
+        require(s1.length >= 3)
+        if (s1.length == 4) {
+            println(1)
+        } else {
+            println(2)
+        }
+    }
+
+    fun testCheck(b: Boolean, notNullString: String?) {
+        check(!b)
+
+        // comment above notNullString
+        checkNotNull(notNullString)
+    }
+
+    fun testDoubles(x: Double, y: Double) {
+        check((x < y))
+        check(!(y < 2 * x))
+    }
+
+    fun doNotTouch(b: Boolean, s1: String) {
+        try {
+            println("hello!")
+        } catch (e: Exception) {
+            if (e is RuntimeException) {
+                throw IllegalStateException(e)
+            }
+        }
+
+        if (b) {
+            throw IndexOutOfBoundsException()
+        }
+
+        if (s1.length < 5) {
+            println("Some other side effect")
+            throw IllegalStateException("oops")
+        }
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/GuardClause.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/GuardClause.kt
@@ -1,5 +1,5 @@
 class Test {
-    fun testRequire(s1: String?, b1: Boolean, b2: Boolean) {
+    fun testRequire(s1: String, b1: Boolean, b2: Boolean) {
         requireNotNull(s1) { "s should not be null" }
 
         require(b1)
@@ -27,7 +27,7 @@ class Test {
     }
 
     fun testDoubles(x: Double, y: Double) {
-        check((x < y))
+        check(x < y)
         check(!(y < 2 * x))
     }
 


### PR DESCRIPTION

<img width="1388" alt="Screenshot 2024-03-13 at 7 56 40 PM" src="https://github.com/JetBrains/intellij-community/assets/53094167/6a4359e2-e0d7-4334-a8b6-462f17d7b21e">
In the spreadsheet, this one is listed as "ReplaceGuardClauseWithFunctionCallInspection." 

I added some more test cases inspired by those under `code-insight/inspections-shared/tests/testData/inspectionsLocal/simplifyNegatedBinaryExpression` (even though it's a different inspection, it's similar enough to provide useful inspiration). 

Unfortunately, I'm still having trouble getting the line breaks formatted correctly in the test (see the attached screenshot). I think it has something to do with the nested blocks that result when replacing the IfElseExpression with a block containing the method call + whatever statements used to live in the else branch. If you have any ideas for a fix I'm all ears, otherwise I'll resume debugging tomorrow.



@abelkov @darthorimar @jocelynluizzi13