### PR TITLE
[kotlin] K2 J2K: Move Explicit API Mode Visibility Checks to JKTree

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/allProcessings.kt
@@ -52,11 +52,6 @@ private val errorsFixingDiagnosticBasedPostProcessingGroup = DiagnosticBasedPost
         Errors.EXPOSED_TYPE_PARAMETER_BOUND
     ),
     diagnosticBasedProcessing(
-        SetExplicitVisibilityFactory,
-        Errors.NO_EXPLICIT_VISIBILITY_IN_API_MODE,
-        Errors.NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING,
-    ),
-    diagnosticBasedProcessing(
         ConvertToIsArrayOfCallFix,
         Errors.CANNOT_CHECK_FOR_ERASED,
     ),

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/modifiers.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/tree/modifiers.kt
@@ -2,6 +2,10 @@
 
 package org.jetbrains.kotlin.nj2k.tree
 
+import com.intellij.openapi.project.ProjectManager
+import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.ExplicitApiMode
+import org.jetbrains.kotlin.idea.base.projectStructure.LanguageVersionSettingsProvider
 import org.jetbrains.kotlin.nj2k.isInterface
 import org.jetbrains.kotlin.nj2k.tree.Modality.*
 import org.jetbrains.kotlin.nj2k.tree.OtherModifier.OVERRIDE
@@ -150,8 +154,13 @@ internal fun JKModifierElement.isRedundant(): Boolean {
                 (it is JKDeclaration && it.parentOfType<JKClass>()?.isInterface() == true)
     }
 
+    val project = ProjectManager.getInstance().getOpenProjects().firstOrNull()
+    val explicitVisibilityRequired = if (project == null) false else
+        LanguageVersionSettingsProvider(project).librarySettings.getFlag(AnalysisFlags.explicitApiMode) != ExplicitApiMode.DISABLED
+
     return when (modifier) {
-        PUBLIC, FINAL -> !hasOverrideModifier
+        PUBLIC -> !hasOverrideModifier && !explicitVisibilityRequired
+        FINAL -> !hasOverrideModifier
         OPEN, ABSTRACT -> isOpenAndAbstractByDefault
         else -> false
     }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/explicitApiMode/strict.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/explicitApiMode/strict.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 // COMPILER_ARGUMENTS: -Xexplicit-api=strict
 public class Test {
     public static void main(String[] args) {}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/explicitApiMode/warning.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/explicitApiMode/warning.java
@@ -1,4 +1,3 @@
-// IGNORE_K2
 // COMPILER_ARGUMENTS: -Xexplicit-api=warning
 public class Test {
     public static void main(String[] args) {}


### PR DESCRIPTION
Delete `NO_EXPLICIT_VISIBILITY_IN_API_MODE` from the postprocessing step and handle it in the `modifers.kt` redundancy check. `PUBLIC` should not be redundant in explicit API mode, so mark it as such.

@abelkov @darthorimar @ermattt