### PR TITLE
Generalize tab pinning logic

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/tabs/TabInfo.kt
+++ b/platform/platform-api/src/com/intellij/ui/tabs/TabInfo.kt
@@ -6,7 +6,10 @@ import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.ui.Queryable
 import com.intellij.openapi.util.NlsContexts
-import com.intellij.ui.*
+import com.intellij.ui.LoadingNode
+import com.intellij.ui.PlaceProvider
+import com.intellij.ui.SimpleColoredText
+import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.SimpleTextAttributes.StyleAttributeConstant
 import com.intellij.ui.content.AlertIcon
 import com.intellij.ui.tabs.impl.JBTabsImpl
@@ -36,6 +39,7 @@ class TabInfo(var component: JComponent) : Queryable, PlaceProvider {
     const val ALERT_STATUS: String = "alertStatus"
     const val HIDDEN: String = "hidden"
     const val ENABLED: String = "enabled"
+    const val PINNED: String = "pinned"
 
     private val DEFAULT_ALERT_ICON = AlertIcon(AllIcons.Nodes.TabAlert, 0, -JBUI.scale(6))
   }
@@ -204,8 +208,13 @@ class TabInfo(var component: JComponent) : Queryable, PlaceProvider {
     return this
   }
 
-  val isPinned: Boolean
-    get() = ClientProperty.isTrue(component, JBTabsImpl.PINNED)
+  var isPinned: Boolean = false
+    set(pinned) {
+      val old = field
+      field = pinned
+      component.putClientProperty(JBTabsImpl.PINNED, if (field) true else null)
+      changeSupport.firePropertyChange(PINNED, old, field)
+    }
 
   val text: @NlsContexts.TabTitle String
     get() = coloredText.toString()

--- a/platform/platform-api/src/com/intellij/ui/tabs/impl/JBTabsImpl.kt
+++ b/platform/platform-api/src/com/intellij/ui/tabs/impl/JBTabsImpl.kt
@@ -104,6 +104,7 @@ open class JBTabsImpl internal constructor(
     QuickActionProvider, MorePopupAware, Accessible {
   companion object {
     @JvmField
+    @Deprecated("use TabInfo.isPinned instead")
     val PINNED: Key<Boolean> = Key.create("pinned")
 
     @JvmField
@@ -1631,6 +1632,10 @@ open class JBTabsImpl internal constructor(
       }
       TabInfo.ENABLED -> {
         updateEnabling()
+      }
+      TabInfo.PINNED -> {
+        resetTabsCache()
+        relayout(forced = true, layoutNow = false)
       }
     }
   }

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorComposite.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorComposite.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.fileEditor.*
 import com.intellij.openapi.fileEditor.ClientFileEditorManager.Companion.assignClientId
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.fileEditor.ex.FileEditorProviderManager
 import com.intellij.openapi.fileEditor.ex.FileEditorWithProvider
 import com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.Companion.DUMB_AWARE
@@ -413,12 +414,17 @@ open class EditorComposite internal constructor(
   }
 
   /**
-   * @return whether editor composite is pinned
+   * Whether the editor composite is pinned
    */
-  var isPinned: Boolean = false
+  @Deprecated("use EditorWindow.isFilePinned and EditorWindow.setFilePinned instead")
+  var isPinned: Boolean
+    get() = ClientProperty.isTrue(compositePanel, JBTabsImpl.PINNED)
     set(pinned) {
-      field = pinned
-      ClientProperty.put(compositePanel, JBTabsImpl.PINNED, if (field) true else null)
+      for (window in FileEditorManagerEx.getInstanceEx(project).windows) {
+        if (this in window.composites()) {
+          window.setFilePinned(file, pinned)
+        }
+      }
     }
 
   private val _isPreviewFlow = MutableStateFlow(false)

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
@@ -1050,6 +1050,7 @@ private class UiBuilder(private val splitters: EditorsSplitters, private val isL
             customizer = { tab ->
               tab.setText(initialTabTitle)
               tab.setIcon(initialTabIcon)
+              tab.isPinned = fileEntry.pinned
 
               initialTabTextAttributes?.let {
                 tab.setDefaultForegroundAndAttributes(foregroundColor = it.first, attributes = it.second)

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
@@ -2096,18 +2096,14 @@ open class FileEditorManagerImpl(
         composite.initDeferred.complete(Unit)
       }
 
-      if (fileEntry.pinned) {
-        composite.isPinned = true
-      }
-      else {
-        if (when {
-            !uiSettings.openInPreviewTabIfPossible -> false
-            fileEntry.isPreview -> true
-            !fileEntry.currentInTab -> false
-            else -> false
-          }) {
-          composite.isPreview = true
-        }
+      if (when {
+          fileEntry.pinned -> false
+          !uiSettings.openInPreviewTabIfPossible -> false
+          fileEntry.isPreview -> true
+          !fileEntry.currentInTab -> false
+          else -> false
+        }) {
+        composite.isPreview = true
       }
 
       tabs.add(createTabInfo(

--- a/platform/platform-impl/src/com/intellij/platform/fileEditor/FileEntry.kt
+++ b/platform/platform-impl/src/com/intellij/platform/fileEditor/FileEntry.kt
@@ -86,7 +86,7 @@ internal fun writeWindow(result: Element, window: EditorWindow, delayedStates: M
       fileElement.addContent(composite.writeDelayedStateAsHistoryEntry(delayedState))
     }
 
-    if (composite.isPinned) {
+    if (tab.isPinned) {
       fileElement.setAttribute(PINNED, "true")
     }
     if (composite === selectedComposite) {


### PR DESCRIPTION
This commit moves some of the logic for pinning tabs from `com.intellij.openapi.fileEditor` to `com.intellij.ui.tabs` and generalizes it.

Pinning tabs is a fundamental functionality that should be implemented in a more generalized manner, allowing other parts of the codebase or plugins utilizing tabs (via JBTabs) to leverage and expand upon this feature. Since the logic for sorting and grouping pinned tabs already resides within JBTabsImpl, maintaining parts of the core pinning logic across multiple packages seems somewhat illogical and inconsistent.

This change would also facilitate the implementation of additional tab-related features. For instance, adding new navigation actions to JBTabsImpl that allow tabs to be moved via keyboard shortcuts could require setting whether a tab is pinned in certain circumstances (such as moving an unpinned tab behind a pinned tab when grouping is enabled).

Additionally, this change resolves a bug where the previous position of pinned tabs was ignored when restoring closed tabs. I did not create a report on YouTrack, as this is a minor issue and the fix is simply a nice side effect of this change.