### PR TITLE
ThreadLeakTracker: avoid busy-waiting (IJPL-159321)

### DIFF
--- a/platform/testFramework/common/src/common/ThreadLeakTracker.java
+++ b/platform/testFramework/common/src/common/ThreadLeakTracker.java
@@ -13,6 +13,7 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.io.FilePageCacheLockFree;
 import com.intellij.util.ui.EDT;
 import com.intellij.util.ui.UIUtil;
+import java.util.concurrent.locks.LockSupport;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
@@ -179,6 +180,8 @@ public final class ThreadLeakTracker {
       // after some time, the submitted task can finish and the thread can become idle
       stackTrace = thread.getStackTrace();
       if (shouldIgnore(thread, stackTrace)) break;
+      // avoid busy-waiting, otherwise other threads might yield priority to this one (see sleepIfNeededToGivePriorityToAnotherThread)
+      LockSupport.parkNanos(10_000_000);
     }
 
     // check once more because the thread name may be set via race


### PR DESCRIPTION
Busy-waiting burns some CPU and potentially slows down the background thread by continuously requesting its stack trace.

More importantly, if ThreadLeakTracker.checkLeak() happens to be called on the EDT inside computePrioritized(), then busy-waiting can cause other threads to get stuck yielding priority to the EDT (in sleepIfNeededToGivePriorityToAnotherThread), leading to a false-positive thread leak error.

Issue link: https://youtrack.jetbrains.com/issue/IJPL-159321