### PR TITLE
[kotlin] J2K: `String.lines()` call should be converted to `lineSequence().asStream()`

### DIFF
--- a/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -3814,6 +3814,21 @@ public abstract class NewJavaToKotlinConverterSingleFileTestGenerated extends Ab
         public void testStreamOperations() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/streamOperations.java");
         }
+
+        @TestMetadata("stringLines.java")
+        public void testStringLines() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/stringLines.java");
+        }
+
+        @TestMetadata("stringLinesCustomClass.java")
+        public void testStringLinesCustomClass() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/stringLinesCustomClass.java");
+        }
+
+        @TestMetadata("stringLinesRef.java")
+        public void testStringLinesRef() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.java");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
@@ -3814,6 +3814,21 @@ public abstract class K2JavaToKotlinConverterSingleFileTestGenerated extends Abs
         public void testStreamOperations() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/streamOperations.java");
         }
+
+        @TestMetadata("stringLines.java")
+        public void testStringLines() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/stringLines.java");
+        }
+
+        @TestMetadata("stringLinesCustomClass.java")
+        public void testStringLinesCustomClass() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/stringLinesCustomClass.java");
+        }
+
+        @TestMetadata("stringLinesRef.java")
+        public void testStringLinesRef() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.java");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
@@ -663,6 +663,16 @@ private class ConversionsHolder(private val symbolProvider: JKSymbolProvider, pr
                 )
         } withReplaceType REPLACE_WITH_QUALIFIER,
 
+        Method("java.lang.String.lines") convertTo CustomExpression { expression ->
+            if (expression !is JKCallExpression) error("Expression should be JKCallExpression")
+            val parent = expression.parent.cast<JKQualifiedExpression>()
+
+            parent::receiver.detached()
+                .callOn(symbolProvider.provideMethodSymbol("kotlin.text.lineSequence"))
+                .callOn(symbolProvider.provideMethodSymbol("kotlin.streams.asStream"))
+                .withFormattingFrom(parent)
+        } withReplaceType REPLACE_WITH_QUALIFIER,
+
         // It is the constructor of "kotlin.String" and not "java.lang.String" because
         // java.lang.String was already converted to kotlin.String in a previous TypeMappingConversion
         NewExpression("kotlin.String") convertTo CustomExpression { newExpression ->

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKSymbolRenderer.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKSymbolRenderer.kt
@@ -34,8 +34,18 @@ class JKSymbolRenderer(private val importStorage: JKImportStorage, project: Proj
 
     fun renderSymbol(symbol: JKSymbol, owner: JKTreeElement?): String {
         val name = symbol.name.escaped()
-        if (!symbol.isFqNameExpected(owner)) return name
         val fqName = symbol.getDisplayFqName().escapedAsQualifiedName()
+
+        if (!symbol.isFqNameExpected(owner)) {
+            if (symbol.safeAs<JKMultiverseFunctionSymbol>()?.isTopLevelBuiltInKotlinFunction == true &&
+                importStorage.isImportNeeded(fqName)
+            ) {
+                importStorage.addImport(fqName)
+            }
+
+            return name
+        }
+
         if (symbol.isFromJavaLangPackage()) return fqName
 
         return when {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/function/mathStaticMethods.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/function/mathStaticMethods.java
@@ -1,5 +1,4 @@
 // IGNORE_K2
-// TODO investigate why extension methods are unresolved in this test (imports are not added)
 public class J {
     void foo(double x, double y, float f) {
         Math.abs(x);

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/function/mathStaticMethods.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/function/mathStaticMethods.kt
@@ -1,9 +1,4 @@
-// ERROR: Unresolved reference: withSign
-// ERROR: Unresolved reference: IEEErem
-// ERROR: Unresolved reference: nextTowards
-// ERROR: Unresolved reference: nextDown
-// ERROR: Unresolved reference: nextUp
-// ERROR: Unresolved reference: pow
+import kotlin.math.IEEErem
 import kotlin.math.abs
 import kotlin.math.acos
 import kotlin.math.asin
@@ -22,6 +17,10 @@ import kotlin.math.ln1p
 import kotlin.math.log10
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.nextDown
+import kotlin.math.nextTowards
+import kotlin.math.nextUp
+import kotlin.math.pow
 import kotlin.math.round
 import kotlin.math.sign
 import kotlin.math.sin
@@ -29,8 +28,8 @@ import kotlin.math.sinh
 import kotlin.math.sqrt
 import kotlin.math.tan
 import kotlin.math.tanh
+import kotlin.math.withSign
 
-// TODO investigate why extension methods are unresolved in this test (imports are not added)
 class J {
     fun foo(x: Double, y: Double, f: Float) {
         abs(x)

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.java
@@ -1,5 +1,4 @@
 // IGNORE_K2
-// TODO investigate why extension methods are unresolved in this test (imports are not added)
 import java.util.stream.Stream;
 
 public class A {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.java
@@ -1,0 +1,20 @@
+// IGNORE_K2
+// TODO investigate why extension methods are unresolved in this test (imports are not added)
+import java.util.stream.Stream;
+
+public class A {
+    Stream<String> foo(String s) {
+        // comment
+
+        bar().lines();
+        Stream<String> lines = s.lines();
+        return s.lines();
+
+
+        // comment
+    }
+
+    String bar() {
+        return "test";
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.kt
@@ -1,14 +1,12 @@
-// ERROR: Unresolved reference: asStream
-// ERROR: Unresolved reference: asStream
-// ERROR: Unresolved reference: asStream
 import java.util.stream.Stream
+import kotlin.streams.asStream
 
 class A {
     fun foo(s: String): Stream<String> {
         // comment
 
         bar().lineSequence().asStream()
-        val lines: Stream<String> = s.lineSequence().asStream()
+        val lines = s.lineSequence().asStream()
         return s.lineSequence().asStream()
 
 

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLines.kt
@@ -1,0 +1,21 @@
+// ERROR: Unresolved reference: asStream
+// ERROR: Unresolved reference: asStream
+// ERROR: Unresolved reference: asStream
+import java.util.stream.Stream
+
+class A {
+    fun foo(s: String): Stream<String> {
+        // comment
+
+        bar().lineSequence().asStream()
+        val lines: Stream<String> = s.lineSequence().asStream()
+        return s.lineSequence().asStream()
+
+
+        // comment
+    }
+
+    fun bar(): String {
+        return "test"
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesCustomClass.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesCustomClass.java
@@ -1,0 +1,8 @@
+public class String {
+    void lines() {}
+
+    static void foo() {
+        String s = new String();
+        s.lines();
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesCustomClass.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesCustomClass.kt
@@ -1,0 +1,10 @@
+class String {
+    fun lines() {}
+
+    companion object {
+        fun foo() {
+            val s = String()
+            s.lines()
+        }
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.java
@@ -1,5 +1,4 @@
 // IGNORE_K2
-// TODO investigate why extension methods are unresolved in this test (imports are not added)
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.java
@@ -1,0 +1,14 @@
+// IGNORE_K2
+// TODO investigate why extension methods are unresolved in this test (imports are not added)
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+public class A {
+    void foo(Callable<Stream<String>> ref) {}
+
+    void bar() {
+        String s = "test";
+        foo(s::lines);
+        foo("test"::lines);
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.kt
@@ -1,16 +1,13 @@
-// ERROR: Unresolved reference: asStream
-// ERROR: Type mismatch: inferred type is Unit! but Stream<String?>! was expected
-// ERROR: Unresolved reference: asStream
-// ERROR: Type mismatch: inferred type is Unit! but Stream<String?>! was expected
 import java.util.concurrent.Callable
 import java.util.stream.Stream
+import kotlin.streams.asStream
 
 class A {
-    fun foo(ref: Callable<Stream<String?>>?) {}
+    fun foo(ref: Callable<Stream<String>>?) {}
 
     fun bar() {
         val s = "test"
-        foo(Callable<Stream<String?>> { s.lineSequence().asStream() })
-        foo(Callable<Stream<String?>> { "test".lineSequence().asStream() })
+        foo { s.lineSequence().asStream() }
+        foo { "test".lineSequence().asStream() }
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/javaStreamsApi/stringLinesRef.kt
@@ -1,0 +1,16 @@
+// ERROR: Unresolved reference: asStream
+// ERROR: Type mismatch: inferred type is Unit! but Stream<String?>! was expected
+// ERROR: Unresolved reference: asStream
+// ERROR: Type mismatch: inferred type is Unit! but Stream<String?>! was expected
+import java.util.concurrent.Callable
+import java.util.stream.Stream
+
+class A {
+    fun foo(ref: Callable<Stream<String?>>?) {}
+
+    fun bar() {
+        val s = "test"
+        foo(Callable<Stream<String?>> { s.lineSequence().asStream() })
+        foo(Callable<Stream<String?>> { "test".lineSequence().asStream() })
+    }
+}


### PR DESCRIPTION
^KTIJ-29317 Fixed