### PR TITLE
[toml] add `pdm.lock`

### DIFF
--- a/plugins/toml/resources/META-INF/plugin.xml
+++ b/plugins/toml/resources/META-INF/plugin.xml
@@ -25,7 +25,7 @@
                   implementationClass="org.toml.lang.psi.TomlFileType"
                   fieldName="INSTANCE"
                   extensions="toml"
-                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile;poetry.lock"/>
+                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;pdm.lock;Pipfile;poetry.lock"/>
         <lang.parserDefinition language="TOML" implementationClass="org.toml.lang.parse.TomlParserDefinition"/>
         <lang.ast.factory language="TOML" implementationClass="org.toml.lang.psi.impl.TomlASTFactory"/>
         <lang.syntaxHighlighter language="TOML" implementationClass="org.toml.ide.TomlHighlighter"/>

--- a/plugins/toml/tests/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
+++ b/plugins/toml/tests/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
@@ -16,6 +16,7 @@ class TomlFileTypeTest : TomlTestBase() {
     fun `test Cargo lock`() = doTest("Cargo.lock")
     fun `test Cargo toml orig`() = doTest("Cargo.toml.orig")
     fun `test Gopkg lock`() = doTest("Gopkg.lock")
+    fun `test PDM lock file`() = doTest("pdm.lock")
     fun `test Pipfile`() = doTest("Pipfile")
     fun `test Poetry lock file`() = doTest("poetry.lock")
     fun `test Cargo config`() = doTest(".cargo/config")


### PR DESCRIPTION
[PDM](https://github.com/pdm-project/pdm) is a fairly popular Python package manager. It can generate a [lock file named pdm.lock](https://pdm-project.org/en/stable/usage/lockfile/) that uses TOML format ([example](https://github.com/pdm-project/pdm)).