### PR TITLE
Don't group delete line actions for undo

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/editor/actions/DeleteLineAction.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/actions/DeleteLineAction.java
@@ -43,7 +43,7 @@ public final class DeleteLineAction extends TextComponentEditorAction {
 
     @Override
     public void executeWriteAction(final @NotNull Editor editor, Caret caret, DataContext dataContext) {
-      CommandProcessor.getInstance().setCurrentCommandGroupId(EditorActionUtil.DELETE_COMMAND_GROUP);
+      CommandProcessor.getInstance().setCurrentCommandGroupId(null);
       CopyPasteManager.getInstance().stopKillRings();
       final Document document = editor.getDocument();
 

--- a/platform/platform-tests/testSrc/com/intellij/openapi/editor/actions/UndoDeleteLineTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/editor/actions/UndoDeleteLineTest.java
@@ -1,0 +1,31 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package com.intellij.openapi.editor.actions;
+
+import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.openapi.editor.impl.AbstractEditorTest;
+
+public class UndoDeleteLineTest extends AbstractEditorTest {
+  @Override
+  protected boolean isRunInCommand() {
+    // Otherwise undoing doesn't work
+    return false;
+  }
+
+  public void test() {
+    String before = """
+      1
+      2
+      3<caret>""";
+
+    String after = """
+      1
+      2<caret>""";
+
+    configureFromFileText(getTestName(false) + ".txt", before);
+    deleteLine();
+    deleteLine();
+    executeAction(IdeActions.ACTION_UNDO);
+    checkResultByText(after);
+  }
+}


### PR DESCRIPTION
Currently consecutive "Delete Line" actions are grouped and reverted together by a single Undo, however this is unintuitive and inconsistent with the behavior of other line-based actions like duplicate line or cut, which are reverted 1-by-1.  A practical example  of this problem is tapping the delete line hotkey to quickly remove multiple lines but accidentally deleting 1 extra line, then hitting undo and having the entire block restored instead of just the last line.

https://youtrack.jetbrains.com/issue/IJPL-52352

Before:
![before](https://github.com/JetBrains/intellij-community/assets/122331465/684daa83-5783-4c11-9c7a-01a420516831)

After:
![after](https://github.com/JetBrains/intellij-community/assets/122331465/1c20425b-9482-46de-aa60-a84b522ac65b)
