### PR TITLE
[j2k] Modify the Java Search for Final Variables for Kotlin Conversion

### DIFF
--- a/java/java-analysis-impl/src/com/intellij/codeInspection/localCanBeFinal/LocalCanBeFinal.java
+++ b/java/java-analysis-impl/src/com/intellij/codeInspection/localCanBeFinal/LocalCanBeFinal.java
@@ -82,42 +82,8 @@ public class LocalCanBeFinal extends AbstractBaseJavaLocalInspectionTool impleme
   @Nullable
   private List<ProblemDescriptor> checkCodeBlock(final PsiCodeBlock body, final InspectionManager manager, final boolean onTheFly) {
     if (body == null) return null;
-    final ControlFlow flow;
-    try {
-      ControlFlowPolicy policy = new ControlFlowPolicy() {
-        @Override
-        public PsiVariable getUsedVariable(@NotNull PsiReferenceExpression refExpr) {
-          if (refExpr.isQualified()) return null;
-
-          PsiElement refElement = refExpr.resolve();
-          if (refElement instanceof PsiLocalVariable || refElement instanceof PsiParameter) {
-            if (!isVariableDeclaredInMethod((PsiVariable)refElement)) return null;
-            return (PsiVariable)refElement;
-          }
-
-          return null;
-        }
-
-        @Override
-        public boolean isParameterAccepted(@NotNull PsiParameter psiParameter) {
-          return isVariableDeclaredInMethod(psiParameter);
-        }
-
-        @Override
-        public boolean isLocalVariableAccepted(@NotNull PsiLocalVariable psiVariable) {
-          return isVariableDeclaredInMethod(psiVariable);
-        }
-
-        private boolean isVariableDeclaredInMethod(PsiVariable psiVariable) {
-          return PsiTreeUtil.getParentOfType(psiVariable, PsiClass.class) == PsiTreeUtil.getParentOfType(body, PsiClass.class);
-        }
-      };
-      flow = ControlFlowFactory.getInstance(body.getProject()).getControlFlow(body, policy, false);
-    }
-    catch (AnalysisCanceledException e) {
-      return null;
-    }
-
+    final ControlFlow flow = getControlFlow(body);
+    if (flow == null) return null;
     int start = flow.getStartOffset(body);
     int end = flow.getEndOffset(body);
 
@@ -142,7 +108,7 @@ public class LocalCanBeFinal extends AbstractBaseJavaLocalInspectionTool impleme
           anchor = block.getParent();
 
           //special case: switch legs
-          Set<PsiReferenceExpression> writeRefs = 
+          Set<PsiReferenceExpression> writeRefs =
             SyntaxTraverser.psiTraverser().withRoot(block)
               .filter(PsiReferenceExpression.class)
               .filter(ref -> PsiUtil.isOnAssignmentLeftHand(ref)).toSet();
@@ -158,7 +124,7 @@ public class LocalCanBeFinal extends AbstractBaseJavaLocalInspectionTool impleme
         int from = flow.getStartOffset(anchor);
         int end = flow.getEndOffset(anchor);
         List<PsiVariable> ssa = ControlFlowUtil.getSSAVariables(flow, from, end, true);
-       
+        
         for (PsiVariable psiVariable : ssa) {
           if (declared.contains(psiVariable) && (!psiVariable.hasInitializer() || !VariableAccessUtils.variableIsAssigned(psiVariable, block))) {
             result.add(psiVariable);
@@ -349,6 +315,51 @@ public class LocalCanBeFinal extends AbstractBaseJavaLocalInspectionTool impleme
     }
 
     return problems;
+  }
+
+  /**
+  * Custom control flow logic that returns true if the variable is declared in the given method
+   *
+   * @param body code block to search
+  * @return ControlFlow or null if not properly initialized
+   */
+  @Nullable
+  public static ControlFlow getControlFlow(final PsiCodeBlock body) {
+    final ControlFlow flow;
+    try {
+      ControlFlowPolicy policy = new ControlFlowPolicy() {
+        @Override
+        public PsiVariable getUsedVariable(@NotNull PsiReferenceExpression refExpr) {
+          if (refExpr.isQualified()) return null;
+
+          PsiElement refElement = refExpr.resolve();
+          if (refElement instanceof PsiLocalVariable || refElement instanceof PsiParameter) {
+            if (!isVariableDeclaredInMethod((PsiVariable)refElement)) return null;
+            return (PsiVariable)refElement;
+          }
+          return null;
+        }
+
+        @Override
+        public boolean isParameterAccepted(@NotNull PsiParameter psiParameter) {
+          return isVariableDeclaredInMethod(psiParameter);
+        }
+
+        @Override
+        public boolean isLocalVariableAccepted(@NotNull PsiLocalVariable psiVariable) {
+          return isVariableDeclaredInMethod(psiVariable);
+        }
+
+        private boolean isVariableDeclaredInMethod(PsiVariable psiVariable) {
+          return PsiTreeUtil.getParentOfType(psiVariable, PsiClass.class) == PsiTreeUtil.getParentOfType(body, PsiClass.class);
+        }
+      };
+      flow = ControlFlowFactory.getInstance(body.getProject()).getControlFlow(body, policy, false);
+    }
+    catch (AnalysisCanceledException e) {
+      return null;
+    }
+    return flow;
   }
 
   private boolean shouldBeIgnored(PsiVariable psiVariable) {

--- a/java/java-tests/testSrc/com/siyeh/ig/psiutils/FinalUtilsTest.java
+++ b/java/java-tests/testSrc/com/siyeh/ig/psiutils/FinalUtilsTest.java
@@ -1,0 +1,73 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.siyeh.ig.psiutils;
+
+import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.psi.*;
+import com.intellij.testFramework.LightJavaCodeInsightTestCase;
+
+import java.util.List;
+
+public class FinalUtilsTest extends LightJavaCodeInsightTestCase {
+
+  public void testCanBeFinal() {
+    String file = """
+      class A {
+          private final int field1 = 0;
+          private int field2 = 0;
+          private int field3 = 0;
+          final int field4 = 0;
+          int field5 = 0;
+          private int field6;
+          private int field7;
+          private int field8;
+          private int field9;
+          private int field10;
+          private int field11;
+            
+          A(int p1, int p2, A a) {
+              field6 = p1;
+              field7 = 10;
+              this.field8 = p2;
+              this.field9 = 10;
+              if (p1 > 0) {
+                  this.field10 = 10;
+              }
+              a.field11 = 10;
+          }
+            
+          void foo() {
+              field3 = field2;
+          }
+      }
+      """;
+    PsiJavaFile
+      javaFile = (PsiJavaFile)PsiFileFactory.getInstance(getProject()).createFileFromText("X.java", JavaFileType.INSTANCE, file);
+    List<String> immutableFields = List.of("field1", "field2", "field4", "field5", "field6", "field7", "field8", "field9");
+    PsiField[] fields = javaFile.getClasses()[0].getFields();
+    for (PsiField field : fields) {
+      assertEquals(immutableFields.contains(field.getName()), FinalUtils.canBeFinal(field));
+    }
+
+  }
+
+  public void testFinalVariable() {
+    String file = """
+    public class Host {
+      private String name;
+  
+      public String getName() {
+        return "Name";
+      }
+    }
+      """;
+    PsiJavaFile
+      javaFile = (PsiJavaFile)PsiFileFactory.getInstance(getProject()).createFileFromText("X.java", JavaFileType.INSTANCE, file);
+    PsiField[] fields = javaFile.getClasses()[0].getFields();
+    for (PsiField field : fields) {
+      if (field.getName().equals("name")) {
+        assertFalse(FinalUtils.canBeFinal(field));
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
As discussed in #2743 , the java plugin to search for "final" variables doesn't quite work for J2K conversions since Kotlin mutability is slightly less strict. As such, making some changes and adding new functions in the Java plugin to leverage the existing infrastructure in the Kotlin J2K plugin.

Here are the separated out Java changes alongside new test cases.

@abelkov @darthorimar @ermattt @amaembo 