### PR TITLE
Sort list of modules in Dependency Analyzer modules dropdown

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
@@ -37,7 +37,7 @@ internal class ExternalProjectSelector(
   }
 
   private fun createPopup(externalProjects: List<DependencyAnalyzerProject>, onChange: (DependencyAnalyzerProject) -> Unit): JBPopup {
-    val content = ExternalProjectPopupContent(externalProjects)
+    val content = ExternalProjectPopupContent(externalProjects.sortedBy { it.title })
       .apply { whenMousePressed { onChange(selectedValue) } }
     return JBPopupFactory.getInstance()
       .createComponentPopupBuilder(content, null)


### PR DESCRIPTION
The module dropdown in the dependency analyzer is currently unsorted, and appears very chaotic for large lists:

<img src="https://github.com/JetBrains/intellij-community/assets/10169241/04999edd-3f5c-45d5-99a3-64974f0d70bc" width="300" />

Much easier to navigate when sorted:

<img src="https://github.com/JetBrains/intellij-community/assets/10169241/2e9aeb7a-b2f0-430d-a1c3-21317f7d4934" width="300" />

