### PR TITLE
Implementation of the AssertFindUsagesEntryCommand

### DIFF
--- a/plugins/performanceTesting/core/src/com/jetbrains/performancePlugin/BaseCommandProvider.java
+++ b/plugins/performanceTesting/core/src/com/jetbrains/performancePlugin/BaseCommandProvider.java
@@ -81,6 +81,7 @@ public final class BaseCommandProvider implements CommandProvider {
       Map.entry(AssertCompletionCommand.PREFIX, AssertCompletionCommand::new),
       Map.entry(ChooseCompletionCommand.PREFIX, ChooseCompletionCommand::new),
       Map.entry(AssertFindUsagesCommand.PREFIX, AssertFindUsagesCommand::new),
+      Map.entry(AssertFindUsagesEntryCommand.PREFIX, AssertFindUsagesEntryCommand::new),
       Map.entry(SetBreakpointCommand.PREFIX, SetBreakpointCommand::new),
       Map.entry(DebugRunConfigurationCommand.PREFIX, DebugRunConfigurationCommand::new),
       Map.entry(DebugStepCommand.PREFIX, DebugStepCommand::new),

--- a/plugins/performanceTesting/core/src/com/jetbrains/performancePlugin/commands/AssertFindUsagesEntryArguments.java
+++ b/plugins/performanceTesting/core/src/com/jetbrains/performancePlugin/commands/AssertFindUsagesEntryArguments.java
@@ -1,0 +1,15 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.performancePlugin.commands;
+
+import com.sampullara.cli.Argument;
+
+public class AssertFindUsagesEntryArguments implements CommandArguments {
+  @Argument
+  String text;
+
+  @Argument
+  String filePath;
+
+  @Argument
+  Integer line;
+}

--- a/plugins/performanceTesting/core/src/com/jetbrains/performancePlugin/commands/AssertFindUsagesEntryCommand.kt
+++ b/plugins/performanceTesting/core/src/com/jetbrains/performancePlugin/commands/AssertFindUsagesEntryCommand.kt
@@ -1,0 +1,50 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.performancePlugin.commands
+
+import com.intellij.openapi.ui.playback.PlaybackContext
+import com.intellij.openapi.ui.playback.commands.PlaybackCommandCoroutineAdapter
+import com.intellij.util.indexing.diagnostic.dump.paths.PortableFilePath
+import com.jetbrains.performancePlugin.utils.DataDumper
+import com.sampullara.cli.Args
+import org.jetbrains.annotations.NonNls
+import java.nio.file.Files
+
+/**
+ * Verifies that a particular option is present in the list. Find usages option properties: text, filePath, line.
+ * Example: %assertFindUsagesEntryCommand [-text code line]|[-filePath a/b/test.kt]|[-line 12]
+ */
+class AssertFindUsagesEntryCommand(text: String, line: Int) : PlaybackCommandCoroutineAdapter(text, line) {
+  companion object {
+    const val PREFIX: @NonNls String = CMD_PREFIX + "assertFindUsagesEntryCommand"
+  }
+
+  override suspend fun doExecute(context: PlaybackContext) {
+    val lastUsageReport = FindUsagesDumper.getFoundUsagesJsonPath() ?: throw IllegalStateException("Find usages report is null")
+    if (!Files.exists(lastUsageReport) || !Files.isRegularFile(lastUsageReport)) {
+      throw IllegalStateException("Find usages report file not exists $lastUsageReport")
+    }
+
+    val options = AssertFindUsagesEntryArguments()
+    Args.parse(options, extractCommandArgument(PREFIX).split("|").flatMap { it.split(" ", limit= 2) }.toTypedArray())
+
+    if (options.text == null && options.filePath == null) {
+      throw IllegalStateException("Provide expected test or position of the find usages option.")
+    }
+    val data: FindUsagesDumper.FoundUsagesReport = DataDumper.read(lastUsageReport, FindUsagesDumper.FoundUsagesReport::class.java)
+    val relativePath = PortableFilePath.RelativePath(PortableFilePath.ProjectRoot, options.filePath)
+    data.usages.find {
+      var isMatch = true
+      if (options.text != null && options.text != it.text) {
+        isMatch = false
+      }
+      if (options.filePath != null && !relativePath.equals(it.portableFilePath)) {
+        isMatch = false
+      }
+      if (options.line != null && options.line != it.line) {
+        isMatch = false
+      }
+
+      return@find isMatch
+    } ?: throw IllegalStateException("Expected FindUsages option wasn't found in the list.")
+  }
+}


### PR DESCRIPTION
This command verifies that the specific code position/code snippet is presented in the recent FindUsages result.