### PR TITLE
[settings-sync] IJPL-13931 Ensure settings categories are respected in the initial sync

### DIFF
--- a/plugins/settings-sync/git/src/com/intellij/settingsSync/git/record/ChangeRecord.kt
+++ b/plugins/settings-sync/git/src/com/intellij/settingsSync/git/record/ChangeRecord.kt
@@ -129,7 +129,7 @@ internal class ChangeRecord(commitId: Int,
       if (fileName == GitSettingsLog.PLUGINS_FILE) return SettingsCategory.PLUGINS
 
       //workaround empty category
-      return getCategory(fileName) ?: SettingsCategory.OTHER
+      return getCategory(fileName)?.first ?: SettingsCategory.OTHER
     }
 
     val changesCategories = changes.map { getChangeCategory(it) }.distinct().sortedBy { getCategoryOrder(it) }.map { toString(it) }

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncBridge.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncBridge.kt
@@ -77,6 +77,10 @@ class SettingsSyncBridge(
   internal fun initialize(initMode: InitMode) {
     coroutineScope.launch {
       try {
+        // Always explicitly flush settings – if this is not done before sending sync events, then remotely synced settings
+        // might not contain the most up–to–date settings state (e.g. sync settings will be stale).
+        saveIdeSettings()
+
         settingsLog.initialize()
 
         // the queue is not activated initially => events will be collected but not processed until we perform all initialization tasks
@@ -109,10 +113,8 @@ class SettingsSyncBridge(
     }
   }
 
-  private fun saveIdeSettings() {
-    runBlockingCancellable {
-      saveSettings(ApplicationManager.getApplication(), forceSavingAllSettings = true)
-    }
+  private suspend fun saveIdeSettings() {
+    saveSettings(ApplicationManager.getApplication(), forceSavingAllSettings = true)
   }
 
   private suspend fun applyInitialChanges(initMode: InitMode) {

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/SyncPluginsGroup.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/SyncPluginsGroup.kt
@@ -18,6 +18,7 @@ internal class SyncPluginsGroup : SyncSubcategoryGroup {
     PluginManagerCore.plugins.forEach {
       if (!it.isBundled && SettingsSyncPluginCategoryFinder.getPluginCategory(it) == SettingsCategory.PLUGINS) {
         bundledPluginsDescriptor.isSubGroupEnd = true
+        // NOTE: the code in `com.intellij.settingsSync.SettingsSyncFilteringKt.getSubCategory` relies on the value being plugin ID
         descriptors.add(getOrCreateDescriptor(it.name, it.pluginId.idString))
       }
     }


### PR DESCRIPTION
Resolves: https://youtrack.jetbrains.com/issue/IJPL-13931/Settings-Sync-ignores-the-category-state-changing-when-enabling-sync-for-the-first-time

As far as I can tell, the Settings Sync code _does_ send only the files you requested, but:

  * it does only send files as they are on the disk – when setting up the sync, the
    `SettingsSyncSettings` state won't get persisted immediately (the IDE only does
    it later, after you exit settings), so another IDE wanting to use that state
    will show all categories enabled (even though the sync will not contain that
    date) until the settings get flushed,
  * settings for plugins didn't get properly categorised – this mean that you could
    either disable the category wholesale, or you would get all the plugins when
    syncing.
    
Those issues were fixed by — respectively — adding an explicit settings flush before
the initial sync and adding code to categorise plugins properly. I think this should
fix the issue as perceived in the UI by an user.