### PR TITLE
PY-46477: Support coverage configuration via setup.cfg and pyproject.toml

### DIFF
--- a/python/helpers/coverage_runner/run_coverage.py
+++ b/python/helpers/coverage_runner/run_coverage.py
@@ -47,11 +47,15 @@ cwd = os.getcwd()
 
 run_xml = os.getenv('PYCHARM_RUN_COVERAGE_XML')
 argv = ["xml", "-o", coverage_file + ".xml", "--ignore-errors"]
-rcfile = cwd + "/.coveragerc"
-if os.path.exists(rcfile):
-    print("Loading rcfile: %s\n" % rcfile)
-    argv += ["--rcfile", rcfile]
 
+supported_rc_files = ['.coveragerc', 'setup.cfg', 'tox.ini', 'pyproject.toml']
+for supported_rc_file in supported_rc_files:
+    rcfile = cwd + "/" + supported_rc_file
+    if os.path.exists(rcfile):
+        print("Loading rcfile: %s\n" % rcfile)
+        argv += ["--rcfile", rcfile]
+        break
+    
 if run_xml:
     os.chdir(cwd)
     main(argv)


### PR DESCRIPTION
Allow to use all the supported configuration files ('.coveragerc', 'setup.cfg', 'tox.ini', and 'pyproject.toml') to configure coverage

fixes: https://youtrack.jetbrains.com/issue/PY-46477