### PR TITLE
[kotlin][debugger] Add support for removed line numbers from lambdas with parameter destructuring

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/KotlinPositionManager.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/KotlinPositionManager.kt
@@ -262,7 +262,7 @@ class KotlinPositionManager(private val debugProcess: DebugProcess) : MultiReque
         if (sameLineLocations.size < 2 || hasFinallyBlockInParent(psiFile)) {
             return false
         }
-        val locationsInSameInlinedFunction = findLocationsInSameInlinedFunction(sameLineLocations, method, sourceFileName)
+        val locationsInSameInlinedFunction = findLocationsInSameInlinedFunction(sameLineLocations, method)
         return locationsInSameInlinedFunction.ifEmpty { sameLineLocations }.indexOf(this) > 0
     }
 
@@ -274,9 +274,9 @@ class KotlinPositionManager(private val debugProcess: DebugProcess) : MultiReque
         }
     }
 
-    private fun Location.findLocationsInSameInlinedFunction(locations: List<Location>, method: Method, sourceFileName: String): List<Location> {
+    private fun Location.findLocationsInSameInlinedFunction(locations: List<Location>, method: Method): List<Location> {
         val leastEnclosingBorders = method
-            .getInlineFunctionBorders(sourceFileName)
+            .getInlineFunctionBorders()
             .getLeastEnclosingBorders(this)
             ?: return emptyList()
         return locations.filter { leastEnclosingBorders.contains(it) }
@@ -292,11 +292,8 @@ class KotlinPositionManager(private val debugProcess: DebugProcess) : MultiReque
         return result
     }
 
-    private fun Method.getInlineFunctionBorders(sourceFileName: String): List<ClosedRange<Location>> {
-        return getInlineFunctionOrArgumentVariables()
-            .mapNotNull { it.getBorders() }
-            .filter { it.start.safeSourceName() == sourceFileName }
-            .toList()
+    private fun Method.getInlineFunctionBorders(): List<ClosedRange<Location>> {
+        return getInlineFunctionOrArgumentVariables().mapNotNull { it.getBorders() }.toList()
     }
 
     private suspend fun getAlternativeSource(location: Location): PsiFile? {

--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/stepping/KotlinRequestHint.kt
@@ -2,23 +2,25 @@
 
 package org.jetbrains.kotlin.idea.debugger.core.stepping
 
+import com.intellij.debugger.DebuggerManagerEx
+import com.intellij.debugger.SourcePosition
+import com.intellij.debugger.engine.*
 import com.intellij.debugger.engine.DebugProcess.JAVA_STRATUM
-import com.intellij.debugger.engine.DebugProcessImpl
-import com.intellij.debugger.engine.MethodFilter
-import com.intellij.debugger.engine.RequestHint
-import com.intellij.debugger.engine.SuspendContextImpl
 import com.intellij.debugger.engine.evaluation.EvaluateException
 import com.intellij.debugger.jdi.ThreadReferenceProxyImpl
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.util.Range
 import com.jetbrains.jdi.ClassTypeImpl
 import com.sun.jdi.Location
 import com.sun.jdi.VMDisconnectedException
 import com.sun.jdi.request.StepRequest
+import org.jetbrains.kotlin.idea.debugger.base.util.safeAllLineLocations
 import org.jetbrains.kotlin.idea.debugger.base.util.safeLineNumber
 import org.jetbrains.kotlin.idea.debugger.base.util.safeLocation
 import org.jetbrains.kotlin.idea.debugger.base.util.safeMethod
 import org.jetbrains.kotlin.idea.debugger.core.*
+import org.jetbrains.kotlin.idea.debugger.core.DebuggerUtils.isGeneratedIrBackendLambdaMethodName
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.org.objectweb.asm.Type
 
@@ -246,6 +248,18 @@ class KotlinStepIntoRequestHint(
                 return STOP
             }
 
+            // When the VM steps into a method, it will stop in the beginning of it,
+            // even if the first line number is declared a number of opcodes later.
+            // This can spoil the debugging in case of stepping into lambdas like:
+            // f { (a, b) -> ... }
+            // However the newest versions of the compiler will not generate line numbers
+            // for parameter destructuring, the debugger will stop in the beginning of a
+            // lambda anyway, and destructured parameters will not be visible in the variables
+            // view. In such situations we need to install a breakpoint to the first location
+            // declared in a lambda and perform a step over to reach it.
+            if (addBreakpointAtFirstDeclaredLocationInLambda(this, context)) {
+                return StepRequest.STEP_OVER
+            }
             return super.getNextStepDepth(context)
         } catch (ignored: VMDisconnectedException) {
         } catch (e: EvaluateException) {
@@ -253,6 +267,50 @@ class KotlinStepIntoRequestHint(
         }
         return STOP
     }
+}
+
+private fun addBreakpointAtFirstDeclaredLocationInLambda(hint: KotlinRequestHint, context: SuspendContextImpl): Boolean {
+    val currentLocation = context.location ?: return false
+    if (!currentLocation.isInKotlinSources()) {
+        return false
+    }
+
+    val method = currentLocation.safeMethod() ?: return false
+    if (!method.name().isGeneratedIrBackendLambdaMethodName()) {
+        return false
+    }
+
+    val firstDeclaredLocation = method.safeAllLineLocations().minByOrNull { it.codeIndex() }
+        ?: return false
+    // If the current location is before the first declared location, then
+    // it means that it is synthetic, and we should skip it when stepping.
+    if (currentLocation.codeIndex() >= firstDeclaredLocation.codeIndex()) {
+        return false
+    }
+
+    val sourcePosition = context.debugProcess.positionManager.getSourcePosition(firstDeclaredLocation) ?: return false
+    val filter = object : BreakpointStepMethodFilter {
+        override fun locationMatches(process: DebugProcessImpl?, location: Location?): Boolean {
+            return location == firstDeclaredLocation
+        }
+
+        override fun getBreakpointPosition(): SourcePosition {
+            return sourcePosition
+        }
+
+        // Not needed
+        override fun getCallingExpressionLines(): Range<Int>? {
+            return null
+        }
+
+        // Not needed
+        override fun getLastStatementLine(): Int {
+            return -1
+        }
+    }
+    val breakpoint = DebuggerManagerEx.getInstanceEx(context.debugProcess.project).getBreakpointManager().addStepIntoBreakpoint(filter) ?: return false
+    DebugProcessImpl.prepareAndSetSteppingBreakpoint(context, breakpoint, hint, true)
+    return true
 }
 
 private fun needTechnicalStepInto(context: SuspendContextImpl): Boolean {

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated 
                 runTest("../testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("../testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated 
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("../testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated 
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("../testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class K2IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
                 runTest("../testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("../testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class K2IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("../testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("../testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class K2IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("../testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/AbstractIrKotlinEvaluateExpressionTest.kt
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/AbstractIrKotlinEvaluateExpressionTest.kt
@@ -321,8 +321,19 @@ abstract class AbstractIrKotlinEvaluateExpressionTest : KotlinDescriptorTestCase
     private fun loadExpressions(testFile: KotlinBaseTest.TestFile): List<CodeFragment> {
         val directives = findLinesWithPrefixesRemoved(testFile.content, "// EXPRESSION: ")
         val expected = findLinesWithPrefixesRemoved(testFile.content, "// RESULT: ")
+        val expectedK2 = findLinesWithPrefixesRemoved(testFile.content, "// RESULT_K2: ")
         assert(directives.size == expected.size) { "Sizes of test directives are different" }
-        return directives.zip(expected).map { (text, result) -> CodeFragment(text, result, CodeFragmentKind.EXPRESSION) }
+        if (expectedK2.isNotEmpty()) {
+            assert(expected.size == expectedK2.size) { "Sizes of test directives are different" }
+        }
+
+        val expectations =
+            if (compileWithK2 && expectedK2.isNotEmpty()) {
+                expectedK2
+            } else {
+                expected
+            }
+        return directives.zip(expectations).map { (text, result) -> CodeFragment(text, result, CodeFragmentKind.EXPRESSION) }
     }
 
     private fun loadCodeBlocks(wholeFile: File): List<CodeFragment> {

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaIrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaIrKotlinEvaluateExpressionTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class IndyLambdaIrKotlinEvaluateExpressionTestGenerated extends 
                 runTest("testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class IndyLambdaIrKotlinEvaluateExpressionTestGenerated extends 
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class IndyLambdaIrKotlinEvaluateExpressionTestGenerated extends 
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated 
                 runTest("testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated 
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated 
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionInMppTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class IrKotlinEvaluateExpressionInMppTestGenerated extends Abstr
                 runTest("testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class IrKotlinEvaluateExpressionInMppTestGenerated extends Abstr
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class IrKotlinEvaluateExpressionInMppTestGenerated extends Abstr
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
                 runTest("testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated exte
                 runTest("testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated exte
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated exte
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
@@ -2212,6 +2212,26 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
                 runTest("testData/evaluation/singleBreakpoint/simple.kt");
             }
 
+            @TestMetadata("smartStepIntoInlineLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoInlineSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoLambdaWithParameterDestructuring.kt")
+            public void testSmartStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("smartStepIntoSamWithParameterDestructuring.kt")
+            public void testSmartStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt");
+            }
+
             @TestMetadata("statements.kt")
             public void testStatements() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/statements.kt");
@@ -2225,6 +2245,36 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
             @TestMetadata("stdlib.kt")
             public void testStdlib() throws Exception {
                 runTest("testData/evaluation/singleBreakpoint/stdlib.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring1.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring1() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuring2.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuring2() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt");
+            }
+
+            @TestMetadata("stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt")
+            public void testStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt");
+            }
+
+            @TestMetadata("stepIntoInlineSamWithParameterDestructuring.kt")
+            public void testStepIntoInlineSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoLambdaWithParameterDestructuring.kt")
+            public void testStepIntoLambdaWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt");
+            }
+
+            @TestMetadata("stepIntoSamWithParameterDestructuring.kt")
+            public void testStepIntoSamWithParameterDestructuring() throws Exception {
+                runTest("testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt");
             }
 
             @TestMetadata("superCallsCaptured.kt")
@@ -2367,6 +2417,11 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
 
             private void runTest(String testDataFilePath) throws Exception {
                 KotlinTestUtils.runTest(this::doMultipleBreakpointsTest, this, TargetBackend.JVM_IR_WITH_IR_EVALUATOR, testDataFilePath);
+            }
+
+            @TestMetadata("breakpointsInLambdasWithDestructuring.kt")
+            public void testBreakpointsInLambdasWithDestructuring() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt");
             }
 
             @TestMetadata("clearCache.kt")

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.k2.out
@@ -1,0 +1,134 @@
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:29 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:31 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:33 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:35 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:38 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:40 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:44 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:46 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:50 lambdaOrdinal = 1
+Run Java
+Connected to the target VM
+breakpointsInLambdasWithDestructuring.kt:29
+Compile bytecode for x + y
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:29)
+    JavaValue[local] x: int = 1 (breakpointsInLambdasWithDestructuring.kt:29)
+    JavaValue[local] y: int = 2 (breakpointsInLambdasWithDestructuring.kt:29)
+breakpointsInLambdasWithDestructuring.kt:31
+Compile bytecode for x
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:31)
+    JavaValue[local] x: int = 1 (breakpointsInLambdasWithDestructuring.kt:31)
+breakpointsInLambdasWithDestructuring.kt:33
+Compile bytecode for x + y
+InlineStackFrame lambda 'inlineFoo' in 'main' (breakpointsInLambdasWithDestructuring.kt:33)
+    JavaValue[local] x: int = 1 (breakpointsInLambdasWithDestructuring.kt:33)
+    JavaValue[local] y: int = 2 (breakpointsInLambdasWithDestructuring.kt:33)
+InlineStackFrame inlineFoo (breakpointsInLambdasWithDestructuring.kt:20)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:33)
+breakpointsInLambdasWithDestructuring.kt:35
+Compile bytecode for y
+InlineStackFrame lambda 'inlineFoo' in 'main' (breakpointsInLambdasWithDestructuring.kt:35)
+    JavaValue[local] y: int = 2 (breakpointsInLambdasWithDestructuring.kt:35)
+InlineStackFrame inlineFoo (breakpointsInLambdasWithDestructuring.kt:20)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:35)
+breakpointsInLambdasWithDestructuring.kt:38
+Compile bytecode for x + y
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:38)
+    JavaValue[local] x: int = 1 (breakpointsInLambdasWithDestructuring.kt:38)
+    JavaValue[local] y: int = 2 (breakpointsInLambdasWithDestructuring.kt:38)
+breakpointsInLambdasWithDestructuring.kt:40
+Compile bytecode for x + y
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:40)
+    JavaValue[local] x: int = 1 (breakpointsInLambdasWithDestructuring.kt:40)
+    JavaValue[local] y: int = 2 (breakpointsInLambdasWithDestructuring.kt:40)
+breakpointsInLambdasWithDestructuring.kt:44
+Compile bytecode for x + y
+InlineStackFrame lambda 'filter' in 'main' (breakpointsInLambdasWithDestructuring.kt:44)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] x: int = 1 (breakpointsInLambdasWithDestructuring.kt:44)
+    JavaValue[local] y: int = 2 (breakpointsInLambdasWithDestructuring.kt:44)
+InlineStackFrame filterTo (_Collections.!EXT!)
+    JavaValue[local] this: java.lang.Iterable =  size = 1
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] destination: java.util.Collection =  size = 0
+    JavaValue[local] element: java.lang.Object = A(x=1, y=2)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+InlineStackFrame filter (_Collections.!EXT!)
+    JavaValue[local] this: java.lang.Iterable =  size = 1
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:44)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+breakpointsInLambdasWithDestructuring.kt:46
+Compile bytecode for x + y
+InlineStackFrame lambda 'forEach' in 'main' (breakpointsInLambdasWithDestructuring.kt:46)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] x: int = 1 (breakpointsInLambdasWithDestructuring.kt:46)
+    JavaValue[local] y: int = 2 (breakpointsInLambdasWithDestructuring.kt:46)
+InlineStackFrame forEach (_Collections.!EXT!)
+    JavaValue[local] this: java.lang.Iterable =  size = 1
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] element: java.lang.Object = A(x=1, y=2)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:46)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+breakpointsInLambdasWithDestructuring.kt:50
+Compile bytecode for key + value
+InlineStackFrame lambda 'forEach' in 'main' (breakpointsInLambdasWithDestructuring.kt:50)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] map: java.util.Map =  size = 1 (breakpointsInLambdasWithDestructuring.kt:48)
+        JavaValue[element] 0 = ... -> ...
+            JavaValue key: java.lang.Integer = 1
+                JavaValue[field] value: int = 1 (Integer.!EXT!)
+            JavaValue value: java.lang.Integer = 2
+                JavaValue[field] value: int = 2 (Integer.!EXT!)
+    JavaValue[local] key: int = 1 (breakpointsInLambdasWithDestructuring.kt:50)
+    JavaValue[local] value: int = 2 (breakpointsInLambdasWithDestructuring.kt:50)
+InlineStackFrame forEach (_Maps.!EXT!)
+    JavaValue[local] this: java.util.Map =  size = 1
+        JavaValue[element] 0 = ... -> ...
+            JavaValue key: java.lang.Integer = 1
+                JavaValue[field] value: int = 1 (Integer.!EXT!)
+            JavaValue value: java.lang.Integer = 2
+                JavaValue[field] value: int = 2 (Integer.!EXT!)
+    JavaValue[local] element: java.util.Map$Entry = ... -> ...
+        JavaValue key: java.lang.Integer = 1
+            JavaValue[field] value: int = 1 (Integer.!EXT!)
+        JavaValue value: java.lang.Integer = 2
+            JavaValue[field] value: int = 2 (Integer.!EXT!)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:50)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] map: java.util.Map =  size = 1 (breakpointsInLambdasWithDestructuring.kt:48)
+        JavaValue[element] 0 = ... -> ...
+            JavaValue key: java.lang.Integer = 1
+                JavaValue[field] value: int = 1 (Integer.!EXT!)
+            JavaValue value: java.lang.Integer = 2
+                JavaValue[field] value: int = 2 (Integer.!EXT!)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.kt
@@ -1,0 +1,82 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package breakpointsInLambdasWithDestructuring
+
+import destructurableClasses.A
+
+fun interface Runnable {
+    fun run(a: A)
+}
+
+fun foo(f: (A) -> Unit) {
+    f(A(1, 2))
+}
+
+fun run(r: Runnable) {
+    r.run(A(1, 2))
+}
+
+inline fun inlineFoo(f: (A) -> Unit) {
+    f(A(1, 2))
+}
+
+inline fun inlineRun(r: Runnable) {
+    r.run(A(1, 2))
+}
+
+fun main() {
+    //Breakpoint! (lambdaOrdinal = 1)
+    foo { (x, y) -> println() }
+    //Breakpoint! (lambdaOrdinal = 1)
+    foo { (x, _) -> println() }
+    //Breakpoint! (lambdaOrdinal = 1)
+    inlineFoo { (x, y) -> println() }
+    //Breakpoint! (lambdaOrdinal = 1)
+    inlineFoo { (_, y) -> println() }
+
+    //Breakpoint! (lambdaOrdinal = 1)
+    run { (x, y) -> println() }
+    //Breakpoint! (lambdaOrdinal = 1)
+    inlineRun { (x, y) -> println() }
+
+    val list = listOf(A(1, 2))
+    //Breakpoint! (lambdaOrdinal = 1)
+    list.filter { (x, y) -> x > y }
+    //Breakpoint! (lambdaOrdinal = 1)
+    list.forEach { (x, y) -> x + y }
+
+    val map = mapOf(1 to 2)
+    //Breakpoint! (lambdaOrdinal = 1)
+    map.forEach { (key, value) -> println() }
+}
+
+// EXPRESSION: x + y
+// RESULT: 'x' is not captured
+// RESULT_K2: 3: I
+// EXPRESSION: x
+// RESULT: 'x' is not captured
+// RESULT_K2: 1: I
+// EXPRESSION: x + y
+// RESULT: 'x' is not captured
+// RESULT_K2: 3: I
+// EXPRESSION: y
+// RESULT: 'y' is not captured
+// RESULT_K2: 2: I
+// EXPRESSION: x + y
+// RESULT: 'x' is not captured
+// RESULT_K2: 3: I
+// EXPRESSION: x + y
+// RESULT: 'x' is not captured
+// RESULT_K2: 3: I
+// EXPRESSION: x + y
+// RESULT: 'x' is not captured
+// RESULT_K2: 3: I
+// EXPRESSION: x + y
+// RESULT: 'x' is not captured
+// RESULT_K2: 3: I
+// EXPRESSION: key + value
+// RESULT: 'key' is not captured
+// RESULT_K2: 3: I
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/breakpointsInLambdasWithDestructuring.out
@@ -1,0 +1,118 @@
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:29 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:31 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:33 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:35 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:38 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:40 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:44 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:46 lambdaOrdinal = 1
+LineBreakpoint created at breakpointsInLambdasWithDestructuring.kt:50 lambdaOrdinal = 1
+Run Java
+Connected to the target VM
+breakpointsInLambdasWithDestructuring.kt:29
+Compile bytecode for x + y
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:29)
+breakpointsInLambdasWithDestructuring.kt:31
+Compile bytecode for x
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:31)
+breakpointsInLambdasWithDestructuring.kt:33
+Compile bytecode for x + y
+InlineStackFrame lambda 'inlineFoo' in 'main' (breakpointsInLambdasWithDestructuring.kt:33)
+InlineStackFrame inlineFoo (breakpointsInLambdasWithDestructuring.kt:20)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:33)
+breakpointsInLambdasWithDestructuring.kt:35
+Compile bytecode for y
+InlineStackFrame lambda 'inlineFoo' in 'main' (breakpointsInLambdasWithDestructuring.kt:35)
+InlineStackFrame inlineFoo (breakpointsInLambdasWithDestructuring.kt:20)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:35)
+breakpointsInLambdasWithDestructuring.kt:38
+Compile bytecode for x + y
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:38)
+breakpointsInLambdasWithDestructuring.kt:40
+Compile bytecode for x + y
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:40)
+breakpointsInLambdasWithDestructuring.kt:44
+Compile bytecode for x + y
+InlineStackFrame lambda 'filter' in 'main' (breakpointsInLambdasWithDestructuring.kt:44)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+InlineStackFrame filterTo (_Collections.!EXT!)
+    JavaValue[local] this: java.lang.Iterable =  size = 1
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] destination: java.util.Collection =  size = 0
+    JavaValue[local] element: java.lang.Object = A(x=1, y=2)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+InlineStackFrame filter (_Collections.!EXT!)
+    JavaValue[local] this: java.lang.Iterable =  size = 1
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:44)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+breakpointsInLambdasWithDestructuring.kt:46
+Compile bytecode for x + y
+InlineStackFrame lambda 'forEach' in 'main' (breakpointsInLambdasWithDestructuring.kt:46)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+InlineStackFrame forEach (_Collections.!EXT!)
+    JavaValue[local] this: java.lang.Iterable =  size = 1
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] element: java.lang.Object = A(x=1, y=2)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:46)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+breakpointsInLambdasWithDestructuring.kt:50
+Compile bytecode for key + value
+InlineStackFrame lambda 'forEach' in 'main' (breakpointsInLambdasWithDestructuring.kt:50)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] map: java.util.Map =  size = 1 (breakpointsInLambdasWithDestructuring.kt:48)
+        JavaValue[element] 0 = ... -> ...
+            JavaValue key: java.lang.Integer = 1
+                JavaValue[field] value: int = 1 (Integer.!EXT!)
+            JavaValue value: java.lang.Integer = 2
+                JavaValue[field] value: int = 2 (Integer.!EXT!)
+InlineStackFrame forEach (_Maps.!EXT!)
+    JavaValue[local] this: java.util.Map =  size = 1
+        JavaValue[element] 0 = ... -> ...
+            JavaValue key: java.lang.Integer = 1
+                JavaValue[field] value: int = 1 (Integer.!EXT!)
+            JavaValue value: java.lang.Integer = 2
+                JavaValue[field] value: int = 2 (Integer.!EXT!)
+    JavaValue[local] element: java.util.Map$Entry = ... -> ...
+        JavaValue key: java.lang.Integer = 1
+            JavaValue[field] value: int = 1 (Integer.!EXT!)
+        JavaValue value: java.lang.Integer = 2
+            JavaValue[field] value: int = 2 (Integer.!EXT!)
+KotlinStackFrame (breakpointsInLambdasWithDestructuring.kt:50)
+    JavaValue[local] list: java.util.List =  size = 1 (breakpointsInLambdasWithDestructuring.kt:42)
+        JavaValue[element] 0: A@uniqueID = A(x=1, y=2)
+            JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+            JavaValue[field] y: int = 2 (destructurableClasses.kt:4)
+    JavaValue[local] map: java.util.Map =  size = 1 (breakpointsInLambdasWithDestructuring.kt:48)
+        JavaValue[element] 0 = ... -> ...
+            JavaValue key: java.lang.Integer = 1
+                JavaValue[field] value: int = 1 (Integer.!EXT!)
+            JavaValue value: java.lang.Integer = 2
+                JavaValue[field] value: int = 2 (Integer.!EXT!)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.k2.out
@@ -1,0 +1,27 @@
+LineBreakpoint created at smartStepIntoInlineLambdaWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+smartStepIntoInlineLambdaWithParameterDestructuring.kt:17
+smartStepIntoInlineLambdaWithParameterDestructuring.kt:20
+smartStepIntoInlineLambdaWithParameterDestructuring.kt:20
+Compile bytecode for a + b + c + d + e + f + g
+InlineStackFrame lambda 'inlineFoo' in 'main' (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] x: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:17)
+    JavaValue[local] g: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] a: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] b: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] c: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] d: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] e: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] f: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+InlineStackFrame inlineFoo (smartStepIntoInlineLambdaWithParameterDestructuring.kt:11)
+    JavaValue[local] a: destructurableClasses.A = A(x=1, y=1) (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+        DummyMessageValueNode = Class has no properties
+KotlinStackFrame (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] x: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:17)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.kt
@@ -1,0 +1,28 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package smartStepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+inline fun inlineFoo(f: (A, B, Int) -> Unit) {
+    val a = A(1, 1)
+    val b = B()
+    f(a, b, 1)
+}
+
+fun main() {
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x = 1
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    inlineFoo { (a, b), (c, d, e, f), g -> println() }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g
+// RESULT: 'a' is not captured
+// RESULT_K2: 7: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineLambdaWithParameterDestructuring.out
@@ -1,0 +1,21 @@
+LineBreakpoint created at smartStepIntoInlineLambdaWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+smartStepIntoInlineLambdaWithParameterDestructuring.kt:17
+smartStepIntoInlineLambdaWithParameterDestructuring.kt:20
+smartStepIntoInlineLambdaWithParameterDestructuring.kt:20
+Compile bytecode for a + b + c + d + e + f + g
+InlineStackFrame lambda 'inlineFoo' in 'main' (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] x: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:17)
+    JavaValue[local] g: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+InlineStackFrame inlineFoo (smartStepIntoInlineLambdaWithParameterDestructuring.kt:11)
+    JavaValue[local] a: destructurableClasses.A = A(x=1, y=1) (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+        DummyMessageValueNode = Class has no properties
+KotlinStackFrame (smartStepIntoInlineLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] x: int = 1 (smartStepIntoInlineLambdaWithParameterDestructuring.kt:17)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.k2.out
@@ -1,0 +1,18 @@
+LineBreakpoint created at smartStepIntoInlineSamWithParameterDestructuring.kt:21
+Run Java
+Connected to the target VM
+smartStepIntoInlineSamWithParameterDestructuring.kt:21
+smartStepIntoInlineSamWithParameterDestructuring.kt:24
+smartStepIntoInlineSamWithParameterDestructuring.kt:24
+Compile bytecode for a + b + c + d + e + f + g
+KotlinStackFrame (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] g: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] a: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] b: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] c: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] d: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] e: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] f: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.kt
@@ -1,0 +1,32 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package smartStepIntoInlineSamWithParameterDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun interface Runnable {
+    fun run(a: A, b: B, c: Int)
+}
+
+inline fun inlineRun(runnable: Runnable) {
+    val a = A(1, 1)
+    val b = B()
+    runnable.run(a, b, 1)
+}
+
+fun main() {
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x = 1
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    inlineRun { (a, b), (c, d, e, f), g -> println() }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g
+// RESULT: 'a' is not captured
+// RESULT_K2: 7: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoInlineSamWithParameterDestructuring.out
@@ -1,0 +1,12 @@
+LineBreakpoint created at smartStepIntoInlineSamWithParameterDestructuring.kt:21
+Run Java
+Connected to the target VM
+smartStepIntoInlineSamWithParameterDestructuring.kt:21
+smartStepIntoInlineSamWithParameterDestructuring.kt:24
+smartStepIntoInlineSamWithParameterDestructuring.kt:24
+Compile bytecode for a + b + c + d + e + f + g
+KotlinStackFrame (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] g: int = 1 (smartStepIntoInlineSamWithParameterDestructuring.kt:24)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.k2.out
@@ -1,0 +1,18 @@
+LineBreakpoint created at smartStepIntoLambdaWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+smartStepIntoLambdaWithParameterDestructuring.kt:17
+smartStepIntoLambdaWithParameterDestructuring.kt:20
+smartStepIntoLambdaWithParameterDestructuring.kt:20
+Compile bytecode for a + b + c + d + e + f + g
+KotlinStackFrame (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] g: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] a: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] b: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] c: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] d: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] e: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] f: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.kt
@@ -1,0 +1,28 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package smartStepIntoLambdaWithParameterDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun foo(f: (A, B, Int) -> Unit) {
+    val a = A(1, 1)
+    val b = B()
+    f(a, b, 1)
+}
+
+fun main() {
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x = 1
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    foo { (a, b), (c, d, e, f), g -> println() }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g
+// RESULT: 'a' is not captured
+// RESULT_K2: 7: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoLambdaWithParameterDestructuring.out
@@ -1,0 +1,12 @@
+LineBreakpoint created at smartStepIntoLambdaWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+smartStepIntoLambdaWithParameterDestructuring.kt:17
+smartStepIntoLambdaWithParameterDestructuring.kt:20
+smartStepIntoLambdaWithParameterDestructuring.kt:20
+Compile bytecode for a + b + c + d + e + f + g
+KotlinStackFrame (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] g: int = 1 (smartStepIntoLambdaWithParameterDestructuring.kt:20)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.k2.out
@@ -1,0 +1,18 @@
+LineBreakpoint created at smartStepIntoSamWithParameterDestructuring.kt:21
+Run Java
+Connected to the target VM
+smartStepIntoSamWithParameterDestructuring.kt:21
+smartStepIntoSamWithParameterDestructuring.kt:24
+smartStepIntoSamWithParameterDestructuring.kt:24
+Compile bytecode for a + b + c + d + e + f + g
+KotlinStackFrame (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] g: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] a: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] b: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] c: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] d: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] e: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] f: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.kt
@@ -1,0 +1,32 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package smartStepIntoSamWithParameterDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun interface Runnable {
+    fun run(a: A, b: B, c: Int)
+}
+
+fun run(runnable: Runnable) {
+    val a = A(1, 1)
+    val b = B()
+    runnable.run(a, b, 1)
+}
+
+fun main() {
+    // STEP_OVER: 1
+    //Breakpoint!
+    val x = 1
+
+    // SMART_STEP_INTO_BY_INDEX: 2
+    run { (a, b), (c, d, e, f), g -> println() }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g
+// RESULT: 'a' is not captured
+// RESULT_K2: 7: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/smartStepIntoSamWithParameterDestructuring.out
@@ -1,0 +1,12 @@
+LineBreakpoint created at smartStepIntoSamWithParameterDestructuring.kt:21
+Run Java
+Connected to the target VM
+smartStepIntoSamWithParameterDestructuring.kt:21
+smartStepIntoSamWithParameterDestructuring.kt:24
+smartStepIntoSamWithParameterDestructuring.kt:24
+Compile bytecode for a + b + c + d + e + f + g
+KotlinStackFrame (smartStepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] g: int = 1 (smartStepIntoSamWithParameterDestructuring.kt:24)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.k2.out
@@ -1,0 +1,30 @@
+LineBreakpoint created at stepIntoInlineLambdaWithParameterDestructuring1.kt:11
+Run Java
+Connected to the target VM
+stepIntoInlineLambdaWithParameterDestructuring1.kt:11
+stepIntoInlineLambdaWithParameterDestructuring1.kt:25
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoInlineLambdaWithParameterDestructuring1.kt:25)
+    JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:16)
+    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:17)
+    JavaValue[local] g: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:19)
+    JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:24)
+    JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:24)
+    JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:15)
+    JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:15)
+    JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:17)
+    JavaValue[local] f: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:18)
+    JavaValue[local] h: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:20)
+    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:20)
+    JavaValue[local] j: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:21)
+    JavaValue[local] k: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:22)
+    JavaValue[local] l: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:23)
+    JavaValue[local] m: int = 1 (stepIntoInlineLambdaWithParameterDestructuring1.kt:23)
+InlineStackFrame inlineFoo (stepIntoInlineLambdaWithParameterDestructuring1.kt:11)
+    JavaValue[local] a: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithParameterDestructuring1.kt:15)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+KotlinStackFrame (stepIntoInlineLambdaWithParameterDestructuring1.kt:15)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.kt
@@ -1,0 +1,34 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package stepIntoInlineLambdaWithParameterDestructuring1
+
+import destructurableClasses.A
+
+inline fun inlineFoo(f: (A, Int, Int, A, Int, A, A, A, Int, Int) -> Unit) {
+    val a = A(1, 1)
+    // STEP_INTO: 1
+    //Breakpoint!
+    f(a, 1, 1, a, 1, a, a, a, 1, 1)
+}
+
+fun main() {
+    inlineFoo { (a, b),
+          c,
+          d, (e,
+              f),
+          g,
+          (h, i),
+          (j,
+              k),
+                (l, m),
+        n, o ->
+        println()
+    }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+// RESULT: Unresolved reference: a
+// RESULT_K2: 15: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring1.out
@@ -1,0 +1,19 @@
+LineBreakpoint created at stepIntoInlineLambdaWithParameterDestructuring1.kt:11
+Run Java
+Connected to the target VM
+stepIntoInlineLambdaWithParameterDestructuring1.kt:11
+stepIntoInlineLambdaWithParameterDestructuring1.kt:15
+InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoInlineLambdaWithParameterDestructuring1.kt:15)
+    JavaValue[local] c: int = 1
+    JavaValue[local] d: int = 1
+    JavaValue[local] g: int = 1
+    JavaValue[local] n: int = 1
+    JavaValue[local] o: int = 1
+InlineStackFrame inlineFoo (stepIntoInlineLambdaWithParameterDestructuring1.kt:11)
+    JavaValue[local] a: destructurableClasses.A = A(x=1, y=1)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+KotlinStackFrame (stepIntoInlineLambdaWithParameterDestructuring1.kt:15)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.k2.out
@@ -1,0 +1,12 @@
+LineBreakpoint created at stepIntoInlineLambdaWithParameterDestructuring2.kt:10
+Run Java
+Connected to the target VM
+stepIntoInlineLambdaWithParameterDestructuring2.kt:10
+stepIntoInlineLambdaWithParameterDestructuring2.kt:16
+Compile bytecode for x + w
+KotlinStackFrame (stepIntoInlineLambdaWithParameterDestructuring2.kt:16)
+    JavaValue[local] w: int = 1 (stepIntoInlineLambdaWithParameterDestructuring2.kt:15)
+    JavaValue[local] x: int = 1 (stepIntoInlineLambdaWithParameterDestructuring2.kt:15)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.kt
@@ -1,0 +1,25 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package stepIntoInlineLambdaWithParameterDestructuring2
+
+import destructurableClasses.A
+
+fun foo(a: A, block: (A, String, Int) -> Unit) {
+    // STEP_INTO: 1
+    //Breakpoint!
+    block(a, "", 1)
+}
+
+fun main() {
+    foo(A(1, 1)) {
+            (x, _), _, w ->
+        println()
+    }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: x + w
+// RESULT: Unresolved reference: x
+// RESULT_K2: 2: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuring2.out
@@ -1,0 +1,10 @@
+LineBreakpoint created at stepIntoInlineLambdaWithParameterDestructuring2.kt:10
+Run Java
+Connected to the target VM
+stepIntoInlineLambdaWithParameterDestructuring2.kt:10
+stepIntoInlineLambdaWithParameterDestructuring2.kt:15
+KotlinStackFrame (stepIntoInlineLambdaWithParameterDestructuring2.kt:15)
+    JavaValue[local] w: int = 1
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.k2.out
@@ -1,0 +1,48 @@
+LineBreakpoint created at stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+Run Java
+Connected to the target VM
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:7
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:8
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:9
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:10
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:7
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:8
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:9
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+destructurableClasses.kt:10
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:32
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+InlineStackFrame lambda 'inlineFoo' in 'main' (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:32)
+    JavaValue[local] c: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:23)
+    JavaValue[local] d: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:24)
+    JavaValue[local] i: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:27)
+    JavaValue[local] a: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:22)
+    JavaValue[local] b: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:22)
+    JavaValue[local] e: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:24)
+    JavaValue[local] f: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:25)
+    JavaValue[local] g: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:25)
+    JavaValue[local] h: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:26)
+    JavaValue[local] j: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:28)
+    JavaValue[local] k: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:28)
+    JavaValue[local] l: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:29)
+    JavaValue[local] m: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:30)
+    JavaValue[local] n: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:31)
+    JavaValue[local] o: int = 1 (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:31)
+InlineStackFrame inlineFoo (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18)
+    JavaValue[local] a: destructurableClasses.A = A(x=1, y=1) (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:22)
+        JavaValue[field] x: int = 1 (destructurableClasses.kt:4)
+        JavaValue[field] y: int = 1 (destructurableClasses.kt:4)
+    JavaValue[local] b: destructurableClasses.B = destructurableClasses.B@hashCode (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:22)
+        DummyMessageValueNode = Class has no properties
+KotlinStackFrame (stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:22)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt
@@ -1,0 +1,41 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+// Since line numbers from parameter destructuring are removed,
+// when pressing 'step into' a user will jump into 'component'
+// functions. To reach the lambda of interest all component function
+// calls should be stepped over. This issue doesn't happen with dataclasses.
+
+inline fun inlineFoo(f: (A, Int, Int, B, Int, A, B) -> Unit) {
+    val a = A(1, 1)
+    val b = B()
+    // STEP_INTO: 17
+    //Breakpoint!
+    f(a, 1, 1, b, 1, a, b)
+}
+
+fun main() {
+    inlineFoo { (a, b),
+          c,
+          d, (e,
+              f, g,
+              h),
+          i,
+          (j, k),
+          (l,
+              m,
+              n, o) ->
+        println()
+    }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+// RESULT: Unresolved reference: a
+// RESULT_K2: 15: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.out
@@ -1,0 +1,27 @@
+LineBreakpoint created at stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+Run Java
+Connected to the target VM
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:18
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:22
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:24
+destructurableClasses.kt:7
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:24
+destructurableClasses.kt:8
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:25
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:24
+destructurableClasses.kt:9
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:25
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:24
+destructurableClasses.kt:10
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:26
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:28
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:29
+destructurableClasses.kt:7
+stepIntoInlineLambdaWithParameterDestructuringAndComponentFunctions.kt:29
+destructurableClasses.kt:8
+KotlinStackFrame (destructurableClasses.kt:8)
+    JavaValue[this] this: B@uniqueID = destructurableClasses.B@hashCode
+        DummyMessageValueNode = Class has no properties
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.k2.out
@@ -1,0 +1,25 @@
+LineBreakpoint created at stepIntoInlineSamWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+stepIntoInlineSamWithParameterDestructuring.kt:17
+stepIntoInlineSamWithParameterDestructuring.kt:31
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+KotlinStackFrame (stepIntoInlineSamWithParameterDestructuring.kt:31)
+    JavaValue[local] c: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:22)
+    JavaValue[local] d: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:23)
+    JavaValue[local] i: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:26)
+    JavaValue[local] a: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:21)
+    JavaValue[local] b: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:21)
+    JavaValue[local] e: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:23)
+    JavaValue[local] f: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] g: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:24)
+    JavaValue[local] h: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:25)
+    JavaValue[local] j: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:27)
+    JavaValue[local] k: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:27)
+    JavaValue[local] l: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:28)
+    JavaValue[local] m: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:29)
+    JavaValue[local] n: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:30)
+    JavaValue[local] o: int = 1 (stepIntoInlineSamWithParameterDestructuring.kt:30)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.kt
@@ -1,0 +1,40 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package stepIntoInlineSamWithParameterDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun interface Runnable {
+    fun run(a: A, b: Int, c: Int, d: B, e: Int, f: A, g: B)
+}
+
+inline fun inlineRun(runnable: Runnable) {
+    val a = A(1, 1)
+    val b = B()
+    // STEP_INTO: 1
+    //Breakpoint!
+    runnable.run(a, 1, 1, b, 1, a, b)
+}
+
+fun main() {
+    inlineRun { (a, b),
+          c,
+          d, (e,
+              f, g,
+              h),
+          i,
+          (j, k),
+          (l,
+              m,
+              n, o) ->
+        println()
+    }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+// RESULT: Unresolved reference: a
+// RESULT_K2: 15: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoInlineSamWithParameterDestructuring.out
@@ -1,0 +1,12 @@
+LineBreakpoint created at stepIntoInlineSamWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+stepIntoInlineSamWithParameterDestructuring.kt:17
+stepIntoInlineSamWithParameterDestructuring.kt:21
+KotlinStackFrame (stepIntoInlineSamWithParameterDestructuring.kt:21)
+    JavaValue[local] c: int = 1
+    JavaValue[local] d: int = 1
+    JavaValue[local] i: int = 1
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.k2.out
@@ -1,0 +1,25 @@
+LineBreakpoint created at stepIntoLambdaWithParameterDestructuring.kt:13
+Run Java
+Connected to the target VM
+stepIntoLambdaWithParameterDestructuring.kt:13
+stepIntoLambdaWithParameterDestructuring.kt:27
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+KotlinStackFrame (stepIntoLambdaWithParameterDestructuring.kt:27)
+    JavaValue[local] c: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:18)
+    JavaValue[local] d: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:19)
+    JavaValue[local] i: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:22)
+    JavaValue[local] a: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:17)
+    JavaValue[local] b: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:17)
+    JavaValue[local] e: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:19)
+    JavaValue[local] f: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] g: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:20)
+    JavaValue[local] h: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:21)
+    JavaValue[local] j: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:23)
+    JavaValue[local] k: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:23)
+    JavaValue[local] l: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:24)
+    JavaValue[local] m: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:25)
+    JavaValue[local] n: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:26)
+    JavaValue[local] o: int = 1 (stepIntoLambdaWithParameterDestructuring.kt:26)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.kt
@@ -1,0 +1,36 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package stepIntoLambdaWithParameterDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun foo(f: (A, Int, Int, B, Int, A, B) -> Unit) {
+    val a = A(1, 1)
+    val b = B()
+    // STEP_INTO: 1
+    //Breakpoint!
+    f(a, 1, 1, b, 1, a, b)
+}
+
+fun main() {
+    foo { (a, b),
+          c,
+          d, (e,
+              f, g,
+              h),
+          i,
+          (j, k),
+          (l,
+              m,
+              n, o) ->
+        println()
+    }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+// RESULT: Unresolved reference: a
+// RESULT_K2: 15: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoLambdaWithParameterDestructuring.out
@@ -1,0 +1,12 @@
+LineBreakpoint created at stepIntoLambdaWithParameterDestructuring.kt:13
+Run Java
+Connected to the target VM
+stepIntoLambdaWithParameterDestructuring.kt:13
+stepIntoLambdaWithParameterDestructuring.kt:17
+KotlinStackFrame (stepIntoLambdaWithParameterDestructuring.kt:17)
+    JavaValue[local] c: int = 1
+    JavaValue[local] d: int = 1
+    JavaValue[local] i: int = 1
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.k2.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.k2.out
@@ -1,0 +1,25 @@
+LineBreakpoint created at stepIntoSamWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+stepIntoSamWithParameterDestructuring.kt:17
+stepIntoSamWithParameterDestructuring.kt:31
+Compile bytecode for a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+KotlinStackFrame (stepIntoSamWithParameterDestructuring.kt:31)
+    JavaValue[local] c: int = 1 (stepIntoSamWithParameterDestructuring.kt:22)
+    JavaValue[local] d: int = 1 (stepIntoSamWithParameterDestructuring.kt:23)
+    JavaValue[local] i: int = 1 (stepIntoSamWithParameterDestructuring.kt:26)
+    JavaValue[local] a: int = 1 (stepIntoSamWithParameterDestructuring.kt:21)
+    JavaValue[local] b: int = 1 (stepIntoSamWithParameterDestructuring.kt:21)
+    JavaValue[local] e: int = 1 (stepIntoSamWithParameterDestructuring.kt:23)
+    JavaValue[local] f: int = 1 (stepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] g: int = 1 (stepIntoSamWithParameterDestructuring.kt:24)
+    JavaValue[local] h: int = 1 (stepIntoSamWithParameterDestructuring.kt:25)
+    JavaValue[local] j: int = 1 (stepIntoSamWithParameterDestructuring.kt:27)
+    JavaValue[local] k: int = 1 (stepIntoSamWithParameterDestructuring.kt:27)
+    JavaValue[local] l: int = 1 (stepIntoSamWithParameterDestructuring.kt:28)
+    JavaValue[local] m: int = 1 (stepIntoSamWithParameterDestructuring.kt:29)
+    JavaValue[local] n: int = 1 (stepIntoSamWithParameterDestructuring.kt:30)
+    JavaValue[local] o: int = 1 (stepIntoSamWithParameterDestructuring.kt:30)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.kt
@@ -1,0 +1,40 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// ATTACH_LIBRARY: utils
+package stepIntoSamWithParameterDestructuring
+
+import destructurableClasses.A
+import destructurableClasses.B
+
+fun interface Runnable {
+    fun run(a: A, b: Int, c: Int, d: B, e: Int, f: A, g: B)
+}
+
+fun run(runnable: Runnable) {
+    val a = A(1, 1)
+    val b = B()
+    // STEP_INTO: 1
+    //Breakpoint!
+    runnable.run(a, 1, 1, b, 1, a, b)
+}
+
+fun main() {
+    run { (a, b),
+          c,
+          d, (e,
+              f, g,
+              h),
+          i,
+          (j, k),
+          (l,
+              m,
+              n, o) ->
+        println()
+    }
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a + b + c + d + e + f + g + h + i + j + k + l + m + n + o
+// RESULT: Unresolved reference: a
+// RESULT_K2: 15: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/stepIntoSamWithParameterDestructuring.out
@@ -1,0 +1,12 @@
+LineBreakpoint created at stepIntoSamWithParameterDestructuring.kt:17
+Run Java
+Connected to the target VM
+stepIntoSamWithParameterDestructuring.kt:17
+stepIntoSamWithParameterDestructuring.kt:21
+KotlinStackFrame (stepIntoSamWithParameterDestructuring.kt:21)
+    JavaValue[local] c: int = 1
+    JavaValue[local] d: int = 1
+    JavaValue[local] i: int = 1
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/lib/utils/destructurableClasses.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/lib/utils/destructurableClasses.kt
@@ -1,0 +1,11 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package destructurableClasses
+
+data class A(val x: Int, val y: Int)
+
+class B {
+    operator fun component1() = 1
+    operator fun component2() = 1
+    operator fun component3() = 1
+    operator fun component4() = 1
+}

--- a/plugins/kotlin/jvm-debugger/test/testData/stepping/filters/stepIntoStdlibFacadeClass.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/stepping/filters/stepIntoStdlibFacadeClass.out
@@ -3,7 +3,7 @@ Run Java
 Connected to the target VM
 stepIntoStdlibFacadeClass.kt:6
 _Arrays.!EXT!
-Intrinsics.!EXT!
+Lambda.!EXT!
 Disconnected from the target VM
 
 Process finished with exit code 0


### PR DESCRIPTION
This pull request adds debugger support for new debug info format for lambdas with parameter destructuring. In the new format line numbers will not be added for the part where destructuring happens.

Corresponding issue: https://youtrack.jetbrains.com/issue/IDEA-335314/Debugger-destructured-parameters-are-not-visible-when-stepping-into-a-lambda

Compiler side pr: https://kotlin.jetbrains.space/p/kotlin/reviews/1150/timeline