### PR TITLE
fix:  Failed to activate conda environment

### DIFF
--- a/python/python-sdk/src/com/jetbrains/python/packaging/CondaExecutablesLocator.kt
+++ b/python/python-sdk/src/com/jetbrains/python/packaging/CondaExecutablesLocator.kt
@@ -22,6 +22,7 @@ private const val UNIX_CONDA_BIN_DIR_NAME = "bin"
 private const val PYTHON_EXE_NAME = "python.exe"
 private const val PYTHON_UNIX_BINARY_NAME = "python"
 private const val WIN_CONTINUUM_DIR_PATH = "AppData\\Local\\Continuum\\"
+private const val WIN_LOCAL_APP_DATA_PATH = "AppData\\Local\\"
 private const val WIN_PROGRAM_DATA_PATH = "C:\\ProgramData\\"
 private const val WIN_C_ROOT_PATH = "C:\\"
 private const val UNIX_OPT_PATH = "/opt/"
@@ -84,6 +85,10 @@ private fun getCondaExecutableByName(condaName: String): Path? {
     if (executableFile != null) return executableFile
 
     if (SystemInfo.isWindows) {
+      condaFolder = userHome / WIN_LOCAL_APP_DATA_PATH / root
+      executableFile = findExecutable(condaName, condaFolder)
+      if (executableFile != null) return executableFile
+      
       condaFolder = userHome / WIN_CONTINUUM_DIR_PATH / root
       executableFile = findExecutable(condaName, condaFolder)
       if (executableFile != null) return executableFile


### PR DESCRIPTION
### Issue Description
An error ocurred while open the Terminal:
```
+ Failed to activate conda environment.
+ ~~~~~~
    + CategoryInfo          : ObjectNotFound: (Failed:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```
![image](https://github.com/user-attachments/assets/517506c6-3fcd-44ee-89cc-01c5844dd2ad)
The actual reason for this error can be found in the logs:
```
2024-07-25 10:35:24,316 [1553431]   INFO - #c.j.p.packaging - System conda executable is not found
2024-07-25 10:35:24,316 [1553431]   WARN - #c.i.p.t.PyVirtualEnvTerminalCustomizer - Can't find null, will not activate conda
```
This is because the default installation location for conda is the local app data directory, but this directory is not in PyCharm's search path list. If the user changes the conda environment path, then PyCharm cannot find the conda path.


### Issue Reproduction
1. Install Miniconda3 on Windows.
2. Verify the installation directory is %USERPROFILE%/AppData/Local/miniconda3.
3. Modify the `%USERPROFILE%/.condarc` file to change the `envs_dirs` and `pkgs_dirs`:
```
envs_dirs:
  - D:\data\conda_envs
pkgs_dirs:
  - D:\data\conda_pkgs
```
4. Use PyCharm to create a conda environment, and open the Terminal in PyCharm.


