### PR TITLE
Avoid bundling duplicate Windows binaries

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/WindowsDistributionBuilder.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/WindowsDistributionBuilder.kt
@@ -41,7 +41,7 @@ internal class WindowsDistributionBuilder(
       copyDir(sourceBinDir.resolve(arch.dirName), distBinDir)
 
       FileSet(sourceBinDir)
-        .includeAll()
+        .include("*.*") // N.B. non-recursive, unlike .includeAll()
         .also {
           if (!context.includeBreakGenLibraries()) {
             @Suppress("SpellCheckingInspection")


### PR DESCRIPTION
IntelliJ 2024.1 contains duplicate Windows binaries. For example:

* bin/restarter.exe
* bin/amd64/restarter.exe
* bin/aarch64/restarter.exe

Only the first binary is used at runtime.

This appears to have been caused by commit c8910659b4, which changed `.include("*.*")` to `.includeAll()`. The latter includes files recursively, thereby including subdirectories such as 'amd64' and 'aarch64'.