### PR TITLE
Support signature polymorphic methods in debugger evaluation

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/engine/evaluation/expression/EvaluatorBuilderImpl.java
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/evaluation/expression/EvaluatorBuilderImpl.java
@@ -6,6 +6,7 @@
  */
 package com.intellij.debugger.engine.evaluation.expression;
 
+import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.daemon.JavaErrorBundle;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.codeInsight.daemon.impl.analysis.HighlightUtil;
@@ -41,6 +42,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.invoke.VarHandle;
 import java.util.*;
 
 public final class EvaluatorBuilderImpl implements EvaluatorBuilder {
@@ -1267,15 +1269,148 @@ public final class EvaluatorBuilderImpl implements EvaluatorBuilder {
       }
 
       boolean mustBeVararg = false;
+      boolean isSignaturePolymorphic = false;
 
       if (psiMethod != null) {
+        isSignaturePolymorphic = AnnotationUtil.isAnnotated(psiMethod, CommonClassNames.JAVA_LANG_INVOKE_MH_POLYMORPHIC, 0);
         processBoxingConversions(psiMethod.getParameterList().getParameters(), argExpressions, resolveResult.getSubstitutor(), argumentEvaluators);
         mustBeVararg = psiMethod.isVarArgs();
+      }
+      if (isSignaturePolymorphic) {
+        PsiType anticipatedReturnType =
+          wrapSignaturePolymorphicCall(expression, psiMethod, objectEvaluator, argExpressions, argumentEvaluators);
+        if (anticipatedReturnType instanceof PsiPrimitiveType && !anticipatedReturnType.equals(PsiTypes.voidType())) {
+          myResult = new UnBoxingEvaluator(myResult);
+        }
+        return;
       }
 
       myResult = new MethodEvaluator(objectEvaluator, contextClass, methodExpr.getReferenceName(),
                                      psiMethod != null ? JVMNameUtil.getJVMSignature(psiMethod) : null, argumentEvaluators,
                                      mustBeVararg);
+    }
+
+    private @Nullable PsiType wrapSignaturePolymorphicCall(@NotNull PsiMethodCallExpression expression,
+                                      PsiMethod psiMethod,
+                                      Evaluator objectEvaluator,
+                                      PsiExpression[] argExpressions,
+                                      Evaluator[] argumentEvaluators) {
+      PsiClassType methodHandleType =
+        PsiType.getTypeByName("java.lang.invoke.MethodHandle", expression.getProject(), expression.getResolveScope());
+      PsiClass methodHandleClass = checkNotNull(methodHandleType.resolve(), "MethodHandle class is missing");
+      PsiMethod psiInvokeWithArguments = methodHandleClass.findMethodsByName("invokeWithArguments", false)[0];
+      PsiType anticipatedReturnType;
+      PsiClassType objectType = PsiType.getJavaLangObject(expression.getManager(), expression.getResolveScope());
+      if (!objectType.equals(psiMethod.getReturnType())) {
+        anticipatedReturnType = psiMethod.getReturnType(); // e.g. boolean, void in VarHandle methods
+      }
+      else if (expression.getParent() instanceof PsiTypeCastExpression cast) {
+        // the user wants this return type explicitly
+        anticipatedReturnType = checkNotNull(cast.getCastType(), "incomplete cast").getType();
+      }
+      else {
+        anticipatedReturnType = objectType;
+      }
+      // for VarHandle, we must avoid evaluation the qualifier twice
+      Evaluator cachingObjectEvaluator = new Evaluator() {
+        private static final Object NOT_CACHED = new Object();
+        private Object cached = NOT_CACHED;
+        @Override
+        public Object evaluate(EvaluationContextImpl context) throws EvaluateException {
+          if (cached == NOT_CACHED) {
+            cached = objectEvaluator.evaluate(context);
+          }
+          return cached;
+        }
+
+        @Override
+        public Modifier getModifier() {
+          return objectEvaluator.getModifier();
+        }
+      };
+      Evaluator invoker = pickInvoker(psiMethod, argExpressions, cachingObjectEvaluator, anticipatedReturnType);
+      Evaluator[] args = ArrayUtil.prepend(cachingObjectEvaluator, argumentEvaluators);
+      myResult =
+        new MethodEvaluator(invoker, null, "invokeWithArguments", JVMNameUtil.getJVMSignature(psiInvokeWithArguments), args, true);
+      return anticipatedReturnType;
+    }
+
+    private static Evaluator pickInvoker(PsiMethod method,
+                                         PsiExpression[] argExpressions,
+                                         Evaluator qualifier,
+                                         PsiType anticipatedReturnType) {
+      PsiClassType methodHandlesType =
+        PsiType.getTypeByName("java.lang.invoke.MethodHandles", method.getProject(), method.getResolveScope());
+      PsiClass methodHandlesClass = Objects.requireNonNull(methodHandlesType.resolve(), "MethodHandles class is missing");
+      JVMName methodHandlesTypeName = JVMNameUtil.getJVMQualifiedName(methodHandlesType);
+      Evaluator methodTypeEvaluator = buildMethodType(method, argExpressions, anticipatedReturnType);
+      if ("MethodHandle".equals(Objects.requireNonNull(method.getContainingClass()).getName())) {
+        String invokerMethodName = method.getName().equals("invoke") ? "invoker" : "exactInvoker";
+        PsiMethod[] invoker = methodHandlesClass.findMethodsByName(invokerMethodName, false);
+        return buildStaticCall(methodHandlesTypeName, invoker[0], methodTypeEvaluator);
+      }
+      else if ("VarHandle".equals(method.getContainingClass().getName())) {
+        // invocations of signature polymorphic methods can be exact or not depending on the VarHandle's state, so we need to pick
+        // the right method dynamically
+        PsiClassType varHandleType = PsiType.getTypeByName("java.lang.invoke.VarHandle", method.getProject(), method.getResolveScope());
+        PsiClass varHandleClass = checkNotNull(varHandleType.resolve(), "missing VarHandle class");
+        PsiMethod hasInvokeExactBehaviorMethod = varHandleClass.findMethodsByName("hasInvokeExactBehavior", false)[0];
+
+        MethodEvaluator hasInvokeExactBehavior =
+          new MethodEvaluator(qualifier, null, "hasInvokeExactBehavior", JVMNameUtil.getJVMSignature(hasInvokeExactBehaviorMethod),
+                              new Evaluator[0]);
+        PsiClassType accessModeType =
+          PsiType.getTypeByName("java.lang.invoke.VarHandle.AccessMode", method.getProject(), method.getResolveScope());
+        TypeEvaluator accessModeTypeEvaluator = new TypeEvaluator(JVMNameUtil.getJVMQualifiedName(accessModeType));
+        Evaluator accessModeEvaluator = new FieldEvaluator(accessModeTypeEvaluator, FieldEvaluator.createClassFilter(accessModeType),
+                                                           VarHandle.AccessMode.valueFromMethodName(method.getName()).name());
+        Evaluator[] args = {accessModeEvaluator, methodTypeEvaluator};
+        PsiMethod varHandleExactInvoker = methodHandlesClass.findMethodsByName("varHandleExactInvoker", false)[0];
+        PsiMethod varHandleInvoker = methodHandlesClass.findMethodsByName("varHandleInvoker", false)[0];
+        Evaluator ifExact = buildStaticCall(methodHandlesTypeName, varHandleExactInvoker, args);
+        Evaluator otherwise = buildStaticCall(methodHandlesTypeName, varHandleInvoker, args);
+        return new ConditionalExpressionEvaluator(hasInvokeExactBehavior, ifExact, otherwise);
+      }
+      throw evaluateException(method.getContainingClass().getName() + " is not supported");
+    }
+
+    private static @NotNull MethodEvaluator buildStaticCall(JVMName className, PsiMethod method, Evaluator... args) {
+      return new MethodEvaluator(new TypeEvaluator(className), className, method.getName(), JVMNameUtil.getJVMSignature(method), args);
+    }
+
+    private static Evaluator buildMethodType(PsiMethod context, PsiExpression[] arguments, PsiType anticipatedReturnType) {
+      Evaluator[] evaluators = new Evaluator[arguments.length];
+      for (int i = 0; i < evaluators.length; i++) {
+        PsiType type = arguments[i].getType();
+        // when passing 'null' to a signature polymorphic method, the signature will get a Void.class type at this position
+        if (PsiTypes.nullType().equals(type)) {
+          type = PsiTypes.voidType().getBoxedType(context);
+        }
+        evaluators[i] = buildDotClassEvaluator(type);
+      }
+      // MethodType.methodType() methods have several overloads, but none that takes varargs directly
+      // so we use MethodType.methodType(Class, Class[]). But that means we need to create an array manually
+      PsiClassType classType = PsiType.getJavaLangClass(context.getManager(), context.getResolveScope());
+      NewArrayInstanceEvaluator parameters =
+        new NewArrayInstanceEvaluator(new TypeEvaluator(JVMNameUtil.getJVMQualifiedName(classType.createArrayType())),
+                                      null,
+                                      new ArrayInitializerEvaluator(evaluators));
+      Evaluator returnType = buildDotClassEvaluator(anticipatedReturnType);
+      PsiClassType methodTypeType = PsiType.getTypeByName("java.lang.invoke.MethodType", context.getProject(), context.getResolveScope());
+      PsiClass methodTypeClass = checkNotNull(methodTypeType.resolve(), "missing MethodType class");
+      PsiMethod methodTypeMethod = ContainerUtil.find(methodTypeClass.findMethodsByName("methodType", false),
+                                                      method -> method.getParameters().length == 2 &&
+                                                                method.getParameters()[1].getType() instanceof PsiArrayType);
+      return buildStaticCall(JVMNameUtil.getJVMQualifiedName(methodTypeType),
+                             checkNotNull(methodTypeMethod, "missing methodType method"),
+                             returnType, parameters);
+    }
+
+    private static <T> @NotNull T checkNotNull(@Nullable T t, String message) {
+      if (t == null) {
+        throw evaluateException(message);
+      }
+      return t;
     }
 
     @Override
@@ -1397,12 +1532,16 @@ public final class EvaluatorBuilderImpl implements EvaluatorBuilder {
     public void visitClassObjectAccessExpression(@NotNull PsiClassObjectAccessExpression expression) {
       PsiType type = expression.getOperand().getType();
 
+      myResult = buildDotClassEvaluator(type);
+    }
+
+    private static Evaluator buildDotClassEvaluator(PsiType type) {
       if (type instanceof PsiPrimitiveType) {
         final JVMName typeName = JVMNameUtil.getJVMRawText(((PsiPrimitiveType)type).getBoxedTypeName());
-        myResult = new FieldEvaluator(new TypeEvaluator(typeName), FieldEvaluator.TargetClassFilter.ALL, "TYPE");
+        return new FieldEvaluator(new TypeEvaluator(typeName), FieldEvaluator.TargetClassFilter.ALL, "TYPE");
       }
       else {
-        myResult = new ClassObjectEvaluator(new TypeEvaluator(JVMNameUtil.getJVMQualifiedName(type)));
+        return new ClassObjectEvaluator(new TypeEvaluator(JVMNameUtil.getJVMQualifiedName(type)));
       }
     }
 


### PR DESCRIPTION
Before, debugger evaluation did not work with signature polymorphic methods as the invocation behaves like reflective invocation:
<details>
<summary>Invocation of signature polymorphic methods throwing exceptions:</summary>

![vh-broken](https://github.com/user-attachments/assets/c37bf501-48cc-4433-af90-5ed9d5c66a73)
![mh-invoke-broken](https://github.com/user-attachments/assets/d66e7894-3747-4b76-ac67-4f260e741fbc)

</details>

With this change, the methods are now invoked indirectly using the `MethodHandles` `invoker/exactInvoker/varHandleInvoker/varHandleExactInvoker` methods plus `invokeWithArguments`.

I made sure the code works with invoke behavior and invokeExact behavior, as well as properly handles primitive types and return type casts:

<details>
<summary>Simple VarHandle#getAndSet</summary>

![vh-working](https://github.com/user-attachments/assets/ae2ac716-7212-4f7c-8577-d71271038d61)

</details>

<details>
<summary>Type mismatch with invokeExact behavior VarHandle#getAndSet</summary>

![evh-working-mismatch](https://github.com/user-attachments/assets/475e49b8-52da-49e4-8de5-b1af5c5e0483)

</details>

<details>
<summary>Return type casting with invokeExact behavior VarHandle#getAndSet</summary>

![evh-working](https://github.com/user-attachments/assets/a51f12a8-7a81-4e41-9158-a82ee4df4a74)

</details>

<details>
<summary>Simple MethodHandle#invoke with type conversion (unboxing, boxing due to Object return type)</summary>

![mh-working-invoke](https://github.com/user-attachments/assets/50908793-5b8f-4673-acf5-660bffc4bc82)

</details>

<details>
<summary>MethodHandle#invokeExact with type mismatch</summary>

![mh-working-invokeExact-mismatch](https://github.com/user-attachments/assets/72b608ed-fe73-496b-b328-3665d3eb390b)

</details>

<details>
<summary>MethodHandle#invokeExact with proper types</summary>

![mh-working-invokeExact-working](https://github.com/user-attachments/assets/002c5693-c763-42de-88ed-fff759accee0)

</details>


I wasn't able to find out where to add tests covering this, please let me know if you want me to add tests for it.

I also made sure that methods returning a `VarHandle` are only invoked once, even though we need to dynamically check whether the VarHandle has invokeExact behavior or not. I also explored creating a string expression and let that get converted instead, but due to the single-invocation requirement, a single expression would be rather difficult, so I decided to manually build the needed elements instead.