### PR TITLE
[kotlin] K2 J2K: Avoid Using Any Type When Stricter Type is Known

### DIFF
--- a/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterSingleFileTestGenerated.java
@@ -6783,6 +6783,11 @@ public abstract class NewJavaToKotlinConverterSingleFileTestGenerated extends Ab
             runTest("../../shared/tests/testData/newJ2k/typeParameters/needTypeArgs.java");
         }
 
+        @TestMetadata("noUnnecessaryAny.java")
+        public void testNoUnnecessaryAny() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.java");
+        }
+
         @TestMetadata("rawTypeCast.java")
         public void testRawTypeCast() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/typeParameters/rawTypeCast.java");

--- a/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
@@ -6783,6 +6783,11 @@ public abstract class K2JavaToKotlinConverterSingleFileTestGenerated extends Abs
             runTest("../../shared/tests/testData/newJ2k/typeParameters/needTypeArgs.java");
         }
 
+        @TestMetadata("noUnnecessaryAny.java")
+        public void testNoUnnecessaryAny() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.java");
+        }
+
         @TestMetadata("rawTypeCast.java")
         public void testRawTypeCast() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/typeParameters/rawTypeCast.java");

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/issues/kt-1048.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/issues/kt-1048.kt
@@ -1,6 +1,5 @@
 // ERROR: The integer literal does not conform to the expected type CapturedType(*)
 // ERROR: The integer literal does not conform to the expected type CapturedType(*)
-// ERROR: Type argument is not within its bounds: should be subtype of 'String?'
 internal class G<T : String?>(t: T)
 
 class Java {
@@ -11,7 +10,7 @@ class Java {
 
     fun test2() {
         val m: HashMap<*, *> = HashMap<Any?, Any?>()
-        val g: G<*> = G<Any?>("")
+        val g: G<*> = G("")
         val g2 = G("")
     }
 }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/rawGenerics/kt-540-rawGenericClass.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/rawGenerics/kt-540-rawGenericClass.kt
@@ -8,7 +8,7 @@ internal class Collection<E>(e: E) {
 
 internal class Test {
     fun main() {
-        val raw1: Collection<*> = Collection<Any?>(1)
+        val raw1: Collection<*> = Collection(1)
         val raw2: Collection<*> = Collection(1)
         val raw3: Collection<*> = Collection("1")
     }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.java
@@ -1,0 +1,12 @@
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+
+public class Test {
+    List<String> xs;
+    @Nullable List<String> strings;
+
+    public void typeParameterWeirdness() {
+        xs = strings != null ? new ArrayList<>(strings) : new ArrayList<String>();
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.k2.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.k2.kt
@@ -1,0 +1,8 @@
+class Test {
+    var xs: List<String?>? = null
+    var strings: List<String?>? = null
+
+    fun typeParameterWeirdness() {
+        xs = if (strings != null) ArrayList(strings) else ArrayList<String?>()
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/typeParameters/noUnnecessaryAny.kt
@@ -1,0 +1,8 @@
+class Test {
+    var xs: List<String>? = null
+    var strings: List<String>? = null
+
+    fun typeParameterWeirdness() {
+        xs = if (strings != null) ArrayList(strings) else ArrayList()
+    }
+}


### PR DESCRIPTION
This PR tries to infer the true type of any `JKNewExpression` with an `Any` type argument. Meta has had many cases of types being set to `Any?` when that is clearly incorrect based on the information provided by that particular expression.

In `TypeMappingConversion`, we now run an extra step if the type argument is `Any` and the number of parameters matches the number of type arguments (since if they don't match, it's impossible to infer anything further). In that case, we:
1. continue with the current type analysis if it's not `Any` or if the corresponding parameter type is null/unknown 
2.  If the corresponding parameter type is not an Int (strong evidence of an indexing param, cannot use to infer type) or an arraytype (would need to get internal type which is harder to infer), use the parameter type instead
3. If none of the above are true, only add the `Any` if there are multiple type arguments required. Otherwise, it's safer to just leave it out.


This will prevent errors such as the one in `plugins/kotlin/j2k/shared/tests/testData/newJ2k/issues/kt-1048.kt` and previously in `noUnnecessaryAny.kt`  where the inferred type is clear but `Any` was used anyways