### PR TITLE
Fix error message warning about the wrong missing file in PathManager

### DIFF
--- a/platform/util/src/com/intellij/openapi/application/PathManager.java
+++ b/platform/util/src/com/intellij/openapi/application/PathManager.java
@@ -108,7 +108,7 @@ public final class PathManager {
       else if (insideIde) {
         result = getHomePathFor(PathManager.class);
         if (result == null) {
-          String advice = SystemInfoRt.isMac ? "reinstall the software." : "make sure bin/idea.properties is present in the installation directory.";
+          String advice = SystemInfoRt.isMac ? "reinstall the software." : "make sure product-info.json is present in the installation directory.";
           throw new RuntimeException("Could not find installation home path. Please " + advice);
         }
       }


### PR DESCRIPTION
The commit https://github.com/JetBrains/intellij-community/commit/70afc86a2730f37989dae2c4ee8f2538e9fa6328 changed which files where checked to find IDE home from  `bin/idea.properties`  
to `product-info.json` but the actual error message was never updated to account for that.

Related youtrack issue: https://youtrack.jetbrains.com/issue/IJPL-160565/Start-Failed-Could-not-find-installation-home-path.-Please-make-sure-bin-idea.properties-is-present-in-the-installation