### PR TITLE
Properly set header fields in ZipArchiveOutputStream

### DIFF
--- a/build/tasks/src/org/jetbrains/intellij/build/io/ZipArchiveOutputStream.kt
+++ b/build/tasks/src/org/jetbrains/intellij/build/io/ZipArchiveOutputStream.kt
@@ -46,9 +46,9 @@ internal class ZipArchiveOutputStream(
     buffer.clear()
     buffer.putInt(0x04034b50)
     // Version needed to extract (minimum)
-    buffer.putShort(0)
+    buffer.putShort(0x0014)
     // General purpose bit flag
-    buffer.putShort(0)
+    buffer.putShort(0x0800)
     // Compression method
     buffer.putShort(ZipEntry.STORED.toShort())
     // File last modification time
@@ -459,6 +459,12 @@ internal class ZipArchiveOutputStream(
 
     val headerOffset = buffer.position()
     buffer.putInt(headerOffset, 0x02014b50)
+    // version made by
+    buffer.putShort(headerOffset + 4, 0x0314)
+    // version needed to extract (minimum)
+    buffer.putShort(headerOffset + 6, 0x0014)
+    // general purpose bit flag
+    buffer.putShort(headerOffset + 8, 0x0800)
     // compression method
     buffer.putShort(headerOffset + 10, method.toShort())
     // CRC-32 of uncompressed data
@@ -475,6 +481,8 @@ internal class ZipArchiveOutputStream(
 
     // file name length
     buffer.putShort(headerOffset + 28, (name.size and 0xffff).toShort())
+    // external file attributes
+    buffer.putInt(headerOffset + 38, 0x81a40000L.toInt())
     // relative offset of local file header
     buffer.putInt(headerOffset + 42, (offset and 0xffffffffL).toInt())
     // file name
@@ -486,9 +494,9 @@ internal class ZipArchiveOutputStream(
 internal fun writeLocalFileHeader(name: ByteArray, size: Int, compressedSize: Int, crc32: Long, method: Int, buffer: ByteBuffer): Int {
   buffer.putInt(0x04034b50)
   // Version needed to extract (minimum)
-  buffer.putShort(0)
+  buffer.putShort(0x0014)
   // General purpose bit flag
-  buffer.putShort(0)
+  buffer.putShort(0x0800)
   // Compression method
   buffer.putShort(method.toShort())
   // File last modification time


### PR DESCRIPTION
File names are written in UTF-8, so bit 11 (language encoding flag) of the general purpose bit flag must be set in both local file headers and central directory entries.

Other zip implementations (e.g. zipinfo, or python's zipfile library) also require other header fields (version requried to extract, version made by) to be set to reasonable values in order to correctly interpret UTF-8 names, so set these as well.

Also set file permissions in the 'external file attributes' central directory entry field to rw-r--r--.