### PR TITLE
IJPL-155932 : Add an `SvgImageExtension` for the Html Toollkit / `JBHtmlPane`

### DIFF
--- a/platform/util/ui/src/com/intellij/util/ui/SvgImageExtension.kt
+++ b/platform/util/ui/src/com/intellij/util/ui/SvgImageExtension.kt
@@ -1,0 +1,162 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.util.ui
+
+import com.intellij.ui.scale.JBUIScale.sysScale
+import com.intellij.ui.scale.ScaleContext
+import com.intellij.util.SVGLoader
+import java.awt.*
+import java.net.URL
+import java.util.concurrent.CompletableFuture
+import javax.swing.SwingUtilities
+import javax.swing.text.AbstractDocument
+import javax.swing.text.Element
+import javax.swing.text.View
+import javax.swing.text.html.HTML
+import javax.swing.text.html.ImageView
+
+/**
+ * An extension to be used with [HTMLEditorKitBuilder] that supports loading SVG images.
+ *
+ * This form in particular is supported
+ * ```html
+ * <img src="https://img.shields.io/badge/build-passing-brightgreen" alt="Build Passing" />
+ * ```
+ *
+ * Add this extension when building the editor kit :
+ *
+ * ```kotlin
+ * JEditorPane().apply {
+ *     contentType = "text/html"
+ *     editorKit = HTMLEditorKitBuilder()
+ *         .withViewFactoryExtensions(
+ *             SvgImageExtension(),
+ *             // other extensions
+ *         )
+ *         .withFontResolver(EditorCssFontResolver.getGlobalInstance())
+ *         .build()
+ *     text = ...
+ * }
+ * ```
+ *
+ * This is using the internal [SVGLoader] to load SVG images.
+ *
+ * @param svgImageProvider a function that provides a [CompletableFuture] of an [Image] given
+ *  the `src` attribute of an image, provided to customize caching (e.g., following `Cache-Control` directive),
+ *  or customize the rendering engine.
+ */
+class SvgImageExtension(private val svgImageProvider: ((svgSrcUrl: String) -> (() -> CompletableFuture<Image?>))? = null) :
+  ExtendableHTMLViewFactory.Extension {
+
+  /**
+   * Creates a [SvgImageExtension] with a preloaded SVGs cache.
+   * @param preloadedSvgs a map of preloaded SVGs images, to be used as a cache.
+   */
+  constructor(preloadedSvgs: Map<String, Image>) : this({ src ->
+                                                          { CompletableFuture.completedFuture(preloadedSvgs[src]) }
+                                                        })
+
+  override fun invoke(element: Element, defaultView: View): View? {
+    // example: <img src="https://img.shields.io/badge/build-passing-brightgreen" alt="Build Passing" />
+    if ("img" != element.name) return null
+
+    val src = (element.attributes.getAttribute(HTML.Attribute.SRC) as? String) ?: return null
+
+    // Using CompletableFuture to avoid blocking the UI thread while waiting on IO for the image
+    val completableFuture = svgImageProvider?.invoke(src)
+                            ?: defaultImageProvider(src)
+
+    return SvgImageView(element, completableFuture)
+  }
+
+  private fun defaultImageProvider(src: String): () -> CompletableFuture<Image?> = {
+    try {
+      // Find a proper pool?
+      CompletableFuture.supplyAsync {
+        try {
+          SVGLoader.load(URL(src), if (JBUI.isPixHiDPI(null as Component?)) 2f else 1f)
+        } catch (e: Exception) {
+          null
+        }
+      }
+    } catch (e: Exception) {
+      CompletableFuture.completedFuture(null)
+    }
+  }
+
+  private class SvgImageView(element: Element, deferredImage: () -> CompletableFuture<Image?>) :
+    ImageView(element) {
+
+    private val svgImageProvider = deferredImage().thenApply {
+      SwingUtilities.invokeLater {
+        safePreferenceChanged()
+        container?.revalidate()
+        container?.repaint(
+          imageBounds.x,
+          imageBounds.y,
+          it?.getWidth(container) ?: imageBounds.width,
+          it?.getHeight(container) ?: imageBounds.height,
+        )
+      }
+      it
+    }
+
+    private val svgImage: Image?
+      get() = if (svgImageProvider.isDone) {
+        svgImageProvider.get()
+      } else {
+        null
+      }
+
+    private val imageBounds = Rectangle()
+
+    override fun getMinimumSpan(axis: Int) = getPreferredSpan(axis)
+
+    override fun getMaximumSpan(axis: Int) = getPreferredSpan(axis)
+
+    override fun getPreferredSpan(axis: Int) = when (val img = svgImage) {
+      null -> super.getPreferredSpan(axis)
+      else -> {
+        when (axis) {
+          X_AXIS -> img.getWidth(container) / sysScale()
+          Y_AXIS -> img.getHeight(container) / sysScale()
+          else -> throw IllegalArgumentException("Invalid axis: $axis")
+        }
+      }
+    }
+
+    override fun paint(g: Graphics, a: Shape) {
+      val rect = a.bounds
+      imageBounds.bounds = rect
+
+      when (val img = svgImage) {
+        null -> super.paint(g, a)
+        else -> {
+          UIUtil.drawImage(
+            g,
+            ImageUtil.ensureHiDPI(img, ScaleContext.create(null as Component?)),
+            rect.x,
+            rect.y,
+            container
+          )
+        }
+      }
+    }
+
+    // This view controls the loading, using null avoids loading anything in parent ImageView
+    override fun getImageURL(): URL? = null
+
+    /**
+     * Invokes `preferenceChanged` on the event dispatching thread.
+     */
+    private fun safePreferenceChanged() {
+      if (SwingUtilities.isEventDispatchThread()) {
+        val doc = document as? AbstractDocument
+        doc?.readLock()
+        preferenceChanged(null, true, true)
+        doc?.readUnlock()
+      } else {
+        SwingUtilities.invokeLater { safePreferenceChanged() }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Offer a pluggable SVG image extension for the `JBHtamlPane` / `HTMLEditorKitBuilder`.

This has been discussed in [IJPL-155932](https://youtrack.jetbrains.com/issue/IJPL-155932/Support-SVG-in-JBHtmlPane-HTMLEditorKitBuilder)

```kotlin
JEditorPane().apply {
    contentType = "text/html"
    editorKit = HTMLEditorKitBuilder()
        .withViewFactoryExtensions(
            SvgImageExtension(),
            ExtendableHTMLViewFactory.Extensions.WORD_WRAP,
        )
        .withFontResolver(EditorCssFontResolver.getGlobalInstance())
        .build()

    UIUtil.doNotScrollToCaret(this)
    caretPosition = 0
    isEditable = false
    foreground = JBColor.foreground()
    isOpaque = false
}
```

Basically, this work is derived from my own work on the topic (the SVG rendering rely on [weisJ/jsvg](https://github.com/weisJ/jsvg)), to try display simple SVG badges from [shields.io](https://shields.io) : https://github.com/bric3/intellij-platform-swing-components/blob/6111771350594a22cf600f1dd0c362245b8fda03/components/src/main/kotlin/io/github/bric3/ij/ui/util/SvgImageExtension.kt

@piotrtomiak suggested to look at [TipUIUtil](https://github.com/JetBrains/intellij-community/blob/def6433a5dd9f0a984cbc6e2835d27c97f2cb5f0/platform/platform-impl/src/com/intellij/ide/util/TipUIUtil.java) as well to use the internal SVG renderer (which is kinda based on JSVG under the hood if I understood things correctly).

However, there are several concerns to be handled there :

* Caching the images, shields.io badges or github build badges URL return the `Cache-Control` HTTP header to indicate the expiration of a badge. This is a valid use case but maybe not for every users of this extension.

* IJ's internal SVG rendering while based on JSVG, maybe lagging behind (latest jsvg is 1.3.0, while latest is 1.5.0), also consumer of this extension may want to use customize the rendering, by tweaking it or changing it altogether.

* Slow IO is blocking the UI. For this reason the image loading has to be asynchronous. In order for this extension to be used by Java and Kotlin (the API is based on `CompletableFuture`)

For this reason the provided extension is getting inspirations from the existing `IconExtension` where a provider can be passed to create a rendered SVG `Image` from an URL.

Typically one can write :

```diff
    editorKit = HTMLEditorKitBuilder()
        .withViewFactoryExtensions(
            SvgImageExtension(
+               JsvgProviderWithCacheControlAwareCache()
            ),
            ExtendableHTMLViewFactory.Extensions.WORD_WRAP,
        )

```

Where `JsvgProviderWithCacheControlAwareCache` looks like that (assuming a dependency on JSVG)

```kotlin
/**
 * To be used in conjunction with [SvgImageExtension] that supports loading SVG images.
 *
 * The cache supports the `Cache-Control` header's `max-age`.
 * Also, the current scale is part of the cache key.
 */
class JsvgProviderWithCacheControlAwareCache : (String) -> () -> CompletableFuture<Image?> {
    private data class CacheKey(
        val src: String,
        val scale: Float
    )

    private data class CacheValue(
        val svgDocument: Image,
        val ttlInSeconds: Long
    )

    private val cache = Caffeine.newBuilder()
        .expireAfter(object : Expiry<CacheKey, CacheValue> {
            override fun expireAfterCreate(k: CacheKey?, v: CacheValue?, currentTime: Long): Long {
                return v?.ttlInSeconds?.let { TimeUnit.SECONDS.toNanos(it) } ?: TimeUnit.DAYS.toNanos(1)
            }

            override fun expireAfterUpdate(k: CacheKey?, v: CacheValue?, currentTime: Long, currentDuration: Long) =
                currentDuration

            override fun expireAfterRead(k: CacheKey?, v: CacheValue?, currentTime: Long, currentDuration: Long) =
                currentDuration
        })
        .maximumSize(30)
        .buildAsync<CacheKey, CacheValue?>()

    override fun invoke(src: String): () -> CompletableFuture<Image?> {
        // Loading is deferred to avoid blocking JEditorPane waiting on IO
        return {
            cache.get(CacheKey(src, JBUIScale.sysScale())) { key ->
                try {
                    URL(key.src).openConnection().run {
                        // Cache-Control: max-age=300, private
                        val cacheTtl = getHeaderField("cache-control")
                            ?.substringBefore(",")
                            ?.substringAfter("max-age=")
                            ?.toLongOrNull()

                        getInputStream().buffered().use { stream ->
                            SVGLoader().load(stream)?.let { svgDoc ->
                                val size = svgDoc.size()

                                val scaledWidth = ceil(size.width * JBUIScale.sysScale())
                                val scaledHeight = ceil(size.height * JBUIScale.sysScale())

                                val img = ImageUtil.createCompatibleTransparentImage(
                                    scaledWidth.toInt(),
                                    scaledHeight.toInt(),
                                ).apply {
                                    val graphics = createGraphics()
                                    graphics.setRenderingHint(
                                        RenderingHints.KEY_ANTIALIASING,
                                        RenderingHints.VALUE_ANTIALIAS_ON
                                    )
                                    graphics.setRenderingHint(
                                        SVGRenderingHints.KEY_SOFT_CLIPPING,
                                        SVGRenderingHints.VALUE_SOFT_CLIPPING_ON
                                    )
                                    svgDoc.render(
                                        null as Component?,
                                        graphics as Graphics2D,
                                        ViewBox(scaledWidth, scaledHeight)
                                    )
                                    graphics.dispose()
                                }

                                CacheValue(img, cacheTtl ?: TimeUnit.DAYS.toSeconds(1))
                            }
                        }
                    }
                } catch (e: Exception) {
                    null
                }
            }.thenApply { it?.svgDocument }
        }
    }
}
```
