### PR TITLE
[gradle] Mark buildSrc modules for Gradle 8.0+

### DIFF
--- a/plugins/gradle/java/src/execution/build/TasksExecutionSettingsBuilder.java
+++ b/plugins/gradle/java/src/execution/build/TasksExecutionSettingsBuilder.java
@@ -147,11 +147,6 @@ public class TasksExecutionSettingsBuilder {
         rootProjectPath = gradleModuleData.getDirectoryToRunTask();
       }
 
-      // all buildSrc runtime projects will be built by gradle implicitly
-      if (gradleModuleData.isBuildSrcModule()) {
-        continue;
-      }
-
       String gradlePath = gradleModuleData.getGradlePath();
       List<TaskData> taskDataList =
         ContainerUtil.mapNotNull(gradleModuleData.findAll(ProjectKeys.TASK), taskData -> taskData.isInherited() ? null : taskData);

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolver.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleProjectResolver.java
@@ -67,6 +67,7 @@ import org.jetbrains.plugins.gradle.settings.DistributionType;
 import org.jetbrains.plugins.gradle.settings.GradleBuildParticipant;
 import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
+import org.jetbrains.plugins.gradle.util.GradleModuleDataKt;
 import org.jetbrains.plugins.gradle.util.telemetry.GradleDaemonOpenTelemetryUtil;
 
 import java.io.File;
@@ -555,6 +556,7 @@ public class GradleProjectResolver implements ExternalSystemProjectResolver<Grad
           .filter(node -> buildSrcProjectPaths.contains(node.getData().getLinkedExternalProjectPath()))
           .forEach(node -> {
             buildSrcModules.put(node.getData().getId(), node);
+            GradleModuleDataKt.setBuildSrcModule(node.getData());
             findAll(node, GradleSourceSetData.KEY).forEach(
               sourceSetNode -> buildSrcModules.put(sourceSetNode.getData().getId(), sourceSetNode));
 

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleCompositeImportingTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleCompositeImportingTest.java
@@ -134,10 +134,13 @@ public class GradleCompositeImportingTest extends GradleImportingTestCase {
 
     importProject();
 
-    DataNode<ModuleData> data = GradleUtil.findGradleModuleData(getModule("my-app"));
+    DataNode<ModuleData> myAppData = GradleUtil.findGradleModuleData(getModule("my-app"));
 
-    assertFalse(GradleModuleDataKt.isBuildSrcModule(data.getData()));
-    assertTrue(GradleModuleDataKt.isIncludedBuild(data.getData()));
+    assertFalse(GradleModuleDataKt.isBuildSrcModule(myAppData.getData()));
+    assertTrue(GradleModuleDataKt.isIncludedBuild(myAppData.getData()));
+
+    DataNode<ModuleData> buildSrcData = GradleUtil.findGradleModuleData(getModule("adhoc.buildSrc"));
+    assertTrue(GradleModuleDataKt.isBuildSrcModule(buildSrcData.getData()));
   }
 
   @Test


### PR DESCRIPTION
After 1fa206f, GradleModuleData.isBuildSrcModule() would incorrectly return false for buildSrc modules when using Gradle 8.0 and higher.

[Related Android Studio bug](https://issuetracker.google.com/issues/328871352)