### PR TITLE
[junit] IDEA-349194 Can't resolve @EnumSource("names") for @ParameterizedTest in Kotlin

### DIFF
--- a/jvm/jvm-analysis-testFramework/src/com/intellij/jvm/analysis/testFramework/JvmGoToRelatedTestBase.kt
+++ b/jvm/jvm-analysis-testFramework/src/com/intellij/jvm/analysis/testFramework/JvmGoToRelatedTestBase.kt
@@ -2,6 +2,7 @@ package com.intellij.jvm.analysis.testFramework
 
 import com.intellij.ide.actions.GotoRelatedSymbolAction
 import com.intellij.navigation.GotoRelatedItem
+import com.intellij.psi.PsiElement
 import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture
 
 /**
@@ -18,5 +19,22 @@ abstract class JvmGoToRelatedTestBase : LightJvmCodeInsightFixtureTestCase() {
     val items = GotoRelatedSymbolAction.getItems(myFixture.getFile(), myFixture.getEditor(), null)
     assertSize(1, items)
     assertion(items.first())
+  }
+
+  protected fun JavaCodeInsightTestFixture.testGoToPsiElement(
+    lang: JvmLanguage,
+    before: String,
+    fileName: String = generateFileName(),
+    assertion: (PsiElement) -> Unit
+  ) {
+    configureByText("$fileName${lang.ext}", before)
+    val offset = getCaretOffset()
+    val referenceAt = myFixture.file.findReferenceAt(offset)
+    val resolved = referenceAt!!.resolve()!!
+    assertion(resolved)
+  }
+
+  private fun getCaretOffset(): Int {
+    return myFixture.editor.caretModel.primaryCaret.offset
   }
 }

--- a/plugins/junit/java-tests/test/com/intellij/execution/junit/JUnitUnusedMethodsTest.java
+++ b/plugins/junit/java-tests/test/com/intellij/execution/junit/JUnitUnusedMethodsTest.java
@@ -1,4 +1,4 @@
-// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.execution.junit;
 
 import com.intellij.codeInspection.deadCode.UnusedDeclarationInspection;
@@ -21,13 +21,13 @@ public class JUnitUnusedMethodsTest extends LightJavaCodeInsightFixtureTestCase 
     myFixture.configureByText("ExampleTest.java", """
       import org.junit.jupiter.api.Nested;
       import org.junit.jupiter.api.Test;
-            
+      
       public class ExampleTest {
           abstract class BaseTest {
               @Test
               public void runTest() {}
           }
-            
+      
           @Nested
           class ChildTest extends BaseTest {}
       }
@@ -51,6 +51,19 @@ public class JUnitUnusedMethodsTest extends LightJavaCodeInsightFixtureTestCase 
         public String myJUnitVersion;
         @Test
         public void ignoredTestMethod() throws Exception {}
+      }
+      """);
+    myFixture.testHighlighting(true, false, false);
+  }
+
+  public void testRecognizeEnumSource() {
+    myFixture.configureByText("Test.java", """           
+      enum Foo { AAA, BBB, <warning descr="Field 'CCC' is never used">CCC</warning> }
+      
+      public class Test {
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EnumSource(value = Foo.class, names = {"AAA", "BBB"})
+        void valid() {}
       }
       """);
     myFixture.testHighlighting(true, false, false);

--- a/plugins/junit/java-tests/test/com/intellij/execution/junit/codeInspection/JavaJUnitParameterizedSourceGoToRelatedTest.kt
+++ b/plugins/junit/java-tests/test/com/intellij/execution/junit/codeInspection/JavaJUnitParameterizedSourceGoToRelatedTest.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.execution.junit.codeInspection
 
 import com.intellij.junit.testFramework.JUnitParameterizedSourceGoToRelatedTestBase
@@ -41,6 +41,58 @@ class JavaJUnitParameterizedSourceGoToRelatedTest : JUnitParameterizedSourceGoTo
       assertNotNull(element)
       assertEquals("abc", element?.name)
       assertEquals(0, element?.parameters?.size)
+    }
+  }
+
+  fun `test go to enum source value`() {
+    myFixture.testGoToPsiElement(JvmLanguage.JAVA, """
+      enum Foo { AAA, BBB }
+      
+      public class ExampleTest {
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EnumSource(
+          value = F<caret>oo.class
+        )
+        void valid() {}
+      }
+    """.trimIndent()) { item ->
+      assertEquals("enum Foo { AAA, BBB }", item.text)
+    }
+  }
+
+  fun `test go to enum source single name`() {
+    myFixture.testGoToPsiElement(JvmLanguage.JAVA, """
+      enum Foo { AAA, BBB }
+      
+      public class ExampleTest {
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EnumSource(
+          value = Foo.class, 
+          names = "B<caret>BB"
+        )
+        void valid() {}
+      }
+    """.trimIndent()) { item ->
+      assertEquals("enum Foo { AAA, BBB }", item.parent.text)
+      assertEquals("BBB", item.text)
+    }
+  }
+
+  fun `test go to enum source multiple names`() {
+    myFixture.testGoToPsiElement(JvmLanguage.JAVA, """
+      enum Foo { AAA, BBB }
+      
+      public class ExampleTest {
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EnumSource(
+          value = Foo.class, 
+          names = {"AAA", "B<caret>BB"}
+        )
+        void valid() {}
+      }
+    """.trimIndent()) { item ->
+      assertEquals("enum Foo { AAA, BBB }", item.parent.text)
+      assertEquals("BBB", item.text)
     }
   }
 }

--- a/plugins/junit/kotlin-tests/test/com/intellij/execution/junit/codeInspection/KotlinJUnitParameterizedSourceGoToRelatedTest.kt
+++ b/plugins/junit/kotlin-tests/test/com/intellij/execution/junit/codeInspection/KotlinJUnitParameterizedSourceGoToRelatedTest.kt
@@ -1,4 +1,4 @@
-// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.execution.junit.codeInspection
 
 import com.intellij.junit.testFramework.JUnitParameterizedSourceGoToRelatedTestBase
@@ -61,6 +61,58 @@ class KotlinJUnitParameterizedSourceGoToRelatedTest : JUnitParameterizedSourceGo
       assertNotNull(element)
       assertEquals("abc", element?.name)
       assertEquals(0, element?.parameters?.size)
+    }
+  }
+
+  fun `test go to enum source value`() {
+    myFixture.testGoToPsiElement(JvmLanguage.KOTLIN, """
+      enum class Foo { AAA, BBB }
+      
+      class ExampleTest {
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EnumSource(
+          value = F<caret>oo::class
+        )
+        fun valid() {}
+      }
+    """.trimIndent()) { item ->
+      assertEquals("enum class Foo { AAA, BBB }", item.text)
+    }
+  }
+
+  fun `test go to enum source single name`() {
+    myFixture.testGoToPsiElement(JvmLanguage.KOTLIN, """
+      enum class Foo { AAA, BBB }
+      
+      class ExampleTest {
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EnumSource(
+          value = Foo::class, 
+          names = ["AAA", "B<caret>BB"]
+        )
+        fun valid() {}
+      }
+    """.trimIndent()) { item ->
+      assertEquals("enum class Foo { AAA, BBB }", item.parent.text)
+      assertEquals("BBB", item.text)
+    }
+  }
+
+  fun `test go to enum source multiple names`() {
+    myFixture.testGoToPsiElement(JvmLanguage.KOTLIN, """
+      enum class Foo { AAA, BBB }
+      
+      class ExampleTest {
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.EnumSource(
+          value = Foo::class, 
+          names = ["AAA", "B<caret>BB"]
+        )
+        fun valid() {}
+      }
+    """.trimIndent()) { item ->
+      assertEquals("enum class Foo { AAA, BBB }", item.parent.text)
+      assertEquals("BBB", item.text)
     }
   }
 }

--- a/plugins/junit/src/com/intellij/execution/junit/references/JUnitReferenceContributor.kt
+++ b/plugins/junit/src/com/intellij/execution/junit/references/JUnitReferenceContributor.kt
@@ -6,7 +6,6 @@ import com.intellij.patterns.uast.capture
 import com.intellij.patterns.uast.injectionHostUExpression
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet
-import com.intellij.util.ProcessingContext
 import com.siyeh.ig.junit.JUnitCommonClassNames.*
 import org.jetbrains.uast.*
 
@@ -17,26 +16,14 @@ class JUnitReferenceContributor : PsiReferenceContributor() {
         ORG_JUNIT_JUPITER_PARAMS_PROVIDER_METHOD_SOURCE,
         PsiAnnotation.DEFAULT_REFERENCED_METHOD_NAME
       ),
-      object : UastInjectionHostReferenceProvider() {
-        override fun getReferencesForInjectionHost(
-          uExpression: UExpression,
-          host: PsiLanguageInjectionHost,
-          context: ProcessingContext
-        ): Array<PsiReference> = arrayOf(MethodSourceReference(host))
-      }
+      uastInjectionHostReferenceProvider { _, host -> arrayOf(MethodSourceReference(host)) }
     )
     registrar.registerUastReferenceProvider(
       injectionHostUExpression().annotationParams(
         listOf(ORG_JUNIT_JUPITER_CONDITION_PROVIDER_ENABLED_IF, ORG_JUNIT_JUPITER_CONDITION_PROVIDER_DISABLED_IF),
         string().equalTo(PsiAnnotation.DEFAULT_REFERENCED_METHOD_NAME)
       ),
-      object : UastInjectionHostReferenceProvider() {
-        override fun getReferencesForInjectionHost(
-          uExpression: UExpression,
-          host: PsiLanguageInjectionHost,
-          context: ProcessingContext
-        ): Array<PsiReference> = arrayOf(DisabledIfEnabledIfReference(host))
-      }
+      uastInjectionHostReferenceProvider { _, host -> arrayOf(DisabledIfEnabledIfReference(host)) }
     )
     registrar.registerUastReferenceProvider(
       injectionHostUExpression()
@@ -45,26 +32,14 @@ class JUnitReferenceContributor : PsiReferenceContributor() {
           val name = ((mode as? UReferenceExpression)?.referenceNameElement as USimpleNameReferenceExpression?)?.identifier
           name == "INCLUDE" || name == "EXCLUDE"
         }),
-      object : UastInjectionHostReferenceProvider() {
-        override fun getReferencesForInjectionHost(
-          uExpression: UExpression,
-          host: PsiLanguageInjectionHost,
-          context: ProcessingContext
-        ): Array<PsiReference> = arrayOf(EnumSourceReference(host))
-      }
+      uastInjectionHostReferenceProvider { _, host -> arrayOf(EnumSourceReference(host)) }
     )
     registrar.registerUastReferenceProvider(
       injectionHostUExpression().annotationParam(ORG_JUNIT_JUPITER_PARAMS_PROVIDER_CSV_FILE_SOURCE, "resources"),
-      object : UastInjectionHostReferenceProvider() {
-        override fun getReferencesForInjectionHost(
-          uExpression: UExpression,
-          host: PsiLanguageInjectionHost,
-          context: ProcessingContext
-        ): Array<PsiReference> {
-          @Suppress("UNCHECKED_CAST")
-          return FileReferenceSet.createSet(host, false, false, false)
-            .allReferences as Array<PsiReference>
-        }
+      uastInjectionHostReferenceProvider { _, host ->
+        @Suppress("UNCHECKED_CAST")
+        FileReferenceSet.createSet(host, false, false, false)
+          .allReferences as Array<PsiReference>
       }
     )
   }

--- a/plugins/junit/src/com/intellij/execution/junit/references/JUnitReferenceContributor.kt
+++ b/plugins/junit/src/com/intellij/execution/junit/references/JUnitReferenceContributor.kt
@@ -7,7 +7,8 @@ import com.intellij.patterns.uast.injectionHostUExpression
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet
 import com.siyeh.ig.junit.JUnitCommonClassNames.*
-import org.jetbrains.uast.*
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UReferenceExpression
 
 class JUnitReferenceContributor : PsiReferenceContributor() {
   override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
@@ -28,8 +29,10 @@ class JUnitReferenceContributor : PsiReferenceContributor() {
     registrar.registerUastReferenceProvider(
       injectionHostUExpression()
         .annotationParam("names", capture(UAnnotation::class.java).filter { annotation ->
-          val mode = annotation.findDeclaredAttributeValue("mode") ?: return@filter true // default is INCLUDE
-          val name = ((mode as? UReferenceExpression)?.referenceNameElement as USimpleNameReferenceExpression?)?.identifier
+          val mode = annotation.findDeclaredAttributeValue("mode")
+                       as? UReferenceExpression
+                     ?: return@filter true // default is INCLUDE
+          val name = mode.resolvedName
           name == "INCLUDE" || name == "EXCLUDE"
         }),
       uastInjectionHostReferenceProvider { _, host -> arrayOf(EnumSourceReference(host)) }


### PR DESCRIPTION
# JUnit: Can't resolve @EnumSource("names") for @ParameterizedTest in Kotlin

## Fixes [IDEA-349194](https://youtrack.jetbrains.com/issue/IDEA-349194)

Now EnumSourceReference is handled with Uast, so Kotlin is supported

**Bonus:** enum fields now has color (looks like PsiMemberReference was missed)

