### PR TITLE
Fix race in IStubElementType (IJPL-160566)

### DIFF
--- a/platform/core-api/src/com/intellij/psi/stubs/IStubElementType.java
+++ b/platform/core-api/src/com/intellij/psi/stubs/IStubElementType.java
@@ -21,8 +21,13 @@ public abstract class IStubElementType<StubT extends StubElement<?>, PsiT extend
 
   public IStubElementType(@NotNull @NonNls String debugName, @Nullable Language language) {
     super(debugName, language);
-    if (!isLazilyRegistered()) {
-      checkNotInstantiatedTooLateWithId(getClass());
+    if (isInitialized() && !isLazilyRegistered()) {
+      Logger.getInstance(IStubElementType.class)
+        .error("All stub element types should be created before index initialization is complete.\n" +
+               "Please add the " + getClass() + " with external ID " + getExternalId() + " containing stub element type constants to \"stubElementTypeHolder\" extension.\n" +
+               "Registered extensions: " + StubElementTypeHolderEP.EP_NAME.getExtensionList() + "\n" +
+               "Registered lazy ids: " +
+               lazyExternalIds);
     }
   }
 
@@ -32,17 +37,6 @@ public abstract class IStubElementType<StubT extends StubElement<?>, PsiT extend
         .error("All stub element types should be created before index initialization is complete.\n" +
                "Please add the " + aClass + " containing stub element type constants to \"stubElementTypeHolder\" extension.\n" +
                "Registered extensions: " + StubElementTypeHolderEP.EP_NAME.getExtensionList());
-    }
-  }
-
-  private void checkNotInstantiatedTooLateWithId(@NotNull Class<?> aClass) {
-    if (isInitialized()) {
-      Logger.getInstance(IStubElementType.class)
-        .error("All stub element types should be created before index initialization is complete.\n" +
-               "Please add the " + aClass + " with external ID " + getExternalId() + " containing stub element type constants to \"stubElementTypeHolder\" extension.\n" +
-               "Registered extensions: " + StubElementTypeHolderEP.EP_NAME.getExtensionList() + "\n" +
-               "Registered lazy ids: " +
-               lazyExternalIds);
     }
   }
 


### PR DESCRIPTION
Previously it queried isLazilyRegistered() before isInitialized(), leading to false-positive errors if initialization happens inbetween.

(Note that isLazilyRegistered() returns false if initialization has not happened yet.)

Issue link: https://youtrack.jetbrains.com/issue/IJPL-160566