### PR TITLE
IJPL-156693 detect local git-bash installation

### DIFF
--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/action/TerminalNewPredefinedSessionAction.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/action/TerminalNewPredefinedSessionAction.java
@@ -145,8 +145,10 @@ public final class TerminalNewPredefinedSessionAction extends DumbAwareAction {
       if (pwsh != null && StringUtil.startsWithIgnoreCase(pwsh.getAbsolutePath(), "C:\\Program Files\\PowerShell\\")) {
         ContainerUtil.addIfNotNull(actions, create(pwsh.getAbsolutePath(), List.of(), "PowerShell"));
       }
-      File gitBash = new File("C:\\Program Files\\Git\\bin\\bash.exe");
-      if (gitBash.isFile()) {
+      File gitBashGlobal = new File("C:\\Program Files\\Git\\bin\\bash.exe");
+      File gitBashLocal = new File(System.getenv("LocalAppData") + "\\Programs\\Git\\bin\\bash.exe");
+      File gitBash = gitBashLocal.isFile() ? gitBashLocal : (gitBashGlobal.isFile() ? gitBashGlobal : null);
+      if (gitBash != null) {
         ContainerUtil.addIfNotNull(actions, create(gitBash.getAbsolutePath(), List.of(), "Git Bash"));
       }
       String cmderRoot = EnvironmentUtil.getValue("CMDER_ROOT");


### PR DESCRIPTION
Detects Git for Windows installed in user scope via `winget install Git.Git --scope user`, allowing "Git Bash" action to show in the list of Terminal Predefined Actions.

More details: https://youtrack.jetbrains.com/issue/IJPL-156693/