### PR TITLE
[settings-sync] IJPL-13201 Allow to choose cross-IDE sync mode when enabling sync

### DIFF
--- a/plugins/settings-sync/src/com/intellij/settingsSync/CloudConfigServerCommunicator.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/CloudConfigServerCommunicator.kt
@@ -61,18 +61,18 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
 
   @VisibleForTesting
   @Throws(IOException::class, UnauthorizedException::class)
-  protected fun currentSnapshotFilePath(): String? {
+  protected fun currentSnapshotFilePath(): Pair<String, Boolean>? {
     try {
       val crossIdeSyncEnabled = isFileExists(CROSS_IDE_SYNC_MARKER_FILE)
       if (crossIdeSyncEnabled != SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled) {
         LOG.info("Cross-IDE sync status on server is: ${enabledOrDisabled(crossIdeSyncEnabled)}. Updating local settings with it.")
         SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled = crossIdeSyncEnabled
       }
-      return if (crossIdeSyncEnabled) {
-        SETTINGS_SYNC_SNAPSHOT_ZIP
+      if (crossIdeSyncEnabled) {
+        return Pair(SETTINGS_SYNC_SNAPSHOT_ZIP, true)
       }
       else {
-        "${ApplicationNamesInfo.getInstance().productName.lowercase()}/$SETTINGS_SYNC_SNAPSHOT_ZIP"
+        return Pair("${ApplicationNamesInfo.getInstance().productName.lowercase()}/$SETTINGS_SYNC_SNAPSHOT_ZIP", false)
       }
     }
     catch (e: Throwable) {
@@ -120,7 +120,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
     val snapshotFilePath: String
     val defaultMessage = "Unknown during checking $CROSS_IDE_SYNC_MARKER_FILE"
     try {
-      snapshotFilePath = currentSnapshotFilePath() ?: return SettingsSyncPushResult.Error(defaultMessage)
+      snapshotFilePath = currentSnapshotFilePath()?.first ?: return SettingsSyncPushResult.Error(defaultMessage)
     }
     catch (ioe: IOException) {
       return SettingsSyncPushResult.Error(ioe.message ?: defaultMessage)
@@ -165,7 +165,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
   override fun checkServerState(): ServerState {
     val idTokenInRequest = getCurrentIdToken()
     try {
-      val snapshotFilePath = currentSnapshotFilePath() ?: return ServerState.Error("Unknown error during checkServerState")
+      val snapshotFilePath = currentSnapshotFilePath()?.first ?: return ServerState.Error("Unknown error during checkServerState")
       val latestVersion = client.getLatestVersion(snapshotFilePath)
       LOG.debug("Latest version info: $latestVersion")
       clearLastRemoteError()
@@ -185,7 +185,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
     LOG.info("Receiving settings snapshot from the cloud config server...")
     val idTokenInRequest = getCurrentIdToken()
     try {
-      val snapshotFilePath = currentSnapshotFilePath() ?: return UpdateResult.Error("Unknown error during receiveUpdates")
+      val (snapshotFilePath, isCrossIdeSync) = currentSnapshotFilePath() ?: return UpdateResult.Error("Unknown error during receiveUpdates")
       val (stream, version) = receiveSnapshotFile(snapshotFilePath)
       clearLastRemoteError()
       if (stream == null) {
@@ -202,7 +202,7 @@ internal open class CloudConfigServerCommunicator(serverUrl: String? = null) : S
           return UpdateResult.NoFileOnServer
         }
         else {
-          return if (snapshot.isDeleted()) UpdateResult.FileDeletedFromServer else UpdateResult.Success(snapshot, version)
+          return if (snapshot.isDeleted()) UpdateResult.FileDeletedFromServer else UpdateResult.Success(snapshot, version, isCrossIdeSync)
         }
       }
       finally {

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncBridge.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncBridge.kt
@@ -100,7 +100,11 @@ class SettingsSyncBridge(
     coroutineScope.launch {
       withProgressText(SettingsSyncBundle.message(initMode.messageKey)) {
         try {
+          // We only due it on `PushToServer` because  with other init modes this method can be called too early in the IDE initialization process
+          // and cause saving settings to fail — see fhttps://github.com/JetBrains/intellij-community/pull/2793#discussion_r1692737467 for context.
           if (initMode == InitMode.PushToServer) {
+            // Flush settings explicitly – if this is not done before sending sync events, then remotely synced settings
+            // might not contain the most up–to–date settings state (e.g. sync settings will be stale).
             saveIdeSettings()
           }
           settingsLog.initialize()
@@ -147,6 +151,16 @@ class SettingsSyncBridge(
 
     settingsLog.logExistingSettings()
     try {
+      // We need to create this remote file before the first sync, otherwise the settings value (even if persisted) will be overwritten by
+      // the sync-server-side value when `com.intellij.settingsSync.CloudConfigServerCommunicator#currentSnapshotFilePath` applies
+      // the remote config received in the first sync.
+      if (SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled) {
+        remoteCommunicator.createFile(CROSS_IDE_SYNC_MARKER_FILE, "")
+      }
+      else {
+        remoteCommunicator.deleteFile(CROSS_IDE_SYNC_MARKER_FILE)
+      }
+
       when (initMode) {
         is InitMode.TakeFromServer -> applySnapshotFromServer(initMode.cloudEvent)
         InitMode.PushToServer -> mergeAndPush(previousState.idePosition, previousState.cloudPosition, FORCE_PUSH)

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncRemoteCommunicator.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncRemoteCommunicator.kt
@@ -39,7 +39,7 @@ sealed class ServerState {
 }
 
 sealed class UpdateResult {
-  class Success(val settingsSnapshot: SettingsSnapshot, val serverVersionId: String?) : UpdateResult()
+  class Success(val settingsSnapshot: SettingsSnapshot, val serverVersionId: String?, val isCrossIdeSyncEnabled: Boolean) : UpdateResult()
   object NoFileOnServer: UpdateResult()
   object FileDeletedFromServer: UpdateResult()
   class Error(@NlsSafe val message: String): UpdateResult()

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/EnableSettingsSyncDialog.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/EnableSettingsSyncDialog.kt
@@ -1,8 +1,8 @@
 package com.intellij.settingsSync.config
 
-import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.settingsSync.SettingsSyncBundle.message
+import com.intellij.settingsSync.SettingsSyncLocalStateHolder
 import com.intellij.settingsSync.SettingsSyncState
 import com.intellij.settingsSync.SettingsSyncStateHolder
 import java.awt.event.ActionEvent
@@ -10,11 +10,15 @@ import javax.swing.AbstractAction
 import javax.swing.Action
 import javax.swing.JComponent
 
-internal class EnableSettingsSyncDialog(parent: JComponent, remoteSettings: SettingsSyncState?) : DialogWrapper(parent, false) {
+internal class EnableSettingsSyncDialog(
+  parent: JComponent,
+  remoteSettings: SettingsSyncState?,
+  remoteSyncScopeSettings: SettingsSyncLocalStateHolder?,
+) : DialogWrapper(parent, false) {
 
-  private lateinit var configPanel: DialogPanel
   private var dialogResult: Result? = null
   val syncSettings: SettingsSyncState = remoteSettings ?: SettingsSyncStateHolder()
+  private val syncScopeSettings = remoteSyncScopeSettings ?: SettingsSyncLocalStateHolder()
   private val remoteSettingsExist: Boolean = remoteSettings != null
 
   init {
@@ -28,9 +32,11 @@ internal class EnableSettingsSyncDialog(parent: JComponent, remoteSettings: Sett
   }
 
   override fun createCenterPanel(): JComponent {
-    configPanel = SettingsSyncPanelFactory.createPanel(message("enable.dialog.select.what.to.sync"), syncSettings)
-    configPanel.reset()
-    return configPanel
+    return  SettingsSyncPanelFactory.createCombinedSyncSettingsPanel(
+      message("enable.dialog.select.what.to.sync"),
+      syncSettings,
+      syncScopeSettings,
+    ).also { it.reset() }
   }
 
   override fun createActions(): Array<Action> =
@@ -60,7 +66,7 @@ internal class EnableSettingsSyncDialog(parent: JComponent, remoteSettings: Sett
   }
 
   private fun applyAndClose(result: Result) {
-    configPanel.apply()
+    applyFields()
     dialogResult = result
     close(0, true)
   }

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncConfigurable.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncConfigurable.kt
@@ -26,7 +26,10 @@ import com.intellij.settingsSync.UpdateResult.*
 import com.intellij.settingsSync.auth.SettingsSyncAuthService
 import com.intellij.settingsSync.statistics.SettingsSyncEventsStatistics
 import com.intellij.ui.components.ActionLink
-import com.intellij.ui.dsl.builder.*
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.RightGap
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.and
 import com.intellij.ui.layout.not
@@ -130,7 +133,11 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
   }
 
   override fun createPanel(): DialogPanel {
-    val categoriesPanel = SettingsSyncPanelFactory.createPanel(message("configurable.what.to.sync.label"), SettingsSyncSettings.getInstance())
+    val syncConfigPanel = SettingsSyncPanelFactory.createCombinedSyncSettingsPanel(
+      message("configurable.what.to.sync.label"),
+      SettingsSyncSettings.getInstance(),
+      SettingsSyncLocalSettings.getInstance(),
+    )
     val authService = SettingsSyncAuthService.getInstance()
     val authAvailable = authService.isLoginAvailable()
     configPanel = panel {
@@ -204,40 +211,20 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
         comment(message("settings.sync.info.message"), 80)
           .visibleIf(isSyncEnabled.not())
       }
+
       row {
-        cell(categoriesPanel)
+        cell(syncConfigPanel)
           .visibleIf(LoggedInPredicate().and(EnabledPredicate()))
           .onApply {
-            categoriesPanel.apply()
+            syncConfigPanel.apply()
+
             SettingsSyncEvents.getInstance().fireCategoriesChanged()
+            SettingsSyncEvents.getInstance().fireSettingsChanged(
+              SyncSettingsEvent.CrossIdeSyncStateChanged(SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled))
           }
-          .onReset { categoriesPanel.reset() }
-          .onIsModified { categoriesPanel.isModified() }
+          .onReset(syncConfigPanel::reset)
+          .onIsModified(syncConfigPanel::isModified)
       }
-
-      panel {
-        row {
-          topGap(TopGap.MEDIUM)
-          label(message("settings.cross.product.sync"))
-        }
-        indent {
-          buttonsGroup {
-            row {
-              radioButton(
-                message("settings.cross.product.sync.choice.only.this.product", ApplicationNamesInfo.getInstance().fullProductName), false)
-            }
-            row {
-              radioButton(message("settings.cross.product.sync.choice.all.products"), true)
-            }
-          }.bind({ SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled },
-                 {
-                   SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled = it
-
-                   SettingsSyncEvents.getInstance().fireSettingsChanged(
-                     SyncSettingsEvent.CrossIdeSyncStateChanged(SettingsSyncLocalSettings.getInstance().isCrossIdeSyncEnabled))
-                 })
-        }
-      }.visibleIf(LoggedInPredicate().and(EnabledPredicate()))
     }
     SettingsSyncEvents.getInstance().addListener(
       object : SettingsSyncEventListener {
@@ -260,8 +247,11 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
 
   override fun serverStateCheckFinished(state: UpdateResult) {
     when (state) {
-      NoFileOnServer, FileDeletedFromServer -> showEnableSyncDialog(null)
-      is Success -> showEnableSyncDialog(state.settingsSnapshot.getState())
+      NoFileOnServer, FileDeletedFromServer -> showEnableSyncDialog(null, null)
+      is Success -> showEnableSyncDialog(
+          state.settingsSnapshot.getState(),
+          SettingsSyncLocalStateHolder(state.isCrossIdeSyncEnabled),
+      )
       is Error -> {
         if (state != SettingsSyncEnabler.State.CANCELLED) {
           showError(message("notification.title.update.error"), state.message)
@@ -286,20 +276,26 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
     updateStatusInfo()
   }
 
-  private fun showEnableSyncDialog(remoteSettings: SettingsSyncState?) {
-    val dialog = EnableSettingsSyncDialog(configPanel, remoteSettings)
+  private fun showEnableSyncDialog(remoteSettings: SettingsSyncState?, remoteSyncScopeSettings: SettingsSyncLocalStateHolder?) {
+    val dialog = EnableSettingsSyncDialog(configPanel, remoteSettings, remoteSyncScopeSettings)
+
     dialog.show()
+
     val dialogResult = dialog.getResult()
+
     if (dialogResult != null) {
       when (dialogResult) {
         EnableSettingsSyncDialog.Result.GET_FROM_SERVER -> {
           syncEnabler.getSettingsFromServer(dialog.syncSettings)
+
           SettingsSyncEventsStatistics.ENABLED_MANUALLY.log(SettingsSyncEventsStatistics.EnabledMethod.GET_FROM_SERVER)
         }
+
         EnableSettingsSyncDialog.Result.PUSH_LOCAL -> {
-          SettingsSyncSettings.getInstance().applyFromState(dialog.syncSettings)
           SettingsSyncSettings.getInstance().syncEnabled = true
+
           syncEnabler.pushSettingsToServer()
+
           if (remoteSettings != null) {
             SettingsSyncEventsStatistics.ENABLED_MANUALLY.log(SettingsSyncEventsStatistics.EnabledMethod.PUSH_LOCAL)
           }
@@ -312,6 +308,7 @@ internal class SettingsSyncConfigurable : BoundConfigurable(message("title.setti
     else {
       SettingsSyncEventsStatistics.ENABLED_MANUALLY.log(SettingsSyncEventsStatistics.EnabledMethod.CANCELED)
     }
+
     reset()
     configPanel.reset()
   }

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncEnabler.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncEnabler.kt
@@ -53,9 +53,7 @@ internal class SettingsSyncEnabler {
         updateResult = result
         if (result is UpdateResult.Success) {
           val cloudEvent = SyncSettingsEvent.CloudChange(result.settingsSnapshot, result.serverVersionId, syncSettings)
-          runBlockingCancellable {
-            saveSettings(ApplicationManager.getApplication(), forceSavingAllSettings = true)
-          }
+
           settingsSyncControls.bridge.initialize(SettingsSyncBridge.InitMode.TakeFromServer(cloudEvent))
         }
       }

--- a/plugins/settings-sync/tests/com/intellij/settingsSync/MockRemoteCommunicator.kt
+++ b/plugins/settings-sync/tests/com/intellij/settingsSync/MockRemoteCommunicator.kt
@@ -53,12 +53,13 @@ internal class MockRemoteCommunicator : TestRemoteCommunicator() {
     ByteArrayOutputStream().use { stream ->
       SettingsSnapshotZipSerializer.serializeToStream(snapshot, stream)
       val content = stream.toByteArray()
-      client.write(currentSnapshotFilePath(), ByteArrayInputStream(content))
+      val (snapshotFilePath, _) = currentSnapshotFilePath() ?: return
+      client.write(snapshotFilePath, ByteArrayInputStream(content))
     }
   }
 
   override fun getVersionOnServer(): SettingsSnapshot? {
-    val snapshotFilePath = currentSnapshotFilePath()
+    val (snapshotFilePath, _) = currentSnapshotFilePath() ?: return null
     return getSnapshotFromVersion(filesAndVersions[snapshotFilePath]?.content)
   }
 

--- a/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncRealIdeTestBase.kt
+++ b/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncRealIdeTestBase.kt
@@ -49,8 +49,9 @@ internal abstract class SettingsSyncRealIdeTestBase : SettingsSyncTestBase() {
     componentStore.resetComponents()
   }
 
-  protected suspend fun initSettingsSync(initMode: SettingsSyncBridge.InitMode = SettingsSyncBridge.InitMode.JustInit) {
+  protected suspend fun initSettingsSync(initMode: SettingsSyncBridge.InitMode = SettingsSyncBridge.InitMode.JustInit, crossIdeSync: Boolean = false) {
     SettingsSyncSettings.getInstance().syncEnabled = true
+    SettingsSyncLocalSettings.getInstance().state.crossIdeSyncEnabled = crossIdeSync;
     val ideMediator = SettingsSyncIdeMediatorImpl(componentStore, configDir, enabledCondition = { true })
     val controls = SettingsSyncMain.init(currentThreadCoroutineScope(), disposable, settingsSyncStorage, configDir, remoteCommunicator, ideMediator)
     updateChecker = controls.updateChecker

--- a/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncTestBase.kt
+++ b/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncTestBase.kt
@@ -11,10 +11,6 @@ import com.intellij.testFramework.junit5.TestDisposable
 import com.intellij.util.io.createDirectories
 import com.intellij.util.io.write
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -25,6 +21,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 
 internal val TIMEOUT_UNIT = TimeUnit.SECONDS
 
@@ -101,6 +98,12 @@ internal abstract class SettingsSyncTestBase {
   protected fun assertFileWithContent(expectedContent: String, file: Path) {
     assertTrue(file.exists(), "File $file does not exist")
     assertEquals(expectedContent, file.readText(), "File $file has unexpected content")
+  }
+
+  protected fun assertIdeCrossSync(expectedIdeCrossSyncState: Boolean?) {
+    val actualIdeCrossSyncState = remoteCommunicator.ideCrossSyncState()
+
+    assertEquals(expectedIdeCrossSyncState, actualIdeCrossSyncState, "Unexpected IDE cross sync state $actualIdeCrossSyncState, expected $actualIdeCrossSyncState")
   }
 
   protected fun assertServerSnapshot(build: SettingsSnapshotBuilder.() -> Unit) {

--- a/plugins/settings-sync/tests/com/intellij/settingsSync/TestRemoteCommunicator.kt
+++ b/plugins/settings-sync/tests/com/intellij/settingsSync/TestRemoteCommunicator.kt
@@ -1,6 +1,5 @@
 package com.intellij.settingsSync
 
-import com.intellij.util.resettableLazy
 import org.junit.Assert
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
@@ -53,4 +52,9 @@ internal open class TestRemoteCommunicator(customServerUrl: String = "http://loc
     return result
   }
 
+  fun ideCrossSyncState(): Boolean? {
+    val (_, crossSyncState) = currentSnapshotFilePath() ?: Pair(null, null)
+
+    return crossSyncState
+  }
 }


### PR DESCRIPTION
Resolves: https://youtrack.jetbrains.com/issue/IJPL-13201/Unable-to-choose-the-type-of-synchronization-in-the-dialog-when-enabling-Setting-Sync

This PR enables selecting the cross-IDE sync mode when initially enabling sync by:

  * extracting all of the Settings Sync settings UI into `SettingsSyncPanelFactory`,
  * changing `SettingsSyncLocalSetting` to follow the same pattern `SettingsSyncSettings`
    uses (to wit, persistent settings and temporary UI state fronted by a common interface),
  * threading the remote cross-IDE sync state value when receiving the initial remote snapshot,
    so that the UI can pre-select the correct radio button,
  * writing cross-IDE sync state marker file before sending the initial state bundle
    to the server.
