### PR TITLE
Add Android Framework and Internal Classes to DEFAULT_STEPPING_FILTERS

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/settings/DebuggerSettings.java
+++ b/java/debugger/impl/src/com/intellij/debugger/settings/DebuggerSettings.java
@@ -58,7 +58,12 @@ public final class DebuggerSettings implements Cloneable, PersistentStateCompone
     new ClassFilter("javassist.*"),
     new ClassFilter("org.apache.webbeans.*"),
     new ClassFilter("com.ibm.ws.*"),
-    new ClassFilter("org.mockito.*")
+    new ClassFilter("org.mockito.*"),
+    new ClassFilter("android.*"),
+    new ClassFilter("com.android.*"),
+    new ClassFilter("libcore.*"),
+    new ClassFilter("dalvik.*"),
+    new ClassFilter("androidx.*"),
   };
 
   public boolean TRACING_FILTERS_ENABLED = true;


### PR DESCRIPTION
Android Studio team would like these classes to be added to `DebuggerSetting.getSteppingFilters()`.

```
android.*
com.android.*
androidx.*
libcore.*
dalvik.*
```

While it's possible to them dynamically only when Android Plugin is enabled (via a plugin ProjectService for example, it would simplify things if we added it to the default because then, the Debugger Tests running on ART which was added in https://github.com/JetBrains/intellij-community/pull/2744 would work out of the box without having to dynamically apply these filters.