### PR TITLE
[kotlin] K2 J2K: Move LiftReturnInspectionBasedProcessing to JKTree

### DIFF
--- a/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/newJ2KConversions.kt
+++ b/plugins/kotlin/j2k/k1.new/src/org/jetbrains/kotlin/nj2k/newJ2KConversions.kt
@@ -65,5 +65,8 @@ fun getNewJ2KConversions(context: NewJ2kConverterContext): List<Conversion> = li
     RemoveUnnecessaryParenthesesConversion(context),
     AddElementsInfoConversion(context),
     AddConstModifierConversion(context),
-    EnumSyntheticValuesMethodConversion(context)
+    EnumSyntheticValuesMethodConversion(context),
+    MarkConditionalStatementsWithLiftedReturnsConversion(context),
+    RemoveLiftedReturnStatementsConversion(context),
+
 )

--- a/plugins/kotlin/j2k/k2/src/org/jetbrains/kotlin/j2k/K2J2KConversions.kt
+++ b/plugins/kotlin/j2k/k2/src/org/jetbrains/kotlin/j2k/K2J2KConversions.kt
@@ -68,4 +68,6 @@ internal fun getK2J2KConversions(context: NewJ2kConverterContext): List<Conversi
     AddConstModifierConversion(context),
     EnumSyntheticValuesMethodConversion(context),
     RemoveUnnecessaryParenthesesConversion(context),
+    MarkConditionalStatementsWithLiftedReturnsConversion(context),
+    RemoveLiftedReturnStatementsConversion(context),
 )

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/MarkConditionalStatementsWithLiftedReturnsConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/MarkConditionalStatementsWithLiftedReturnsConversion.kt
@@ -1,0 +1,32 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.kotlin.nj2k.conversions
+
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.nj2k.NewJ2kConverterContext
+import org.jetbrains.kotlin.nj2k.RecursiveConversion
+import org.jetbrains.kotlin.nj2k.statements
+import org.jetbrains.kotlin.nj2k.tree.*
+
+class MarkConditionalStatementsWithLiftedReturnsConversion(context: NewJ2kConverterContext) : RecursiveConversion(context) {
+    context(KtAnalysisSession)
+    override fun applyToElement(element: JKTreeElement): JKTreeElement {
+        if (element !is JKIfElseStatement && element !is JKKtWhenBlock) return recurse(element)
+        if (element is JKIfElseStatement) {
+            if (element.elseBranch.statements.isNotEmpty() && element.thenBranch.statements.isNotEmpty() &&
+                element.thenBranch.statements.all {it is JKReturnStatement} && element.elseBranch.statements.all {it is JKReturnStatement}
+            ) {
+                element.hasLiftedReturn = true
+            }
+        }
+        else if (element is JKKtWhenBlock) {
+            element.hasLiftedReturn = when {
+                element.cases.isEmpty() -> false
+                element.cases.none { it.labels.isNotEmpty() && it.labels.any { label -> label is JKKtElseWhenLabel } } -> false
+                else -> element.cases.all { case -> case.statement is JKReturnStatement }
+            }
+        }
+
+        return recurse(element)
+    }
+}

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/RemoveLiftedReturnStatementsConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/RemoveLiftedReturnStatementsConversion.kt
@@ -1,0 +1,29 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.kotlin.nj2k.conversions
+
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.nj2k.NewJ2kConverterContext
+import org.jetbrains.kotlin.nj2k.RecursiveConversion
+import org.jetbrains.kotlin.nj2k.asStatement
+import org.jetbrains.kotlin.nj2k.tree.*
+
+class RemoveLiftedReturnStatementsConversion(context: NewJ2kConverterContext) : RecursiveConversion(context) {
+    context(KtAnalysisSession)
+    override fun applyToElement(element: JKTreeElement): JKTreeElement {
+        if (element !is JKReturnStatement) return recurse(element)
+        if (!element.returnShouldBeLifted()) return recurse(element)
+        element.invalidate()
+        return recurse(element.expression.asStatement())
+    }
+
+    private fun JKReturnStatement.returnShouldBeLifted(): Boolean {
+        var parent = parent
+        while (parent != null) {
+            if (parent is JKKtWhenBlock) return parent.hasLiftedReturn
+            if (parent is JKIfElseStatement) return parent.hasLiftedReturn
+            parent = parent.parent
+        }
+        return false
+    }
+}

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKCodeBuilder.kt
@@ -13,7 +13,10 @@ import org.jetbrains.kotlin.nj2k.tree.JKClass.ClassKind.*
 import org.jetbrains.kotlin.nj2k.tree.Modality.FINAL
 import org.jetbrains.kotlin.nj2k.tree.Visibility.PUBLIC
 import org.jetbrains.kotlin.nj2k.tree.visitors.JKVisitorWithCommentsPrinting
-import org.jetbrains.kotlin.nj2k.types.*
+import org.jetbrains.kotlin.nj2k.types.JKContextType
+import org.jetbrains.kotlin.nj2k.types.isAnnotationMethod
+import org.jetbrains.kotlin.nj2k.types.isInterface
+import org.jetbrains.kotlin.nj2k.types.isUnit
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 class JKCodeBuilder(context: NewJ2kConverterContext) {
@@ -367,8 +370,10 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
             }
         }
 
-
         override fun visitIfElseStatementRaw(ifElseStatement: JKIfElseStatement) {
+            if (ifElseStatement.hasLiftedReturn) {
+                printer.print("return ")
+            }
             printer.print("if (")
             ifElseStatement.condition.accept(this)
             printer.print(") ")
@@ -861,6 +866,9 @@ class JKCodeBuilder(context: NewJ2kConverterContext) {
         }
 
         override fun visitKtWhenBlockRaw(ktWhenBlock: JKKtWhenBlock) {
+            if (ktWhenBlock.hasLiftedReturn) {
+                printer.print("return ")
+            }
             printer.print("when (")
             ktWhenBlock.expression.accept(this)
             printer.print(")")

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/elements.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/elements.kt
@@ -295,6 +295,7 @@ interface JKJavaSwitchBlock : JKElement {
 interface JKKtWhenBlock : JKElement, JKFormattingOwner {
     val expression: JKExpression
     val cases: List<JKKtWhenCase>
+    var hasLiftedReturn: Boolean
 }
 
 sealed class JKJavaResourceElement : JKTreeElement(), PsiOwner by PsiOwnerImpl()

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/expressions.kt
@@ -441,6 +441,7 @@ class JKKtWhenExpression(
 ) : JKExpression(), JKKtWhenBlock {
     override var expression: JKExpression by child(expression)
     override var cases: List<JKKtWhenCase> by children(cases)
+    override var hasLiftedReturn: Boolean = false
     override fun accept(visitor: JKVisitor) = visitor.visitKtWhenExpression(this)
 
     override fun calculateType(typeFactory: JKTypeFactory): JKType? = expressionType

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/statements.kt
@@ -39,6 +39,7 @@ class JKIfElseStatement(condition: JKExpression, thenBranch: JKStatement, elseBr
     var condition by child(condition)
     var thenBranch by child(thenBranch)
     var elseBranch by child(elseBranch)
+    var hasLiftedReturn: Boolean = false
     override fun accept(visitor: JKVisitor) = visitor.visitIfElseStatement(this)
 }
 
@@ -83,6 +84,7 @@ class JKKtWhenStatement(
 ) : JKStatement(), JKKtWhenBlock {
     override var expression: JKExpression by child(expression)
     override var cases: List<JKKtWhenCase> by children(cases)
+    override var hasLiftedReturn: Boolean = false
 
     override fun accept(visitor: JKVisitor) = visitor.visitKtWhenStatement(this)
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/ifStatement/singleLine.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/ifStatement/singleLine.java
@@ -1,3 +1,2 @@
-// IGNORE_K2
 //statement
 if (true) return 1; else return 0;

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/newJavaFeatures/switchExpression/KT-13552.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/newJavaFeatures/switchExpression/KT-13552.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 public class SwitchDemo {
     public static int test(int i) {
         String monthString = "<empty>";

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/nullability/MethodReturnsNull.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/nullability/MethodReturnsNull.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class C {
     String foo(boolean b) {
         if (b) {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/LiftReturnSingleStatement.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postProcessing/LiftReturnSingleStatement.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 class Test {
     public static int getInt(int i) {
         switch (i) {

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/switch/KT-13552.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/switch/KT-13552.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 public class SwitchDemo {
     public static int test(int i) {
         String monthString = "<empty>";

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/switch/enumConstants.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/switch/enumConstants.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 enum ColorEnum {
     GREEN
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/switch/nestedIf.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/switch/nestedIf.kt
@@ -1,11 +1,6 @@
 fun foo(i: Int, j: Int): String {
     return when (i) {
-        0 -> if (j > 0) {
-            "1"
-        } else {
-            "2"
-        }
-
+        0 -> if (j > 0) "1" else "2"
         1 -> "3"
         else -> "4"
     }


### PR DESCRIPTION
This PR moves `LiftReturnInspectionBasedProcessing` for nonnested return statements into the tree by marking conditionals that always return with `hasLiftedReturn`, then changing the `JKReturnStatement` to a non-return statement, and then printing `return` in the printing phase.

Notably, I ran into errors trying to make the Conditionals into JKReturnStatements prior to printing, because of issues converting between statements and expressions. 

**This does not yet handle nested return statements, so I haven't removed the `LiftReturnInspectionBasedProcessing` post-processing from K1. Putting this up now anyways since it fixes 6 K2 test cases

@abelkov @darthorimar @ermattt