### PR TITLE
Add new getters to enable to decompile in memory

### DIFF
--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/Fernflower.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/main/Fernflower.java
@@ -131,4 +131,8 @@ public class Fernflower implements IDecompiledData {
       return null;
     }
   }
+
+  public StructContext getStructContext() {
+    return structContext;
+  }
 }

--- a/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/StructContext.java
+++ b/plugins/java-decompiler/engine/src/org/jetbrains/java/decompiler/struct/StructContext.java
@@ -164,4 +164,12 @@ public class StructContext {
   public Map<String, StructClass> getClasses() {
     return classes;
   }
+
+  public LazyLoader getLoader() {
+    return loader;
+  }
+
+  public Map<String, ContextUnit> getUnits() {
+    return units;
+  }
 }


### PR DESCRIPTION
Add new getters to enable to decompile in memory without such reflection hacks:

https://github.com/nbauma109/transformer-api/blob/5c76d0a0eef2a1bfbd9d36aed42669bcf3e375f6/src/main/java/com/heliosdecompiler/transformerapi/decompilers/fernflower/FernflowerDecompiler.java#L49-L54