### PR TITLE
KTIJ-29798 @Language annotation is ignored on enum class constructors

### DIFF
--- a/plugins/kotlin/injection/base/src/org/jetbrains/kotlin/idea/base/injection/KotlinLanguageInjectionContributorBase.kt
+++ b/plugins/kotlin/injection/base/src/org/jetbrains/kotlin/idea/base/injection/KotlinLanguageInjectionContributorBase.kt
@@ -320,10 +320,10 @@ abstract class KotlinLanguageInjectionContributorBase : LanguageInjectionContrib
         return null
     }
 
-    private fun getNameReference(callee: KtExpression?): KtNameReferenceExpression? {
+    private fun getNameReference(callee: KtExpression?): KtSimpleNameExpression? {
         if (callee is KtConstructorCalleeExpression)
-            return callee.constructorReferenceExpression as? KtNameReferenceExpression
-        return callee as? KtNameReferenceExpression
+            return callee.constructorReferenceExpression
+        return callee as? KtSimpleNameExpression
     }
 
     private fun getArgument(host: KtElement): KtValueArgument? = when (val parent = host.parent) {

--- a/plugins/kotlin/injection/base/tests/test/org/jetbrains/kotlin/idea/base/injection/KotlinInjectionTestBase.kt
+++ b/plugins/kotlin/injection/base/tests/test/org/jetbrains/kotlin/idea/base/injection/KotlinInjectionTestBase.kt
@@ -319,6 +319,17 @@ abstract class KotlinInjectionTestBase : AbstractInjectionTest() {
         languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false
     )
 
+    fun testInjectionOffCustomParameterInEnumConstructorWithAnnotation() = doInjectionPresentTest(
+        """
+        import org.intellij.lang.annotations.Language
+
+        enum class Test(@Language("HTML") val s: String){
+          ONE("<caret>some")
+        }
+        """,
+        languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false
+    )
+
     fun testInjectionOfCustomParameterJavaWithAnnotation() = doInjectionPresentTest(
         """
         fun bar() { Test.foo("<caret>some") }


### PR DESCRIPTION
![image](https://github.com/JetBrains/intellij-community/assets/85900443/6a4e52d2-8cd6-406d-99ab-def11196eaf8)

[KTIJ-29798](https://youtrack.jetbrains.com/issue/KTIJ-29798/Language-annotation-is-ignored-on-enum-class-constructors)
