### PR TITLE
KTIJ-14684: Allow sam-with-receiver Kotlin compiler module to work in test source sets

### DIFF
--- a/plugins/kotlin/compiler-plugins/sam-with-receiver/common/src/org/jetbrains/kotlin/idea/compilerPlugin/samWithReceiver/IdeSamWithReceiverComponentContributor.kt
+++ b/plugins/kotlin/compiler-plugins/sam-with-receiver/common/src/org/jetbrains/kotlin/idea/compilerPlugin/samWithReceiver/IdeSamWithReceiverComponentContributor.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
 import org.jetbrains.kotlin.idea.base.scripting.projectStructure.ScriptDependenciesInfo
 import org.jetbrains.kotlin.idea.base.scripting.projectStructure.ScriptModuleInfo
-import org.jetbrains.kotlin.idea.base.projectStructure.moduleInfo.ModuleProductionSourceInfo
+import org.jetbrains.kotlin.idea.base.projectStructure.moduleInfo.ModuleSourceInfo
 import org.jetbrains.kotlin.idea.compilerPlugin.getSpecialAnnotations
 import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.platform.jvm.isJvm
@@ -53,7 +53,7 @@ class IdeSamWithReceiverComponentContributor(val project: Project) : StorageComp
             when (val moduleInfo = moduleDescriptor.getCapability(ModuleInfo.Capability)) {
                 is ScriptModuleInfo -> moduleInfo.scriptDefinition.annotationsForSamWithReceivers
                 is ScriptDependenciesInfo.ForFile -> moduleInfo.scriptDefinition.annotationsForSamWithReceivers
-                is ModuleProductionSourceInfo -> getAnnotationsForModule(moduleInfo.module)
+                is ModuleSourceInfo -> getAnnotationsForModule(moduleInfo.module)
                 else -> null
             } ?: return
 


### PR DESCRIPTION
Resolves https://youtrack.jetbrains.com/issue/KTIJ-14684. 

Quite a straightforward fix - Previously the implementation of `IdeSamWithReceiverComponentContributor::registerModuleComponents` added a `SamWithReceiverResolverExtension` to the component container only `ModuleProductionSourceInfo` modules. I changed it to add the extension for general `ModuleSourceInfo` modules (which includes both `ModuleProductionSourceInfo` and `ModuleTestSourceInfo` modules).

To test, open the [sam-receiver-kotlin-bug](https://github.com/big-guy/sam-receiver-kotlin-bug) (see https://youtrack.jetbrains.com/issue/KTIJ-22591) Gradle project in the IDE and navigate to the `ImplTest.kt` file in the `test` source root. The references in the lambda body in the `onFoo` method call should resolve properly.