### PR TITLE
[PY-27985] Add pygame package alias for pygame-ce

### DIFF
--- a/python/python-psi-impl/resources/tools/packages
+++ b/python/python-psi-impl/resources/tools/packages
@@ -4781,3 +4781,4 @@ slugify python-slugify
 huggingface_hub huggingface-hub
 tensorflow_text tensorflow-text
 tensorflow_graphics tensorflow-graphics
+pygame pygame-ce


### PR DESCRIPTION
pygame-ce is a fork and drop in replacement of pygame and to make migration easier, uses the pygame package name (but on pypi it is up as pygame-ce, and so pycharm does not detect it in requirements.txt)   
Related issues: [PY-27985](https://youtrack.jetbrains.com/issue/PY-27985) and https://github.com/pygame-community/pygame-ce/issues/2478