### PR TITLE
[kotlin] K2 J2K: Move MayBeConstantInspection to JKTree

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -110,7 +110,6 @@ private val inspectionLikePostProcessingGroup = InspectionLikeProcessingGroup(
     DestructureForLoopParameterProcessing(),
     LiftReturnInspectionBasedProcessing(),
     LiftAssignmentInspectionBasedProcessing(),
-    MayBeConstantInspectionBasedProcessing(),
     RemoveForExpressionLoopParameterTypeProcessing(),
     intentionBasedProcessing(ConvertToRawStringTemplateIntention(), additionalChecker = ::shouldConvertToRawString),
     intentionBasedProcessing(IndentRawStringIntention()),

--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/inspectionLikeProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/inspectionLikeProcessings.kt
@@ -239,20 +239,6 @@ internal class LocalVarToValInspectionBasedProcessing : InspectionLikeProcessing
     }
 }
 
-internal class MayBeConstantInspectionBasedProcessing : InspectionLikeProcessingForElement<KtProperty>(KtProperty::class.java) {
-    private val inspection = MayBeConstantInspection()
-
-    override fun isApplicableTo(element: KtProperty, settings: ConverterSettings): Boolean {
-        if (!isInspectionEnabledInCurrentProfile(inspection, element.project)) return false
-        val status = element.getStatus()
-        return status == MayBeConstantInspectionBase.Status.MIGHT_BE_CONST || status == MayBeConstantInspectionBase.Status.JVM_FIELD_MIGHT_BE_CONST
-    }
-
-    override fun apply(element: KtProperty) {
-        AddConstModifierFix.addConstModifier(element)
-    }
-}
-
 internal class RemoveExplicitAccessorInspectionBasedProcessing :
     InspectionLikeProcessingForElement<KtPropertyAccessor>(KtPropertyAccessor::class.java) {
     override fun isApplicableTo(element: KtPropertyAccessor, settings: ConverterSettings): Boolean =

--- a/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/newJ2KConversions.kt
+++ b/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/newJ2KConversions.kt
@@ -62,5 +62,6 @@ fun getNewJ2KConversions(context: NewJ2kConverterContext): List<Conversion> = li
     FunctionalInterfacesConversion(context),
     FilterImportsConversion(context),
     AddElementsInfoConversion(context),
+    AddConstModifierConversion(context),
     EnumSyntheticValuesMethodConversion(context)
 )

--- a/plugins/kotlin/j2k/k2/src/org/jetbrains/kotlin/j2k/K2J2KConversions.kt
+++ b/plugins/kotlin/j2k/k2/src/org/jetbrains/kotlin/j2k/K2J2KConversions.kt
@@ -64,5 +64,6 @@ internal fun getK2J2KConversions(context: NewJ2kConverterContext): List<Conversi
     RemoveRedundantQualifiersForCallsConversion(context),
     FunctionalInterfacesConversion(context),
     FilterImportsConversion(context),
+    AddConstModifierConversion(context),
     EnumSyntheticValuesMethodConversion(context)
 )

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/AddConstModifierConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/AddConstModifierConversion.kt
@@ -1,0 +1,42 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.kotlin.nj2k.conversions
+
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.nj2k.NewJ2kConverterContext
+import org.jetbrains.kotlin.nj2k.RecursiveConversion
+import org.jetbrains.kotlin.nj2k.tree.*
+import org.jetbrains.kotlin.nj2k.tree.JKClass.ClassKind
+import org.jetbrains.kotlin.nj2k.tree.Mutability.IMMUTABLE
+import org.jetbrains.kotlin.nj2k.tree.OtherModifier.CONST
+import org.jetbrains.kotlin.nj2k.types.asPrimitiveType
+import org.jetbrains.kotlin.nj2k.types.fqName
+
+
+class AddConstModifierConversion(context: NewJ2kConverterContext) : RecursiveConversion(context) {
+    context(KtAnalysisSession)
+    override fun applyToElement(element: JKTreeElement): JKTreeElement {
+        if (element !is JKField) return recurse(element)
+        if (element.mutability != IMMUTABLE || element.initializer is JKStubExpression) return recurse(element)
+        if (element.otherModifierElements.any { it.otherModifier == CONST }) return recurse(element)
+        if (KOTLIN_TYPES.none { it == element.type.type.fqName } && element.type.type.asPrimitiveType() == null) return recurse(element)
+        val parent = element.parentOfType<JKClass>()
+        if (element.parentOfType<JKExpression>() != null || element.parentOfType<JKMethod>() != null) return recurse(element)
+        if (parent == null || parent.classKind == ClassKind.OBJECT || parent.classKind == ClassKind.COMPANION) {
+            element.otherModifierElements += JKOtherModifierElement(CONST)
+        }
+        return recurse(element)
+    }
+
+    private val KOTLIN_TYPES = setOf(
+        "kotlin.Boolean",
+        "kotlin.Byte",
+        "kotlin.Short",
+        "kotlin.String",
+        "kotlin.Int",
+        "kotlin.Float",
+        "kotlin.Long",
+        "kotlin.Double"
+    )
+}
+

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/annotations/serialVersionUID.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/annotations/serialVersionUID.java
@@ -1,5 +1,3 @@
-// IGNORE_K2
-
 import java.io.Serializable;
 
 public class Bar implements Serializable {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/notUtilityClass.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/notUtilityClass.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class Base {
     public static final int CONSTANT = 10;
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/utilityClass1.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/utilityClass1.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class Util {
     public static void util1() {}
     public static void util2() {}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/utilityClass2.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/utilityClass2.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class Util {
     private Util(){}
 

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/utilityClass3.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/class/utilityClass3.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 abstract class Util {
     public static void util1() {}
     public static void util2() {}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/issues/kt-20421.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/issues/kt-20421.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class Base {
     static final int F = 0;
 }


### PR DESCRIPTION
**draft commit because it currently fails on cases where mutability is not yet determined (will be fixed when mutability is migrated earlier) and when we have cases of static init blocks in java that get merged into one expression in Kotlin, because it hasn't happened yet at this stage.

This diff adds `const` modifiers to fields that meet the given criteria: immutable, initialized immediately, primitive type or string, and top level or in a companion / object. 

This does not currently handle @JVMField cases -> do we add the `const` and remove the annotation in these cases?

@abelkov @darthorimar @ermattt