### PR TITLE
os._exit(1) --> os._exit(0)

### DIFF
--- a/python/helpers/pydev/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/python/helpers/pydev/pydevd_attach_to_process/add_code_to_python_process.py
@@ -519,7 +519,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
 
     cmd.extend([
         "-o 'process detach'",
-        "-o 'script import os; os._exit(1)'",
+        "-o 'script import os; os._exit(0)'",
     ])
 
     # print ' '.join(cmd)


### PR DESCRIPTION
Currently, exiting with a non-zero value results in an error in PyCharm's console when attaching to a process (see below), this fixes this issue.

...
  File ".../add_code_to_python_process.py", line 534, in run_python_code_mac
    subprocess.check_call(' '.join(cmd), shell=True, env=env)
  File ".../python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'lldb --no-lldbinit --script-language Python -o ... -o 'script import os; os._exit(1)'' returned non-zero exit status 1.

(tested on macOS with PyCharm Build #PY-241.14494.241)