### PR TITLE
Migrate from FileComparisonFailure to FileComparisonFailedError in testFramework

### DIFF
--- a/java/testFramework/src/com/intellij/codeInsight/JavaCodeInsightTestCase.java
+++ b/java/testFramework/src/com/intellij/codeInsight/JavaCodeInsightTestCase.java
@@ -28,6 +28,7 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.pom.java.LanguageLevel;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiDocumentManager;
@@ -35,7 +36,6 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiPackage;
 import com.intellij.psi.impl.source.PostprocessReformattingAspect;
 import com.intellij.psi.search.ProjectScope;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.testFramework.*;
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
 import com.intellij.util.ArrayUtil;
@@ -404,7 +404,7 @@ public abstract class JavaCodeInsightTestCase extends JavaPsiTestCase {
 
       String actualText = StringUtil.convertLineSeparators(myFile.getText());
       if (!Objects.equals(expectedText, actualText)) {
-        throw new FileComparisonFailure("Text mismatch in file " + filePath, expectedText, actualText, vFile.getPath());
+        throw new FileComparisonFailedError("Text mismatch in file " + filePath, expectedText, actualText, vFile.getPath());
       }
 
       EditorTestUtil.verifyCaretAndSelectionState(myEditor, caretState);

--- a/java/testFramework/src/com/intellij/debugger/impl/OutputChecker.java
+++ b/java/testFramework/src/com/intellij/debugger/impl/OutputChecker.java
@@ -21,8 +21,8 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.util.text.StringUtilRt;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.project.IntelliJProjectConfiguration;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.util.PathUtil;
 import com.intellij.util.Producer;
 import com.intellij.util.UriUtil;
@@ -192,7 +192,7 @@ public class OutputChecker {
           System.out.println("Rest from actual text is: \"" + actual.substring(len) + "\"");
         }
 
-        throw new FileComparisonFailure(null, expected, actual, outFile.getPath());
+        throw new FileComparisonFailedError(null, expected, actual, outFile.getPath());
       }
     }
   }

--- a/platform/testFramework/core/src/com/intellij/platform/testFramework/core/FileComparisonFailedError.kt
+++ b/platform/testFramework/core/src/com/intellij/platform/testFramework/core/FileComparisonFailedError.kt
@@ -1,7 +1,6 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.platform.testFramework.core
 
-import com.intellij.rt.execution.junit.FileComparisonData
 import org.opentest4j.AssertionFailedError
 import org.opentest4j.FileInfo
 import org.opentest4j.ValueWrapper
@@ -18,7 +17,7 @@ open class FileComparisonFailedError @JvmOverloads constructor(
   message,
   createFileInfo(expected, expectedFilePath),
   createFileInfo(actual, actualFilePath)
-), FileComparisonData {
+) {
 
   init {
     require(expectedFilePath == null || File(expectedFilePath).isFile) {
@@ -27,22 +26,6 @@ open class FileComparisonFailedError @JvmOverloads constructor(
     require(actualFilePath == null || File(actualFilePath).isFile) {
       "'actualFilePath' should point to the existing file or be null"
     }
-  }
-
-  override fun getFilePath(): String? {
-    return getFilePath(expected)
-  }
-
-  override fun getActualFilePath(): String? {
-    return getFilePath(actual)
-  }
-
-  override fun getActualStringPresentation(): String {
-    return getFileText(actual)
-  }
-
-  override fun getExpectedStringPresentation(): String {
-    return getFileText(expected)
   }
 
   companion object {

--- a/platform/testFramework/extensions/src/com/intellij/testFramework/assertions/JdomAssert.kt
+++ b/platform/testFramework/extensions/src/com/intellij/testFramework/assertions/JdomAssert.kt
@@ -5,7 +5,7 @@ import com.intellij.configurationStore.deserialize
 import com.intellij.configurationStore.serialize
 import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.util.text.StringUtilRt
-import com.intellij.rt.execution.junit.FileComparisonFailure
+import com.intellij.platform.testFramework.core.FileComparisonFailedError
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.internal.Objects
 import org.intellij.lang.annotations.Language
@@ -29,7 +29,7 @@ class JdomAssert(actual: Element?) : AbstractAssert<JdomAssert, Element?>(actual
 
     val expected = JDOMUtil.load(file)
     if (!JDOMUtil.areElementsEqual(actual, expected)) {
-      throw FileComparisonFailure(null, StringUtilRt.convertLineSeparators(Files.readString(file)), JDOMUtil.writeElement(actual!!), file.toString())
+      throw FileComparisonFailedError(null, StringUtilRt.convertLineSeparators(Files.readString(file)), JDOMUtil.writeElement(actual!!), file.toString())
     }
     return this
   }

--- a/platform/testFramework/extensions/src/com/intellij/testFramework/assertions/snapshot.kt
+++ b/platform/testFramework/extensions/src/com/intellij/testFramework/assertions/snapshot.kt
@@ -5,7 +5,7 @@ import com.intellij.concurrency.ConcurrentCollectionFactory
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.util.text.StringUtilRt
-import com.intellij.rt.execution.junit.FileComparisonFailure
+import com.intellij.platform.testFramework.core.FileComparisonFailedError
 import com.intellij.testFramework.UsefulTestCase
 import com.intellij.util.io.readChars
 import com.intellij.util.io.write
@@ -62,7 +62,7 @@ internal fun loadSnapshotContent(snapshotFile: Path, convertLineSeparators: Bool
   return content
 }
 
-@Throws(FileComparisonFailure::class)
+@Throws(FileComparisonFailedError::class)
 fun compareFileContent(actual: Any, snapshotFile: Path, updateIfMismatch: Boolean = isUpdateSnapshotIfMismatch(), writeIfNotFound: Boolean = true) {
   val actualContent = if (actual is CharSequence) getNormalizedActualContent(actual) else dumpData(actual).trimEnd()
 
@@ -95,7 +95,7 @@ fun compareFileContent(actual: Any, snapshotFile: Path, updateIfMismatch: Boolea
                   "Expected: '${expected.contextAround(firstMismatch, 10)}'\n" +
                   "Actual  : '${actualContent.contextAround(firstMismatch, 10)}'\n" +
                   "Inspect your code changes or run with `-Dtest.update.snapshots` to update"
-    throw FileComparisonFailure(message, expected.toString(), actualContent.toString(), snapshotFile.toString())
+    throw FileComparisonFailedError(message, expected.toString(), actualContent.toString(), snapshotFile.toString())
   }
 }
 

--- a/platform/testFramework/src/com/intellij/testFramework/EditorTestUtil.java
+++ b/platform/testFramework/src/com/intellij/testFramework/EditorTestUtil.java
@@ -46,12 +46,12 @@ import com.intellij.openapi.util.*;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.encoding.EncodingManager;
 import com.intellij.openapi.vfs.encoding.EncodingProjectManager;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.source.tree.injected.InjectedLanguageEditorUtil;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
 import com.intellij.util.SmartList;
 import com.intellij.util.ThrowableRunnable;
@@ -488,7 +488,7 @@ public final class EditorTestUtil {
         String actual = CaretAndSelectionMarkup.renderActualState(editor);
         if (expectedFilePath != null) {
           if (!expected.equals(actual)) {
-            throw new FileComparisonFailure(e.getMessage(), expected, actual, expectedFilePath);
+            throw new FileComparisonFailedError(e.getMessage(), expected, actual, expectedFilePath);
           }
         } else {
           assertEquals(e.getMessage(), expected, actual);

--- a/platform/testFramework/src/com/intellij/testFramework/EqualsToFile.kt
+++ b/platform/testFramework/src/com/intellij/testFramework/EqualsToFile.kt
@@ -17,7 +17,7 @@
 package com.intellij.testFramework
 
 import com.intellij.openapi.util.text.StringUtil
-import com.intellij.rt.execution.junit.FileComparisonFailure
+import com.intellij.platform.testFramework.core.FileComparisonFailedError
 import junit.framework.TestCase
 import java.io.File
 
@@ -37,6 +37,6 @@ fun assertEqualsToFile(description: String, expected: File, actual: String) {
   val actualText =
     StringUtil.convertLineSeparators(actual.trim()).trimTrailingWhitespacesAndAddNewlineAtEOF()
   if (expectedText != actualText) {
-    throw FileComparisonFailure(description, expectedText, actualText, expected.absolutePath)
+    throw FileComparisonFailedError(description, expectedText, actualText, expected.absolutePath)
   }
 }

--- a/platform/testFramework/src/com/intellij/testFramework/ExpectedHighlightingData.java
+++ b/platform/testFramework/src/com/intellij/testFramework/ExpectedHighlightingData.java
@@ -20,10 +20,10 @@ import com.intellij.openapi.util.text.LineColumn;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.util.text.Strings;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.SmartPsiElementPointer;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
 import com.intellij.util.DocumentUtil;
 import com.intellij.util.MathUtil;
@@ -425,7 +425,7 @@ public class ExpectedHighlightingData {
           filePath = file.getUserData(VfsTestUtil.TEST_DATA_FILE_PATH);
         }
       }
-      throw new FileComparisonFailure(failMessage.toString(), myText, getActualLineMarkerFileText(markerInfos), filePath);
+      throw new FileComparisonFailedError(failMessage.toString(), myText, getActualLineMarkerFileText(markerInfos), filePath);
     }
   }
 
@@ -600,7 +600,7 @@ public class ExpectedHighlightingData {
       // uncomment to overwrite, don't forget to revert on commit!
       //VfsTestUtil.overwriteTestData(filePath, actual);
       //return;
-      throw new FileComparisonFailure(failMessage, myText, actual, filePath);
+      throw new FileComparisonFailedError(failMessage, myText, actual, filePath);
     }
     assertEquals(failMessage + "\n", myText, actual);
     fail(failMessage);

--- a/platform/testFramework/src/com/intellij/testFramework/LightPlatformCodeInsightTestCase.java
+++ b/platform/testFramework/src/com/intellij/testFramework/LightPlatformCodeInsightTestCase.java
@@ -37,11 +37,11 @@ import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.encoding.EncodingProjectManager;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.source.PostprocessReformattingAspect;
 import com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.util.ThrowableRunnable;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -443,7 +443,7 @@ public abstract class LightPlatformCodeInsightTestCase extends LightPlatformTest
       String fileText1 = myFile.getText();
       String failMessage = getMessage("Text mismatch", message);
       if (filePath != null && !newFileText.equals(fileText1)) {
-        throw new FileComparisonFailure(failMessage, newFileText, fileText1, filePath);
+        throw new FileComparisonFailedError(failMessage, newFileText, fileText1, filePath);
       }
       assertEquals(failMessage, newFileText, fileText1);
 
@@ -469,7 +469,7 @@ public abstract class LightPlatformCodeInsightTestCase extends LightPlatformTest
       String fileText1 = editor.getDocument().getText();
       String failMessage = getMessage("Text mismatch", message);
       if (filePath != null && !newFileText.equals(fileText1)) {
-        throw new FileComparisonFailure(failMessage, newFileText, fileText1, filePath);
+        throw new FileComparisonFailedError(failMessage, newFileText, fileText1, filePath);
       }
       assertEquals(failMessage, newFileText, fileText1);
 

--- a/platform/testFramework/src/com/intellij/testFramework/PlatformTestUtil.java
+++ b/platform/testFramework/src/com/intellij/testFramework/PlatformTestUtil.java
@@ -59,9 +59,9 @@ import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileFilter;
 import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.reference.impl.PsiMultiReference;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.testFramework.common.TestApplicationKt;
 import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
 import com.intellij.ui.ClientProperty;
@@ -815,8 +815,8 @@ public final class PlatformTestUtil {
         assertArrayEquals(fileExpected.getPath(), fileExpected.contentsToByteArray(), fileActual.contentsToByteArray());
       }
       else if (!StringUtil.equals(expected, actual)) {
-        throw new FileComparisonFailure("Text mismatch in the file " + fileExpected.getName(), expected, actual,
-                                        fileActual.getUserData(VfsTestUtil.TEST_DATA_FILE_PATH));
+        throw new FileComparisonFailedError("Text mismatch in the file " + fileExpected.getName(), expected, actual,
+                                            fileActual.getUserData(VfsTestUtil.TEST_DATA_FILE_PATH));
       }
     }
   }

--- a/platform/testFramework/src/com/intellij/testFramework/UsefulTestCase.java
+++ b/platform/testFramework/src/com/intellij/testFramework/UsefulTestCase.java
@@ -23,10 +23,10 @@ import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileVisitor;
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.impl.source.PostprocessReformattingAspect;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.testFramework.common.TestApplicationKt;
 import com.intellij.testFramework.common.ThreadUtil;
 import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
@@ -987,7 +987,7 @@ public abstract class UsefulTestCase extends TestCase {
     String expected = StringUtil.convertLineSeparators(trimBeforeComparing ? fileText.trim() : fileText);
     String actual = StringUtil.convertLineSeparators(trimBeforeComparing ? actualText.trim() : actualText);
     if (!Objects.equals(expected, actual)) {
-      throw new FileComparisonFailure(messageProducer == null ? null : messageProducer.get(), expected, actual, filePath);
+      throw new FileComparisonFailedError(messageProducer == null ? null : messageProducer.get(), expected, actual, filePath);
     }
   }
 
@@ -997,7 +997,7 @@ public abstract class UsefulTestCase extends TestCase {
 
   public static void assertTextEquals(@Nullable String message, @NotNull String expectedText, @NotNull String actualText) {
     if (!expectedText.equals(actualText)) {
-      throw new FileComparisonFailure(Strings.notNullize(message), expectedText, actualText, null);
+      throw new FileComparisonFailedError(Strings.notNullize(message), expectedText, actualText, null);
     }
   }
 

--- a/platform/testFramework/src/com/intellij/testFramework/codeInsight/hierarchy/HierarchyViewTestFixture.java
+++ b/platform/testFramework/src/com/intellij/testFramework/codeInsight/hierarchy/HierarchyViewTestFixture.java
@@ -6,7 +6,7 @@ import com.intellij.ide.hierarchy.HierarchyTreeStructure;
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.openapi.util.JDOMUtil;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -63,9 +63,9 @@ public final class HierarchyViewTestFixture {
     catch (Throwable e) {
       String actual = dump(treeStructure, null, comparator, 0);
       if (!expectedStructure.equals(actual)) {
-        throw new FileComparisonFailure("XML structure comparison for your convenience, actual failure details BELOW",
-                                        expectedStructure, actual,
-                                        expectedFile == null ? null : expectedFile.getAbsolutePath());
+        throw new FileComparisonFailedError("XML structure comparison for your convenience, actual failure details BELOW",
+                                            expectedStructure, actual,
+                                            expectedFile == null ? null : expectedFile.getAbsolutePath());
       }
       throw new RuntimeException(e);
     }

--- a/platform/testFramework/src/com/intellij/testFramework/fixtures/impl/CodeInsightTestFixtureImpl.java
+++ b/platform/testFramework/src/com/intellij/testFramework/fixtures/impl/CodeInsightTestFixtureImpl.java
@@ -108,6 +108,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.readOnlyHandler.ReadonlyStatusHandlerImpl;
 import com.intellij.openapi.vfs.*;
 import com.intellij.openapi.vfs.impl.VirtualFilePointerTracker;
+import com.intellij.platform.testFramework.core.FileComparisonFailedError;
 import com.intellij.profile.codeInspection.ProjectInspectionProfileManager;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.PsiManagerEx;
@@ -124,7 +125,6 @@ import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectori
 import com.intellij.refactoring.rename.*;
 import com.intellij.refactoring.rename.api.RenameTarget;
 import com.intellij.refactoring.rename.impl.RenameKt;
-import com.intellij.rt.execution.junit.FileComparisonFailure;
 import com.intellij.testFramework.*;
 import com.intellij.testFramework.fixtures.*;
 import com.intellij.testFramework.utils.inlays.CaretAndInlaysInfo;
@@ -1881,7 +1881,7 @@ public class CodeInsightTestFixtureImpl extends BaseFixture implements CodeInsig
 
     if (!Objects.equals(expectedText, actualText)) {
       if (loader.filePath == null) {
-        throw new FileComparisonFailure(expectedFile, expectedText, actualText, null);
+        throw new FileComparisonFailedError(expectedFile, expectedText, actualText, null);
       }
 
       if (loader.caretState.hasExplicitCaret()) {
@@ -1895,7 +1895,7 @@ public class CodeInsightTestFixtureImpl extends BaseFixture implements CodeInsig
           expectedText = stripTrailingSpaces(expectedText);
         }
       }
-      throw new FileComparisonFailure(expectedFile, expectedText, actualText, loader.filePath);
+      throw new FileComparisonFailedError(expectedFile, expectedText, actualText, loader.filePath);
     }
 
     EditorTestUtil.verifyCaretAndSelectionState(editor, loader.caretState, expectedFile, loader.filePath);
@@ -2016,7 +2016,7 @@ public class CodeInsightTestFixtureImpl extends BaseFixture implements CodeInsig
     }
     String actual = getFoldingDescription(doCheckCollapseStatus);
     if (!expectedContent.equals(actual)) {
-      throw new FileComparisonFailure(verificationFile.getName(), expectedContent, actual, verificationFile.getPath());
+      throw new FileComparisonFailedError(verificationFile.getName(), expectedContent, actual, verificationFile.getPath());
     }
   }
 

--- a/platform/testFramework/src/com/intellij/testFramework/utils/inlays/InlayParameterHintsTest.kt
+++ b/platform/testFramework/src/com/intellij/testFramework/utils/inlays/InlayParameterHintsTest.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.VisualPosition
 import com.intellij.openapi.util.TextRange
-import com.intellij.rt.execution.junit.FileComparisonFailure
+import com.intellij.platform.testFramework.core.FileComparisonFailedError
 import com.intellij.testFramework.VfsTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import junit.framework.ComparisonFailure
@@ -87,7 +87,7 @@ class InlayHintsChecker(private val myFixture: CodeInsightTestFixture) {
       entries.asReversed().forEach { proposedText.insert(it.first, it.second) }
 
       VfsTestUtil.TEST_DATA_FILE_PATH.get(file.virtualFile)?.let { originalPath ->
-        throw FileComparisonFailure("Hints differ", originalText, proposedText.toString(), originalPath)
+        throw FileComparisonFailedError("Hints differ", originalText, proposedText.toString(), originalPath)
       } ?: throw ComparisonFailure("Hints differ", originalText, proposedText.toString())
     }
 

--- a/platform/testFramework/src/com/intellij/util/io/impl/DirectoryContentSpecImpl.kt
+++ b/platform/testFramework/src/com/intellij/util/io/impl/DirectoryContentSpecImpl.kt
@@ -3,7 +3,7 @@ package com.intellij.util.io.impl
 
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.CharsetToolkit
-import com.intellij.rt.execution.junit.FileComparisonFailure
+import com.intellij.platform.testFramework.core.FileComparisonFailedError
 import com.intellij.util.io.*
 import org.junit.Assert.assertEquals
 import org.junit.ComparisonFailure
@@ -236,7 +236,7 @@ private fun assertDirectoryContentMatches(file: Path,
               val (expected, actual) = if (expectedDataIsInSpec) specString to fileString else fileString to specString
               val (expectedPath, actualPath) = if (expectedDataIsInSpec) specFilePath to null else null to specFilePath
               errorReporter.reportError(relativePath,
-                                        FileComparisonFailure("File content mismatch$place:", expected, actual, expectedPath, actualPath))
+                                        FileComparisonFailedError("File content mismatch$place:", expected, actual, expectedPath, actualPath))
             }
           }
           else {


### PR DESCRIPTION
The testFrameworks package was using `FileComparisonFailure` for asserts which comes from the `intellij.java.rt` module. 

In the newer broken up test frameworks in intellij-platform-gradle-plugin, the usage of the test frameworks could lead to ClassNotFoundExceptions on this class when testing against the smaller IDEs.

This PR tries to replace the usages of the deprecated class to cut down on the reliance of `intellij.java.rt` inside of `intellij.platform.testFramework`.

`DynamicExtensionPointsTester` also appears to reach into `intellij.java.rt` for `com.intellij.rt.execution.junit.MapSerializerUtil` and that usages looked unsafe to touch for someone with no knowledge of what those print statements power

`FileComparisonData` was dropped from `FileComparisonFailedError` to rely only upon opentest4j

See https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1632