### PR TITLE
Fixed condition for plugin updates check

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/plugins/StandalonePluginUpdateChecker.kt
+++ b/platform/platform-impl/src/com/intellij/ide/plugins/StandalonePluginUpdateChecker.kt
@@ -105,7 +105,7 @@ open class StandalonePluginUpdateChecker(
   open fun verifyUpdate(status: PluginUpdateStatus.Update): PluginUpdateStatus = status
 
   fun pluginUsed() {
-    if (!UpdateSettings.getInstance().isCheckNeeded) return
+    if (!UpdateSettings.getInstance().isPluginsCheckNeeded) return
     if (ApplicationManager.getApplication().isHeadlessEnvironment) return
 
     val lastUpdateTime = PropertiesComponent.getInstance().getLong(updateTimestampProperty, 0L)


### PR DESCRIPTION
It seems in this scenario we'd like to check for plugin updates and no the IDE updates itself.