### PR TITLE
[kotlin][rfc] J2K: Add postprocessing extension point

### DIFF
--- a/plugins/kotlin/base/test/test/org/jetbrains/kotlin/idea/base/test/IgnoreTests.kt
+++ b/plugins/kotlin/base/test/test/org/jetbrains/kotlin/idea/base/test/IgnoreTests.kt
@@ -115,9 +115,11 @@ object IgnoreTests {
         additionalFiles: List<Path>,
         test: (isTestEnabled: Boolean) -> Unit
     ) {
-        check(!
-              (directive is EnableOrDisableTestDirective.Enable && (
-                     directive.directiveText == DIRECTIVES.FIR_IDENTICAL || directive.directiveText == DIRECTIVES.FIR_COMPARISON))) {
+        check(
+            !
+            (directive is EnableOrDisableTestDirective.Enable && (
+                    directive.directiveText == DIRECTIVES.FIR_IDENTICAL || directive.directiveText == DIRECTIVES.FIR_COMPARISON))
+        ) {
             "It's not allowed to run runTestIfEnabledByDirective with FIR_IDENTICAL or FIR_COMPARISON"
         }
         if (ALWAYS_CONSIDER_TEST_AS_PASSING) {
@@ -165,6 +167,7 @@ object IgnoreTests {
                 is EnableOrDisableTestDirective.Disable -> {
                     testFile.removeDirectivesFromFileAndAdditionalFiles(directive, additionalFiles)
                 }
+
                 is EnableOrDisableTestDirective.Enable -> {
                     testFile.insertDirectivesToFileAndAdditionalFile(directive, additionalFiles, directivePosition)
                 }
@@ -267,6 +270,7 @@ object IgnoreTests {
     object DIRECTIVES {
         @Deprecated(message = "use IGNORE_K2 instead")
         const val FIR_COMPARISON: String = "// FIR_COMPARISON"
+
         @Deprecated(message = "use IGNORE_K2 instead")
         const val FIR_COMPARISON_MULTILINE_COMMENT: String = "/* FIR_COMPARISON */"
 
@@ -275,6 +279,7 @@ object IgnoreTests {
 
         @Deprecated(message = "use IGNORE_K2 instead")
         const val IGNORE_FIR: String = "// IGNORE_FIR"
+
         @Deprecated(message = "use IGNORE_K2_MULTILINE_COMMENT instead")
         const val IGNORE_FIR_MULTILINE_COMMENT: String = "/* IGNORE_FIR */"
 
@@ -285,6 +290,8 @@ object IgnoreTests {
         const val IGNORE_FE10_BINDING_BY_FIR: String = "// IGNORE_FE10_BINDING_BY_FIR"
 
         const val IGNORE_K1: String = "// IGNORE_K1"
+
+        const val J2K_POSTPROCESSOR_EXTENSIONS: String = "// J2K_POSTPROCESSOR_EXTENSIONS"
 
         fun of(mode: KotlinPluginMode): String = if (mode == KotlinPluginMode.K2) IGNORE_K2 else IGNORE_K1
     }

--- a/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/JavaToKotlinAction.kt
+++ b/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/actions/JavaToKotlinAction.kt
@@ -46,11 +46,8 @@ import org.jetbrains.kotlin.idea.statistics.ConversionType
 import org.jetbrains.kotlin.idea.statistics.J2KFusCollector
 import org.jetbrains.kotlin.idea.util.application.executeCommand
 import org.jetbrains.kotlin.idea.util.getAllFilesRecursively
-import org.jetbrains.kotlin.j2k.ConverterSettings
+import org.jetbrains.kotlin.j2k.*
 import org.jetbrains.kotlin.j2k.ConverterSettings.Companion.defaultSettings
-import org.jetbrains.kotlin.j2k.ExternalCodeProcessing
-import org.jetbrains.kotlin.j2k.FilesResult
-import org.jetbrains.kotlin.j2k.J2kConverterExtension
 import org.jetbrains.kotlin.j2k.J2kConverterExtension.Kind.*
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
@@ -82,7 +79,12 @@ class JavaToKotlinAction : AnAction() {
                 val progressIndicator = ProgressManager.getInstance().progressIndicator!!
 
                 val conversionTime = measureTimeMillis {
-                    converterResult = converter.filesToKotlin(javaFiles, postProcessor, progressIndicator)
+                    converterResult = converter.filesToKotlin(
+                        javaFiles,
+                        postProcessor,
+                        progressIndicator,
+                        postprocessorExtensions = J2kPostprocessorExtension.EP_NAME.extensionList
+                    )
                 }
                 val linesCount = runReadAction {
                     javaFiles.sumOf { StringUtil.getLineBreakCount(it.text) }

--- a/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -5880,6 +5880,25 @@ public abstract class NewJavaToKotlinConverterSingleFileTestGenerated extends Ab
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("../../shared/tests/testData/newJ2k/postprocessorExtensions")
+    public static class PostprocessorExtensions extends AbstractNewJavaToKotlinConverterSingleFileTest {
+        @java.lang.Override
+        @org.jetbrains.annotations.NotNull
+        public final KotlinPluginMode getPluginMode() {
+            return KotlinPluginMode.K1;
+        }
+
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        @TestMetadata("classWithParamsAndProperties.java")
+        public void testClassWithParamsAndProperties() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/postprocessorExtensions/classWithParamsAndProperties.java");
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("../../shared/tests/testData/newJ2k/prefixOperator")
     public static class PrefixOperator extends AbstractNewJavaToKotlinConverterSingleFileTest {
         @java.lang.Override

--- a/plugins/kotlin/j2k/k1.old/src/org/jetbrains/kotlin/j2k/OldJavaToKotlinConverter.kt
+++ b/plugins/kotlin/j2k/k1.old/src/org/jetbrains/kotlin/j2k/OldJavaToKotlinConverter.kt
@@ -35,7 +35,8 @@ class OldJavaToKotlinConverter(
     override fun filesToKotlin(
         files: List<PsiJavaFile>,
         postProcessor: PostProcessor,
-        progressIndicator: ProgressIndicator
+        progressIndicator: ProgressIndicator,
+        postprocessorExtensions: List<J2kPostprocessorExtension>
     ): FilesResult {
         val withProgressProcessor = OldWithProgressProcessor(progressIndicator, files)
         val (results, externalCodeProcessing) = ApplicationManager.getApplication().runReadAction(Computable {

--- a/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
@@ -5880,6 +5880,25 @@ public abstract class K2JavaToKotlinConverterSingleFileTestGenerated extends Abs
     }
 
     @RunWith(JUnit3RunnerWithInners.class)
+    @TestMetadata("../../shared/tests/testData/newJ2k/postprocessorExtensions")
+    public static class PostprocessorExtensions extends AbstractK2JavaToKotlinConverterSingleFileTest {
+        @java.lang.Override
+        @org.jetbrains.annotations.NotNull
+        public final KotlinPluginMode getPluginMode() {
+            return KotlinPluginMode.K2;
+        }
+
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+        }
+
+        @TestMetadata("classWithParamsAndProperties.java")
+        public void testClassWithParamsAndProperties() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/postprocessorExtensions/classWithParamsAndProperties.java");
+        }
+    }
+
+    @RunWith(JUnit3RunnerWithInners.class)
     @TestMetadata("../../shared/tests/testData/newJ2k/prefixOperator")
     public static class PrefixOperator extends AbstractK2JavaToKotlinConverterSingleFileTest {
         @java.lang.Override

--- a/plugins/kotlin/j2k/shared/kotlin.j2k.shared.iml
+++ b/plugins/kotlin/j2k/shared/kotlin.j2k.shared.iml
@@ -40,5 +40,8 @@
     <orderEntry type="module" module-name="kotlin.base.psi" />
     <orderEntry type="module" module-name="kotlin.base.util" />
     <orderEntry type="module" module-name="kotlin.fir.frontend-independent" />
+    <orderEntry type="module" module-name="kotlin.code-insight.utils" />
+    <orderEntry type="module" module-name="intellij.platform.core" />
+    <orderEntry type="module" module-name="intellij.platform.util" />
   </component>
 </module>

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/j2k/J2kPostprocessorExtension.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/j2k/J2kPostprocessorExtension.kt
@@ -1,0 +1,43 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.j2k
+
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.psi.KtFile
+import com.intellij.openapi.application.writeAction
+
+/**
+ * The `org.jetbrains.kotlin.j2kPostprocessorExtension` extension point enables running custom postprocessing steps on Java files before they
+ * are converted to Kotlin. At runtime, all registered extensions are collected and executed sequentially. To implement your own
+ * postprocessor in a separate plugin, simply extend this interface and register the extension point in your plugin's xml file, e.g.
+ * ```
+ * <extensions defaultExtensionNs="org.jetbrains.kotlin">
+ *   <j2kPostprocessorExtension implementation="org.jetbrains.kotlin.j2k.FooPostprocessorExtension"/>
+ * </extensions>
+ * ```
+ *
+ * All postprocessors are run on a background thread using coroutines, write actions must be wrapped in `j2kWriteAction { ... }` so that
+ * they are executed on the EDT thread with the write lock. Read actions must be wrapped in `runReadAction { ... }`, and analysis must be
+ * done outside write actions.
+ */
+interface J2kPostprocessorExtension {
+    /**
+     * Override this method to analyze and edit Java files before conversion. This method is always executed on a background thread, so
+     * write actions must be wrapped in `j2kWriteAction { ... }`. Read actions must be wrapped in `readAction { ... }`, and analysis must
+     * be done outside write actions.
+     */
+    suspend fun processFiles(project: Project, files: List<KtFile>)
+
+    companion object {
+        val EP_NAME = ExtensionPointName<J2kPostprocessorExtension>("org.jetbrains.kotlin.j2kPostprocessorExtension")
+
+        suspend fun <T> j2kWriteAction(action: () -> T) {
+            writeAction {
+                CommandProcessor.getInstance().runUndoTransparentAction {
+                    action()
+                }
+            }
+        }
+    }
+}

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverter.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/j2k/JavaToKotlinConverter.kt
@@ -13,7 +13,8 @@ abstract class JavaToKotlinConverter {
     abstract fun filesToKotlin(
         files: List<PsiJavaFile>,
         postProcessor: PostProcessor,
-        progressIndicator: ProgressIndicator = EmptyProgressIndicator()
+        progressIndicator: ProgressIndicator = EmptyProgressIndicator(),
+        postprocessorExtensions: List<J2kPostprocessorExtension> = emptyList()
     ): FilesResult
 
     abstract fun elementsToKotlin(inputElements: List<PsiElement>): Result

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/PostprocessorExtensionsRunner.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/PostprocessorExtensionsRunner.kt
@@ -1,0 +1,45 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.nj2k
+
+import com.intellij.openapi.progress.*
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.idea.codeinsight.utils.commitAndUnblockDocument
+import org.jetbrains.kotlin.j2k.J2kPostprocessorExtension
+import org.jetbrains.kotlin.psi.KtFile
+
+/**
+ * Before conversion, runs all registered custom postprocessor extensions (i.e. classes implementing `J2kPostprocessorExtension` and
+ * registered in their parent plugin's xml file).
+ */
+object PostprocessorExtensionsRunner {
+    private const val PHASE_NAME = "Custom Postprocessing"
+
+    fun runRegisteredPostprocessors(project: Project, ktFiles: List<KtFile>, postprocessorExtensions: List<J2kPostprocessorExtension>) {
+        if (postprocessorExtensions.isEmpty()) return
+        val postprocessorsCount = postprocessorExtensions.size
+        ProgressManager.progress(PHASE_NAME, "Found $postprocessorsCount postprocessors to run on Java files before conversion")
+        for ((i, postprocessor) in postprocessorExtensions.withIndex()) {
+            ProgressManager.checkCanceled()
+            ProgressManager.progress(PHASE_NAME, "Running postprocessor ${i + 1}/$postprocessorsCount")
+            try {
+                runBlockingCancellable {
+                    postprocessor.processFiles(project, ktFiles)
+                }
+                commitAllDocuments(ktFiles)
+            } catch (e: ProcessCanceledException) {
+                throw e
+            } catch (t: Throwable) {
+                commitAllDocuments(ktFiles)
+                throw t
+            }
+        }
+    }
+
+    private fun commitAllDocuments(ktFiles: List<KtFile>) {
+        ktFiles.forEach {
+            runUndoTransparentActionInEdt(inWriteAction = true) {
+                it.commitAndUnblockDocument()
+            }
+        }
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/test/org/jetbrains/kotlin/j2k/AbstractJavaToKotlinConverterPartialTest.kt
+++ b/plugins/kotlin/j2k/shared/tests/test/org/jetbrains/kotlin/j2k/AbstractJavaToKotlinConverterPartialTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.j2k.J2kConverterExtension.Kind.K2
 import org.jetbrains.kotlin.nj2k.NewJavaToKotlinConverter
 
 abstract class AbstractJavaToKotlinConverterPartialTest : AbstractJavaToKotlinConverterSingleFileTest() {
-    override fun fileToKotlin(text: String, settings: ConverterSettings): String {
+    override fun fileToKotlin(text: String, settings: ConverterSettings, postprocessorExtensions: List<J2kPostprocessorExtension>): String {
         val file = createJavaFile(text)
         val element = myFixture.elementAtCaret
 
@@ -19,7 +19,8 @@ abstract class AbstractJavaToKotlinConverterPartialTest : AbstractJavaToKotlinCo
         return NewJavaToKotlinConverter(project, module, settings).filesToKotlin(
             listOf(file),
             postProcessor,
-            EmptyProgressIndicator()
-        ) { it == element }.results.single()
+            EmptyProgressIndicator(),
+        { it == element }, emptyList()
+        ).results.single()
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postprocessorExtensions/classWithParamsAndProperties.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/postprocessorExtensions/classWithParamsAndProperties.java
@@ -1,0 +1,28 @@
+// J2K_POSTPROCESSOR_EXTENSIONS
+public class Main {
+
+    private String mName;
+    private int mCount;
+
+    public Main(String name) {
+        this.mName = name;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        this.mName = name;
+    }
+
+    public void increment() {
+        mCount++;
+    }
+    public static void main(String[] a) {
+        System.out.println("Hello world!");
+    }
+    public static void doThing(int i) {
+        throw new RuntimeException("oops");
+    }
+}

--- a/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
+++ b/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
@@ -83,6 +83,10 @@
     <extensionPoint qualifiedName="org.jetbrains.kotlin.libraryVersionProvider"
                     interface="org.jetbrains.kotlin.idea.configuration.KotlinLibraryVersionProvider"
                     dynamic="true"/>
+    <extensionPoint
+            qualifiedName="org.jetbrains.kotlin.j2kPostprocessorExtension"
+            interface="org.jetbrains.kotlin.j2k.J2kPostprocessorExtension"
+            dynamic="true"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Based on testing this extension point with two dummy postprocessors (see [draft PR](https://github.com/ermattt/intellij-community/pull/53), this works as expected:
- it runs the custom postprocessors on a background thread, and successfully applies their changes after conversion
- changes due to conversion and changes due to postprocessing are rolled back with a single undo action (i.e. Ctl + z).

NB: The custom postprocessors run after the "built-in" postprocessors (i.e. `NewJ2kPostProcessor`/`K2J2KPostprocessor`) but before external code processing.

You can see the example preprocessors in action (plus the undo behavior) in the attached video zip.
[Screen Recording 2024-07-04 at 10.21.00 PM.zip](https://github.com/user-attachments/files/16104221/Screen.Recording.2024-07-04.at.10.21.00.PM.zip)


This is the counterpart to the [PR for adding preprocessors](https://github.com/JetBrains/intellij-community/pull/2784)

[KTIJ-29835](https://youtrack.jetbrains.com/issue/KTIJ-29835/J2K-Add-extension-point-for-custom-conversions-processings)

@abelkov @darthorimar @jocelynluizzi13