### PR TITLE
IDEA-349803: Eliminate the gap before the tab actions' icons

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ContentLayout.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ContentLayout.java
@@ -9,7 +9,12 @@ import com.intellij.ui.ExperimentalUI;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.content.ContentManagerEvent;
+import com.intellij.util.SmartList;
 import com.intellij.util.ui.JBUI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JPanel;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.border.Border;
@@ -66,6 +71,38 @@ public abstract class ContentLayout {
       label.setBorder(border);
     }
     label.setVisible(shouldShowId());
+  }
+
+  /**
+   * Returns a list of child components that are not instances of {@link BaseLabel}.
+   */
+  protected @NotNull java.util.List<Component> getNonLabelComponents() {
+    List<Component> result = null;
+    JPanel tabComponent = ui.getTabComponent();
+    int n = tabComponent.getComponentCount();
+    for (int i = 0; i < n; i++) {
+      Component component = tabComponent.getComponent(i);
+      if (!(component instanceof BaseLabel)) {
+        if (result == null) {
+          result = new SmartList<>(component);
+        }
+        else {
+          result.add(component);
+        }
+      }
+    }
+    return result == null ? Collections.emptyList() : result;
+  }
+
+  /**
+   * Calculates the sum of preferred widths of the given components.
+   */
+  protected int calculateTotalPreferredWidth(Collection<Component> components) {
+    int width = 0;
+    for (Component c : components) {
+      width += c.getPreferredSize().width;
+    }
+    return width;
   }
 
   private String getTitleSuffix() {

--- a/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowHeader.kt
+++ b/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowHeader.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowContentUiType
-import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.impl.DockToolWindowAction
 import com.intellij.openapi.wm.impl.ToolWindowImpl
 import com.intellij.openapi.wm.impl.content.SingleContentLayout
@@ -242,13 +241,13 @@ abstract class ToolWindowHeader internal constructor(
   private fun manageWestPanelTabComponentAndToolbar(init: Boolean) {
     if (!init) { // remove to avoid extra events, toolbars update on addNotify!
       westPanel.remove(contentUi.tabComponent)
-      toolbarWest?.apply { westPanel.remove(component) }
+      toolbarWest?.apply { contentUi.tabComponent.remove(component) }
       return
     }
     // Makes sure toolbar stays after the tab component
     val allowDnd = ClientProperty.isTrue(toolWindow.component as Component?, ToolWindowContentUi.ALLOW_DND_FOR_TABS)
     westPanel.add(contentUi.tabComponent, if (allowDnd) CC().grow() else CC().growY())
-    toolbarWest?.apply { westPanel.add(component, CC().pushX()) }
+    toolbarWest?.apply { contentUi.tabComponent.add(component, CC().pushX()) }
   }
 
   override fun propertyChange(evt: PropertyChangeEvent?) {
@@ -295,8 +294,8 @@ abstract class ToolWindowHeader internal constructor(
         setReservePlaceAutoPopupIcon(false)
         isOpaque = false
         border = JBUI.Borders.empty()
-        if (westPanel.isShowing) {
-          westPanel.add(this, CC().pushX())
+        if (contentUi.tabComponent.isShowing) {
+          contentUi.tabComponent.add(component, CC().pushX())
         }
       }
     }


### PR DESCRIPTION
The gap was caused by ToolWindowContentUi.TabPanel pushing ToolWindowHeader.toolbarWest to the far right when the preferred width of TabPanel was larger than the sum of widths of its visible children. Since reducing the preferred width would prevent TabPanel from growing when its container becomes wider, we move ToolWindowHeader.toolbarWest inside ToolWindowContentUi.TabPanel instead, This way that toolbarWest can be positioned adjacent to the rightmost visible tab regardless of the TabPanel's preferred width.