### PR TITLE
Leveraging IntelliJ IDEA for Android Studio's Cloud Settings Sync

### DIFF
--- a/plugins/settings-sync/resources/META-INF/plugin.xml
+++ b/plugins/settings-sync/resources/META-INF/plugin.xml
@@ -28,6 +28,8 @@
                              provider="com.intellij.settingsSync.config.SettingsSyncConfigurableProvider"
                              groupId="root"
                              groupWeight="5"/>
+    <applicationService serviceInterface="com.intellij.settingsSync.SettingsSyncMain"
+                        serviceImplementation="com.intellij.settingsSync.SettingsSyncMainImpl"/>
     <applicationService serviceInterface="com.intellij.settingsSync.auth.SettingsSyncAuthService"
                         serviceImplementation="com.intellij.settingsSync.auth.SettingsSyncDefaultAuthService"
                         testServiceImplementation="com.intellij.settingsSync.SettingsSyncTestAuthService"/>

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSnapshotZipSerializer.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSnapshotZipSerializer.kt
@@ -21,7 +21,7 @@ import java.util.function.Consumer
 import java.util.stream.Collectors
 import kotlin.io.path.*
 
-internal object SettingsSnapshotZipSerializer {
+object SettingsSnapshotZipSerializer {
   private const val METAINFO = ".metainfo"
   private const val INFO = "info.json"
   const val PLUGINS = "plugins.json"

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncIdeMediatorImpl.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncIdeMediatorImpl.kt
@@ -29,7 +29,7 @@ import java.util.function.Predicate
 import kotlin.concurrent.withLock
 import kotlin.io.path.*
 
-internal class SettingsSyncIdeMediatorImpl(private val componentStore: ComponentStoreImpl,
+class SettingsSyncIdeMediatorImpl(private val componentStore: ComponentStoreImpl,
                                            private val rootConfig: Path,
                                            private val enabledCondition: () -> Boolean) : StreamProvider, SettingsSyncIdeMediator {
 

--- a/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncStatusTracker.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/SettingsSyncStatusTracker.kt
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nls
 import java.util.*
 
 @Service
-internal class SettingsSyncStatusTracker {
+class SettingsSyncStatusTracker {
   private var lastSyncTime = -1L
   private var errorMessage: String? = null
 

--- a/plugins/settings-sync/src/com/intellij/settingsSync/auth/SettingsSyncAuthService.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/auth/SettingsSyncAuthService.kt
@@ -3,7 +3,7 @@ package com.intellij.settingsSync.auth
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.ui.JBAccountInfoService
 
-internal interface SettingsSyncAuthService {
+interface SettingsSyncAuthService {
   companion object {
     fun getInstance(): SettingsSyncAuthService = ApplicationManager.getApplication().getService(SettingsSyncAuthService::class.java)
   }

--- a/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncEnabler.kt
+++ b/plugins/settings-sync/src/com/intellij/settingsSync/config/SettingsSyncEnabler.kt
@@ -14,7 +14,7 @@ import com.intellij.util.EventDispatcher
 import kotlinx.coroutines.*
 import java.util.*
 
-internal class SettingsSyncEnabler {
+class SettingsSyncEnabler {
   private val eventDispatcher = EventDispatcher.create(Listener::class.java)
 
   object State {

--- a/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncAuthTest.kt
+++ b/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncAuthTest.kt
@@ -40,7 +40,11 @@ internal class SettingsSyncAuthTest : BasePlatformTestCase() {
   @TestFor(issues = ["IDEA-307565"])
   fun `idToken is invalidated after unauthorized exception`() {
     val authServiceSpy = spy<SettingsSyncDefaultAuthService>()
-    ApplicationManager.getApplication().replaceService(SettingsSyncAuthService::class.java, authServiceSpy, SettingsSyncMain.getInstance())
+    ApplicationManager.getApplication().replaceService(
+      SettingsSyncAuthService::class.java,
+      authServiceSpy,
+      SettingsSyncMain.getInstance() as SettingsSyncMainImpl
+    )
 
     val accountInfoService = mock<JBAccountInfoService>()
     `when`(accountInfoService.idToken).thenReturn("OLD-ID-TOKEN")
@@ -84,7 +88,11 @@ internal class SettingsSyncAuthTest : BasePlatformTestCase() {
     assertTrue(SettingsSyncSettings.getInstance().syncEnabled)
 
     val authServiceSpy = spy<SettingsSyncDefaultAuthService>()
-    ApplicationManager.getApplication().replaceService(SettingsSyncAuthService::class.java, authServiceSpy, SettingsSyncMain.getInstance())
+    ApplicationManager.getApplication().replaceService(
+      SettingsSyncAuthService::class.java,
+      authServiceSpy,
+      SettingsSyncMain.getInstance() as SettingsSyncMainImpl
+    )
 
     val accountInfoService = mock<JBAccountInfoService>()
     `when`(accountInfoService.idToken).thenReturn(null)

--- a/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncFlowTest.kt
+++ b/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncFlowTest.kt
@@ -41,7 +41,7 @@ internal class SettingsSyncFlowTest : SettingsSyncTestBase() {
     waitForInit: Boolean = true,
   ) {
     SettingsSyncSettings.getInstance().state = SettingsSyncSettings.getInstance().state.withSyncEnabled(true)
-    val controls = SettingsSyncMain.init(currentThreadCoroutineScope(), disposable, settingsSyncStorage, configDir, remoteCommunicator, ideMediator)
+    val controls = SettingsSyncMainImpl.init(currentThreadCoroutineScope(), disposable, settingsSyncStorage, configDir, remoteCommunicator, ideMediator)
     updateChecker = controls.updateChecker
     bridge = controls.bridge
     bridge.initialize(initMode)

--- a/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncRealIdeTestBase.kt
+++ b/plugins/settings-sync/tests/com/intellij/settingsSync/SettingsSyncRealIdeTestBase.kt
@@ -53,7 +53,7 @@ internal abstract class SettingsSyncRealIdeTestBase : SettingsSyncTestBase() {
     SettingsSyncSettings.getInstance().syncEnabled = true
     SettingsSyncLocalSettings.getInstance().state.crossIdeSyncEnabled = crossIdeSync;
     val ideMediator = SettingsSyncIdeMediatorImpl(componentStore, configDir, enabledCondition = { true })
-    val controls = SettingsSyncMain.init(currentThreadCoroutineScope(), disposable, settingsSyncStorage, configDir, remoteCommunicator, ideMediator)
+    val controls = SettingsSyncMainImpl.init(currentThreadCoroutineScope(), disposable, settingsSyncStorage, configDir, remoteCommunicator, ideMediator)
     updateChecker = controls.updateChecker
     bridge = controls.bridge
     bridge.initialize(initMode)


### PR DESCRIPTION
Android Studio aims to implement settings synchronization using its own cloud service. To avoid redundant development, we propose that IntelliJ IDEA, which already possesses a robust settings sync plugin, introduce minor modifications to facilitate the replacement of the underlying sync service. This would allow Android Studio to leverage IntelliJ IDEA's existing sync functionality without altering the core features or user experience.