### PR TITLE
Fix incorrect comparison warnings.

### DIFF
--- a/java/java-analysis-impl/resources/messages/InspectionGadgetsBundle.properties
+++ b/java/java-analysis-impl/resources/messages/InspectionGadgetsBundle.properties
@@ -139,7 +139,7 @@ primitive.array.argument.to.var.arg.method.problem.descriptor=Confusing primitiv
 object.comparison.display.name=Object comparison using '==', instead of 'equals()'
 object.comparison.enumerated.ignore.option=Ignore '==' between enum variables
 object.comparison.klass.ignore.option=Ignore '==' between final class types without 'equals()' implementation
-object.comparison.problem.description=Object values are compared using <code>#ref</code>, not 'equals()' #loc
+object.comparison.problem.description=Object values are compared using 'equals()', not <code>#ref</code> #loc
 equality.to.safe.equals.quickfix=Replace '==' with null-safe 'equals()'
 inequality.to.safe.not.equals.quickfix=Replace '!=' with null-safe '!equals()'
 default.tostring.call.display.name=Call to default 'toString()'
@@ -167,7 +167,7 @@ static.field.via.subclass.problem.descriptor=Static field <code>#ref</code> decl
 static.field.via.subclass.rationalize.quickfix=Rationalize static field access
 string.comparison.display.name=String comparison using '==', instead of 'equals()'
 number.comparison.display.name=Number comparison using '==', instead of 'equals()'
-string.comparison.problem.descriptor=String values are compared using <code>#ref</code>, not 'equals()' #loc
+string.comparison.problem.descriptor=String values are compared using 'equals()', not <code>#ref</code> #loc
 number.comparison.problem.descriptor=Number objects are compared using <code>#ref</code>, not 'equals()' #loc
 subtraction.in.compareto.display.name=Subtraction in 'compareTo()'
 subtraction.in.compareto.problem.descriptor=Subtraction <code>#ref</code> in 'compareTo()' may result in overflow or precision loss #loc
@@ -1808,7 +1808,7 @@ try.finally.can.be.try.with.resources.display.name='try finally' can be replaced
 try.finally.can.be.try.with.resources.problem.descriptor=<code>#ref</code> can use automatic resource management #loc
 try.finally.can.be.try.with.resources.quickfix=Replace with 'try' with resources
 array.comparison.display.name=Array comparison using '==', instead of 'Arrays.equals()'
-array.comparison.problem.descriptor=Array objects are compared using <code>#ref</code>, not 'Arrays.equals()' #loc
+array.comparison.problem.descriptor=Array objects are compared using 'Arrays.equals()', not <code>#ref</code> #loc
 array.hash.code.display.name='hashCode()' called on array
 array.hash.code.problem.descriptor=<code>#ref()</code> called on array should probably be 'Arrays.hashCode()' #loc
 objects.hash.problem.descriptor=Array passed to 'Objects.hash()' should be wrapped in 'Arrays.hashcode()'

--- a/java/java-tests/testData/ig/com/siyeh/igtest/bugs/array_equality/ArrayEquality.java
+++ b/java/java-tests/testData/ig/com/siyeh/igtest/bugs/array_equality/ArrayEquality.java
@@ -1,7 +1,7 @@
 class ArrayEquality {
 
   boolean a(String[] a, String[] b) {
-    return a <warning descr="Array objects are compared using '==', not 'Arrays.equals()'">==</warning> b;
+    return a <warning descr="Array objects are compared using 'Arrays.equals()', not '=='">==</warning> b;
   }
 
   boolean b(Number[] n) {

--- a/java/java-tests/testData/ig/com/siyeh/igtest/bugs/object_equality/ObjectEquality.java
+++ b/java/java-tests/testData/ig/com/siyeh/igtest/bugs/object_equality/ObjectEquality.java
@@ -65,8 +65,8 @@ public class ObjectEquality {
   // The interface 'java.util.Collection' does not require 'equals' and 'hashCode'
   // to implement a value-based comparison.
   void compareCollections(Collection<String> coll1, Collection<String> coll2) {
-    test(coll1 <warning descr="Object values are compared using '==', not 'equals()'">==</warning> coll2);
-    test(coll1 <warning descr="Object values are compared using '!=', not 'equals()'">!=</warning> coll2);
+    test(coll1 <warning descr="Object values are compared using 'equals()', not '=='">==</warning> coll2);
+    test(coll1 <warning descr="Object values are compared using 'equals()', not '!='">!=</warning> coll2);
     test(coll1 == null);
     test(coll1 != null);
     test(null == coll2);
@@ -76,8 +76,8 @@ public class ObjectEquality {
   // The interface 'java.util.List' defines a contract for its 'equals' and 'hashCode' methods,
   // therefore comparing lists with '==' is unusual.
   void compareLists(List<String> list1, List<String> list2) {
-    test(list1 <warning descr="Object values are compared using '==', not 'equals()'">==</warning> list2);
-    test(list1 <warning descr="Object values are compared using '!=', not 'equals()'">!=</warning> list2);
+    test(list1 <warning descr="Object values are compared using 'equals()', not '=='">==</warning> list2);
+    test(list1 <warning descr="Object values are compared using 'equals()', not '!='">!=</warning> list2);
     test(list1 == null);
     test(list1 != null);
     test(null == list2);
@@ -87,8 +87,8 @@ public class ObjectEquality {
   // The interface 'java.util.Set' defines a contract for its 'equals' and 'hashCode' methods,
   // therefore comparing sets with '==' is unusual.
   void compareSets(Set<String> set1, Set<String> set2) {
-    test(set1 <warning descr="Object values are compared using '==', not 'equals()'">==</warning> set2);
-    test(set1 <warning descr="Object values are compared using '!=', not 'equals()'">!=</warning> set2);
+    test(set1 <warning descr="Object values are compared using 'equals()', not '=='">==</warning> set2);
+    test(set1 <warning descr="Object values are compared using 'equals()', not '!='">!=</warning> set2);
     test(set1 == null);
     test(set1 != null);
     test(null == set2);
@@ -98,8 +98,8 @@ public class ObjectEquality {
   // The interface 'java.util.Map' defines a contract for its 'equals' and 'hashCode' methods,
   // therefore comparing maps with '==' is unusual.
   void compareMaps(Map<String, Object> map1, Map<String, Object> map2) {
-    test(map1 <warning descr="Object values are compared using '==', not 'equals()'">==</warning> map2);
-    test(map1 <warning descr="Object values are compared using '!=', not 'equals()'">!=</warning> map2);
+    test(map1 <warning descr="Object values are compared using 'equals()', not '=='">==</warning> map2);
+    test(map1 <warning descr="Object values are compared using 'equals()', not '!='">!=</warning> map2);
     test(null == map2);
     test(null != map2);
     test(map1 == null);
@@ -134,17 +134,17 @@ public class ObjectEquality {
   void compareOrder(MyFinal fin, MyClass cls, Object obj) {
     test(fin == obj);
     test(obj == fin);
-    test(cls <warning descr="Object values are compared using '==', not 'equals()'">==</warning> obj);
-    test(obj <warning descr="Object values are compared using '==', not 'equals()'">==</warning> cls);
+    test(cls <warning descr="Object values are compared using 'equals()', not '=='">==</warning> obj);
+    test(obj <warning descr="Object values are compared using 'equals()', not '!='">==</warning> cls);
   }
 
   // When comparing two expressions whose declared type is an interface,
   // it is generally unknown whether the dynamic types may be compared using '==' or not.
   void compareInterface(MyFinalInterface fini1, MyFinalInterface fini2, Object obj, MyFinal fin) {
-    test(fini1 <warning descr="Object values are compared using '==', not 'equals()'">==</warning> fini2);
+    test(fini1 <warning descr="Object values are compared using 'equals()', not '=='">==</warning> fini2);
 
-    test(fini1 <warning descr="Object values are compared using '==', not 'equals()'">==</warning> obj);
-    test(obj <warning descr="Object values are compared using '==', not 'equals()'">==</warning> fini2);
+    test(fini1 <warning descr="Object values are compared using 'equals()', not '=='">==</warning> obj);
+    test(obj <warning descr="Object values are compared using 'equals()', not '=='">==</warning> fini2);
 
     test(fini1 == fin);
     test(fin == fini2);
@@ -161,7 +161,7 @@ public class ObjectEquality {
     MyFinal fin
   ) {
     // There may be subclasses of MyNonFinal that implement MyFinalInterface.
-    test(fini <warning descr="Object values are compared using '==', not 'equals()'">==</warning> nfin);
+    test(fini <warning descr="Object values are compared using 'equals()', not '=='">==</warning> nfin);
 
     test(uni == fini);
 
@@ -220,8 +220,8 @@ public class ObjectEquality {
 
     // In methods other than 'equals', comparing 'this' by reference is suspicious.
     void notEquals(Object obj) {
-      test(this <warning descr="Object values are compared using '==', not 'equals()'">==</warning> obj);
-      test(obj <warning descr="Object values are compared using '==', not 'equals()'">==</warning> this);
+      test(this <warning descr="Object values are compared using 'equals()', not '=='">==</warning> obj);
+      test(obj <warning descr="Object values are compared using 'equals()', not '=='">==</warning> this);
     }
 
     @Override
@@ -238,7 +238,7 @@ public class ObjectEquality {
       if (obj == null || getClass() != obj.getClass()) return false;
       MyBean other = (MyBean)obj;
       // In the 'equals' method, comparing fields is no different than anywhere else.
-      return field <warning descr="Object values are compared using '==', not 'equals()'">==</warning> other.field;
+      return field <warning descr="Object values are compared using 'equals()', not '=='">==</warning> other.field;
     }
 
     @Override

--- a/java/java-tests/testData/ig/com/siyeh/igtest/bugs/object_equality/ObjectEquality.java
+++ b/java/java-tests/testData/ig/com/siyeh/igtest/bugs/object_equality/ObjectEquality.java
@@ -135,7 +135,7 @@ public class ObjectEquality {
     test(fin == obj);
     test(obj == fin);
     test(cls <warning descr="Object values are compared using 'equals()', not '=='">==</warning> obj);
-    test(obj <warning descr="Object values are compared using 'equals()', not '!='">==</warning> cls);
+    test(obj <warning descr="Object values are compared using 'equals()', not '=='">==</warning> cls);
   }
 
   // When comparing two expressions whose declared type is an interface,

--- a/java/java-tests/testData/ig/com/siyeh/igtest/bugs/string_equality/StringEquality.java
+++ b/java/java-tests/testData/ig/com/siyeh/igtest/bugs/string_equality/StringEquality.java
@@ -4,11 +4,11 @@ public class StringEquality {
 
   void foo(String s, String t) {
     final boolean a = s == null;
-    final boolean b = t <warning descr="String values are compared using '==', not 'equals()'">==</warning> s;
+    final boolean b = t <warning descr="String values are compared using 'equals()', not '=='">==</warning> s;
     final boolean c = t ==<EOLError descr="Expression expected"></EOLError><EOLError descr="';' expected"></EOLError>
   }
 
   void notEquals(String s, String t) {
-    boolean a = s <warning descr="String values are compared using '!=', not 'equals()'">!=</warning> t;
+    boolean a = s <warning descr="String values are compared using 'equals()', not '!='">!=</warning> t;
   }
 }


### PR DESCRIPTION
IDE gives incorrect warning messages while comparing Arrays, Strings, and Objects.

I have modified the affected files to display correct warning messages.