### PR TITLE
Open relative files to the project root from markdown preview

### DIFF
--- a/plugins/markdown/core/src/org/intellij/plugins/markdown/ui/preview/accessor/impl/MarkdownLinkOpenerImpl.kt
+++ b/plugins/markdown/core/src/org/intellij/plugins/markdown/ui/preview/accessor/impl/MarkdownLinkOpenerImpl.kt
@@ -156,18 +156,18 @@ internal class MarkdownLinkOpenerImpl: MarkdownLinkOpener {
       }
     }
 
-    private fun URI.findVirtualFile(): VirtualFile? {
+    private fun URI.findVirtualFile(project: Project?): VirtualFile? {
       val actualPath = when {
         SystemInfo.isWindows -> UriUtil.trimLeadingSlashes(path)
         else -> path
       }
       val path = Path.of(actualPath)
-      return VfsUtil.findFile(path, true)
+      return VfsUtil.findFile(path, project, true)
     }
 
     private fun actuallyOpenInEditor(project: Project?, uri: URI): Boolean {
       val anchor = uri.fragment
-      val targetFile = uri.findVirtualFile() ?: return false
+      val targetFile = uri.findVirtualFile(project) ?: return false
       @Suppress("NAME_SHADOWING")
       val project = project ?: guessProjectForFile(targetFile) ?: return false
       if (anchor == null) {


### PR DESCRIPTION
I have a project hosted in Azure DevOps and for proper navigation within markdown files I have to use absolute links relative to the project, like `/documentation/service.md`. 

A link like `[documentation](/documentation/service.md)` opens properly from the editor, but from the preview window this results in an error "Browser configuration problem - The file /documentation/service.md does not exist". While the path is relative to the project root from the editor, it seems like this is treated as an absolute path from the preview window.

With this PR the current behavior is extended to also check if there is also a file that is relative from the project root when it could not be found as an absolute file.