### PR TITLE
IDEA-349803: Eliminate the gap before the tab actions' icons

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ContentLayout.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/ContentLayout.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.openapi.wm.impl.content;
 
+import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.ui.popup.ListPopup;
 import com.intellij.openapi.util.NlsActions.ActionText;
 import com.intellij.ui.ClientProperty;
@@ -66,6 +67,14 @@ public abstract class ContentLayout {
       label.setBorder(border);
     }
     label.setVisible(shouldShowId());
+  }
+
+  /**
+   * Returns the preferred width of the tab toolbar if present, otherwise 0.
+   */
+  protected int getTabToolbarPreferredWidth() {
+    ActionToolbar tabToolbar = ui.getTabToolbar();
+    return tabToolbar == null ? 0 : tabToolbar.getComponent().getPreferredSize().width;
   }
 
   private String getTitleSuffix() {

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/TabContentLayout.java
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/content/TabContentLayout.java
@@ -5,6 +5,7 @@ import com.intellij.ide.ActivityTracker;
 import com.intellij.ide.dnd.DnDSupport;
 import com.intellij.ide.dnd.DnDTarget;
 import com.intellij.openapi.actionSystem.ActionPlaces;
+import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
@@ -147,6 +148,7 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
     ContentManager manager = ui.getContentManager();
     LayoutData data = new LayoutData(ui);
 
+    data.toolbarWidth = getTabToolbarPreferredWidth();
     data.eachX = getTabLayoutStart();
     data.eachY = 0;
 
@@ -159,102 +161,112 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
     }
     int tabsStart = data.eachX;
 
-    if (manager.getContentCount() == 0) return;
+    boolean toolbarUpdateNeeded = false;
+    if (manager.getContentCount() != 0) {
+      Content selected = manager.getSelectedContent();
+      if (selected == null) {
+        selected = manager.getContents()[0];
+      }
 
-    Content selected = manager.getSelectedContent();
-    if (selected == null) {
-      selected = manager.getContents()[0];
-    }
-
-    if (lastLayout != null &&
-        (idLabel == null || idLabel.isValid()) &&
-        lastLayout.layoutSize.equals(bounds.getSize()) &&
-        lastLayout.contentCount == manager.getContentCount() &&
-        ContainerUtil.all(tabs, Component::isValid)) {
-      for (ContentTabLabel each : tabs) {
-        if (each.getContent() == selected && each.getBounds().width != 0) {
-          return; // keep last layout
+      if (lastLayout != null &&
+          (idLabel == null || idLabel.isValid()) &&
+          lastLayout.layoutSize.equals(bounds.getSize()) &&
+          lastLayout.contentCount == manager.getContentCount() &&
+          lastLayout.toolbarWidth == data.toolbarWidth &&
+          ContainerUtil.all(tabs, Component::isValid)) {
+        for (ContentTabLabel each : tabs) {
+          if (each.getContent() == selected && each.getBounds().width != 0) {
+            return; // keep last layout
+          }
         }
       }
-    }
 
-    ArrayList<JLabel> toLayout = new ArrayList<>();
-    Collection<JLabel> toDrop = new HashSet<>();
+      ArrayList<JLabel> toLayout = new ArrayList<>();
+      Collection<JLabel> toDrop = new HashSet<>();
 
-    for (JLabel eachTab : tabs) {
-      final Dimension eachSize = eachTab.getPreferredSize();
-      data.requiredWidth += eachSize.width;
-      toLayout.add(eachTab);
-    }
-
-    if (ui.dropOverIndex != -1 && !isSingleContentView) {
-      data.requiredWidth += ui.dropOverWidth;
-      int index = Math.min(toLayout.size(), Math.max(0, ui.dropOverIndex - 1));
-      toLayout.add(index, dropOverPlaceholder);
-    }
-
-    data.toFitWidth = bounds.getSize().width - data.eachX;
-
-    final ContentTabLabel selectedTab = contentToTabs.get(selected);
-    while (true) {
-      if (data.requiredWidth <= data.toFitWidth) break;
-      if (toLayout.size() <= 1) break;
-
-      JLabel firstLabel = toLayout.get(0);
-      JLabel lastLabel = toLayout.get(toLayout.size() - 1);
-      JLabel labelToDrop;
-      if (firstLabel != selectedTab && firstLabel != dropOverPlaceholder) {
-        labelToDrop = firstLabel;
+      for (JLabel eachTab : tabs) {
+        final Dimension eachSize = eachTab.getPreferredSize();
+        data.requiredWidth += eachSize.width;
+        toLayout.add(eachTab);
       }
-      else if (lastLabel != selectedTab && lastLabel != dropOverPlaceholder) {
-        labelToDrop = lastLabel;
-      }
-      else {
-        break;
-      }
-      data.requiredWidth -= (labelToDrop.getPreferredSize().width + 1);
-      toDrop.add(labelToDrop);
-      toLayout.remove(labelToDrop);
-    }
 
-    boolean reachedBounds = false;
-    TabsDrawMode toDrawTabs = isToDrawTabs();
-    for (JLabel each : toLayout) {
-      if (toDrawTabs == TabsDrawMode.HIDE) {
-        each.setBounds(0, 0, 0, 0);
-        continue;
+      if (ui.dropOverIndex != -1 && !isSingleContentView) {
+        data.requiredWidth += ui.dropOverWidth;
+        int index = Math.min(toLayout.size(), Math.max(0, ui.dropOverIndex - 1));
+        toLayout.add(index, dropOverPlaceholder);
       }
-      data.eachY = 0;
-      final Dimension eachSize = each.getPreferredSize();
-      if (data.eachX + eachSize.width < data.toFitWidth + tabsStart) {
-        each.setBounds(data.eachX, data.eachY, eachSize.width, bounds.height - data.eachY);
-        data.eachX += eachSize.width;
-      }
-      else {
-        if (!reachedBounds) {
-          final int width = bounds.width - data.eachX;
-          each.setBounds(data.eachX, data.eachY, width, bounds.height - data.eachY);
-          data.eachX += width;
+
+      data.toFitWidth = bounds.getSize().width - data.toolbarWidth - data.eachX;
+
+      final ContentTabLabel selectedTab = contentToTabs.get(selected);
+      while (true) {
+        if (data.requiredWidth <= data.toFitWidth) break;
+        if (toLayout.size() <= 1) break;
+
+        JLabel firstLabel = toLayout.get(0);
+        JLabel lastLabel = toLayout.get(toLayout.size() - 1);
+        JLabel labelToDrop;
+        if (firstLabel != selectedTab && firstLabel != dropOverPlaceholder) {
+          labelToDrop = firstLabel;
+        }
+        else if (lastLabel != selectedTab && lastLabel != dropOverPlaceholder) {
+          labelToDrop = lastLabel;
         }
         else {
-          each.setBounds(0, 0, 0, 0);
+          break;
         }
-        reachedBounds = true;
+        data.requiredWidth -= (labelToDrop.getPreferredSize().width + 1);
+        toDrop.add(labelToDrop);
+        toLayout.remove(labelToDrop);
+      }
+
+      boolean reachedBounds = false;
+      TabsDrawMode toDrawTabs = isToDrawTabs();
+      for (JLabel each : toLayout) {
+        if (toDrawTabs == TabsDrawMode.HIDE) {
+          each.setBounds(0, 0, 0, 0);
+          continue;
+        }
+        data.eachY = 0;
+        final Dimension eachSize = each.getPreferredSize();
+        if (data.eachX + eachSize.width < data.toFitWidth + tabsStart) {
+          each.setBounds(data.eachX, data.eachY, eachSize.width, bounds.height - data.eachY);
+          data.eachX += eachSize.width;
+        }
+        else {
+          if (!reachedBounds) {
+            final int width = bounds.width - data.eachX - data.toolbarWidth;
+            each.setBounds(data.eachX, data.eachY, width, bounds.height - data.eachY);
+            data.eachX += width;
+          }
+          else {
+            each.setBounds(0, 0, 0, 0);
+          }
+          reachedBounds = true;
+        }
+      }
+
+      for (JLabel each : toDrop) {
+        each.setBounds(0, 0, 0, 0);
+      }
+
+      if (toDrop.isEmpty()) {
+        toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset != null;
+        data.morePopupOffset = null;
+      }
+      else {
+        toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset == null;
+        data.morePopupOffset = new Point(data.eachX + data.toolbarWidth + MORE_ICON_BORDER, bounds.height);
       }
     }
 
-    for (JLabel each : toDrop) {
-      each.setBounds(0, 0, 0, 0);
-    }
-
-    boolean toolbarUpdateNeeded;
-    if (!toDrop.isEmpty()) {
-      toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset == null;
-      data.morePopupOffset = new Point(data.eachX + MORE_ICON_BORDER, bounds.height);
-    }
-    else {
-      toolbarUpdateNeeded = lastLayout != null && lastLayout.morePopupOffset != null;
-      data.morePopupOffset = null;
+    // Tab toolbar is positioned at the end.
+    ActionToolbar tabToolbar = ui.getTabToolbar();
+    if (tabToolbar != null) {
+      JComponent component = tabToolbar.getComponent();
+      Dimension size = component.getPreferredSize();
+      component.setBounds(data.eachX, data.eachY + (bounds.height - size.height) / 2, size.width, size.height);
+      data.eachX += component.getWidth();
     }
 
     lastLayout = data;
@@ -289,6 +301,9 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
         }
       }
     }
+
+    result += getTabToolbarPreferredWidth();
+
     return result;
   }
 
@@ -327,6 +342,7 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
     public int eachX;
     public int eachY;
     public int contentCount;
+    public int toolbarWidth;
 
     LayoutData(ToolWindowContentUi ui) {
       layoutSize = ui.getTabComponent().getSize();
@@ -374,20 +390,24 @@ class TabContentLayout extends ContentLayout implements MorePopupAware {
 
   @Override
   public void rebuild() {
-    ui.getTabComponent().removeAll();
+    JPanel tabComponent = ui.getTabComponent();
 
-    ui.getTabComponent().add(idLabel);
+    tabComponent.removeAll();
+
+    tabComponent.add(idLabel);
     ToolWindowContentUi.initMouseListeners(idLabel, ui, true);
 
     for (ContentTabLabel each : tabs) {
-      ui.getTabComponent().add(each);
+      tabComponent.add(each);
       ToolWindowContentUi.initMouseListeners(each, ui, false);
     }
     if ((!isSingleContentView || !Registry.is("debugger.new.tool.window.layout.dnd", false))
         && ui.dropOverIndex >= 0 && !tabs.isEmpty()) {
-      int index = Math.min(ui.dropOverIndex, ui.getTabComponent().getComponentCount());
-      ui.getTabComponent().add(dropOverPlaceholder, index);
+      int index = Math.min(ui.dropOverIndex, tabComponent.getComponentCount());
+      tabComponent.add(dropOverPlaceholder, index);
     }
+
+    ui.connectTabToolbar();
   }
 
   @Override

--- a/platform/platform-impl/src/com/intellij/toolWindow/InternalDecoratorImpl.kt
+++ b/platform/platform-impl/src/com/intellij/toolWindow/InternalDecoratorImpl.kt
@@ -161,7 +161,7 @@ class InternalDecoratorImpl internal constructor(
     internal fun headerNeedsTopBorder(header: ToolWindowHeader): Boolean {
       val decorator = findNearestDecorator(header) ?: return false
       return decorator.toolWindow.type == ToolWindowType.WINDOWED &&
-          SideProperty.TOP_TOOL_WINDOW_EDGE in decorator.getSideProperties(decorator)
+        SideProperty.TOP_TOOL_WINDOW_EDGE in decorator.getSideProperties(decorator)
     }
 
     @JvmStatic
@@ -238,7 +238,7 @@ class InternalDecoratorImpl internal constructor(
       override val isActive: Boolean
         get() {
           return toolWindow.isActive && !toolWindow.toolWindowManager.isNewUi &&
-                 ClientProperty.get(this@InternalDecoratorImpl, INACTIVE_LOOK) != true
+            ClientProperty.get(this@InternalDecoratorImpl, INACTIVE_LOOK) != true
         }
 
       override fun hideToolWindow() {
@@ -287,6 +287,7 @@ class InternalDecoratorImpl internal constructor(
         }
         return
       }
+
       Mode.VERTICAL_SPLIT, Mode.HORIZONTAL_SPLIT -> {
         val splitter = OnePixelSplitter(mode == Mode.VERTICAL_SPLIT)
         splitter.setFirstComponent(firstDecorator)
@@ -400,14 +401,17 @@ class InternalDecoratorImpl internal constructor(
         firstDecorator == null || secondDecorator == null -> {
           return
         }
+
         firstDecorator!!.mode!!.isSplit -> {
           raise(true)
           return
         }
+
         secondDecorator!!.mode!!.isSplit -> {
           raise(false)
           return
         }
+
         else -> {
           for (c in firstDecorator!!.contentManager.contents) {
             moveContent(c, firstDecorator!!, this)
@@ -440,12 +444,10 @@ class InternalDecoratorImpl internal constructor(
 
   val headerToolbarActions: ActionGroup
     get() = header.getToolbarActions()
-  val headerToolbarWestActions: ActionGroup
-    get() = header.getToolbarWestActions()
 
   override fun toString(): String {
     return toolWindow.id + ": " + StringUtil.trimMiddle(contentManager.contents.joinToString { it.displayName ?: "null" }, 40) +
-           " #" + System.identityHashCode(this)
+      " #" + System.identityHashCode(this)
   }
 
   private fun initDivider(): JComponent {
@@ -528,7 +530,7 @@ class InternalDecoratorImpl internal constructor(
 
   fun setTabActions(actions: List<AnAction>) {
     tabActions = actions
-    header.setTabActions(actions)
+    contentUi.setTabActions(actions)
     firstDecorator?.setTabActions(actions)
     secondDecorator?.setTabActions(actions)
   }
@@ -558,7 +560,7 @@ class InternalDecoratorImpl internal constructor(
       y: Int,
       width: Int,
       height: Int,
-      ) {
+    ) {
       g.color = JBColor.border()
       if (insets.top > 0) {
         LinePainter2D.paint(g, x.toDouble(), (y + insets.top - 1).toDouble(), (x + width - 1).toDouble(),
@@ -605,19 +607,22 @@ class InternalDecoratorImpl internal constructor(
       val toolWindowManager = window.toolWindowManager
       val windowInfo = window.windowInfo
       if (toolWindowManager.project.isDisposed ||
-          !toolWindowManager.isToolWindowRegistered(window.id) ||
-          window.isDisposed || !windowInfo.type.isInternal) {
+        !toolWindowManager.isToolWindowRegistered(window.id) ||
+        window.isDisposed || !windowInfo.type.isInternal) {
         return JBInsets.emptyInsets()
       }
       val anchor = windowInfo.anchor
       val sideProperties = getSideProperties(c)
       val top = if (SideProperty.TOP_DIVIDER !in sideProperties && toolWindow.type != ToolWindowType.FLOATING &&
-                    SideProperty.TOP_TOOL_WINDOW_EDGE in sideProperties) 1 else 0
+        SideProperty.TOP_TOOL_WINDOW_EDGE in sideProperties) 1
+      else 0
       val bottom = 0
       var left = if (SideProperty.LEFT_DIVIDER !in sideProperties && anchor == ToolWindowAnchor.RIGHT &&
-                     SideProperty.LEFT_TOOL_WINDOW_EDGE in sideProperties) 1 else 0
+        SideProperty.LEFT_TOOL_WINDOW_EDGE in sideProperties) 1
+      else 0
       var right = if (SideProperty.RIGHT_DIVIDER !in sideProperties && anchor == ToolWindowAnchor.LEFT &&
-                      SideProperty.RIGHT_TOOL_WINDOW_EDGE in sideProperties) 1 else 0
+        SideProperty.RIGHT_TOOL_WINDOW_EDGE in sideProperties) 1
+      else 0
       paintLeftExternalBorder = left > 0
       paintRightExternalBorder = right > 0
       paintLeftInternalBorder = false
@@ -657,22 +662,22 @@ class InternalDecoratorImpl internal constructor(
         // In the 5th case we draw borders on the right side of the divider. The choice between left and right is random, but drawing both looks ugly.
         if ((
             anchor == ToolWindowAnchor.RIGHT &&
-            hasEditorLikeComponentOnTheLeft() &&
-            (isTouchingTheEditor || otherDecoratorInSplitter?.hasEditorLikeComponentOnTheRight() == true) // cases 1 & 2
-          ) || (
+              hasEditorLikeComponentOnTheLeft() &&
+              (isTouchingTheEditor || otherDecoratorInSplitter?.hasEditorLikeComponentOnTheRight() == true) // cases 1 & 2
+            ) || (
             anchor == ToolWindowAnchor.BOTTOM &&
-            hasEditorLikeComponentOnTheLeft() &&
-            isSplitter &&
-            !isFirstInSplitter &&
-            otherDecoratorInSplitter?.hasEditorLikeComponentOnTheRight() == true // case 5
-        )) {
+              hasEditorLikeComponentOnTheLeft() &&
+              isSplitter &&
+              !isFirstInSplitter &&
+              otherDecoratorInSplitter?.hasEditorLikeComponentOnTheRight() == true // case 5
+            )) {
           ++left
           paintLeftInternalBorder = true
         }
         if (
-            anchor == ToolWindowAnchor.LEFT &&
-            hasEditorLikeComponentOnTheRight() &&
-            (isTouchingTheEditor || otherDecoratorInSplitter?.hasEditorLikeComponentOnTheLeft() == true) // cases 3 & 4
+          anchor == ToolWindowAnchor.LEFT &&
+          hasEditorLikeComponentOnTheRight() &&
+          (isTouchingTheEditor || otherDecoratorInSplitter?.hasEditorLikeComponentOnTheLeft() == true) // cases 3 & 4
         ) {
           ++right
           paintRightInternalBorder = true
@@ -709,13 +714,15 @@ class InternalDecoratorImpl internal constructor(
               if (!reachedToolWindow) {
                 result.remove(SideProperty.BOTTOM_TOOL_WINDOW_EDGE)
               }
-            } else {
+            }
+            else {
               result.add(SideProperty.TOP_DIVIDER)
               if (!reachedToolWindow) {
                 result.remove(SideProperty.TOP_TOOL_WINDOW_EDGE)
               }
             }
-          } else if (component == splitter.firstComponent) {
+          }
+          else if (component == splitter.firstComponent) {
             result.add(SideProperty.RIGHT_DIVIDER)
             if (!reachedToolWindow) {
               result.remove(SideProperty.RIGHT_TOOL_WINDOW_EDGE)
@@ -776,8 +783,8 @@ class InternalDecoratorImpl internal constructor(
   fun updateActiveAndHoverState() {
     val isHoverAlphaAnimationEnabled =
       toolWindow.toolWindowManager.isNewUi &&
-      !AdvancedSettings.getBoolean("ide.always.show.tool.window.header.icons") &&
-      toolWindow.component.getClientProperty(ToolWindowContentUi.DONT_HIDE_TOOLBAR_IN_HEADER) != true
+        !AdvancedSettings.getBoolean("ide.always.show.tool.window.header.icons") &&
+        toolWindow.component.getClientProperty(ToolWindowContentUi.DONT_HIDE_TOOLBAR_IN_HEADER) != true
     val narrow = this.toolWindow.decorator?.width?.let { it < JBUI.scale(120) } ?: false
     val isVisible = narrow || !isHoverAlphaAnimationEnabled || isWindowHovered || header.isPopupShowing || toolWindow.isActive
 
@@ -786,9 +793,9 @@ class InternalDecoratorImpl internal constructor(
       toolbar.alphaContext.isVisible = isVisible
     }
 
-    val toolbarWest = header.getToolbarWest()
-    if (toolbarWest != null && toolbarWest is AlphaAnimated) {
-      toolbarWest.alphaContext.isVisible = isVisible
+    val tabToolbar = contentUi.tabToolbar
+    if (tabToolbar != null && tabToolbar is AlphaAnimated) {
+      tabToolbar.alphaContext.isVisible = isVisible
     }
   }
 
@@ -904,8 +911,8 @@ class InternalDecoratorImpl internal constructor(
     private var isDragging = false
     private fun isInDragZone(e: MouseEvent): Boolean {
       if (!divider.isShowing
-          || (divider.width == 0 && divider.height == 0)
-          || e.id == MouseEvent.MOUSE_DRAGGED) return false
+        || (divider.width == 0 && divider.height == 0)
+        || e.id == MouseEvent.MOUSE_DRAGGED) return false
 
       val point = SwingUtilities.convertPoint(e.component, e.point, divider)
       val isTopBottom = decorator.toolWindow.windowInfo.anchor.isHorizontal
@@ -996,10 +1003,10 @@ class InternalDecoratorImpl internal constructor(
   private inner class AccessibleInternalDecorator : AccessibleJPanel() {
     override fun getAccessibleName(): String {
       return super.getAccessibleName()
-             ?: (
-               ((toolWindow.title?.takeIf(String::isNotEmpty) ?: toolWindow.stripeTitle).takeIf(String::isNotEmpty) ?: toolWindow.id)
-               + " " + IdeBundle.message("internal.decorator.accessible.postfix")
-                )
+        ?: (
+          ((toolWindow.title?.takeIf(String::isNotEmpty) ?: toolWindow.stripeTitle).takeIf(String::isNotEmpty) ?: toolWindow.id)
+            + " " + IdeBundle.message("internal.decorator.accessible.postfix")
+          )
     }
 
     override fun getAccessibleRole(): AccessibleRole {
@@ -1013,6 +1020,7 @@ class InternalDecoratorImpl internal constructor(
     RIGHT_DIVIDER,
     TOP_DIVIDER,
     BOTTOM_DIVIDER,
+
     // Sides adjacent to the edges of the containing tool window.
     LEFT_TOOL_WINDOW_EDGE,
     RIGHT_TOOL_WINDOW_EDGE,


### PR DESCRIPTION
The gap was caused by ToolWindowContentUi.TabPanel pushing the tab actions toolbar (ToolWindowHeader.toolbarWest) to the far right when the preferred width of TabPanel was larger than the sum of widths of its visible children. Since reducing the preferred width would prevent TabPanel from growing when its container becomes wider, the tab actions toolbar has been moved inside ToolWindowContentUi.TabPanel instead, This way the tab actions toolbar can be positioned adjacent to the rightmost visible tab regardless of the TabPanel's preferred width.

Code related to the tab actions toolbar has been moved from ToolWindowHeader to ToolWindowContentUi.