### PR TITLE
KTIJ-29850: Do not suggest privatizing functions referenced by callable references

### DIFF
--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/inspections/MemberVisibilityCanBePrivateInspection.kt
@@ -120,6 +120,13 @@ class MemberVisibilityCanBePrivateInspection : AbstractKotlinInspection() {
                     return@Processor false
                 }
             }
+            // Do not privatize functions referenced by callable references
+            if (usage.getStrictParentOfType<KtCallableReferenceExpression>() != null) {
+                // Consider the reference is used outside of the class,
+                // as KFunction#call would fail even on references inside that same class
+                otherUsageFound = true
+                return@Processor false
+            }
             val function = usage.getParentOfTypesAndPredicate<KtDeclarationWithBody>(
                 true, KtNamedFunction::class.java, KtPropertyAccessor::class.java
             ) { true }

--- a/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/idea/tests/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -7536,6 +7536,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/memberVisibilityCanBePrivate/annotation.kt");
         }
 
+        @TestMetadata("callableReferences.kt")
+        public void testCallableReferences() throws Exception {
+            runTest("testData/inspectionsLocal/memberVisibilityCanBePrivate/callableReferences.kt");
+        }
+
         @TestMetadata("JvmFieldOnParameter.kt")
         public void testJvmFieldOnParameter() throws Exception {
             runTest("testData/inspectionsLocal/memberVisibilityCanBePrivate/JvmFieldOnParameter.kt");
@@ -7544,6 +7549,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         @TestMetadata("JvmFieldOnProperty.kt")
         public void testJvmFieldOnProperty() throws Exception {
             runTest("testData/inspectionsLocal/memberVisibilityCanBePrivate/JvmFieldOnProperty.kt");
+        }
+
+        @TestMetadata("sameClassCallableReferences.kt")
+        public void testSameClassCallableReferences() throws Exception {
+            runTest("testData/inspectionsLocal/memberVisibilityCanBePrivate/sameClassCallableReferences.kt");
         }
 
         @TestMetadata("sameClassFunctionCall.kt")

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/callableReferences.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/callableReferences.kt
@@ -1,0 +1,12 @@
+// PROBLEM: none
+class A {
+    fun runFunction(func: KFunction<*>) {}
+}
+
+class B {
+    fun <caret>myFunction() {}
+
+    fun run() {
+        runFunction(::myFunction)
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/sameClassCallableReferences.kt
+++ b/plugins/kotlin/idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/sameClassCallableReferences.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+class B {
+    fun runFunction(func: KFunction<*>) {}
+
+    fun <caret>myFunction() {}
+
+    fun run() {
+        runFunction(::myFunction)
+    }
+}

--- a/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
+++ b/plugins/kotlin/k2-fe10-bindings/test/org/jetbrains/kotlin/idea/k2/fe10bindings/inspections/Fe10BindingLocalInspectionTestGenerated.java
@@ -1492,6 +1492,11 @@ public abstract class Fe10BindingLocalInspectionTestGenerated extends AbstractFe
             runTest("../idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/annotation.kt");
         }
 
+        @TestMetadata("callableReferences.kt")
+        public void testCallableReferences() throws Exception {
+            runTest("../idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/callableReferences.kt");
+        }
+
         @TestMetadata("JvmFieldOnParameter.kt")
         public void testJvmFieldOnParameter() throws Exception {
             runTest("../idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/JvmFieldOnParameter.kt");
@@ -1500,6 +1505,11 @@ public abstract class Fe10BindingLocalInspectionTestGenerated extends AbstractFe
         @TestMetadata("JvmFieldOnProperty.kt")
         public void testJvmFieldOnProperty() throws Exception {
             runTest("../idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/JvmFieldOnProperty.kt");
+        }
+
+        @TestMetadata("sameClassCallableReferences.kt")
+        public void testSameClassCallableReferences() throws Exception {
+            runTest("../idea/tests/testData/inspectionsLocal/memberVisibilityCanBePrivate/sameClassCallableReferences.kt");
         }
 
         @TestMetadata("sameClassFunctionCall.kt")


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/KTIJ-29850

Callable references are considered as usages outside of the class, as calling them reflectively causes an `IllegalAccessException`