### PR TITLE
IJPL-160814 Do not report errors for Kotlin object extensions on EPs that support them

### DIFF
--- a/platform/core-api/src/com/intellij/openapi/extensions/SupportsKotlinObjects.java
+++ b/platform/core-api/src/com/intellij/openapi/extensions/SupportsKotlinObjects.java
@@ -1,0 +1,22 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.openapi.extensions;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an Extension Point bean class whose extensions can safely be Kotlin objects.
+ * <p/>
+ * The {@link #value} is the attribute name for the instance field name, or empty if extensions do not need to declare one.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface SupportsKotlinObjects {
+
+  /**
+   * @return the attribute name for the instance field name, or empty if extensions do not need to declare one.
+   */
+  String value() default "";
+}

--- a/platform/platform-impl/src/com/intellij/openapi/fileTypes/impl/FileTypeBean.java
+++ b/platform/platform-impl/src/com/intellij/openapi/fileTypes/impl/FileTypeBean.java
@@ -1,10 +1,7 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.openapi.fileTypes.impl;
 
-import com.intellij.openapi.extensions.PluginAware;
-import com.intellij.openapi.extensions.PluginDescriptor;
-import com.intellij.openapi.extensions.PluginId;
-import com.intellij.openapi.extensions.RequiredElement;
+import com.intellij.openapi.extensions.*;
 import com.intellij.openapi.fileTypes.FileNameMatcher;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.LanguageFileType;
@@ -19,6 +16,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+@SupportsKotlinObjects("fieldName")
 public final class FileTypeBean implements PluginAware {
   private final Collection<FileNameMatcher> myMatchers = new HashSet<>();
 

--- a/platform/statistics/src/com/intellij/internal/statistic/service/fus/collectors/CounterUsageCollectorEP.java
+++ b/platform/statistics/src/com/intellij/internal/statistic/service/fus/collectors/CounterUsageCollectorEP.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.internal.statistic.service.fus.collectors;
 
+import com.intellij.openapi.extensions.SupportsKotlinObjects;
 import com.intellij.util.xmlb.annotations.Attribute;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * "groupId" and "version" fields are deprecated.
  */
+@SupportsKotlinObjects
 public final class CounterUsageCollectorEP {
   /**
    * @deprecated Please use {@link CounterUsageCollectorEP#implementationClass} and {@link CounterUsagesCollector#getGroup()}.

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/CompanionObjects.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/CompanionObjects.kt
@@ -83,3 +83,8 @@ class MyCompanionObjectModuleService {
     fun any() = "any"
   }
 }
+
+class CompanionObjectCustomWithMandatoryField {
+  companion <error descr="Kotlin object registered as extension">object</error> : CustomExtensionTypeBase() {
+  }
+}

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/CorrectClassesAndObjects.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/CorrectClassesAndObjects.kt
@@ -161,3 +161,13 @@ fun any() {
 private fun takeSerializable(@Suppress("UNUSED_PARAMETER") serializable: Serializable) {
   // any
 }
+
+class CompanionObjectCustomWithOptionalField {
+  companion object : CustomExtensionTypeBase() {
+  }
+}
+
+class CompanionObjectCustomWithMandatoryField {
+  companion object : CustomExtensionTypeBase() {
+  }
+}

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/InnerObjects.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/InnerObjects.kt
@@ -60,3 +60,7 @@ class ServicesOuterClass {
     fun any() = "any"
   }
 }
+
+class OuterCustomExtension {
+  object <error descr="Kotlin object registered as extension">CustomExtension</error> : CustomExtensionTypeBase()
+}

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/SingletonObjects.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/SingletonObjects.kt
@@ -51,3 +51,5 @@ object <error descr="Kotlin object registered as extension">MyProjectSingletonSe
 object <error descr="Kotlin object registered as extension">MyModuleSingletonService</error> {
   fun any() = "any"
 }
+
+object <error descr="Kotlin object registered as extension">CustomExtension</error> : CustomExtensionTypeBase()

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/companionObjectExtensions.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/companionObjectExtensions.xml
@@ -24,6 +24,9 @@
     <projectService serviceImplementation="MyCompanionObjectProjectService$WithName"/>
     <moduleService serviceImplementation="MyCompanionObjectModuleService$Companion"/>
 
+    <!-- Custom bean: -->
+    <customWithMandatoryField implementationClass="CompanionObjectCustomWithMandatoryField$Companion"/>
+
   </extensions>
 
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/correctExtensions.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/correctExtensions.xml
@@ -42,5 +42,9 @@
     <projectService serviceImplementation="ServicesOuterClass$MyProjectService"/>
     <moduleService serviceImplementation="ServicesOuterClass$MyModuleService"/>
 
+    <!-- Custom bean: -->
+    <customWithOptionalField implementationClass="CompanionObjectCustomWithOptionalField"/>
+    <customWithMandatoryField implementationClass="CompanionObjectCustomWithMandatoryField" fieldName="INSTANCE"/>
+
   </extensions>
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/extensionPointsDeclarations.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/extensionPointsDeclarations.xml
@@ -31,5 +31,16 @@
       <with tag="className" implements="com.intellij.codeInsight.intention.IntentionAction"/>
     </extensionPoint>
 
+    <extensionPoint name="customWithOptionalField"
+                    beanClass="CustomKotlinObjectAwareOptionalFieldBean"
+                    dynamic="true">
+      <with attribute="implementationClass" implements="CustomExtensionType"/>
+    </extensionPoint>
+    <extensionPoint name="customWithMandatoryField"
+                    beanClass="CustomKotlinObjectAwareMandatoryFieldBean"
+                    dynamic="true">
+      <with attribute="implementationClass" implements="CustomExtensionType"/>
+    </extensionPoint>
+
   </extensionPoints>
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/innerObjectExtensions.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/innerObjectExtensions.xml
@@ -21,6 +21,9 @@
     <projectService serviceImplementation="ServicesOuterClass$MyProjectSingletonService"/>
     <moduleService serviceImplementation="ServicesOuterClass$MyModuleSingletonService"/>
 
+    <!-- Custom bean: -->
+    <customWithMandatoryField implementationClass="OuterCustomExtension$CustomExtension"/>
+
   </extensions>
 
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/singletonObjectExtensions.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/code/extensions/singletonObjectExtensions.xml
@@ -22,6 +22,9 @@
     <projectService serviceImplementation="MyProjectSingletonService"/>
     <moduleService serviceImplementation="MyModuleSingletonService"/>
 
+    <!-- Custom bean: -->
+    <customWithMandatoryField implementationClass="CustomExtension"/>
+
   </extensions>
 
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/CompanionObjectCustomExtension.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/CompanionObjectCustomExtension.kt
@@ -1,0 +1,4 @@
+class MyCompanionObjectCustomExtension {
+  companion object : CustomExtensionTypeBase() {
+  }
+}

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/CustomExtensions.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/CustomExtensions.kt
@@ -1,0 +1,5 @@
+object SingletonCustomExtension : CustomExtensionTypeBase() {
+}
+
+class MyCustomExtension : CustomExtensionTypeBase() {
+}

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/InnerCustomExtensions.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/InnerCustomExtensions.kt
@@ -1,0 +1,8 @@
+class CustomExtensionOuterClass {
+
+  object SingletonCustomExtension : CustomExtensionTypeBase() {
+  }
+
+  class MyCustomExtension : CustomExtensionTypeBase() {
+  }
+}

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/companionObjectExtensions.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/companionObjectExtensions.xml
@@ -22,6 +22,8 @@
     <projectService serviceImplementation="<error descr="Extension class is a Kotlin object">MyCompanionObjectProjectService$WithName</error>" testServiceImplementation="<error descr="Extension class is a Kotlin object">MyCompanionObjectProjectService$WithName</error>" headlessImplementation="<error descr="Extension class is a Kotlin object">MyCompanionObjectProjectService$WithName</error>"/>
     <moduleService serviceImplementation="<error descr="Extension class is a Kotlin object">MyCompanionObjectModuleService$Companion</error>" testServiceImplementation="<error descr="Extension class is a Kotlin object">MyCompanionObjectModuleService$Companion</error>" headlessImplementation="<error descr="Extension class is a Kotlin object">MyCompanionObjectModuleService$Companion</error>"/>
 
+    <!-- Custom bean: -->
+    <customWithMandatoryField implementationClass="<error descr="Extension class is a Kotlin object">MyCompanionObjectCustomExtension$Companion</error>"/>
   </extensions>
 
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/extensionPointsDeclarations.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/extensionPointsDeclarations.xml
@@ -31,5 +31,15 @@
       <with tag="className" implements="com.intellij.codeInsight.intention.IntentionAction"/>
     </extensionPoint>
 
+    <extensionPoint name="customWithOptionalField"
+                    beanClass="CustomKotlinObjectAwareOptionalFieldBean"
+                    dynamic="true">
+      <with attribute="implementationClass" implements="CustomExtensionType"/>
+    </extensionPoint>
+    <extensionPoint name="customWithMandatoryField"
+                    beanClass="CustomKotlinObjectAwareMandatoryFieldBean"
+                    dynamic="true">
+      <with attribute="implementationClass" implements="CustomExtensionType"/>
+    </extensionPoint>
   </extensionPoints>
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/innerObjectExtensions.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/innerObjectExtensions.xml
@@ -50,6 +50,18 @@
     <projectService serviceImplementation="ServicesOuterClass$MyProjectService"/>
     <moduleService serviceImplementation="ServicesOuterClass$MyModuleService"/>
 
+    <!-- Custom bean: -->
+    <!-- INCORRECT: fieldName is mandatory -->
+    <customWithMandatoryField implementationClass="<error descr="Extension class is a Kotlin object">CustomExtensionOuterClass$SingletonCustomExtension</error>"/>
+    <!-- CORRECT: fieldName is provided -->
+    <customWithMandatoryField implementationClass="CustomExtensionOuterClass$SingletonCustomExtension" fieldName="INSTANCE"/>
+    <!-- CORRECT: fieldName is optional -->
+    <customWithOptionalField implementationClass="CustomExtensionOuterClass$SingletonCustomExtension"/>
+    <!-- CORRECT: regular class -->
+    <customWithMandatoryField implementationClass="CustomExtensionOuterClass$MyCustomExtension"/>
+    <!-- CORRECT: regular class -->
+    <customWithOptionalField implementationClass="CustomExtensionOuterClass$MyCustomExtension"/>
+
   </extensions>
 
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/singletonObjectExtensions.xml
+++ b/plugins/devkit/devkit-kotlin-tests/testData/inspections/registrationProblems/xml/extensions/singletonObjectExtensions.xml
@@ -50,6 +50,18 @@
     <projectService serviceImplementation="MyProjectService"/>
     <moduleService serviceImplementation="MyModuleService"/>
 
+    <!-- Custom bean: -->
+    <!-- INCORRECT: fieldName is mandatory -->
+    <customWithMandatoryField implementationClass="<error descr="Extension class is a Kotlin object">SingletonCustomExtension</error>"/>
+    <!-- CORRECT: fieldName is provided -->
+    <customWithMandatoryField implementationClass="SingletonCustomExtension" fieldName="INSTANCE"/>
+    <!-- CORRECT: fieldName is optional -->
+    <customWithOptionalField implementationClass="SingletonCustomExtension"/>
+    <!-- CORRECT: regular class -->
+    <customWithMandatoryField implementationClass="MyCustomExtension"/>
+    <!-- CORRECT: regular class -->
+    <customWithOptionalField implementationClass="MyCustomExtension"/>
+
   </extensions>
 
 </idea-plugin>

--- a/plugins/devkit/devkit-kotlin-tests/testSrc/org/jetbrains/idea/devkit/kotlin/inspections/KotlinObjectExtensionRegistrationInspectionTest.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testSrc/org/jetbrains/idea/devkit/kotlin/inspections/KotlinObjectExtensionRegistrationInspectionTest.kt
@@ -14,6 +14,7 @@ internal class KotlinObjectExtensionRegistrationInspectionTest : KotlinObjectExt
   fun testSingletonObjectExtensionsRegistered() {
     myFixture.testHighlighting("singletonObjectExtensions.xml",
                                "Configurables.kt",
+                               "CustomExtensions.kt",
                                "FileTypes.kt",
                                "IntentionActions.kt",
                                "Services.kt")
@@ -22,6 +23,7 @@ internal class KotlinObjectExtensionRegistrationInspectionTest : KotlinObjectExt
   fun testInnerObjectExtensionsRegistered() {
     myFixture.testHighlighting("innerObjectExtensions.xml",
                                "InnerConfigurables.kt",
+                               "InnerCustomExtensions.kt",
                                "InnerFileTypes.kt",
                                "InnerIntentionActions.kt",
                                "InnerServices.kt")
@@ -30,6 +32,7 @@ internal class KotlinObjectExtensionRegistrationInspectionTest : KotlinObjectExt
   fun testCompanionObjectExtensionsRegistered() {
     myFixture.testHighlighting("companionObjectExtensions.xml",
                                "CompanionObjectConfigurables.kt",
+                               "CompanionObjectCustomExtension.kt",
                                "CompanionObjectFileTypes.kt",
                                "CompanionObjectIntentionActions.kt",
                                "CompanionObjectServices.kt")

--- a/plugins/devkit/devkit-kotlin-tests/testSrc/org/jetbrains/idea/devkit/kotlin/inspections/KotlinObjectExtensionRegistrationInspectionTestBase.kt
+++ b/plugins/devkit/devkit-kotlin-tests/testSrc/org/jetbrains/idea/devkit/kotlin/inspections/KotlinObjectExtensionRegistrationInspectionTestBase.kt
@@ -29,6 +29,12 @@ internal abstract class KotlinObjectExtensionRegistrationInspectionTestBase : Pl
       }
     """.trimIndent())
     myFixture.addClass("""
+      package com.intellij.openapi.extensions;
+      public @interface SupportsKotlinObjects {
+        String value() default "";
+      }
+    """.trimIndent())
+    myFixture.addClass("""
       package com.intellij.openapi.options;
       import com.intellij.util.xmlb.annotations.*;
       @Tag("configurable")
@@ -55,7 +61,9 @@ internal abstract class KotlinObjectExtensionRegistrationInspectionTestBase : Pl
     """.trimIndent())
     myFixture.addClass("""
       package com.intellij.openapi.fileTypes.impl;
+      import com.intellij.openapi.extensions.SupportsKotlinObjects;
       import com.intellij.util.xmlb.annotations.*;
+      @SupportsKotlinObjects("fieldName")
       public final class FileTypeBean {
         @Attribute("implementationClass") public String implementationClass;
         @Attribute("fieldName") public String fieldName;
@@ -127,6 +135,28 @@ internal abstract class KotlinObjectExtensionRegistrationInspectionTestBase : Pl
       public final class IntentionActionBean {
         @Tag public String className;
         @Tag public String language;
+      }
+    """.trimIndent())
+    myFixture.addClass("""
+      public abstract class CustomExtensionTypeBase {
+      }
+    """.trimIndent())
+    myFixture.addClass("""
+      import com.intellij.openapi.extensions.SupportsKotlinObjects;
+      import com.intellij.util.xmlb.annotations.*;
+      @SupportsKotlinObjects
+      public final class CustomKotlinObjectAwareOptionalFieldBean {
+        @Attribute("implementationClass") public String implementationClass;
+        @Attribute("fieldName") public String fieldName;
+      }
+    """.trimIndent())
+    myFixture.addClass("""
+      import com.intellij.openapi.extensions.SupportsKotlinObjects;
+      import com.intellij.util.xmlb.annotations.*;
+      @SupportsKotlinObjects("fieldName")
+      public final class CustomKotlinObjectAwareMandatoryFieldBean {
+        @Attribute("implementationClass") public String implementationClass;
+        @Attribute("fieldName") public String fieldName;
       }
     """.trimIndent())
     setPluginXml("extensionPointsDeclarations.xml")


### PR DESCRIPTION
This solution adds a new marker annotation for bean classes and an optional attribute to match the behavior of the hardcoded exceptions.

Note the hardcoded exceptions are not removed as it would report errors on them when working on older IDE versions.