### PR TITLE
[git-stash] navigate to the first stash under the root from the context when "Unstash Changes..." action is called

### DIFF
--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/savedPatches/SavedPatchesUi.kt
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/savedPatches/SavedPatchesUi.kt
@@ -186,8 +186,12 @@ open class SavedPatchesUi(project: Project,
     return providers.find { it.dataClass.isInstance(selectedPatch.data) } ?: return providers.first()
   }
 
-  fun expandPatchesByProvider(provider: SavedPatchesProvider<*>) {
-    patchesTree.expandPatchesByProvider(provider)
+  fun showFirstUnderProvider(provider: SavedPatchesProvider<*>) {
+    patchesTree.invokeAfterRefresh { patchesTree.showFirstUnderProvider(provider) }
+  }
+
+  fun showFirstUnderObject(provider: SavedPatchesProvider<*>, userObject: Any) {
+    patchesTree.invokeAfterRefresh { patchesTree.showFirstUnderObject(provider, userObject) }
   }
 
   @ApiStatus.Internal

--- a/plugins/git4idea/src/git4idea/actions/GitUnstash.java
+++ b/plugins/git4idea/src/git4idea/actions/GitUnstash.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.changes.ChangeListManager;
 import com.intellij.openapi.vcs.changes.ui.ChangesViewContentManager;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.vcs.VcsShowToolWindowTabAction;
 import git4idea.i18n.GitBundle;
 import git4idea.stash.ui.GitStashContentProvider;
 import git4idea.ui.GitUnstashDialog;
@@ -14,8 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-import static git4idea.stash.ui.GitStashContentProviderKt.isStashTabAvailable;
-import static git4idea.stash.ui.GitStashContentProviderKt.isStashTabVisible;
+import static git4idea.stash.ui.GitStashContentProviderKt.*;
 
 /**
  * Git unstash action
@@ -30,17 +28,6 @@ public class GitUnstash extends GitRepositoryAction {
     return GitBundle.message("unstash.action.name");
   }
 
-  @Override
-  public void actionPerformed(@NotNull AnActionEvent e) {
-    Project project = e.getProject();
-    if (project != null && isStashTabAvailable() && ChangesViewContentManager.getToolWindowFor(project, GitStashContentProvider.TAB_NAME) != null) {
-      VcsShowToolWindowTabAction.activateVcsTab(project, GitStashContentProvider.TAB_NAME, false);
-      return;
-    }
-
-    super.actionPerformed(e);
-  }
-
   /**
    * {@inheritDoc}
    */
@@ -48,7 +35,11 @@ public class GitUnstash extends GitRepositoryAction {
   protected void perform(final @NotNull Project project,
                          final @NotNull List<VirtualFile> gitRoots,
                          final @NotNull VirtualFile defaultRoot) {
-    final ChangeListManager changeListManager = ChangeListManager.getInstance(project);
+    if (isStashTabAvailable() && ChangesViewContentManager.getToolWindowFor(project, GitStashContentProvider.TAB_NAME) != null) {
+      showStashes(project, defaultRoot);
+      return;
+    }
+    ChangeListManager changeListManager = ChangeListManager.getInstance(project);
     if (changeListManager.isFreezedWithNotification(GitBundle.message("unstash.error.can.not.unstash.changes.now"))) return;
     GitUnstashDialog.showUnstashDialog(project, gitRoots, defaultRoot);
   }

--- a/plugins/git4idea/src/git4idea/stash/GitStashChangesSaver.java
+++ b/plugins/git4idea/src/git4idea/stash/GitStashChangesSaver.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.vcs.VcsNotifier;
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
 import com.intellij.openapi.vcs.merge.MergeDialogCustomizer;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.containers.ContainerUtil;
 import com.intellij.vcs.log.Hash;
 import git4idea.GitActivity;
 import git4idea.GitStashUsageCollector;
@@ -124,10 +125,11 @@ public class GitStashChangesSaver extends GitChangesSaver {
 
   @Override
   public void showSavedChanges() {
+    VirtualFile firstRoot = ContainerUtil.getFirstItem(myStashedRoots.keySet());
     if (isStashTabAvailable()) {
-      showStashes(myProject);
+      showStashes(myProject, firstRoot);
     } else {
-      GitUnstashDialog.showUnstashDialog(myProject, new ArrayList<>(myStashedRoots.keySet()), myStashedRoots.keySet().iterator().next());
+      GitUnstashDialog.showUnstashDialog(myProject, new ArrayList<>(myStashedRoots.keySet()), firstRoot);
     }
   }
 
@@ -171,11 +173,12 @@ public class GitStashChangesSaver extends GitChangesSaver {
         .setDisplayId(UNSTASH_WITH_CONFLICTS)
         .addAction(NotificationAction.createSimple(
           GitBundle.messagePointer("stash.unstash.unresolved.conflict.warning.notification.show.stash.action"), () -> {
+            VirtualFile firstRoot = ContainerUtil.getFirstItem(myStashedRoots);
             if (isStashTabAvailable()) {
-              showStashes(myProject);
+              showStashes(myProject, firstRoot);
             } else {
               // we don't use #showSavedChanges to specify unmerged root first
-              GitUnstashDialog.showUnstashDialog(myProject, new ArrayList<>(myStashedRoots), myStashedRoots.iterator().next());
+              GitUnstashDialog.showUnstashDialog(myProject, new ArrayList<>(myStashedRoots), firstRoot);
             }
           }))
         .addAction(NotificationAction.createSimple(

--- a/plugins/git4idea/src/git4idea/stash/GitStashUtils.kt
+++ b/plugins/git4idea/src/git4idea/stash/GitStashUtils.kt
@@ -292,12 +292,12 @@ object GitStashOperations {
   fun showSuccessNotification(project: Project, successfulRoots: Collection<VirtualFile>, hasErrors: Boolean) {
     val actions = buildList {
       if (isStashTabAvailable()) {
-        add(NotificationAction.createSimple(GitBundle.message("stash.view.stashes.link")) { showStashes(project) })
+        add(NotificationAction.createSimple(GitBundle.message("stash.view.stashes.link")) { showStashes(project, successfulRoots.firstOrNull()) })
       }
       else if (isStagingAreaAvailable(project)) {
         add(NotificationAction.createSimpleExpiring(GitBundle.message("stash.enable.stashes.link")) {
           stashToolWindowRegistryOption().setValue(true)
-          showStashes(project)
+          showStashes(project, successfulRoots.firstOrNull())
         })
       }
     }


### PR DESCRIPTION
This PR addresses the problem described in [IJPL-156748](https://youtrack.jetbrains.com/issue/IJPL-156748/Unstash-Changes-does-not-navigate-to-the-corresponding-root) by selecting the first stash in the target repository root in the stashes tree.