### PR TITLE
[kotlin] K2 J2K: Move SimplifyNegatedBinaryExpressionInspection to JKTree Phase

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -103,9 +103,6 @@ private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
     inspectionBasedProcessing(IfThenToElvisInspection(highlightStatement = true, inlineWithPrompt = false), writeActionNeeded = false) {
         it.shouldBeTransformed()
     },
-    inspectionBasedProcessing(KotlinInspectionFacade.instance.simplifyNegatedBinaryExpression) {
-        it.canBeSimplifiedWithoutChangingSemantics()
-    },
     inspectionBasedProcessing(ReplaceGetOrSetInspection()),
     intentionBasedProcessing(ObjectLiteralToLambdaIntention(), writeActionNeeded = true),
     intentionBasedProcessing(RemoveUnnecessaryParenthesesIntention()) {

--- a/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/newJ2KConversions.kt
+++ b/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/newJ2KConversions.kt
@@ -42,6 +42,7 @@ fun getNewJ2KConversions(context: NewJ2kConverterContext): List<Conversion> = li
     LabeledStatementConversion(context),
     ArrayOperationsConversion(context),
     EqualsOperatorConversion(context),
+    SimplifyNegatedBinaryExpressionConversion(context),
     TypeMappingConversion(context),
     InternalDeclarationConversion(context),
     InnerClassConversion(context),

--- a/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -5414,6 +5414,29 @@ public abstract class NewJavaToKotlinConverterSingleFileTestGenerated extends Ab
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression")
+    public static class SimplifyNegatedBinaryExpression extends AbstractNewJavaToKotlinConverterSingleFileTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        @TestMetadata("equals.java")
+        public void testEquals() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/equals.java");
+        }
+
+        @TestMetadata("greaterThan.java")
+        public void testGreaterThan() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/greaterThan.java");
+        }
+
+        @TestMetadata("lessThan.java")
+        public void testLessThan() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/lessThan.java");
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("../../shared/tests/testData/newJ2k/staticMembers")
     public static class StaticMembers extends AbstractNewJavaToKotlinConverterSingleFileTest {
         private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/j2k/k2/src/org/jetbrains/kotlin/j2k/K2J2KConversions.kt
+++ b/plugins/kotlin/j2k/k2/src/org/jetbrains/kotlin/j2k/K2J2KConversions.kt
@@ -45,6 +45,7 @@ internal fun getK2J2KConversions(context: NewJ2kConverterContext): List<Conversi
     LabeledStatementConversion(context),
     ArrayOperationsConversion(context),
     EqualsOperatorConversion(context),
+    SimplifyNegatedBinaryExpressionConversion(context),
     TypeMappingConversion(context),
     InternalDeclarationConversion(context),
     InnerClassConversion(context),

--- a/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
@@ -5414,6 +5414,29 @@ public abstract class K2JavaToKotlinConverterSingleFileTestGenerated extends Abs
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression")
+    public static class SimplifyNegatedBinaryExpression extends AbstractK2JavaToKotlinConverterSingleFileTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        @TestMetadata("equals.java")
+        public void testEquals() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/equals.java");
+        }
+
+        @TestMetadata("greaterThan.java")
+        public void testGreaterThan() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/greaterThan.java");
+        }
+
+        @TestMetadata("lessThan.java")
+        public void testLessThan() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/lessThan.java");
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("../../shared/tests/testData/newJ2k/staticMembers")
     public static class StaticMembers extends AbstractK2JavaToKotlinConverterSingleFileTest {
         private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/SimplifyNegatedBinaryExpressionConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/SimplifyNegatedBinaryExpressionConversion.kt
@@ -1,0 +1,70 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.kotlin.nj2k.conversions
+
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.nj2k.NewJ2kConverterContext
+import org.jetbrains.kotlin.nj2k.RecursiveConversion
+import org.jetbrains.kotlin.nj2k.tree.*
+import org.jetbrains.kotlin.nj2k.types.JKJavaPrimitiveType
+import org.jetbrains.kotlin.nj2k.types.asPrimitiveType
+
+class SimplifyNegatedBinaryExpressionConversion(context: NewJ2kConverterContext) : RecursiveConversion(context) {
+    context(KtAnalysisSession)
+    override fun applyToElement(element: JKTreeElement): JKTreeElement {
+        if (element !is JKPrefixExpression || element.operator.token != JKOperatorToken.EXCL) return recurse(element)
+        val expression = element.expression
+        if (expression !is JKParenthesizedExpression) return recurse(element)
+        val innerExpression = expression.expression
+        val hasParenthesis = hasParenthesis(element.parent)
+        if (innerExpression is JKIsExpression) {
+            expression::expression.detached()
+            innerExpression.negateSymbol = true
+            return if (hasParenthesis) recurse(JKParenthesizedExpression(innerExpression)) else recurse(innerExpression)
+        }
+        if (innerExpression is JKBinaryExpression && isAbleToBeSimplified(innerExpression)) {
+            val negatedToken = getNegatedToken(innerExpression.operator.token) ?: return recurse(element)
+            innerExpression::left.detached()
+            innerExpression::right.detached()
+            val binaryExpression = JKBinaryExpression(
+                innerExpression.left, innerExpression.right, JKKtOperatorImpl(
+                    negatedToken,
+                    typeFactory.types.nullableAny
+                )
+            )
+            return if (hasParenthesis) recurse(JKParenthesizedExpression(binaryExpression)) else recurse(binaryExpression)
+        }
+        return recurse(element)
+    }
+
+    private fun getNegatedToken(operator: JKOperatorToken): JKOperatorToken? {
+        return when (operator) {
+            JKOperatorToken.EQEQ -> JKOperatorToken.EXCLEQ
+            JKOperatorToken.EXCLEQ -> JKOperatorToken.EQEQ
+            JKOperatorToken.EQEQEQ -> JKOperatorToken.EXCLEQEQEQ
+            JKOperatorToken.EXCLEQEQEQ -> JKOperatorToken.EQEQEQ
+            JKOperatorToken.LT -> JKOperatorToken.GTEQ
+            JKOperatorToken.GTEQ -> JKOperatorToken.LT
+            JKOperatorToken.GT -> JKOperatorToken.LTEQ
+            JKOperatorToken.LTEQ -> JKOperatorToken.GT
+            else -> null
+        }
+    }
+
+    private fun isAbleToBeSimplified(element: JKBinaryExpression): Boolean {
+        val operatorToken = element.operator.token
+        if (operatorToken != JKOperatorToken.LT && operatorToken != JKOperatorToken.LTEQ
+            && operatorToken != JKOperatorToken.GT && operatorToken != JKOperatorToken.GTEQ
+        ) return true
+        val leftType = element.left.calculateType(typeFactory)?.asPrimitiveType()
+        val rightType = element.right.calculateType(typeFactory)?.asPrimitiveType()
+        return leftType != JKJavaPrimitiveType.FLOAT && leftType != JKJavaPrimitiveType.DOUBLE
+                && rightType != JKJavaPrimitiveType.FLOAT && rightType != JKJavaPrimitiveType.DOUBLE
+    }
+
+    private fun hasParenthesis(element: JKElement?): Boolean = when (element) {
+        is JKIfElseStatement, is JKReturnStatement -> false
+        else -> true
+    }
+}
+

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
@@ -268,7 +268,7 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
 
         override fun visitIsExpressionRaw(isExpression: JKIsExpression) {
             isExpression.expression.accept(this)
-            printer.printWithSurroundingSpaces("is")
+            printer.printWithSurroundingSpaces(if (isExpression.negateSymbol)  "!is" else "is")
             isExpression.type.accept(this)
         }
 

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
@@ -320,6 +320,7 @@ class JKAssignmentChainLetLink(
 class JKIsExpression(expression: JKExpression, type: JKTypeElement) : JKExpression() {
     var type by child(type)
     var expression by child(expression)
+    var negateSymbol = false
     override val expressionType: JKType? get() = null
     override fun calculateType(typeFactory: JKTypeFactory) = typeFactory.types.boolean
     override fun accept(visitor: JKVisitor) = visitor.visitIsExpression(this)

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/NotIs.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/NotIs.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class C {
     void foo(Object o) {
         if (!(o instanceof String)) return;

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/equals.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/equals.java
@@ -1,0 +1,10 @@
+class C {
+    void foo(Object o) {
+        if (!(0 != 1)) return;
+        System.out.println("String");
+    }
+
+    public boolean bar() {
+        return 1 == 2 == !(3 == 4);
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/equals.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/equals.kt
@@ -1,0 +1,10 @@
+internal class C {
+    fun foo(o: Any?) {
+        if (0 == 1) return
+        println("String")
+    }
+
+    fun bar(): Boolean {
+        return 1 == 2 == (3 != 4)
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/greaterThan.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/greaterThan.java
@@ -1,0 +1,11 @@
+class C {
+    void foo(Object o) {
+        if (!(0 < 1)) return;
+        System.out.println("Foo");
+    }
+
+    void bar(Object o) {
+        if (!(0 <= 1)) return;
+        System.out.println("Bar");
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/greaterThan.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/greaterThan.kt
@@ -1,0 +1,11 @@
+internal class C {
+    fun foo(o: Any?) {
+        if (0 >= 1) return
+        println("Foo")
+    }
+
+    fun bar(o: Any?) {
+        if (0 > 1) return
+        println("Bar")
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/lessThan.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/lessThan.java
@@ -1,0 +1,11 @@
+class C {
+    void foo(Object o) {
+        if (!(0 > 1)) return;
+        System.out.println("Foo");
+    }
+
+    void bar(Object o) {
+        if (!(0 >= 1)) return;
+        System.out.println("Bar");
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/lessThan.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/simplifyNegatedBinaryExpression/lessThan.kt
@@ -1,0 +1,11 @@
+internal class C {
+    fun foo(o: Any?) {
+        if (0 <= 1) return
+        println("Foo")
+    }
+
+    fun bar(o: Any?) {
+        if (0 < 1) return
+        println("Bar")
+    }
+}


### PR DESCRIPTION
We can move `SimplifyNegatedBinaryExpressionInspection` to the JKTree phase by running the checks for a negated expression in `JavaToJKTreeBuilder`. 

In this section, there's 3 potential cases:
1. `!(foo is bar)` - Fixed by adding a flag to `JKIsExpression` that handles the `!` in printing
2. `!(foo == bar)` or `!(foo != bar)` - Simplify this when converting the PSI to a JKBinary expression. Note that I'm only simplifying equals/not equals, not "greater than" or any other symbols because it looks like we ignore those in `NegatedBinaryExpressionSimplificationUtils#canBeSimplifiedWithoutChangingSemantics`
3. `Object.equals(foo, bar)` or `foo.equals(bar)`— we can convert this directly to a `JKBinaryExpression` with `JavaTokenType.NE `


@abelkov @darthorimar @ermattt