### PR TITLE
Add getters to be able to decompile in memory

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -131,4 +131,8 @@ public class Fernflower implements IDecompiledData {
       return null;
     }
   }
+
+  public StructContext getStructContext() {
+    return structContext;
+  }
 }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -164,4 +164,20 @@ public class StructContext {
   public Map<String, StructClass> getClasses() {
     return classes;
   }
-}
+
+  public IResultSaver getSaver() {
+    return saver;
+  }
+
+  public IDecompiledData getDecompiledData() {
+    return decompiledData;
+  }
+
+  public LazyLoader getLoader() {
+    return loader;
+  }
+
+  public Map<String, ContextUnit> getUnits() {
+    return units;
+  }
+}}


### PR DESCRIPTION
Enable to decompile in memory without reflection hacks :

https://github.com/nbauma109/transformer-api/blob/5c76d0a0eef2a1bfbd9d36aed42669bcf3e375f6/src/main/java/com/heliosdecompiler/transformerapi/decompilers/fernflower/FernflowerDecompiler.java#L49-L54

