### PR TITLE
[IDEA-349449] UpdateCheckerService should display results

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateChecker.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateChecker.kt
@@ -73,7 +73,7 @@ private class UpdateCheckerHelper(private val coroutineScope: CoroutineScope) {
   /**
    * For scheduled update checks.
    */
-  fun updateAndShowResult(showResults: Boolean = false): ActionCallback {
+  fun updateAndShowResult(showResults: Boolean = true): ActionCallback {
     val callback = ActionCallback()
     coroutineScope.launch(limitedDispatcher) {
       doUpdateAndShowResult(


### PR DESCRIPTION
I think this was meant to be true, which allows the other noisy checks to still not display results but `UpdateCheckerService` to still display results.