### PR TITLE
[kotlin] J2K: Move PLATFORM_CLASS_MAPPED_TO_KOTLIN diagnostic to Printing phase

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -29,10 +29,6 @@ private val errorsFixingDiagnosticBasedPostProcessingGroup = DiagnosticBasedPost
     diagnosticBasedProcessing(AddModifierFixFE10.createFactory(KtTokens.OVERRIDE_KEYWORD), Errors.VIRTUAL_MEMBER_HIDDEN),
     invisibleMemberDiagnosticBasedProcessing(MakeVisibleFactory, Errors.INVISIBLE_MEMBER),
 
-    diagnosticBasedProcessing(Errors.PLATFORM_CLASS_MAPPED_TO_KOTLIN) { element: KtDotQualifiedExpression, _ ->
-        val parent = element.parent as? KtImportDirective ?: return@diagnosticBasedProcessing
-        parent.delete()
-    },
     diagnosticBasedProcessing(
         UnsafeCallExclExclFixFactory,
         Errors.UNSAFE_CALL,

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JKImportStorage.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JKImportStorage.kt
@@ -39,6 +39,7 @@ class JKImportStorage(languageSettings: LanguageVersionSettings) {
         if (!allowSingleIdentifierImport && fqName.asString().count { it == '.' } < 1) return false
         if (fqName in NULLABILITY_ANNOTATIONS) return false
         if (fqName in defaultImports) return false
+        if (IMPLICIT_IMPORTS.any { it.matches(fqName.asString()) }) return false
         return true
     }
 
@@ -46,6 +47,13 @@ class JKImportStorage(languageSettings: LanguageVersionSettings) {
         isImportNeeded(FqName(fqName), allowSingleIdentifierImport)
 
     companion object {
+
+        val IMPLICIT_IMPORTS = setOf(
+            Regex("kotlin\\.jvm\\.functions\\.Function[0-9]"),
+            Regex("java\\.util\\.((Set)|(Collection)|(List)|(Map)|(Iterator)|(Integer))"),
+            Regex("java\\.lang\\.((Throwable)|(Cloneable)|(String)|(Comparable)|(Object)|(CharSequence))")
+        )
+
         private val JAVA_TYPE_WRAPPERS_WHICH_HAVE_CONFLICTS_WITH_KOTLIN_ONES = setOf(
             FqName(CommonClassNames.JAVA_LANG_BYTE),
             FqName(CommonClassNames.JAVA_LANG_SHORT),

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
@@ -165,6 +165,7 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
         }
 
         override fun visitImportStatementRaw(importStatement: JKImportStatement) {
+            if (JKImportStorage.IMPLICIT_IMPORTS.any { it.matches(importStatement.name.value) }) return
             printer.print("import ")
             val importNameEscaped =
                 importStatement.name.value.escapedAsQualifiedName()


### PR DESCRIPTION
Remove the `PLATFORM_CLASS_MAPPED_TO_KOTLIN` diagnostic processing by adding checks for `IMPLICIT_IMPORTS` earlier in the process.

Need to run the check both in the printing stage and in `JKImportStorage` because copy/paste tests do not hit `JKImportStorage` and some of the regular tests do not end up printing these specific imports in the print imports phase.

Went through the `PLATFORM_CLASS_MAPPED_TO_KOTLIN` diagnostic test cases to find all of the possible imports where this warning would appear.

@abelkov @darthorimar @ermattt 