### PR TITLE
Add ExpandCollapseToggleAction to IdeActions

### DIFF
--- a/java/java-tests/testSrc/com/intellij/openapi/editor/impl/JavaFoldingTest.java
+++ b/java/java-tests/testSrc/com/intellij/openapi/editor/impl/JavaFoldingTest.java
@@ -95,6 +95,25 @@ public class JavaFoldingTest extends JavaFoldingTestCase {
     assertEquals(text.indexOf("}", text.indexOf("i++")), myFixture.getEditor().getCaretModel().getOffset());
   }
 
+  public void testExpandCollapseRegionTogglesFold() {
+    String text = """
+      class Test {
+          void test(int i) {
+              if (i > 1) {
+                  <caret>i++;
+              }
+          }
+      }
+      """;
+    configure(text);
+    assertEquals(2, getExpandedFoldRegionsCount());
+
+    myFixture.performEditorAction(IdeActions.ACTION_EXPAND_COLLAPSE_TOGGLE_REGION);
+    assertEquals(1, getExpandedFoldRegionsCount());
+
+    myFixture.performEditorAction(IdeActions.ACTION_EXPAND_COLLAPSE_TOGGLE_REGION);
+    assertEquals(2, getExpandedFoldRegionsCount());
+  }
   public void testFoldGroup() {
     // Implied by IDEA-79420
     myFoldingSettings.setCollapseLambdas(true);

--- a/platform/ide-core/src/com/intellij/openapi/actionSystem/IdeActions.java
+++ b/platform/ide-core/src/com/intellij/openapi/actionSystem/IdeActions.java
@@ -205,6 +205,7 @@ public interface IdeActions {
   String ACTION_COLLAPSE_REGION_RECURSIVELY = "CollapseRegionRecursively";
   String ACTION_EXPAND_TO_LEVEL_1 = "ExpandToLevel1";
   String ACTION_EXPAND_ALL_TO_LEVEL_1 = "ExpandAllToLevel1";
+  String ACTION_EXPAND_COLLAPSE_TOGGLE_REGION = "ExpandCollapseToggleAction";
 
   String ACTION_NEW_HORIZONTAL_TAB_GROUP = "NewHorizontalTabGroup";
   String ACTION_NEW_VERTICAL_TAB_GROUP = "NewVerticalTabGroup";


### PR DESCRIPTION
Main driver is to add `za` toggle fold support to ideaVim https://youtrack.jetbrains.com/issue/VIM-566/Support-more-Vim-folding-commands

IdeaVim imports these actions [here](https://github.com/JetBrains/ideavim/blob/master/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt#L48). Technically IdeaVim can pass the raw string `ExpandCollapseToggleAction` to use the toggling but that's flimsy