### PR TITLE
KTIJ-30548 Add check if the context module is common

### DIFF
--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/testing/KotlinMultiplatformAllInDirectoryConfigurationProducer.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/testing/KotlinMultiplatformAllInDirectoryConfigurationProducer.kt
@@ -38,7 +38,7 @@ class KotlinMultiplatformAllInDirectoryConfigurationProducer
         }
 
         val module = context.module ?: return null
-        if (module.platform.isCommon()) {
+        if (module.platform.isCommon() || module.isMultiPlatformModule) {
             return null
         }
 

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/testing/KotlinMultiplatformAllInPackageConfigurationProducer.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/testing/KotlinMultiplatformAllInPackageConfigurationProducer.kt
@@ -60,7 +60,7 @@ class KotlinMultiplatformAllInPackageConfigurationProducer: AllInPackageGradleCo
         }
 
         val module = context.module ?: return null
-        if (module.platform.isCommon()) {
+        if (module.platform.isCommon() || module.isMultiPlatformModule) {
             return null
         }
 


### PR DESCRIPTION
even is the targeted platform is not.
The module could be a multiplatform module common by different tests even if the targeted platform is not common.