### PR TITLE
[platform] IJPL-11679 Fix run widget doesn't use last run config if its stored externally in .run folder

### DIFF
--- a/platform/execution-impl/src/com/intellij/execution/impl/RunManagerImpl.kt
+++ b/platform/execution-impl/src/com/intellij/execution/impl/RunManagerImpl.kt
@@ -943,9 +943,16 @@ open class RunManagerImpl @NonInjectable constructor(val project: Project, share
     }
 
     if (selectedConfiguration == null) {
+      // NOTE: we use a local variable, because `notYetAppliedInitialSelectedConfigurationId` is a mutable property that can change
+      //       between the assignment and the conditional
+      val configurationToApply = selectedConfigurationId ?: ""
+
+      notYetAppliedInitialSelectedConfigurationId = configurationToApply
+
       // Empty string means that there's no information about initially selected RC in workspace.xml => IDE should select any.
-      notYetAppliedInitialSelectedConfigurationId = selectedConfigurationId ?: ""
-      selectAnyConfiguration()
+      if (configurationToApply.isEmpty()) {
+        selectAnyConfiguration()
+      }
     }
   }
 


### PR DESCRIPTION
Fixes issue described here: [[IJPL-11679] Run widget doesn't use last run config if it's stored externally in .run folder](https://youtrack.jetbrains.com/issue/IJPL-11679/Run-widget-doesnt-use-last-run-config-if-its-stored-externally-in-.run-folder)