### PR TITLE
IDEA-349803: Eliminate the gap before the tab actions' icons

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ComboContentLayout.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ComboContentLayout.java
@@ -9,6 +9,8 @@ import com.intellij.ui.MouseDragHelper;
 import com.intellij.ui.awt.RelativePoint;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.util.ui.JBUI;
+import java.util.List;
+import javax.swing.JPanel;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
@@ -39,7 +41,6 @@ final class ComboContentLayout extends ContentLayout {
   public void layout() {
     Rectangle bounds = ui.getTabComponent().getBounds();
     Dimension idSize = isIdVisible() ? idLabel.getPreferredSize() : JBUI.emptySize();
-
     int eachX = 0;
     int eachY = 0;
 
@@ -47,7 +48,8 @@ final class ComboContentLayout extends ContentLayout {
     eachX += idSize.width;
 
     Dimension comboSize = comboLabel.getPreferredSize();
-    int spaceLeft = bounds.width - eachX - (isToDrawCombo() && isIdVisible() ? 3 : 0);
+    int nonLabelWidth = calculateTotalPreferredWidthOfNonLabelComponents();
+    int spaceLeft = bounds.width - eachX - nonLabelWidth - (isToDrawCombo() && isIdVisible() ? 3 : 0);
 
     int width = comboSize.width;
     if (width > spaceLeft) {
@@ -55,11 +57,19 @@ final class ComboContentLayout extends ContentLayout {
     }
 
     comboLabel.setBounds(eachX, eachY, width, bounds.height);
+    eachX += width;
+
+    // Non-label components are positioned at the end.
+    for (Component c : getNonLabelComponents(false)) {
+      Dimension size = c.getPreferredSize();
+      c.setBounds(eachX, eachY + (bounds.height - size.height) / 2, size.width, size.height);
+      eachX += c.getWidth();
+    }
   }
 
   @Override
   public int getMinimumWidth() {
-    return idLabel == null ? 0 : idLabel.getPreferredSize().width;
+    return (idLabel == null ? 0 : idLabel.getPreferredSize().width) + calculateTotalPreferredWidthOfNonLabelComponents();
   }
 
   @Override
@@ -70,13 +80,20 @@ final class ComboContentLayout extends ContentLayout {
 
   @Override
   public void rebuild() {
-    ui.getTabComponent().removeAll();
+    JPanel tabComponent = ui.getTabComponent();
+    List<Component> nonLabelComponents = getNonLabelComponents(true);
+    tabComponent.removeAll();
 
-    ui.getTabComponent().add(idLabel);
+    tabComponent.add(idLabel);
     ToolWindowContentUi.initMouseListeners(idLabel, ui, true);
 
-    ui.getTabComponent().add(comboLabel);
+    tabComponent.add(comboLabel);
     ToolWindowContentUi.initMouseListeners(comboLabel, ui, false);
+
+    // Add back the non-label components.
+    for (Component c : nonLabelComponents) {
+      tabComponent.add(c);
+    }
   }
 
   boolean isToDrawCombo() {

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ContentLayout.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ContentLayout.java
@@ -9,7 +9,12 @@ import com.intellij.ui.ExperimentalUI;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.content.ContentManagerEvent;
+import com.intellij.util.SmartList;
 import com.intellij.util.ui.JBUI;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.border.Border;
@@ -66,6 +71,43 @@ public abstract class ContentLayout {
       label.setBorder(border);
     }
     label.setVisible(shouldShowId());
+  }
+
+  /**
+   * Returns a list of child components that are not instances of {@link JLabel}.
+   */
+  protected @NotNull List<Component> getNonLabelComponents(boolean includeHidden) {
+    List<Component> result = null;
+    JPanel tabComponent = ui.getTabComponent();
+    int n = tabComponent.getComponentCount();
+    for (int i = 0; i < n; i++) {
+      Component component = tabComponent.getComponent(i);
+      if (!(component instanceof JLabel) && component.isVisible()) {
+        if (result == null) {
+          result = new SmartList<>(component);
+        }
+        else {
+          result.add(component);
+        }
+      }
+    }
+    return result == null ? Collections.emptyList() : result;
+  }
+
+  /**
+   * Calculates the sum of preferred widths of visible child components that are not instances of {@link JLabel}.
+   */
+  protected int calculateTotalPreferredWidthOfNonLabelComponents() {
+    int width = 0;
+    JPanel tabComponent = ui.getTabComponent();
+    int n = tabComponent.getComponentCount();
+    for (int i = 0; i < n; i++) {
+      Component component = tabComponent.getComponent(i);
+      if (!(component instanceof JLabel) && component.isVisible()) {
+        width += component.getPreferredSize().width;
+      }
+    }
+    return width;
   }
 
   private String getTitleSuffix() {

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/TabContentLayout.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/TabContentLayout.java
@@ -147,6 +147,7 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
     ContentManager manager = ui.getContentManager();
     LayoutData data = new LayoutData(ui);
 
+    data.nonLabelWidth = calculateTotalPreferredWidthOfNonLabelComponents();
     data.eachX = getTabLayoutStart();
     data.eachY = 0;
 
@@ -159,102 +160,110 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
     }
     int tabsStart = data.eachX;
 
-    if (manager.getContentCount() == 0) return;
+    boolean toolbarUpdateNeeded = false;
+    if (manager.getContentCount() != 0) {
+      Content selected = manager.getSelectedContent();
+      if (selected == null) {
+        selected = manager.getContents()[0];
+      }
 
-    Content selected = manager.getSelectedContent();
-    if (selected == null) {
-      selected = manager.getContents()[0];
-    }
-
-    if (lastLayout != null &&
-        (idLabel == null || idLabel.isValid()) &&
-        lastLayout.layoutSize.equals(bounds.getSize()) &&
-        lastLayout.contentCount == manager.getContentCount() &&
-        ContainerUtil.all(tabs, Component::isValid)) {
-      for (ContentTabLabel each : tabs) {
-        if (each.getContent() == selected && each.getBounds().width != 0) {
-          return; // keep last layout
+      if (lastLayout != null &&
+          (idLabel == null || idLabel.isValid()) &&
+          lastLayout.layoutSize.equals(bounds.getSize()) &&
+          lastLayout.contentCount == manager.getContentCount() &&
+          lastLayout.nonLabelWidth == data.nonLabelWidth &&
+          ContainerUtil.all(tabs, Component::isValid)) {
+        for (ContentTabLabel each : tabs) {
+          if (each.getContent() == selected && each.getBounds().width != 0) {
+            return; // keep last layout
+          }
         }
       }
-    }
 
-    ArrayList<JLabel> toLayout = new ArrayList<>();
-    Collection<JLabel> toDrop = new HashSet<>();
+      ArrayList<JLabel> toLayout = new ArrayList<>();
+      Collection<JLabel> toDrop = new HashSet<>();
 
-    for (JLabel eachTab : tabs) {
-      final Dimension eachSize = eachTab.getPreferredSize();
-      data.requiredWidth += eachSize.width;
-      toLayout.add(eachTab);
-    }
-
-    if (ui.dropOverIndex != -1 && !isSingleContentView) {
-      data.requiredWidth += ui.dropOverWidth;
-      int index = Math.min(toLayout.size(), Math.max(0, ui.dropOverIndex - 1));
-      toLayout.add(index, dropOverPlaceholder);
-    }
-
-    data.toFitWidth = bounds.getSize().width - data.eachX;
-
-    final ContentTabLabel selectedTab = contentToTabs.get(selected);
-    while (true) {
-      if (data.requiredWidth <= data.toFitWidth) break;
-      if (toLayout.size() <= 1) break;
-
-      JLabel firstLabel = toLayout.get(0);
-      JLabel lastLabel = toLayout.get(toLayout.size() - 1);
-      JLabel labelToDrop;
-      if (firstLabel != selectedTab && firstLabel != dropOverPlaceholder) {
-        labelToDrop = firstLabel;
+      for (JLabel eachTab : tabs) {
+        final Dimension eachSize = eachTab.getPreferredSize();
+        data.requiredWidth += eachSize.width;
+        toLayout.add(eachTab);
       }
-      else if (lastLabel != selectedTab && lastLabel != dropOverPlaceholder) {
-        labelToDrop = lastLabel;
-      }
-      else {
-        break;
-      }
-      data.requiredWidth -= (labelToDrop.getPreferredSize().width + 1);
-      toDrop.add(labelToDrop);
-      toLayout.remove(labelToDrop);
-    }
 
-    boolean reachedBounds = false;
-    TabsDrawMode toDrawTabs = isToDrawTabs();
-    for (JLabel each : toLayout) {
-      if (toDrawTabs == TabsDrawMode.HIDE) {
-        each.setBounds(0, 0, 0, 0);
-        continue;
+      if (ui.dropOverIndex != -1 && !isSingleContentView) {
+        data.requiredWidth += ui.dropOverWidth;
+        int index = Math.min(toLayout.size(), Math.max(0, ui.dropOverIndex - 1));
+        toLayout.add(index, dropOverPlaceholder);
       }
-      data.eachY = 0;
-      final Dimension eachSize = each.getPreferredSize();
-      if (data.eachX + eachSize.width < data.toFitWidth + tabsStart) {
-        each.setBounds(data.eachX, data.eachY, eachSize.width, bounds.height - data.eachY);
-        data.eachX += eachSize.width;
-      }
-      else {
-        if (!reachedBounds) {
-          final int width = bounds.width - data.eachX;
-          each.setBounds(data.eachX, data.eachY, width, bounds.height - data.eachY);
-          data.eachX += width;
+
+      data.toFitWidth = bounds.getSize().width - data.nonLabelWidth - data.eachX;
+
+      final ContentTabLabel selectedTab = contentToTabs.get(selected);
+      while (true) {
+        if (data.requiredWidth <= data.toFitWidth) break;
+        if (toLayout.size() <= 1) break;
+
+        JLabel firstLabel = toLayout.get(0);
+        JLabel lastLabel = toLayout.get(toLayout.size() - 1);
+        JLabel labelToDrop;
+        if (firstLabel != selectedTab && firstLabel != dropOverPlaceholder) {
+          labelToDrop = firstLabel;
+        }
+        else if (lastLabel != selectedTab && lastLabel != dropOverPlaceholder) {
+          labelToDrop = lastLabel;
         }
         else {
-          each.setBounds(0, 0, 0, 0);
+          break;
         }
-        reachedBounds = true;
+        data.requiredWidth -= (labelToDrop.getPreferredSize().width + 1);
+        toDrop.add(labelToDrop);
+        toLayout.remove(labelToDrop);
+      }
+
+      boolean reachedBounds = false;
+      TabsDrawMode toDrawTabs = isToDrawTabs();
+      for (JLabel each : toLayout) {
+        if (toDrawTabs == TabsDrawMode.HIDE) {
+          each.setBounds(0, 0, 0, 0);
+          continue;
+        }
+        data.eachY = 0;
+        final Dimension eachSize = each.getPreferredSize();
+        if (data.eachX + eachSize.width < data.toFitWidth + tabsStart) {
+          each.setBounds(data.eachX, data.eachY, eachSize.width, bounds.height - data.eachY);
+          data.eachX += eachSize.width;
+        }
+        else {
+          if (!reachedBounds) {
+            final int width = bounds.width - data.eachX - data.nonLabelWidth;
+            each.setBounds(data.eachX, data.eachY, width, bounds.height - data.eachY);
+            data.eachX += width;
+          }
+          else {
+            each.setBounds(0, 0, 0, 0);
+          }
+          reachedBounds = true;
+        }
+      }
+
+      for (JLabel each : toDrop) {
+        each.setBounds(0, 0, 0, 0);
+      }
+
+      if (toDrop.isEmpty()) {
+        toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset != null;
+        data.morePopupOffset = null;
+      }
+      else {
+        toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset == null;
+        data.morePopupOffset = new Point(data.eachX + data.nonLabelWidth + MORE_ICON_BORDER, bounds.height);
       }
     }
 
-    for (JLabel each : toDrop) {
-      each.setBounds(0, 0, 0, 0);
-    }
-
-    boolean toolbarUpdateNeeded;
-    if (!toDrop.isEmpty()) {
-      toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset == null;
-      data.morePopupOffset = new Point(data.eachX + MORE_ICON_BORDER, bounds.height);
-    }
-    else {
-      toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset != null;
-      data.morePopupOffset = null;
+    // Non-label components are positioned at the end.
+    for (Component c : getNonLabelComponents(false)) {
+      Dimension size = c.getPreferredSize();
+      c.setBounds(data.eachX, data.eachY + (bounds.height - size.height) / 2, size.width, size.height);
+      data.eachX += c.getWidth();
     }
 
     lastLayout = data;
@@ -289,6 +298,9 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
         }
       }
     }
+
+    result += calculateTotalPreferredWidthOfNonLabelComponents();
+
     return result;
   }
 
@@ -327,6 +339,7 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
     public int eachX;
     public int eachY;
     public int contentCount;
+    public int nonLabelWidth;
 
     LayoutData(ToolWindowContentUi ui) {
       layoutSize = ui.getTabComponent().getSize();
@@ -374,19 +387,27 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
 
   @Override
   public void rebuild() {
-    ui.getTabComponent().removeAll();
+    JPanel tabComponent = ui.getTabComponent();
+    List<Component> nonLabelComponents = getNonLabelComponents(true);
 
-    ui.getTabComponent().add(idLabel);
+    tabComponent.removeAll();
+
+    tabComponent.add(idLabel);
     ToolWindowContentUi.initMouseListeners(idLabel, ui, true);
 
     for (ContentTabLabel each : tabs) {
-      ui.getTabComponent().add(each);
+      tabComponent.add(each);
       ToolWindowContentUi.initMouseListeners(each, ui, false);
     }
     if ((!isSingleContentView || !Registry.is("debugger.new.tool.window.layout.dnd", false))
         && ui.dropOverIndex >= 0 && !tabs.isEmpty()) {
-      int index = Math.min(ui.dropOverIndex, ui.getTabComponent().getComponentCount());
-      ui.getTabComponent().add(dropOverPlaceholder, index);
+      int index = Math.min(ui.dropOverIndex, tabComponent.getComponentCount());
+      tabComponent.add(dropOverPlaceholder, index);
+    }
+
+    // Add back the non-label components.
+    for (Component c : nonLabelComponents) {
+      tabComponent.add(c);
     }
   }
 

--- a/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowHeader.kt
+++ b/platform/platform-impl/src/com/intellij/toolWindow/ToolWindowHeader.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowContentUiType
-import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.impl.DockToolWindowAction
 import com.intellij.openapi.wm.impl.ToolWindowImpl
 import com.intellij.openapi.wm.impl.content.SingleContentLayout
@@ -242,13 +241,13 @@ abstract class ToolWindowHeader internal constructor(
   private fun manageWestPanelTabComponentAndToolbar(init: Boolean) {
     if (!init) { // remove to avoid extra events, toolbars update on addNotify!
       westPanel.remove(contentUi.tabComponent)
-      toolbarWest?.apply { westPanel.remove(component) }
+      toolbarWest?.apply { contentUi.tabComponent.remove(component) }
       return
     }
     // Makes sure toolbar stays after the tab component
     val allowDnd = ClientProperty.isTrue(toolWindow.component as Component?, ToolWindowContentUi.ALLOW_DND_FOR_TABS)
     westPanel.add(contentUi.tabComponent, if (allowDnd) CC().grow() else CC().growY())
-    toolbarWest?.apply { westPanel.add(component, CC().pushX()) }
+    toolbarWest?.apply { contentUi.tabComponent.add(component, CC().pushX()) }
   }
 
   override fun propertyChange(evt: PropertyChangeEvent?) {
@@ -295,8 +294,8 @@ abstract class ToolWindowHeader internal constructor(
         setReservePlaceAutoPopupIcon(false)
         isOpaque = false
         border = JBUI.Borders.empty()
-        if (westPanel.isShowing) {
-          westPanel.add(this, CC().pushX())
+        if (contentUi.tabComponent.isShowing) {
+          contentUi.tabComponent.add(component, CC().pushX())
         }
       }
     }


### PR DESCRIPTION
The gap was caused by ToolWindowContentUi.TabPanel pushing ToolWindowHeader.toolbarWest to the far right when the preferred width of TabPanel was larger than the sum of widths of its visible children. Since reducing the preferred width would prevent TabPanel from growing when its container becomes wider, we move ToolWindowHeader.toolbarWest inside ToolWindowContentUi.TabPanel instead, This way toolbarWest can be positioned adjacent to the rightmost visible tab regardless of the TabPanel's preferred width.