### PR TITLE
IJPL-160843: compile modules from implicit auto-layout plugins

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
@@ -1125,18 +1125,8 @@ internal suspend fun setLastModifiedTime(directory: Path, context: BuildContext)
  */
 internal fun collectIncludedPluginModules(enabledPluginModules: Collection<String>, product: ProductModulesLayout, result: MutableSet<String>, context: BuildContext) {
   result.addAll(enabledPluginModules)
-  val enabledPluginModuleSet = if (enabledPluginModules is Set<String> || enabledPluginModules.size < 2) {
-    enabledPluginModules
-  }
-  else {
-    enabledPluginModules.toHashSet()
-  }
-
-  for (plugin in product.pluginLayouts) {
-    if (!enabledPluginModuleSet.contains(plugin.mainModule)) {
-      continue
-    }
-
+  val pluginLayouts = getPluginLayoutsByJpsModuleNames(modules = enabledPluginModules, productLayout = context.productProperties.productLayout)
+  for (plugin in pluginLayouts) {
     plugin.includedModules.mapTo(result) { it.moduleName }
     result.addAll((context as BuildContextImpl).jarPackagerDependencyHelper.readPluginIncompleteContentFromDescriptor(context.findRequiredModule(plugin.mainModule)))
   }


### PR DESCRIPTION
Note that `getPluginLayoutsByJpsModuleNames()` automatically creates a `pluginAuto()` layout for plugins not explicitly listed in `ProductLayout.pluginLayouts`.

Issue link: https://youtrack.jetbrains.com/issue/IJPL-160843