### PR TITLE
Use relative path for cache hash

### DIFF
--- a/platform/build-scripts/downloader/src/org/jetbrains/intellij/build/dependencies/BuildDependenciesDownloader.kt
+++ b/platform/build-scripts/downloader/src/org/jetbrains/intellij/build/dependencies/BuildDependenciesDownloader.kt
@@ -127,7 +127,8 @@ object BuildDependenciesDownloader {
                                  vararg options: BuildDependenciesExtractOptions): Path {
     cleanUpIfRequired(communityRoot)
     val cachePath = getDownloadCachePath(communityRoot)
-    val hash = hashString(archiveFile.toString() + getExtractOptionsShortString(options)).substring(0, 6)
+    val relative = cachePath.relativize(archiveFile)
+    val hash = hashString(relative.toString() + getExtractOptionsShortString(options)).substring(0, 6)
     val directoryName = "${archiveFile.fileName}.${hash}.d"
     val targetDirectory = cachePath.resolve(directoryName)
     val flagFile = cachePath.resolve("${directoryName}.flag")


### PR DESCRIPTION
When creating a hash for a directory name, use the relative path instead of absolute path. This gives a consistent naming allowing reusing caches in different root directories