### PR TITLE
Allow configuring test maven repositories

### DIFF
--- a/java/testFramework/src/com/intellij/testFramework/fixtures/MavenDependencyUtil.java
+++ b/java/testFramework/src/com/intellij/testFramework/fixtures/MavenDependencyUtil.java
@@ -102,6 +102,13 @@ public final class MavenDependencyUtil {
 
   @NotNull
   public static List<RemoteRepositoryDescription> getRemoteRepositoryDescriptions() {
+    String repoForTesting = System.getProperty("maven.repo.for.testing");
+    if (repoForTesting != null) {
+      return List.of(new RemoteRepositoryDescription(
+        "intellij-dependencies",
+        "IntelliJ Dependencies",
+        repoForTesting));
+    }
     return REPOS_FOR_TESTING;
   }
 }


### PR DESCRIPTION
Hi! Android Studio engineer here! We are starting to run debugger tests on Android, and we need to be able to specify our own custom maven url/directory. Hope this change makes sense. Thanks!