### PR TITLE
An ability to ignore well-known leaks in LeakHunter added

### DIFF
--- a/platform/core-impl/src/com/intellij/util/ref/DebugReflectionUtil.java
+++ b/platform/core-impl/src/com/intellij/util/ref/DebugReflectionUtil.java
@@ -229,7 +229,7 @@ public final class DebugReflectionUtil {
      * when null, it can be computed from field.getName()
      */
     private final String fieldName;
-    private final BackLink<?> backLink;
+    final BackLink<?> backLink;
     private final int depth;
 
     BackLink(@NotNull V value, @Nullable Field field, @Nullable String fieldName, @Nullable BackLink<?> backLink) {
@@ -252,6 +252,10 @@ public final class DebugReflectionUtil {
       return result.toString();
     }
 
+    String getFieldName() {
+      return this.fieldName != null ? this.fieldName : field.getDeclaringClass().getName() + "." + field.getName();
+    }
+
     void print(@NotNull StringBuilder result) {
       String valueStr;
       Object value = this.value;
@@ -270,9 +274,8 @@ public final class DebugReflectionUtil {
         valueStr = "(" + e.getMessage() + " while computing .toString())";
       }
 
-      Field field = this.field;
-      String fieldName = this.fieldName != null ? this.fieldName : field.getDeclaringClass().getName() + "." + field.getName();
-      result.append("via '").append(fieldName).append("'; Value: '").append(valueStr).append("' of ").append(value.getClass()).append("\n");
+      result.append("via '").append(getFieldName()).append("'; Value: '").append(valueStr).append("' of ").append(value.getClass())
+        .append("\n");
     }
   }
 }

--- a/platform/core-impl/src/com/intellij/util/ref/IgnoredTraverseEntry.java
+++ b/platform/core-impl/src/com/intellij/util/ref/IgnoredTraverseEntry.java
@@ -1,0 +1,8 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.util.ref;
+
+import java.util.function.Predicate;
+
+public interface IgnoredTraverseEntry extends
+                                      Predicate<DebugReflectionUtil.BackLink<?>> {
+}

--- a/platform/core-impl/src/com/intellij/util/ref/IgnoredTraverseReference.java
+++ b/platform/core-impl/src/com/intellij/util/ref/IgnoredTraverseReference.java
@@ -1,0 +1,48 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.util.ref;
+
+import kotlin.NotImplementedError;
+import org.jetbrains.annotations.NotNull;
+
+public class IgnoredTraverseReference implements IgnoredTraverseEntry {
+
+
+  private final String myField;
+  private final int myIndex;
+
+  /**
+   * Constructs a rule that allows to ignore some known leakage path. It allows to keep the LeakHunter-based checks enabled while "skipping"
+   * some well-known leaks.
+   *
+   * @param field field name in the CLASS_FQN.field_name format
+   * @param index index of the {@param field} frame. Index can be positive and negative. If it's positive it will be enumerated starting
+   *              from the traverse root, from the traverse leaf if it's negative.
+   */
+  public IgnoredTraverseReference(@NotNull final String field, int index) {
+    myField = field;
+    myIndex = index;
+  }
+
+  @Override
+  public boolean test(@NotNull final DebugReflectionUtil.BackLink<?> link) {
+    if (myIndex >= 0) {
+      throw new NotImplementedError("Handling of positive indexes is not implemented yet");
+    }
+    return checkNegativeIndex(link);
+  }
+
+  private boolean checkNegativeIndex(@NotNull final DebugReflectionUtil.BackLink<?> link) {
+    int currentIndex = myIndex;
+    DebugReflectionUtil.BackLink<?> backLink = link;
+
+    while (currentIndex < -1) {
+      backLink = backLink.backLink;
+      currentIndex++;
+      if (backLink == null) {
+        return false;
+      }
+    }
+
+    return myField.equals(backLink.getFieldName());
+  }
+}

--- a/platform/platform-tests/testSrc/com/intellij/openapi/application/impl/util.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/application/impl/util.kt
@@ -38,7 +38,7 @@ fun assertReferenced(root: Any, referenced: Any) {
   val rootSupplier: Supplier<Map<Any, String>> = Supplier {
     mapOf(root to "root")
   }
-  LeakHunter.processLeaks(rootSupplier, referenced.javaClass, null) { leaked, _ ->
+  LeakHunter.processLeaks(rootSupplier, referenced.javaClass, null, null) { leaked, _ ->
     foundObjects.add(leaked)
     true
   }

--- a/platform/platform-tests/testSrc/com/intellij/openapi/util/LeakHunterIgnoreReferencesTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/util/LeakHunterIgnoreReferencesTest.kt
@@ -1,0 +1,37 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.openapi.util
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.LeakHunter
+import com.intellij.testFramework.common.timeoutRunBlocking
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.util.ref.IgnoredTraverseEntry
+import com.intellij.util.ref.IgnoredTraverseReference
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.util.function.Supplier
+import kotlin.time.Duration.Companion.seconds
+
+@TestApplication
+class LeakHunterIgnoreReferencesTest {
+  @Test
+  fun `leaked disposable ignored`(): Unit = timeoutRunBlocking(60.seconds) {
+    val ref = ReferenceToDisposable(TestDisposable())
+    assertThrows<AssertionError> { checkReferenced(ref, listOf()) }
+    assertDoesNotThrow { checkReferenced(ref, listOf(IgnoredTraverseReference("com.intellij.openapi.util.ReferenceToDisposable.ref", -1))) }
+  }
+}
+
+fun checkReferenced(root: Any, ignoredTraverseEntries: List<IgnoredTraverseEntry>) {
+  val rootSupplier: Supplier<Map<Any, String>> = Supplier {
+    mapOf(root to "root")
+  }
+  LeakHunter.checkLeak(rootSupplier, TestDisposable::class.java, ignoredTraverseEntries) { true }
+}
+
+class TestDisposable : Disposable {
+  override fun dispose() {}
+}
+
+class ReferenceToDisposable(val ref: Disposable)

--- a/platform/testFramework/common/src/common/testApplication.kt
+++ b/platform/testFramework/common/src/common/testApplication.kt
@@ -66,6 +66,7 @@ import com.intellij.util.WalkingState
 import com.intellij.util.concurrency.AppScheduledExecutorService
 import com.intellij.util.indexing.FileBasedIndex
 import com.intellij.util.indexing.FileBasedIndexImpl
+import com.intellij.util.ref.IgnoredTraverseEntry
 import com.intellij.util.ui.EDT
 import com.intellij.util.ui.EdtInvocationManager
 import com.jetbrains.JBR
@@ -326,8 +327,14 @@ fun Application.cleanupApplicationCaches() {
 @TestOnly
 @Internal
 fun assertNonDefaultProjectsAreNotLeaked() {
+  assertNonDefaultProjectsAreNotLeaked(emptyList())
+}
+
+@TestOnly
+@Internal
+fun assertNonDefaultProjectsAreNotLeaked(ignoredTraverseEntries : List<IgnoredTraverseEntry>) {
   try {
-    LeakHunter.checkNonDefaultProjectLeak()
+    LeakHunter.checkNonDefaultProjectLeakWithIgnoredEntries(ignoredTraverseEntries)
   }
   catch (e: AssertionError) {
     publishHeapDump(LEAKED_PROJECTS)

--- a/platform/testFramework/src/com/intellij/project/TestProjectManager.kt
+++ b/platform/testFramework/src/com/intellij/project/TestProjectManager.kt
@@ -278,6 +278,7 @@ private fun reportLeakedProjects(leakedProjects: Iterable<Project>) {
   val dumpPath = publishHeapDump(LEAKED_PROJECTS)
   LeakHunter.processLeaks(LeakHunter.allRoots(), ProjectImpl::class.java,
                           { hashCodes.contains(System.identityHashCode(it)) },
+                          null,
                           { leaked, backLink ->
                             val hashCode = System.identityHashCode(leaked)
                             message += LeakHunter.getLeakedObjectDetails(leaked, backLink, false)


### PR DESCRIPTION
It allows to keep the LeakHunter-based checks enabled while "skipping" some well-known leaks.