### PR TITLE
IJPL-11682 Save run configuration with scheme type prefix

### DIFF
--- a/platform/execution-impl/src/com/intellij/execution/impl/RunConfigurationSchemeManager.kt
+++ b/platform/execution-impl/src/com/intellij/execution/impl/RunConfigurationSchemeManager.kt
@@ -26,7 +26,7 @@ internal class RunConfigurationSchemeManager(private val manager: RunManagerImpl
     return when {
       isShared -> {
         if (scheme.type.isManaged) {
-          scheme.name
+          "${scheme.type.id}-${scheme.name}"
         }
         else {
           // do not use name as a scheme key for Unknown RC or for Rider (some Rider RC types can use RC with not unique names)


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/IJPL-11682/Saving-new-shared-run-configurations-silently-overwrites-old-ones-with-same-name

This problem is resolved by prepending type of configuration in front of the name, eg. configuration with name `foo` and type `JUnit` will be saved as `JUnit_foo.xml`.

This solution has the side effect of changing names of existing files, stored eg. in repositories. If two people are working on the same codebase with stored run configuration files, and they have different IntelliJ versions (before and after this fix), they will constantly rename the config files back and forth, which is a drawback.

Alternative solution:
- Completely prohibit having two configurations of different types with the same name (It is already the case for two configs with the same type)