### PR TITLE
[plaform] IDEA-276272: TABS_NONE can have multiple windows in split views

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/actions/Switcher.kt
+++ b/platform/platform-impl/src/com/intellij/ide/actions/Switcher.kt
@@ -831,11 +831,11 @@ object Switcher : BaseSwitcherAction(null) {
 
       private fun findAppropriateWindow(window: EditorWindow?): EditorWindow? {
         if (window == null) return null
-        if (UISettings.getInstance().editorTabPlacement == UISettings.TABS_NONE) {
-          return window.owner.currentWindow
-        }
         val windows = window.owner.getWindows()
-        return if (ArrayUtil.contains(window, *windows)) window else if (windows.isNotEmpty()) windows[0] else null
+
+        return if (ArrayUtil.contains(window, *windows)) window
+        else if (UISettings.getInstance().editorTabPlacement == UISettings.TABS_NONE) window.owner.currentWindow
+        else if (windows.isNotEmpty()) windows[0] else null
       }
 
       @TestOnly


### PR DESCRIPTION
This commit fixes [https://youtrack.jetbrains.com/issue/IDEA-276272](https://youtrack.jetbrains.com/issue/IDEA-276272)

When TABS_NONE was on, it was forcing the current window in the `findAppropriateWindow` method.

Actually, even with TABS_NONE, we can split view and have multiple windows. 