### PR TITLE
KTIJ-24692 Delegating to 'var' property: "Remove var" quick fix produces incompilable code if property belongs to outer class

### DIFF
--- a/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k1/test/org/jetbrains/kotlin/idea/codeInsight/inspections/shared/SharedK1LocalInspectionTestGenerated.java
@@ -369,6 +369,16 @@ public abstract class SharedK1LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/delegationToVarProperty/parameter.kt");
         }
 
+        @TestMetadata("usedForOtherClass.kt")
+        public void testUsedForOtherClass() throws Exception {
+            runTest("../testData/inspectionsLocal/delegationToVarProperty/usedForOtherClass.kt");
+        }
+
+        @TestMetadata("usedInFunction.kt")
+        public void testUsedInFunction() throws Exception {
+            runTest("../testData/inspectionsLocal/delegationToVarProperty/usedInFunction.kt");
+        }
+
         @TestMetadata("valParameter.kt")
         public void testValParameter() throws Exception {
             runTest("../testData/inspectionsLocal/delegationToVarProperty/valParameter.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/k2/test/org/jetbrains/kotlin/idea/k2/codeInsight/inspections/shared/SharedK2LocalInspectionTestGenerated.java
@@ -369,6 +369,16 @@ public abstract class SharedK2LocalInspectionTestGenerated extends AbstractShare
             runTest("../testData/inspectionsLocal/delegationToVarProperty/parameter.kt");
         }
 
+        @TestMetadata("usedForOtherClass.kt")
+        public void testUsedForOtherClass() throws Exception {
+            runTest("../testData/inspectionsLocal/delegationToVarProperty/usedForOtherClass.kt");
+        }
+
+        @TestMetadata("usedInFunction.kt")
+        public void testUsedInFunction() throws Exception {
+            runTest("../testData/inspectionsLocal/delegationToVarProperty/usedInFunction.kt");
+        }
+
         @TestMetadata("valParameter.kt")
         public void testValParameter() throws Exception {
             runTest("../testData/inspectionsLocal/delegationToVarProperty/valParameter.kt");

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/delegationToVarProperty/usedForOtherClass.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/delegationToVarProperty/usedForOtherClass.kt
@@ -1,0 +1,4 @@
+// PROBLEM: none
+class Foo(<caret>var text: CharSequence) {
+    inner class Bar: CharSequence by text
+}

--- a/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/delegationToVarProperty/usedInFunction.kt
+++ b/plugins/kotlin/code-insight/inspections-shared/tests/testData/inspectionsLocal/delegationToVarProperty/usedInFunction.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+class Foo(<caret>var text: CharSequence): CharSequence by text {
+    fun bar() {
+        text = ""
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24692