### PR TITLE
[IDEA-347310] Run GradleDependencyReportTask without configuration cache

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/dependency/analyzer/GradleDependencyAnalyzerContributor.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/dependency/analyzer/GradleDependencyAnalyzerContributor.kt
@@ -189,6 +189,7 @@ class GradleDependencyAnalyzerContributor(private val project: Project) : Depend
       GradleTaskManager.runCustomTask(
         project, GradleBundle.message("gradle.dependency.analyzer.loading"),
         GradleDependencyReportTask::class.java,
+        listOf("--no-configuration-cache"),
         directoryToRunTask,
         fullGradlePath,
         taskConfiguration,

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/task/GradleTaskManager.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/task/GradleTaskManager.java
@@ -477,13 +477,15 @@ public class GradleTaskManager implements ExternalSystemTaskManager<GradleExecut
   public static void runCustomTask(@NotNull Project project,
                                    @NotNull @Nls String executionName,
                                    @NotNull Class<? extends Task> taskClass,
+                                   @NotNull List<String> gradleFlags,
                                    @NotNull String projectPath,
                                    @NotNull String gradlePath,
                                    @Nullable String taskConfiguration,
                                    @NotNull ProgressExecutionMode progressExecutionMode,
                                    @Nullable TaskCallback callback,
                                    @NotNull Set<Class<?>> toolingExtensionClasses) {
-    String taskName = taskClass.getSimpleName();
+    String flags = gradleFlags.isEmpty() ? "" : " " + String.join(" ", gradleFlags);
+    String taskName = taskClass.getSimpleName() + flags;
     String taskType = taskClass.getName();
     Set<Class<?>> tools = new HashSet<>(toolingExtensionClasses);
     tools.add(taskClass);
@@ -498,12 +500,13 @@ public class GradleTaskManager implements ExternalSystemTaskManager<GradleExecut
   public static void runCustomTask(@NotNull Project project,
                                    @NotNull @Nls String executionName,
                                    @NotNull Class<? extends Task> taskClass,
+                                   @NotNull List<String> gradleFlags,
                                    @NotNull String projectPath,
                                    @NotNull String gradlePath,
                                    @Nullable String taskConfiguration,
                                    @NotNull ProgressExecutionMode progressExecutionMode,
                                    @Nullable TaskCallback callback) {
-    runCustomTask(project, executionName, taskClass, projectPath, gradlePath, taskConfiguration, progressExecutionMode, callback,
-                  new HashSet<>());
+    runCustomTask(project, executionName, taskClass, gradleFlags, projectPath, gradlePath, taskConfiguration, progressExecutionMode,
+                  callback, new HashSet<>());
   }
 }


### PR DESCRIPTION
On projects with configuration cache enabled, the `ConfigurationContainer` object will not contain any of the configuration info needed to generate the dependency report. This is true even if we removed now-forbidden accesses to `getProject()` and injected it through the Gradle services. So it just runs the task without configuration cache.

`runCustomTask` is only ever used by `GradleDependencyAnalyzerContributor` but still extended the API just in case.