### PR TITLE
Adds a toggle for underlined hyperlink in `JBHtmlEditorKit`

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/components/JBHtmlPane.kt
+++ b/platform/platform-api/src/com/intellij/ui/components/JBHtmlPane.kt
@@ -144,6 +144,7 @@ open class JBHtmlPane(
     val editorKit = HTMLEditorKitBuilder()
       .replaceViewFactoryExtensions(*extensions.toTypedArray())
       .withFontResolver(myPaneConfiguration.fontResolver ?: service.defaultEditorCssFontResolver())
+      .withUnderlinedHoveredHyperlink(myPaneConfiguration.underlinedHoveredHyperlink)
       .build()
     updateDocumentationPaneDefaultCssRules(editorKit)
 

--- a/platform/platform-api/src/com/intellij/ui/components/JBHtmlPaneConfiguration.kt
+++ b/platform/platform-api/src/com/intellij/ui/components/JBHtmlPaneConfiguration.kt
@@ -48,6 +48,7 @@ class JBHtmlPaneConfiguration private constructor(builder: Builder) {
   internal val iconResolver: (String) -> Icon? = builder.iconResolver
   internal val customStyleSheetProviders: List<(backgroundColor: Color) -> StyleSheet> = builder.customStyleSheetProviders.toList()
   internal val fontResolver: CSSFontResolver? = builder.fontResolver
+  internal val underlinedHoveredHyperlink = builder.underlinedHoveredHyperlink
   internal val extensions: List<ExtendableHTMLViewFactory.Extension> = builder.extensions.toList()
 
   constructor() : this(builder())
@@ -96,6 +97,17 @@ class JBHtmlPaneConfiguration private constructor(builder: Builder) {
      * make sure to support font family names `_EditorFont_` and `_EditorFontNoLigatures_`.
      */
     var fontResolver: CSSFontResolver? = null
+
+    /**
+     * Toggle whether hyperlinks are underlined when hovered.
+     *
+     * This is useful if another implementation needs to apply a different style
+     * to hyperlinks when hovered (this can be done by adding an [javax.swing.event.HyperlinkListener]
+     * to the [JBHtmlPane]).
+     *
+     * Default is true.
+     */
+    var underlinedHoveredHyperlink: Boolean = true
 
     /**
      * Provide a list of additional extensions for the [ExtendableHTMLViewFactory]

--- a/platform/util/ui/src/com/intellij/util/ui/HTMLEditorKitBuilder.kt
+++ b/platform/util/ui/src/com/intellij/util/ui/HTMLEditorKitBuilder.kt
@@ -19,6 +19,7 @@ class HTMLEditorKitBuilder {
   private var needGapsBetweenParagraphs = false
   private var loadCssFromFile = true
   private var fontResolver: CSSFontResolver? = null
+  private var underlinedHoveredHyperlink = true
 
   /**
    * Allows replacing default [ExtendableHTMLViewFactory] extensions
@@ -80,10 +81,15 @@ class HTMLEditorKitBuilder {
     fontResolver = resolver
   }
 
+  fun withUnderlinedHoveredHyperlink(flag: Boolean): HTMLEditorKitBuilder = apply {
+    underlinedHoveredHyperlink = flag
+  }
+
   fun build(): HTMLEditorKit {
     val styleSheet = overriddenRootStyle ?: createHtmlStyleSheet()
     return JBHtmlEditorKit(viewFactory, styleSheet, !loadCssFromFile).apply {
-      if (fontResolver != null) setFontResolver(fontResolver)
+      if (fontResolver != null) { setFontResolver(fontResolver) }
+      setUnderlineHoveredHyperlink(underlinedHoveredHyperlink)
     }
   }
 

--- a/platform/util/ui/src/com/intellij/util/ui/JBHtmlEditorKit.java
+++ b/platform/util/ui/src/com/intellij/util/ui/JBHtmlEditorKit.java
@@ -38,6 +38,7 @@ public class JBHtmlEditorKit extends HTMLEditorKit {
   private final @NotNull HTMLEditorKit.LinkController myLinkController = new MouseExitSupportLinkController();
   private final @NotNull HyperlinkListener myHyperlinkListener = new LinkUnderlineListener();
   private final boolean myDisableLinkedCss;
+  private boolean myUnderlineHoveredHyperlink = true;
 
   private @Nullable CSSFontResolver myFontResolver;
 
@@ -72,6 +73,17 @@ public class JBHtmlEditorKit extends HTMLEditorKit {
     myViewFactory = viewFactory;
     myDisableLinkedCss = disableLinkedCss;
     myStyle = defaultStyle;
+  }
+
+  /**
+   * Toggle whether hyperlinks are underlined when hovered.
+   *
+   * This is useful if another implementation needs to apply a different style
+   * to hyperlinks when hovered (this can be done by adding a {@link HyperlinkListener}
+   * to the {@link JEditorPane}).
+   */
+  public void setUnderlineHoveredHyperlink(boolean underlineHoveredHyperlink) {
+    myUnderlineHoveredHyperlink = underlineHoveredHyperlink;
   }
 
   /**
@@ -135,7 +147,9 @@ public class JBHtmlEditorKit extends HTMLEditorKit {
         pane.removePropertyChangeListener(this);
       }
     });
-    pane.addHyperlinkListener(myHyperlinkListener);
+    if (myUnderlineHoveredHyperlink) {
+      pane.addHyperlinkListener(myHyperlinkListener);
+    }
 
     java.util.List<LinkController> listeners1 = filterLinkControllerListeners(pane.getMouseListeners());
     java.util.List<LinkController> listeners2 = filterLinkControllerListeners(pane.getMouseMotionListeners());


### PR DESCRIPTION
The purpose of this is to allow to disable the underlining of overed hyperlink. This underline styling is added by default in the `JBHtmlEditorKit` via `myHyperlinkListener = new LinkUnderlineListener();`, however it prevents to style hyperlink differently, because this listener will always be invoked last.

<details><summary><code>JEditorPane::fireHyperlinkUpdate</code></summary>

```java
    public void fireHyperlinkUpdate(HyperlinkEvent e) {
        // Guaranteed to return a non-null array
        Object[] listeners = listenerList.getListenerList();
        // Process the listeners last to first, notifying
        // those that are interested in this event
        for (int i = listeners.length-2; i>=0; i-=2) {
            if (listeners[i]==HyperlinkListener.class) {
                ((HyperlinkListener)listeners[i+1]).hyperlinkUpdate(e);
            }
        }
    }
```

</details>

`JEditorPane::addHyperlinkListener` with custom `HyperlinkListener`.

```java
jEd.addHyperlinkListener(
    object : HyperlinkListener {
        override fun hyperlinkUpdate(e: HyperlinkEvent) {
            val editorPane = e.inputEvent.component as? JEditorPane ?: return
            val styledDocument = editorPane.document as? HTMLDocument ?: return
            e.sourceElement ?: return
            val characterElement = styledDocument.getCharacterElement(e.sourceElement.startOffset)
            val style = when (e.eventType) {
                HyperlinkEvent.EventType.ENTERED -> styledDocument.getStyle("a:hover")
                HyperlinkEvent.EventType.EXITED -> styledDocument.getStyle(".highlight")
                else -> return
            }
            styledDocument.setCharacterAttributes(
                characterElement.startOffset,
                characterElement.endOffset - characterElement.startOffset,
                style,
                false
            )
        }
    }
)
```


<details><summary>Other <code>JEditorPane</code> init code</summary>

```kotlin
JEditorPane().apply {
    contentType = "text/html"
    editorKit = HTMLEditorKitBuilder()
        .withViewFactoryExtensions(ExtendableHTMLViewFactory.Extensions.WORD_WRAP)
        .withFontResolver(EditorCssFontResolver.getGlobalInstance())
        .build()
        .also {
            @Suppress("UnstableApiUsage")
            val editorFontStyle =
                """{ font-family:"${EditorCssFontResolver.EDITOR_FONT_NAME_NO_LIGATURES_PLACEHOLDER}";fo
                    DocumentationSettings.getMonospaceFontSizeCorrection(false)
                }%; }"""
            it.styleSheet.apply {
                addRule("code $editorFontStyle")
                // addRule("a { color: ${ColorUtil.toHtmlColor(JBUI.CurrentTheme.Link.Foreground.ENABLED
            }
        }
    text = """
        <html><body>
        <code>some code and <a class="highlight" href="highlight-1">some highlighted stuff</a></code>
        </body></html>
        """.trimIndent()
    (document as HTMLDocument).apply {
        styleSheet.addRule(
            """
            a { text-decoration: none; }
            .highlight {
                color: ${ColorUtil.toHtmlColor(foreground)};
                background-color: ${ColorUtil.toHtmlColor(JBColor.YELLOW)};
                text-decoration: none;
            }
            a:hover {
                color: ${ColorUtil.toHtmlColor(foreground)};
                background-color: ${ColorUtil.toHtmlColor(JBColor.ORANGE)};
                text-decoration: none;
            }""".trimIndent()
        )
    }
    UIUtil.doNotScrollToCaret(this)
    caretPosition = 0
    isEditable = false
}
```

</details>

Now one can write

```diff
    editorKit = HTMLEditorKitBuilder()
        .withViewFactoryExtensions(ExtendableHTMLViewFactory.Extensions.WORD_WRAP)
        .withFontResolver(EditorCssFontResolver.getGlobalInstance())
+       .withUnderlinedHoveredHyperlink(false)
        .build()
```

Or 

```diff
    val paneConfig = JBHtmlPaneConfiguration {
        fontResolver = EditorCssFontResolver.getGlobalInstance()
+       underlinedHoveredHyperlink = false
    }
    JBHtmlPane(styleConfig, paneConfig)
```

Note that previous behavior is maintained by setting default to true, i.e. the `LinkUnderlineListener` is installed by default. So existing implementation don't have to adapt their code.

-----

Ref: https://youtrack.jetbrains.com/issue/IJPL-148864/Cant-change-link-style-when-using-JBHtmlEditorKit-JBHtmlPane