### PR TITLE
Fix EditorTextEndWithSelection/EditorTextStartWithSelection for VSCod…

### DIFF
--- a/plugins/keymaps/vscode-keymap/resources/keymaps/VSCode OSX.xml
+++ b/plugins/keymaps/vscode-keymap/resources/keymaps/VSCode OSX.xml
@@ -246,9 +246,16 @@
     <action id="EditorTextEnd">
         <keyboard-shortcut first-keystroke="meta down" />
     </action>
+    <action id="EditorTextEndWithSelection">
+      <keyboard-shortcut first-keystroke="shift meta down"/>
+    </action>
     <action id="EditorTextStart">
         <keyboard-shortcut first-keystroke="meta up" />
     </action>
+    <action id="EditorTextStartWithSelection">
+      <keyboard-shortcut first-keystroke="shift meta up"/>
+    </action>
+
     <action id="EditorToggleCase" />
     <action id="EditorToggleColumnMode">
         <keyboard-shortcut first-keystroke="shift alt i" />


### PR DESCRIPTION
…e for Mac OS Key Mapping

The vscode for macos mapping was missing the EditorTextEndWithSelection/EditorTextStartWithSelection key mappings.

Xcode and VSCode both use the Shift+CMD+Up/Down keystrokes accordingly.

VSCode KeyMap references:
- cursorBottomSelect (https://github.com/microsoft/vscode-docs/blob/1b7a6496ee24b25f2a01855bbe3ff3ff18580c45/build/keybindings/doc.keybindings.osx.json#L16)
- cursorTopSelect (https://github.com/microsoft/vscode-docs/blob/1b7a6496ee24b25f2a01855bbe3ff3ff18580c45/build/keybindings/doc.keybindings.osx.json#L86)