### PR TITLE
IDEA-80032 Support classifiers with Maven sources

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/workspaceModel/WorkspaceModuleImporter.kt
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/importing/workspaceModel/WorkspaceModuleImporter.kt
@@ -187,7 +187,7 @@ internal class WorkspaceModuleImporter(
     val libraryRootsProvider = {
       val classes = MavenImportUtil.getArtifactUrlForClassifierAndExtension(artifact, null, null)
       val javadoc = MavenImportUtil.getArtifactUrlForClassifierAndExtension(artifact, "javadoc", "jar")
-      val sources = MavenImportUtil.getArtifactUrlForClassifierAndExtension(artifact, "sources", "jar")
+      val sources = MavenImportUtil.getArtifactUrlForClassifierAndExtension(artifact,  if (artifact.classifier.isNullOrBlank()) "sources" else (artifact.classifier + "-sources"), "jar")
 
       // Keep the list of roots sorted by url to avoid extra "roots changed" events after loading the `.iml` files.
       // The `.iml` files keep the order of roots sorted.

--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProject.java
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/project/MavenProject.java
@@ -1197,6 +1197,9 @@ public class MavenProject {
       Pair<String, String> result = each.getExtraArtifactClassifierAndExtension(artifact, type);
       if (result != null) return result;
     }
+    if (MavenExtraArtifactType.SOURCES.equals(type) && !StringUtil.isEmptyOrSpaces(artifact.getClassifier())) {
+      return Pair.create(artifact.getClassifier() + "-" + type.getDefaultClassifier(), type.getDefaultExtension());
+    }
     return Pair.create(type.getDefaultClassifier(), type.getDefaultExtension());
   }
 

--- a/plugins/maven/src/test/java/org/jetbrains/idea/maven/importing/ArtifactsDownloadingTest.kt
+++ b/plugins/maven/src/test/java/org/jetbrains/idea/maven/importing/ArtifactsDownloadingTest.kt
@@ -94,6 +94,32 @@ class ArtifactsDownloadingTest : ArtifactsDownloadingTestCase() {
   }
 
   @Test
+  fun DownloadingDependencySourcesWithClassifier() = runBlocking {
+    importProjectAsync("""
+                    <groupId>test</groupId>
+                    <artifactId>project</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.primefaces</groupId>
+                        <artifactId>primefaces</artifactId>
+                        <version>14.0.4</version>
+                        <classifier>jakarta</classifier>
+                      </dependency>
+                    </dependencies>
+                    """.trimIndent())
+
+    val sources = File(repositoryPath, "/org/primefaces/primefaces/14.0.4/primefaces-14.0.4-jakarta-sources.jar")
+    assertFalse(sources.exists())
+
+    val project = projectsTree.rootProjects[0]
+    val dep = project.dependencies[0]
+    projectsManager.downloadArtifacts(listOf(project), listOf(dep), true, false)
+
+    assertTrue(sources.exists())
+  }
+
+  @Test
   fun DownloadingSpecificDependency() = runBlocking {
     importProjectAsync("""
                     <groupId>test</groupId>


### PR DESCRIPTION
This resolves the issue when using a Maven dependency with a classifier.  Previously, the sources without the classifier would be downloaded.  This modifies the behavior to download the sources with the classifier.

I didn't find any tests to edit for WorkspaceModuleImporter.kt, but if there's something existing I can update it.

A few notes before merging.
1. I noticed that may be related to my changes is that when viewing the source files, the breadcrumbs at the bottom right show a different source jar depending on where you click within the source file on screen. Sometimes it shows as `primefaces-14.0.4-jakarta.jar` and sometimes it shows as `primefaces-14.0.4-jakarta-sources.jar`.
2. This only adds the prefix for sources, it does not do it for javadocs.  I'm not sure if it's the right approach or not for javadocs.
3. If the sources don't exist with the artifact classifier prefix, then there is not any fallback to the sources without the classifier prefix.

### Manual Test Steps
1. Create a new Java -> Maven project within IntelliJ.
4. Modify the existing pom.xml with the below dependency.
  ```xml
<dependency>
    <groupId>org.primefaces</groupId>
    <artifactId>primefaces</artifactId>
    <version>14.0.4</version>
    <classifier>jakarta</classifier>
</dependency>
  ```
5. Reload the Maven project and download sources.
6. Expand the "External Libraries" in the file explorer.
7. Navigate to `Maven: org.primefaces:primefaces:jakarta:14.0.4` and expand the library.
8. Open the `org.primefaces.application.exceptionhandler.PrimeExceptionHandler` class and review the imports at the top of the file, confirm they are the `jakarta` imports.
9. Remove the `classifier` from the dependency.
10. Reload the Maven project and download sources.
11. Repeat the same general steps to confirm that the `javax` imports are used now.
12. Navigate to `Maven: org.primefaces:primefaces:14.0.4` and expand the library.
13. Open the `org.primefaces.application.exceptionhandler.PrimeExceptionHandler` class and review the imports at the top of the file, confirm they are the `javax` imports.