### PR TITLE
Add Android Studio icons to newer load API calls

### DIFF
--- a/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/IconsClassGenerator.kt
+++ b/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/IconsClassGenerator.kt
@@ -125,9 +125,11 @@ internal open class IconsClassGenerator(
         val imagesI = imageCollector.collectSubDir(resourceRoot, "studio/illustrations", includePhantom = true)
         imageCollector.printUsedIconRobots()
 
+        val (studioImages, studioMappings) = imageCollector.mergeImages(imagesS, module)
+
         return listOf(
           IconClassInfo(packageName, "AndroidIcons", Path.of(sourceRoot, "icons/AndroidIcons.java"), imagesA),
-          IconClassInfo(packageName, "StudioIcons", Path.of(sourceRoot, "icons/StudioIcons.java"), imagesS),
+          IconClassInfo(packageName, "StudioIcons", Path.of(sourceRoot, "icons/StudioIcons.java"), studioImages, studioMappings),
           IconClassInfo(packageName, "StudioIllustrations", Path.of(sourceRoot, "icons/StudioIllustrations.java"), imagesI),
         )
       }

--- a/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/ImageCollector.kt
+++ b/platform/build-scripts/icons/src/org/jetbrains/intellij/build/images/ImageCollector.kt
@@ -180,6 +180,7 @@ internal class ImageCollector(
   }
 
   fun collectSubDir(sourceRoot: JpsModuleSourceRoot, name: String, includePhantom: Boolean = false): List<ImageInfo> {
+    collectMappingFile(sourceRoot.path)
     processRoot(sourceRoot, sourceRoot.path.resolve(name))
     val result = icons.values.toMutableList()
     if (includePhantom) {
@@ -330,11 +331,16 @@ internal class ImageCollector(
 
   private fun collectMappingFile(rootDir: Path) {
     if (mappingFile == null) {
-      val mappings = rootDir.listDirectoryEntries("*Mapping*.json")
-      if (mappings.size == 1) {
-        mappings.isNotEmpty()
-        mappingFile = mappings[0]
+      try {
+        val mappings = rootDir.listDirectoryEntries("*Mapping*.json")
+        if (mappings.size == 1) {
+          mappings.isNotEmpty()
+          mappingFile = mappings[0]
+        }
+      } catch (e: NoSuchFileException) {
+        println("Tried to access directory: $rootDir for a mapping file, but the directory did not exist")
       }
+
     }
   }
 


### PR DESCRIPTION
This allows for slightly faster startup by not requiring reading in the IconMapper's json file when the plugin is loaded. Additionally, it allows for removal of the iconMapper extension from IntelliJ side once all plugins are off of it.