### PR TITLE
[Kotlin debugger] Add bytecode inspection for ART in KotlinSyntheticTypeComponentProvider 

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/kotlin.jvm-debugger.core.iml
+++ b/plugins/kotlin/jvm-debugger/core/kotlin.jvm-debugger.core.iml
@@ -53,5 +53,7 @@
     <orderEntry type="module" module-name="intellij.java.debugger.impl" />
     <orderEntry type="module" module-name="intellij.java.psi.impl" />
     <orderEntry type="module" module-name="kotlin.code-insight.utils" />
+    <orderEntry type="library" name="google-dexlib2" level="project" />
+    <orderEntry type="library" name="Guava" level="project" />
   </component>
 </module>


### PR DESCRIPTION
When trying to detect synthetic methods, KotlinSyntheticTypeComponentProvider uses bytecode inspection to verify that a method simply delegates to a default implementation in an interface. This inspection didn't work for ART, because bytecode on ART is different. This commit implements ART specific bytecode inspection and by that improves stepping behaviour in Android Studio. For example in this test case: `afterDefaultParameterValuesIntf.kt`.