### PR TITLE
PY-42693 (wip): Infer completitions for lambda parameters in PyCharm

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/codeInsight/lambda/PyLambdaTypeProvider.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/codeInsight/lambda/PyLambdaTypeProvider.java
@@ -1,0 +1,42 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.python.codeInsight.lambda;
+
+import com.jetbrains.python.psi.*;
+import com.jetbrains.python.psi.types.PyType;
+import com.jetbrains.python.psi.types.PyTypeProviderBase;
+import com.jetbrains.python.psi.types.TypeEvalContext;
+import org.jetbrains.annotations.NotNull;
+
+public class PyLambdaTypeProvider extends PyTypeProviderBase {
+  @Override
+  public PyType getCallableType(@NotNull PyCallable callable, @NotNull TypeEvalContext context) {
+    if (callable instanceof PyLambdaExpression lambdaExpression) {
+      var parent = lambdaExpression.getParent();
+      if (parent instanceof PyArgumentList argumentList) {
+        var callExpression = argumentList.getCallExpression();
+        if (callExpression != null) {
+          var callee = callExpression.getCallee();
+          if (callee != null) {
+            int argumentIndex = 0;
+            for (var expression : argumentList.getArguments()) {
+              if (expression == lambdaExpression) {
+                break;
+              }
+              argumentIndex++;
+            }
+            if (argumentIndex > argumentList.getArguments().length) {
+              return null;
+            }
+            if (callee instanceof PyReferenceExpression referenceExpression) {
+              var reference = referenceExpression.getReference().resolve();
+              if (reference instanceof PyFunction function) {
+                return function.getParameters(context).get(argumentIndex).getType(context);
+              }
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/python/python-psi-impl/src/com/jetbrains/python/codeInsight/typing/PyTypingTypeProvider.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/codeInsight/typing/PyTypingTypeProvider.java
@@ -29,6 +29,7 @@ import com.jetbrains.python.codeInsight.functionTypeComments.psi.PyFunctionTypeA
 import com.jetbrains.python.psi.*;
 import com.jetbrains.python.psi.impl.PyBuiltinCache;
 import com.jetbrains.python.psi.impl.PyCallExpressionHelper;
+import com.jetbrains.python.psi.impl.PyNamedParameterImpl;
 import com.jetbrains.python.psi.impl.PyPsiUtils;
 import com.jetbrains.python.psi.impl.stubs.PyClassElementType;
 import com.jetbrains.python.psi.impl.stubs.PyTypingAliasStubType;
@@ -543,6 +544,25 @@ public final class PyTypingTypeProvider extends PyTypeProviderWithCustomContext<
             .nonNull()
             .findFirst()
             .orElse(null);
+        }
+      }
+    } else if (referenceTarget instanceof PyNamedParameterImpl namedParameter) {
+      if (namedParameter.getParent() instanceof PyParameterList parameterList) {
+        if (parameterList.getParent() instanceof PyLambdaExpression lambdaExpression) {
+          var lambdaParameters = lambdaExpression.getParameters(context.getTypeContext());
+          var parameterIndex = 0;
+
+          for (var parameter : lambdaExpression.getParameterList().getParameters()) {
+            if (Objects.equals(parameter.getName(), namedParameter.getName())) {
+              break;
+            }
+            parameterIndex++;
+          }
+
+          var type = lambdaParameters.get(parameterIndex).getType(context.getTypeContext());
+          if (type != null) {
+            return Ref.create(type);
+          }
         }
       }
     }

--- a/python/src/intellij.python.community.impl.xml
+++ b/python/src/intellij.python.community.impl.xml
@@ -720,6 +720,7 @@
     <visitorFilter language="PythonStub" implementationClass="com.jetbrains.python.pyi.PyiVisitorFilter"/>
 
     <typeProvider implementation="com.jetbrains.python.debugger.PyCallSignatureTypeProvider"/>
+    <typeProvider implementation="com.jetbrains.python.codeInsight.lambda.PyLambdaTypeProvider"/>
 
     <!-- NumPy -->
     <documentationLinkProvider implementation="com.jetbrains.python.numpy.codeInsight.SciPyDocumentationLinkProvider"/>


### PR DESCRIPTION
A partial fix for https://youtrack.jetbrains.com/issue/PY-42693/PyCharm-cannot-infer-type-for-lambda-parameters

Added a new TypeProvider that tries to determine the callable type of a lambda in Python. In particular:

- If the lambda is part of an argument list that has a call expression with a known callee
- Then it finds the position of the lambda inside the argument list, and resolves the callee. The type of the entire lambda expression is determined to be the same as the type of the Nth argument of the callee (where N is the lambda's position in the argument list).

Modified PyTypingTypeProvider to determine type of lambda named parameters. In particular:

- If a NamedParameter is in a parameter list belonging to a lambda expression
- Then get the type of the Nth parameter (where N is the index of the NamedParameter in the lambda expression)

With these changes, code completions work; i.e., given

```python
from typing import Callable

class A:
    my_attribute: int

def function(a: A, fun: Callable[[A], int]):
    return fun(a)

a = A()
a.my_attribute = 10
function(a, lambda parameter: parameter.my_
```

it would suggest the completion "my_attribute", which has type "int".

However, code insights still suggests parameter is `Any`, and doesn't seem to check the return type of the lambda expression.

Needs tests.

(I am unfamiliar with the code base and unsure where to go from here)