### PR TITLE
[PY-66222] Fix IndexNotReadyException errors

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/validation/CompatibilityVisitor.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/validation/CompatibilityVisitor.java
@@ -7,6 +7,7 @@ import com.intellij.codeInspection.util.InspectionMessage;
 import com.intellij.lang.ASTNode;
 import com.intellij.modcommand.ModPsiUpdater;
 import com.intellij.modcommand.PsiUpdateModCommandQuickFix;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.NlsSafe;
@@ -803,6 +804,10 @@ public abstract class CompatibilityVisitor extends PyAnnotator {
         file instanceof PyFile &&
         ((PyFile)file).hasImportFromFuture(FutureFeature.ANNOTATIONS) &&
         isInAnnotation) {
+      return;
+    }
+
+    if (DumbService.isDumb(file.getProject())) {
       return;
     }
 


### PR DESCRIPTION
This is because Python annotators are now allowed to run in dumb mode.

YouTrack issue: https://youtrack.jetbrains.com/issues?q=&preview=PY-66222