### PR TITLE
Fix false warnings on signature polymorphic method lookup

### DIFF
--- a/java/java-impl-inspections/src/com/intellij/codeInspection/reflectiveAccess/JavaLangInvokeHandleSignatureInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/reflectiveAccess/JavaLangInvokeHandleSignatureInspection.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.codeInspection.reflectiveAccess;
 
+import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.daemon.JavaErrorBundle;
 import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo;
 import com.intellij.codeInsight.lookup.*;
@@ -25,7 +26,6 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.invoke.VarHandle;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -207,7 +207,6 @@ public final class JavaLangInvokeHandleSignatureInspection extends AbstractBaseJ
                                   @NotNull PsiReferenceExpression factoryMethodExpression,
                                   @NotNull ProblemsHolder holder) {
     if (!ownerClass.isExact()) return;
-    if (!isStaticExpected && isSignaturePolymorphic(ownerClass, methodName)) return;
     final PsiMethod[] methods = ownerClass.getPsiClass().findMethodsByName(methodName, true);
     if (methods.length == 0) {
       holder.registerProblem(methodNameExpression, JavaErrorBundle.message("cannot.resolve.method", methodName));
@@ -226,6 +225,10 @@ public final class JavaLangInvokeHandleSignatureInspection extends AbstractBaseJ
         holder.registerProblem(factoryMethodNameElement, message, LocalQuickFix.notNullElements(fix));
         return;
       }
+    }
+    PsiMethod onlyMethod = ContainerUtil.getOnlyItem(filteredMethods);
+    if (onlyMethod != null && AnnotationUtil.isAnnotated(onlyMethod, CommonClassNames.JAVA_LANG_INVOKE_MH_POLYMORPHIC, 0)) {
+      return;
     }
 
     final ReflectiveSignature methodSignature = composeMethodSignature(methodTypeExpression);
@@ -255,23 +258,6 @@ public final class JavaLangInvokeHandleSignatureInspection extends AbstractBaseJ
       }
     }
   }
-
-  private static boolean isSignaturePolymorphic(@NotNull ReflectiveClass ownerClass,
-                                                @NotNull String methodName) {
-    if ("java.lang.invoke.MethodHandle".equals(ownerClass.getPsiClass().getQualifiedName())) {
-      return methodName.equals("invoke") || methodName.equals("invokeExact");
-    }
-    if ("java.lang.invoke.VarHandle".equals(ownerClass.getPsiClass().getQualifiedName())) {
-      try {
-        //noinspection ResultOfMethodCallIgnored
-        VarHandle.AccessMode.valueFromMethodName(methodName);
-        return true;
-      } catch (IllegalArgumentException ignored) {
-      }
-    }
-    return false;
-  }
-
 
   private static void checkSpecial(@NotNull ReflectiveClass ownerClass,
                                    @NotNull PsiExpression callerClassExpression,

--- a/java/java-impl-inspections/src/com/intellij/codeInspection/reflectiveAccess/JavaLangInvokeHandleSignatureInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/reflectiveAccess/JavaLangInvokeHandleSignatureInspection.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.invoke.VarHandle;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -206,6 +207,7 @@ public final class JavaLangInvokeHandleSignatureInspection extends AbstractBaseJ
                                   @NotNull PsiReferenceExpression factoryMethodExpression,
                                   @NotNull ProblemsHolder holder) {
     if (!ownerClass.isExact()) return;
+    if (!isStaticExpected && isSignaturePolymorphic(ownerClass, methodName)) return;
     final PsiMethod[] methods = ownerClass.getPsiClass().findMethodsByName(methodName, true);
     if (methods.length == 0) {
       holder.registerProblem(methodNameExpression, JavaErrorBundle.message("cannot.resolve.method", methodName));
@@ -252,6 +254,22 @@ public final class JavaLangInvokeHandleSignatureInspection extends AbstractBaseJ
         }
       }
     }
+  }
+
+  private static boolean isSignaturePolymorphic(@NotNull ReflectiveClass ownerClass,
+                                                @NotNull String methodName) {
+    if ("java.lang.invoke.MethodHandle".equals(ownerClass.getPsiClass().getQualifiedName())) {
+      return methodName.equals("invoke") || methodName.equals("invokeExact");
+    }
+    if ("java.lang.invoke.VarHandle".equals(ownerClass.getPsiClass().getQualifiedName())) {
+      try {
+        //noinspection ResultOfMethodCallIgnored
+        VarHandle.AccessMode.valueFromMethodName(methodName);
+        return true;
+      } catch (IllegalArgumentException ignored) {
+      }
+    }
+    return false;
   }
 
 

--- a/java/java-tests/testData/inspection/invokeHandleSignature/SignaturePolymorphic.java
+++ b/java/java-tests/testData/inspection/invokeHandleSignature/SignaturePolymorphic.java
@@ -1,0 +1,18 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+class SignaturePolymorphic {
+  public static void main(String... args) throws Throwable {
+    // signature polymorphic methods allow any lookup, do not warn
+    MethodHandles.lookup().findVirtual(MethodHandle.class, "invoke", MethodType.methodType(int.class, String.class, double.class));
+    MethodHandles.lookup().findVirtual(VarHandle.class, "compareAndSet", MethodType.methodType(int.class, String.class, double.class));
+    // static lookup still warns as the methods are virtual
+    MethodHandles.lookup().<warning descr="Method 'invoke' is not static">findStatic</warning>(MethodHandle.class, "invoke", MethodType.methodType(int.class, String.class, double.class));
+    MethodHandles.lookup().<warning descr="Method 'compareAndSet' is not static">findStatic</warning>(VarHandle.class, "compareAndSet", MethodType.methodType(int.class, String.class, double.class));
+    // unrelated methods in the relevant classes cause warnings
+    MethodHandles.lookup().findVirtual(MethodHandle.class, "toString", <warning descr="Cannot resolve method 'int toString(String, double)'">MethodType.methodType(int.class, String.class, double.class)</warning>);
+    MethodHandles.lookup().findVirtual(VarHandle.class, "toString", <warning descr="Cannot resolve method 'int toString(String, double)'">MethodType.methodType(int.class, String.class, double.class)</warning>);
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInspection/JavaLangInvokeHandleSignatureTest.kt
+++ b/java/java-tests/testSrc/com/intellij/java/codeInspection/JavaLangInvokeHandleSignatureTest.kt
@@ -51,6 +51,8 @@ class JavaLangInvokeHandleSignatureTest : LightJavaCodeInsightFixtureTestCase() 
 
   fun testVarArgMethodHandle() = doTest()
 
+  fun testSignaturePolymorphic() = doTest()
+
   private fun doTest() {
     myFixture.testHighlighting("${getTestName(false)}.java")
   }


### PR DESCRIPTION
`MethodHandle.invoke(Exact)` and `VarHandle.{access-mode}` behave differently than other methods when using `MethodHandle.Lookup#findVirtual`. According to the API specification (https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/invoke/VarHandle.html#interoperation-between-varhandles-and-the-core-reflection-api-heading):

> The [Lookup.findVirtual](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/invoke/MethodHandles.Lookup.html#findVirtual(java.lang.Class,java.lang.String,java.lang.invoke.MethodType)) API is also able to return a method handle to call an access mode method for any specified access mode type and is equivalent in behavior to [MethodHandles.varHandleInvoker(java.lang.invoke.VarHandle.AccessMode, java.lang.invoke.MethodType)](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/invoke/MethodHandles.html#varHandleInvoker(java.lang.invoke.VarHandle.AccessMode,java.lang.invoke.MethodType)).

As a consequence, the signature mismatch warning should not be emitted for those methods.