### PR TITLE
[settings-sync] IJPL-13931 Ensure settings categories are respected in the initial sync

### DIFF
--- a/plugins/settings-sync/src/com/intellij/settingsSync/CloudConfigServerCommunicator.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/CloudConfigServerCommunicator.kt
@@ -61,18 +61,18 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
 
   @VisibleForTesting
   @Throws(IOException::class, UnauthorizedException::class)
-  protected fun currentSnapshotFilePath(): String? {
+  protected fun currentSnapshotFilePath(): Pair<String, Boolean>? {
     try {
       val crossIdeSyncEnabled = isFileExists(CROSS_IDE_SYNC_MARKER_FILE)
       if (crossIdeSyncEnabled != SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled) {
         LOG.info("Cross-IDE sync status on server is: ${enabledOrDisabled(crossIdeSyncEnabled)}. Updating local settings with it.")
         SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled = crossIdeSyncEnabled
       }
-      return if (crossIdeSyncEnabled) {
-        SETTINGS_SYNC_SNAPSHOT_ZIP
+      if (crossIdeSyncEnabled) {
+        return Pair(SETTINGS_SYNC_SNAPSHOT_ZIP, true)
       }
       else {
-        "${ApplicationNamesInfo.getInstance().productName.lowercase()}/$SETTINGS_SYNC_SNAPSHOT_ZIP"
+        return Pair("${ApplicationNamesInfo.getInstance().productName.lowercase()}/$SETTINGS_SYNC_SNAPSHOT_ZIP", false)
       }
     }
     catch (e: Throwable) {
@@ -120,7 +120,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
     val snapshotFilePath: String
     val defaultMessage = "Unknown during checking $CROSS_IDE_SYNC_MARKER_FILE"
     try {
-      snapshotFilePath = currentSnapshotFilePath() ?: return SettingsSyncPushResult.Error(defaultMessage)
+      snapshotFilePath = currentSnapshotFilePath()?.first ?: return SettingsSyncPushResult.Error(defaultMessage)
     }
     catch (ioe: IOException) {
       return SettingsSyncPushResult.Error(ioe.message ?: defaultMessage)
@@ -165,7 +165,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
   override fun checkServerState(): ServerState {
     val idTokenInRequest = getCurrentIdToken()
     try {
-      val snapshotFilePath = currentSnapshotFilePath() ?: return ServerState.Error("Unknown error during checkServerState")
+      val snapshotFilePath = currentSnapshotFilePath()?.first ?: return ServerState.Error("Unknown error during checkServerState")
       val latestVersion = client.getLatestVersion(snapshotFilePath)
       LOG.debug("Latest version info: $latestVersion")
       clearLastRemoteError()
@@ -185,7 +185,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
     LOG.info("Receiving settings snapshot from the cloud config server...")
     val idTokenInRequest = getCurrentIdToken()
     try {
-      val snapshotFilePath = currentSnapshotFilePath() ?: return UpdateResult.Error("Unknown error during receiveUpdates")
+      val (snapshotFilePath, isCrossIdeSync) = currentSnapshotFilePath() ?: return UpdateResult.Error("Unknown error during receiveUpdates")
       val (stream, version) = receiveSnapshotFile(snapshotFilePath)
       clearLastRemoteError()
       if (stream == null) {
@@ -202,7 +202,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
           return UpdateResult.NoFileOnServer
         }
         else {
-          return if (snapshot.isDeleted()) UpdateResult.FileDeletedFromServer else UpdateResult.Success(snapshot, version)
+          return if (snapshot.isDeleted()) UpdateResult.FileDeletedFromServer else UpdateResult.Success(snapshot, version, isCrossIdeSync)
         }
       }
       finally {

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncBridge.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncBridge.kt
@@ -77,6 +77,11 @@ class SettingsSyncBridge(
   internal fun initialize(initMode: InitMode) {
     coroutineScope.launch {
       try {
+        // Always explicitly flush settings – if this is not done before sending sync events, then remotely synced settings might not contain
+        // most up–to–date settings state (e.g. stale disabled categories).
+        runBlockingCancellable {
+          saveSettings(ApplicationManager.getApplication(), forceSavingAllSettings = true)
+        }
         settingsLog.initialize()
 
         // the queue is not activated initially => events will be collected but not processed until we perform all initialization tasks
@@ -120,6 +125,23 @@ class SettingsSyncBridge(
 
     settingsLog.logExistingSettings()
     try {
+      // We need to create this remote file before the first sync, otherwise the settings value (even if persisted) will be overwritten by
+      // the sync-server-side value when `com.intellij.settingsSync.CloudConfigServerCommunicator#currentSnapshotFilePath` applies
+      // the remote config received in the first sync.
+      //
+      // NOTE: it appears that `createFile` and `deleteFile` are not idempotent – calling them without first checking for the current
+      //       state of the file can cause "Sync failed. VersionId differs from the last available on server" issues.
+      if (SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled) {
+        if (!remoteCommunicator.isFileExists(CROSS_IDE_SYNC_MARKER_FILE)) {
+          remoteCommunicator.createFile(CROSS_IDE_SYNC_MARKER_FILE, "")
+        }
+      }
+      else {
+        if (remoteCommunicator.isFileExists(CROSS_IDE_SYNC_MARKER_FILE)) {
+          remoteCommunicator.deleteFile(CROSS_IDE_SYNC_MARKER_FILE)
+        }
+      }
+
       when (initMode) {
         is InitMode.TakeFromServer -> applySnapshotFromServer(initMode.cloudEvent)
         InitMode.PushToServer -> mergeAndPush(previousState.idePosition, previousState.cloudPosition, FORCE_PUSH)

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncRemoteCommunicator.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncRemoteCommunicator.kt
@@ -39,7 +39,7 @@ sealed class ServerState {
 }
 
 sealed class UpdateResult {
-  class Success(val settingsSnapshot: SettingsSnapshot, val serverVersionId: String?) : UpdateResult()
+  class Success(val settingsSnapshot: SettingsSnapshot, val serverVersionId: String?, val isCrossIdeSyncEnabled: Boolean) : UpdateResult()
   object NoFileOnServer: UpdateResult()
   object FileDeletedFromServer: UpdateResult()
   class Error(@NlsSafe val message: String): UpdateResult()

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/EnableSettingsSyncDialog.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/EnableSettingsSyncDialog.kt
@@ -1,8 +1,8 @@
 package com.intellij.settingsSync.config
 
-import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.settingsSync.SettingsSyncBundle.message
+import com.intellij.settingsSync.SettingsSyncLocalStateHolder
 import com.intellij.settingsSync.SettingsSyncState
 import com.intellij.settingsSync.SettingsSyncStateHolder
 import java.awt.event.ActionEvent
@@ -10,11 +10,15 @@ import javax.swing.AbstractAction
 import javax.swing.Action
 import javax.swing.JComponent
 
-internal class EnableSettingsSyncDialog(parent: JComponent, remoteSettings: SettingsSyncState?) : DialogWrapper(parent, false) {
+internal class EnableSettingsSyncDialog(
+  parent: JComponent,
+  remoteSettings: SettingsSyncState?,
+  remoteSyncScopeSettings: SettingsSyncLocalStateHolder?,
+) : DialogWrapper(parent, false) {
 
-  private lateinit var configPanel: DialogPanel
   private var dialogResult: Result? = null
   val syncSettings: SettingsSyncState = remoteSettings ?: SettingsSyncStateHolder()
+  val syncScopeSettings = remoteSyncScopeSettings ?: SettingsSyncLocalStateHolder() // SettingsSyncLocalSettings.getInstance()
   private val remoteSettingsExist: Boolean = remoteSettings != null
 
   init {
@@ -28,9 +32,11 @@ internal class EnableSettingsSyncDialog(parent: JComponent, remoteSettings: Sett
   }
 
   override fun createCenterPanel(): JComponent {
-    configPanel = SettingsSyncPanelFactory.createPanel(message("enable.dialog.select.what.to.sync"), syncSettings)
-    configPanel.reset()
-    return configPanel
+    return  SettingsSyncPanelFactory.createCombinedSyncSettingsPanel(
+      message("enable.dialog.select.what.to.sync"),
+      syncSettings,
+      syncScopeSettings,
+    ).also { it.reset() }
   }
 
   override fun createActions(): Array<Action> =
@@ -60,7 +66,7 @@ internal class EnableSettingsSyncDialog(parent: JComponent, remoteSettings: Sett
   }
 
   private fun applyAndClose(result: Result) {
-    configPanel.apply()
+    applyFields()
     dialogResult = result
     close(0, true)
   }

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncConfigurable.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncConfigurable.kt
@@ -25,7 +25,10 @@ import com.intellij.settingsSync.UpdateResult.*
 import com.intellij.settingsSync.auth.SettingsSyncAuthService
 import com.intellij.settingsSync.statistics.SettingsSyncEventsStatistics
 import com.intellij.ui.components.ActionLink
-import com.intellij.ui.dsl.builder.*
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.RightGap
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.and
 import com.intellij.ui.layout.not
@@ -129,7 +132,11 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
   }
 
   override fun createPanel(): DialogPanel {
-    val categoriesPanel = SettingsSyncPanelFactory.createPanel(message("configurable.what.to.sync.label"), SettingsSyncSettings.getInstance())
+    val syncConfigPanel = SettingsSyncPanelFactory.createCombinedSyncSettingsPanel(
+      message("configurable.what.to.sync.label"),
+      SettingsSyncSettings.getInstance(),
+      SettingsSyncLocalSettings.getInstance(),
+    )
     val authService = SettingsSyncAuthService.getInstance()
     val authAvailable = authService.isLoginAvailable()
     configPanel = panel {
@@ -203,40 +210,14 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
         comment(message("settings.sync.info.message"), 80)
           .visibleIf(isSyncEnabled.not())
       }
+
       row {
-        cell(categoriesPanel)
+        cell(syncConfigPanel)
           .visibleIf(LoggedInPredicate().and(EnabledPredicate()))
-          .onApply {
-            categoriesPanel.apply()
-            SettingsSyncEvents.getInstance().fireCategoriesChanged()
-          }
-          .onReset { categoriesPanel.reset() }
-          .onIsModified { categoriesPanel.isModified() }
+          .onApply(syncConfigPanel::apply)
+          .onReset(syncConfigPanel::reset)
+          .onIsModified(syncConfigPanel::isModified)
       }
-
-      panel {
-        row {
-          topGap(TopGap.MEDIUM)
-          label(message("settings.cross.product.sync"))
-        }
-        indent {
-          buttonsGroup {
-            row {
-              radioButton(
-                message("settings.cross.product.sync.choice.only.this.product", ApplicationNamesInfo.getInstance().fullProductName), false)
-            }
-            row {
-              radioButton(message("settings.cross.product.sync.choice.all.products"), true)
-            }
-          }.bind({ SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled },
-                 {
-                   SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled = it
-
-                   SettingsSyncEvents.getInstance().fireSettingsChanged(
-                     SyncSettingsEvent.CrossIdeSyncStateChanged(SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled))
-                 })
-        }
-      }.visibleIf(LoggedInPredicate().and(EnabledPredicate()))
     }
     SettingsSyncEvents.getInstance().addListener(
       object : SettingsSyncEventListener {
@@ -259,8 +240,11 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
 
   override fun serverStateCheckFinished(state: UpdateResult) {
     when (state) {
-      NoFileOnServer, FileDeletedFromServer -> showEnableSyncDialog(null)
-      is Success -> showEnableSyncDialog(state.settingsSnapshot.getState())
+      NoFileOnServer, FileDeletedFromServer -> showEnableSyncDialog(null, null)
+      is Success -> showEnableSyncDialog(
+          state.settingsSnapshot.getState(),
+          SettingsSyncLocalStateHolder(state.isCrossIdeSyncEnabled),
+      )
       is Error -> {
         if (state != SettingsSyncEnabler.State.CANCELLED) {
           showError(message("notification.title.update.error"), state.message)
@@ -285,20 +269,26 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
     updateStatusInfo()
   }
 
-  private fun showEnableSyncDialog(remoteSettings: SettingsSyncState?) {
-    val dialog = EnableSettingsSyncDialog(configPanel, remoteSettings)
+  private fun showEnableSyncDialog(remoteSettings: SettingsSyncState?, remoteSyncScopeSettings: SettingsSyncLocalStateHolder?) {
+    val dialog = EnableSettingsSyncDialog(configPanel, remoteSettings, remoteSyncScopeSettings)
+
     dialog.show()
+
     val dialogResult = dialog.getResult()
+
     if (dialogResult != null) {
       when (dialogResult) {
         EnableSettingsSyncDialog.Result.GET_FROM_SERVER -> {
           syncEnabler.getSettingsFromServer(dialog.syncSettings)
+
           SettingsSyncEventsStatistics.ENABLED_MANUALLY.log(SettingsSyncEventsStatistics.EnabledMethod.GET_FROM_SERVER)
         }
+
         EnableSettingsSyncDialog.Result.PUSH_LOCAL -> {
-          SettingsSyncSettings.getInstance().applyFromState(dialog.syncSettings)
           SettingsSyncSettings.getInstance().syncEnabled = true
+
           syncEnabler.pushSettingsToServer()
+
           if (remoteSettings != null) {
             SettingsSyncEventsStatistics.ENABLED_MANUALLY.log(SettingsSyncEventsStatistics.EnabledMethod.PUSH_LOCAL)
           }
@@ -311,6 +301,7 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
     else {
       SettingsSyncEventsStatistics.ENABLED_MANUALLY.log(SettingsSyncEventsStatistics.EnabledMethod.CANCELED)
     }
+
     reset()
     configPanel.reset()
   }

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncEnabler.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncEnabler.kt
@@ -48,9 +48,7 @@ internal class SettingsSyncEnabler {
         updateResult = result
         if (result is UpdateResult.Success) {
           val cloudEvent = SyncSettingsEvent.CloudChange(result.settingsSnapshot, result.serverVersionId, syncSettings)
-          runBlockingCancellable {
-            saveSettings(ApplicationManager.getApplication(), forceSavingAllSettings = true)
-          }
+
           settingsSyncControls.bridge.initialize(SettingsSyncBridge.InitMode.TakeFromServer(cloudEvent))
         }
       }

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncPanelFactory.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncPanelFactory.kt
@@ -1,14 +1,17 @@
 package com.intellij.settingsSync.config
 
+import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.settingsSync.*
 import com.intellij.settingsSync.SettingsSyncBundle.message
-import com.intellij.settingsSync.SettingsSyncState
 import com.intellij.ui.CheckBoxList
 import com.intellij.ui.CheckBoxListListener
 import com.intellij.ui.SeparatorComponent
 import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.dsl.builder.TopGap
+import com.intellij.ui.dsl.builder.bind
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
@@ -22,7 +25,58 @@ import javax.swing.JComponent
 import javax.swing.JPanel
 
 internal object SettingsSyncPanelFactory {
-  fun createPanel(syncLabel: @Nls String, state: SettingsSyncState): DialogPanel {
+  fun createCombinedSyncSettingsPanel(
+    syncLabel: @Nls String,
+    syncSettings: SettingsSyncState,
+    syncScopeSettings: SettingsSyncLocalState,
+  ): DialogPanel {
+    val categoriesPanel = createSyncCategoriesPanel(syncLabel, syncSettings)
+    val syncScopePanel = createSyncScopePanel(syncScopeSettings)
+
+    return panel {
+      row {
+        cell(categoriesPanel)
+          .onApply(categoriesPanel::apply)
+          .onReset(categoriesPanel::reset)
+          .onIsModified(categoriesPanel::isModified)
+      }
+
+      row {
+        cell(syncScopePanel)
+          .onApply(syncScopePanel::apply)
+          .onReset(syncScopePanel::reset)
+          .onIsModified(syncScopePanel::isModified)
+      }
+      onApply {
+        SettingsSyncLocalSettings.getInstance().applyFromState(syncScopeSettings)
+        SettingsSyncSettings.getInstance().applyFromState(syncSettings)
+
+        SettingsSyncEvents.getInstance().fireSettingsChanged(
+          SyncSettingsEvent.CrossIdeSyncStateChanged(SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled))
+        SettingsSyncEvents.getInstance().fireCategoriesChanged()
+      }
+    }
+  }
+
+  private fun createSyncScopePanel(state: SettingsSyncLocalState): DialogPanel {
+    return panel {
+      row {
+        topGap(TopGap.MEDIUM)
+        label(message("settings.cross.product.sync"))
+      }
+      buttonsGroup(indent = true) {
+        row {
+          val productName = ApplicationNamesInfo.getInstance().fullProductName
+          radioButton(message("settings.cross.product.sync.choice.only.this.product", productName), false)
+        }
+        row {
+          radioButton(message("settings.cross.product.sync.choice.all.products"), true)
+        }
+      }.bind(state::isCrossIdeSyncEnabled)
+    }
+  }
+
+  private fun createSyncCategoriesPanel(syncLabel: @Nls String, state: SettingsSyncState): DialogPanel {
     return panel {
       row {
         label(syncLabel)


### PR DESCRIPTION
Fixes ticket described here: [[IJPL-13931] Settings Sync ignores the category state changing when enabling sync for the first time](https://youtrack.jetbrains.com/issue/IJPL-13931/Settings-Sync-ignores-the-category-state-changing-when-enabling-sync-for-the-first-time)

This commit mostly fixes sync not respecting plugin subcategories. Part of the fix is also contained in the fix for IJPL-13201, as without flushing the settings to disk before syncing, the remote server would've received stale settings.