### PR TITLE
Scrollable and searchable dependency analyzer module list

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
@@ -1,7 +1,6 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.openapi.externalSystem.dependency.analyzer.util
 
-import com.intellij.ide.plugins.newui.HorizontalLayout
 import com.intellij.openapi.externalSystem.dependency.analyzer.DependencyAnalyzerProject
 import com.intellij.openapi.externalSystem.ui.ExternalSystemIconProvider
 import com.intellij.openapi.externalSystem.util.ExternalSystemBundle
@@ -10,7 +9,6 @@ import com.intellij.openapi.observable.util.bind
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.observable.util.whenItemSelected
-import com.intellij.openapi.observable.util.whenMousePressed
 import com.intellij.openapi.ui.popup.JBPopupListener
 import com.intellij.openapi.ui.popup.LightweightWindowEvent
 import com.intellij.ui.DocumentAdapter
@@ -21,13 +19,10 @@ import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBList.createDefaultListModel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.panels.ListLayout
-import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
-import java.awt.Color
 import java.awt.Component
 import java.awt.Dimension
-import java.awt.FlowLayout
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
@@ -20,9 +20,14 @@ import com.intellij.ui.components.DropDownLink
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBList.createDefaultListModel
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.panels.ListLayout
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
+import java.awt.Color
 import java.awt.Component
+import java.awt.Dimension
+import java.awt.FlowLayout
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
@@ -39,23 +44,23 @@ internal class ExternalProjectSelector(
     val dropDownLink = ExternalProjectDropDownLink(property, externalProjects)
       .apply { border = JBUI.Borders.empty(BORDER, ICON_TEXT_GAP / 2, BORDER, BORDER) }
     val label = JLabel(iconProvider.projectIcon)
+      .apply { preferredSize = Dimension(iconProvider.projectIcon.iconWidth + BORDER, iconProvider.projectIcon.iconHeight) }
       .apply { border = JBUI.Borders.empty(BORDER, BORDER, BORDER, ICON_TEXT_GAP / 2) }
       .apply { labelFor = dropDownLink }
 
-    layout = HorizontalLayout(0)
+    layout = ListLayout.horizontal(0)
     border = JBUI.Borders.empty()
     add(label)
     add(dropDownLink)
   }
 
   private fun createPopup(externalProjects: List<DependencyAnalyzerProject>, onChange: (DependencyAnalyzerProject) -> Unit): JBPopup {
-    val content = ExternalProjectPopupContent(externalProjects, onChange)
+    val content = ExternalProjectPopupContent(externalProjects)
     return JBPopupFactory.getInstance()
       .createComponentPopupBuilder(content, null)
       .setRequestFocus(true)
       .createPopup()
       .apply {
-        content.whenMousePressed(listener = ::closeOk)
         // Add a MouseListener to handle mouse click events
         content.list.addMouseListener(object : MouseAdapter() {
           override fun mouseClicked(e: MouseEvent) {
@@ -83,8 +88,6 @@ internal class ExternalProjectSelector(
         })
 
         addListener(object : JBPopupListener {
-          override fun onClosed(event: LightweightWindowEvent) {}
-
           override fun beforeShown(event: LightweightWindowEvent) {
             SwingUtilities.invokeLater {
               content.filterField.requestFocusInWindow()
@@ -94,7 +97,7 @@ internal class ExternalProjectSelector(
       }
   }
 
-  private inner class ExternalProjectPopupContent(externalProject: List<DependencyAnalyzerProject>, onChange: (DependencyAnalyzerProject) -> Unit) : JPanel() {
+  private inner class ExternalProjectPopupContent(externalProject: List<DependencyAnalyzerProject>) : JPanel() {
     val list: JBList<DependencyAnalyzerProject>
     val filterField = SearchTextField(false)
     var listModel: DefaultListModel<DependencyAnalyzerProject>

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
@@ -1,6 +1,8 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.openapi.externalSystem.dependency.analyzer.util
 
+import com.intellij.icons.AllIcons
+import com.intellij.icons.ExpUiIcons
 import com.intellij.ide.plugins.newui.HorizontalLayout
 import com.intellij.openapi.externalSystem.dependency.analyzer.DependencyAnalyzerProject
 import com.intellij.openapi.externalSystem.ui.ExternalSystemIconProvider
@@ -13,6 +15,7 @@ import com.intellij.openapi.observable.util.whenItemSelected
 import com.intellij.openapi.observable.util.whenMousePressed
 import com.intellij.openapi.ui.popup.JBPopupListener
 import com.intellij.openapi.ui.popup.LightweightWindowEvent
+import com.intellij.ui.ExperimentalUI
 import com.intellij.ui.ListUtil
 import com.intellij.ui.components.DropDownLink
 import com.intellij.ui.components.JBList
@@ -21,7 +24,10 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.Component
+import java.awt.Graphics
+import java.awt.Insets
 import javax.swing.*
+import javax.swing.border.AbstractBorder
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
 
@@ -72,6 +78,7 @@ internal class ExternalProjectSelector(
     init {
       listModel = createDefaultListModel(externalProject)
       list = JBList<DependencyAnalyzerProject>(listModel)
+      list.setVisibleRowCount(15)
       list.border = emptyListBorder()
       list.cellRenderer = ExternalProjectRenderer()
       list.selectionMode = ListSelectionModel.SINGLE_SELECTION
@@ -100,6 +107,20 @@ internal class ExternalProjectSelector(
           list.model = listModel
         }
       })
+
+      val icon: Icon = getFindIcon()
+
+      filterField.border = object : AbstractBorder() {
+        override fun paintBorder(c: Component, g: Graphics, x: Int, y: Int, width: Int, height: Int) {
+          super.paintBorder(c, g, x, y, width, height)
+          icon.paintIcon(c, g, x + 5, y + 5)
+        }
+
+        override fun getBorderInsets(c: Component): Insets {
+          return JBUI.insets(0, icon.iconWidth + 10, 0, 0)
+        }
+      }
+
 
       val scrollPane = JBScrollPane(list)
       layout = BorderLayout()
@@ -156,6 +177,10 @@ internal class ExternalProjectSelector(
       whenItemSelected { text = itemToString(selectedItem) }
       bind(property)
     }
+  }
+
+  private fun getFindIcon() : Icon{
+    return if (ExperimentalUI.isNewUI()) ExpUiIcons.General.Search else AllIcons.Actions.Find
   }
 }
 

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/dependency/analyzer/util/ExternalProjectUiUtil.kt
@@ -1,8 +1,6 @@
 // Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.openapi.externalSystem.dependency.analyzer.util
 
-import com.intellij.icons.AllIcons
-import com.intellij.icons.ExpUiIcons
 import com.intellij.ide.plugins.newui.HorizontalLayout
 import com.intellij.openapi.externalSystem.dependency.analyzer.DependencyAnalyzerProject
 import com.intellij.openapi.externalSystem.ui.ExternalSystemIconProvider
@@ -16,7 +14,6 @@ import com.intellij.openapi.observable.util.whenMousePressed
 import com.intellij.openapi.ui.popup.JBPopupListener
 import com.intellij.openapi.ui.popup.LightweightWindowEvent
 import com.intellij.ui.DocumentAdapter
-import com.intellij.ui.ExperimentalUI
 import com.intellij.ui.ListUtil
 import com.intellij.ui.SearchTextField
 import com.intellij.ui.components.DropDownLink
@@ -59,6 +56,32 @@ internal class ExternalProjectSelector(
       .createPopup()
       .apply {
         content.whenMousePressed(listener = ::closeOk)
+        // Add a MouseListener to handle mouse click events
+        content.list.addMouseListener(object : MouseAdapter() {
+          override fun mouseClicked(e: MouseEvent) {
+            val selectedProject = content.list.selectedValue
+            if (selectedProject != null) {
+              // Handle the selected project
+              onChange(selectedProject)
+              closeOk(e)
+            }
+          }
+        })
+
+        // Add a KeyListener to handle enter key events
+        content.list.addKeyListener(object : KeyAdapter() {
+          override fun keyPressed(e: KeyEvent) {
+            if (e.keyCode == KeyEvent.VK_ENTER) {
+              val selectedProject = content.list.selectedValue
+              if (selectedProject != null) {
+                // Handle the selected project
+                onChange(selectedProject)
+                closeOk(e)
+              }
+            }
+          }
+        })
+
         addListener(object : JBPopupListener {
           override fun onClosed(event: LightweightWindowEvent) {}
 
@@ -86,30 +109,6 @@ internal class ExternalProjectSelector(
       ListUtil.installAutoSelectOnMouseMove(list)
       setupListPopupPreferredWidth(list)
 
-      // Add a MouseListener to handle mouse click events
-      list.addMouseListener(object : MouseAdapter() {
-        override fun mouseClicked(e: MouseEvent) {
-          val selectedProject = list.selectedValue
-          if (selectedProject != null) {
-            // Handle the selected project
-            onChange(selectedProject)
-          }
-        }
-      })
-
-      // Add a KeyListener to handle enter key events
-      list.addKeyListener(object : KeyAdapter() {
-        override fun keyPressed(e: KeyEvent) {
-          if (e.keyCode == KeyEvent.VK_ENTER) {
-            val selectedProject = list.selectedValue
-            if (selectedProject != null) {
-              // Handle the selected project
-              onChange(selectedProject)
-            }
-          }
-        }
-      })
-
       // Create a SearchTextField for the user to enter their search query
       filterField.addDocumentListener(object : DocumentAdapter() {
         override fun textChanged(e: DocumentEvent) {
@@ -124,7 +123,7 @@ internal class ExternalProjectSelector(
       filterField.addKeyboardListener(object : KeyAdapter() {
         override fun keyPressed(e: KeyEvent) {
           when (e.keyCode) {
-            KeyEvent.VK_UP, KeyEvent.VK_DOWN,KeyEvent.VK_ENTER  -> {
+            KeyEvent.VK_UP, KeyEvent.VK_DOWN, KeyEvent.VK_ENTER -> {
               list.dispatchEvent(e)
             }
           }
@@ -185,10 +184,6 @@ internal class ExternalProjectSelector(
       whenItemSelected { text = itemToString(selectedItem) }
       bind(property)
     }
-  }
-
-  private fun getFindIcon(): Icon {
-    return if (ExperimentalUI.isNewUI()) ExpUiIcons.General.Search else AllIcons.Actions.Find
   }
 }
 


### PR DESCRIPTION
The dependency analyzer currently does not support any form of scrolling or searching which can be problematic for big multimodule projects.

This PR aims to provide both of those functionalities.

Scrollable when more than 15 items:

<img width="245" alt="image" src="https://github.com/JetBrains/intellij-community/assets/5272219/849c9ff9-d870-4cd2-8a7e-d51153a356b2">

Searchable:

<img width="230" alt="image" src="https://github.com/JetBrains/intellij-community/assets/5272219/6ca3d20f-26f4-49f4-bf02-8a23d1edcea9">


Also fixed an issue where the project icon was sometimes rendered cut off on the dependency analyzer

Before:

<img width="131" alt="image" src="https://github.com/JetBrains/intellij-community/assets/5272219/a77c8c18-a0c1-416b-9dc6-785f725990ca">


After:

<img width="94" alt="image" src="https://github.com/JetBrains/intellij-community/assets/5272219/dce364c0-65fa-4f6e-9a8c-2bbed3b22c34">

