### PR TITLE
[kotlin] J2K: Port JavaMapForEachInspection functionality to BuiltinMembersConversion 

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -94,7 +94,6 @@ private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
     RemoveExplicitPropertyTypeProcessing(),
     RemoveRedundantNullabilityProcessing(),
     inspectionBasedProcessing(FoldInitializerAndIfToElvisInspection(), writeActionNeeded = false),
-    inspectionBasedProcessing(JavaMapForEachInspection()),
     inspectionBasedProcessing(IfThenToSafeAccessInspection(inlineWithPrompt = false), writeActionNeeded = false) {
         it.shouldBeTransformed()
     },

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
@@ -368,6 +368,29 @@ private class ConversionsHolder(private val symbolProvider: JKSymbolProvider, pr
         Method("java.util.Map.keySet") convertTo Field("kotlin.collections.Map.keys"),
         Method("java.util.Map.size") convertTo Field("kotlin.collections.Map.size"),
         Method("java.util.Map.values") convertTo Field("kotlin.collections.Map.values"),
+        Method("java.util.Map.forEach") convertTo CustomExpression { expression ->
+            val forEachExpression = expression as JKCallExpression
+            val lambdaArgument = forEachExpression.arguments.arguments.singleOrNull()?.value?.safeAs<JKLambdaExpression>()
+                ?: return@CustomExpression expression
+            if (lambdaArgument.parameters.size != 2) return@CustomExpression expression
+
+            // Analogous to changes made by `JavaMapForEachInspection`
+            JKCallExpressionImpl(
+                symbolProvider.provideMethodSymbol("kotlin.collections.Map.forEach"),
+                JKArgumentList(
+                    JKLambdaExpression(
+                        lambdaArgument::statement.detached(), listOf(
+                            JKKtDestructuringDeclaration(lambdaArgument.parameters.map {
+                                JKKtDestructuringDeclarationEntry(
+                                    it::type.detached(),
+                                    it::name.detached()
+                                )
+                            })
+                        )
+                    )
+                )
+            )
+        },
         Method("java.util.Collection.size") convertTo Field("kotlin.collections.Collection.size"),
         Method("java.util.Collection.remove") convertTo Method("kotlin.collections.MutableCollection.remove"),
         Method("java.util.Collection.toArray") convertTo Method("kotlin.collections.toTypedArray") withByArgumentsFilter { it.isEmpty() },

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
@@ -268,7 +268,7 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
 
         override fun visitIsExpressionRaw(isExpression: JKIsExpression) {
             isExpression.expression.accept(this)
-            printer.printWithSurroundingSpaces(if (isExpression.isNegated)  "!is" else "is")
+            printer.printWithSurroundingSpaces(if (isExpression.isNegated) "!is" else "is")
             isExpression.type.accept(this)
         }
 
@@ -284,14 +284,32 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
             ) {
                 printer.printWithSurroundingSpaces("val")
             }
-            parameter.name.accept(this)
-            if (parameter.type.present() && parameter.type.type !is JKContextType) {
-                printer.print(": ")
-                parameter.type.accept(this)
-            }
+
+            renderVariableDeclaration(parameter)
             if (parameter.initializer !is JKStubExpression) {
                 printer.printWithSurroundingSpaces("=")
                 parameter.initializer.accept(this)
+            }
+        }
+
+        override fun visitDestructuringDeclarationEntryRaw(destructuringDeclaration: JKKtDestructuringDeclaration) {
+            printer.par {
+                destructuringDeclaration.destructuringDeclarationEntries.withIndex().forEach {
+                    it.value.accept(this)
+                    if (it.index < destructuringDeclaration.destructuringDeclarationEntries.lastIndex) printer.print(", ")
+                }
+            }
+        }
+
+        override fun visitDestructuringDeclarationEntryRaw(destructuringDeclarationEntry: JKKtDestructuringDeclarationEntry) {
+            renderVariableDeclaration(destructuringDeclarationEntry)
+        }
+
+        private fun renderVariableDeclaration(variable: JKVariable) {
+            variable.name.accept(this)
+            if (variable.type.present() && variable.type.type !is JKContextType) {
+                printer.print(": ")
+                variable.type.accept(this)
             }
         }
 
@@ -307,11 +325,7 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
 
         override fun visitForLoopVariableRaw(forLoopVariable: JKForLoopVariable) {
             forLoopVariable.annotationList.accept(this)
-            forLoopVariable.name.accept(this)
-            if (forLoopVariable.type.present() && forLoopVariable.type.type !is JKContextType) {
-                printer.print(": ")
-                forLoopVariable.type.accept(this)
-            }
+            renderVariableDeclaration(forLoopVariable)
         }
 
         override fun visitMethodRaw(method: JKMethod) {
@@ -542,11 +556,7 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
             printer.print(" ")
             localVariable.annotationList.accept(this)
             renderModifiersList(localVariable)
-            localVariable.name.accept(this)
-            if (localVariable.type.present() && localVariable.type.type != JKContextType) {
-                printer.print(": ")
-                localVariable.type.accept(this)
-            }
+            renderVariableDeclaration(localVariable)
             if (localVariable.initializer !is JKStubExpression) {
                 printer.printWithSurroundingSpaces("=")
                 localVariable.initializer.accept(this)

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/declarations.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/declarations.kt
@@ -118,6 +118,7 @@ open class JKParameter(
     override var name by child(name)
     override var type by child(type)
     override var annotationList by child(annotationList)
+
     override fun accept(visitor: JKVisitor) = visitor.visitParameter(this)
 }
 
@@ -127,6 +128,34 @@ class JKJavaRecordComponent(
     isVarArgs: Boolean,
     annotationList: JKAnnotationList
 ) : JKParameter(type, name, isVarArgs, annotationList = annotationList)
+
+/**
+ * Similar to `KtDestructuringDeclaration`. This class extends `JKParameter` because it's possible to have a list of several parameters,
+ * with one or more containing destructuring declarations, e.g. the JKParameter `index` and the JKKtDestructuringDeclaration `(s1, s2)` in
+ * `listOf<Pair<String, String>>().filterIndexed { index, (s1, s2) -> index < 5 && s1 != s2 }`
+ */
+class JKKtDestructuringDeclaration(destructuringDeclarations: List<JKKtDestructuringDeclarationEntry>) :
+    JKParameter(JKTypeElement(JKNoType), JKNameIdentifier("")) {
+    val destructuringDeclarationEntries by children(destructuringDeclarations)
+
+    override fun accept(visitor: JKVisitor) = visitor.visitDestructuringDeclaration(this)
+}
+
+/**
+ * Analogous to `KtDestructuringDeclarationEntry`. Similar to the PSI version of this class, `JKKtDestructuringDeclarationEntry` is a child
+ * node of a class extending `JKParameter` (`JKKtDestructuringDeclaration`).
+ */
+class JKKtDestructuringDeclarationEntry(
+    type: JKTypeElement,
+    name: JKNameIdentifier
+) : JKVariable() {
+    override val name by child(name)
+    override var type by child(type)
+    override var initializer: JKExpression by child(JKStubExpression())
+    override var annotationList: JKAnnotationList by child(JKAnnotationList())
+
+    override fun accept(visitor: JKVisitor) = visitor.visitDestructuringDeclarationEntry(this)
+}
 
 class JKEnumConstant(
     name: JKNameIdentifier,

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/visitors/JKVisitor.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/visitors/JKVisitor.kt
@@ -12,6 +12,8 @@ abstract class JKVisitor {
     open fun visitLocalVariable(localVariable: JKLocalVariable) = visitVariable(localVariable)
     open fun visitForLoopVariable(forLoopVariable: JKForLoopVariable) = visitVariable(forLoopVariable)
     open fun visitParameter(parameter: JKParameter) = visitVariable(parameter)
+    open fun visitDestructuringDeclaration(destructuringDeclaration: JKKtDestructuringDeclaration) = visitTreeElement(destructuringDeclaration)
+    open fun visitDestructuringDeclarationEntry(destructuringDeclarationEntry: JKKtDestructuringDeclarationEntry) = visitTreeElement(destructuringDeclarationEntry)
     open fun visitEnumConstant(enumConstant: JKEnumConstant) = visitVariable(enumConstant)
     open fun visitTypeParameter(typeParameter: JKTypeParameter) = visitDeclaration(typeParameter)
     open fun visitMethod(method: JKMethod) = visitDeclaration(method)

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/visitors/JKVisitorWithCommentsPrinting.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/visitors/JKVisitorWithCommentsPrinting.kt
@@ -60,6 +60,22 @@ abstract class JKVisitorWithCommentsPrinting : JKVisitor() {
 
     open fun visitForLoopVariableRaw(forLoopVariable: JKForLoopVariable) = visitVariableRaw(forLoopVariable)
 
+    override fun visitDestructuringDeclaration(destructuringDeclaration: JKKtDestructuringDeclaration) {
+        printLeftNonCodeElements(destructuringDeclaration)
+        visitDestructuringDeclarationEntryRaw(destructuringDeclaration)
+        printRightNonCodeElements(destructuringDeclaration)
+    }
+
+    open fun visitDestructuringDeclarationEntryRaw(destructuringDeclaration: JKKtDestructuringDeclaration) = visitTreeElement(destructuringDeclaration)
+
+    override fun visitDestructuringDeclarationEntry(destructuringDeclarationEntry: JKKtDestructuringDeclarationEntry) {
+        printLeftNonCodeElements(destructuringDeclarationEntry)
+        visitDestructuringDeclarationEntryRaw(destructuringDeclarationEntry)
+        printRightNonCodeElements(destructuringDeclarationEntry)
+    }
+
+    open fun visitDestructuringDeclarationEntryRaw(destructuringDeclarationEntry: JKKtDestructuringDeclarationEntry) = visitTreeElement(destructuringDeclarationEntry)
+
     override fun visitParameter(parameter: JKParameter) {
         printLeftNonCodeElements(parameter)
         visitParameterRaw(parameter)

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/java8MapForEachWithFullJdk.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/java8MapForEachWithFullJdk.java
@@ -1,12 +1,25 @@
 // IGNORE_K2
 
 import java.util.HashMap;
+import java.util.function.BiConsumer;
 
 class Test {
     void test(HashMap<String, String> map) {
         map.forEach((key, value) -> foo(key, value));
+        map.forEach((k, v) -> System.out.println("don't use params"));
+
+        BiConsumer<String, String> biConsumer = new MyBiConsumer();
+        map.forEach(biConsumer);
     }
 
     void foo(String key, String value) {
+    }
+
+    class MyBiConsumer implements BiConsumer<String, String> {
+
+        public void accept(String k, String v)
+        {
+            System.out.println();
+        }
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/java8MapForEachWithFullJdk.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/java8MapForEachWithFullJdk.kt
@@ -1,8 +1,20 @@
+import java.util.function.BiConsumer
+
 internal class Test {
     fun test(map: HashMap<String?, String?>) {
         map.forEach { (key: String?, value: String?) -> foo(key, value) }
+        map.forEach { (k: String?, v: String?) -> println("don't use params") }
+
+        val biConsumer: BiConsumer<String?, String?> = MyBiConsumer()
+        map.forEach(biConsumer)
     }
 
     fun foo(key: String?, value: String?) {
+    }
+
+    internal inner class MyBiConsumer : BiConsumer<String?, String?> {
+        override fun accept(k: String?, v: String?) {
+            println()
+        }
     }
 }


### PR DESCRIPTION
Replaces previous [PR](https://github.com/JetBrains/intellij-community/pull/2645).

It might make sense to generalize some of this logic when porting `DestructureForLoopParameterProcessing`, but that's a job for another PR!

Note that in addition to porting over the logic for destructuring lambda parameters in calls to `Map::forEach`, I also had to introduce two JKTree element classes, which are similar to `KtDestructuringDeclaration` and `KtDestructuringDeclarationEntry`.  The JKTree versions are a little simpler though, with the most significant drawback being that they don't (currently) support nested destructuring declarations. I figured it's pretty unlikely we'll encounter that case during a Java-to-Kotlin conversion, however, so hopefully this implementation is sufficient.


@abelkov @darthorimar @jocelynluizzi13