### PR TITLE
Only create FixAllIntention when quick fix is available for batch.

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/intention/impl/config/IntentionManagerImpl.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/intention/impl/config/IntentionManagerImpl.java
@@ -123,9 +123,10 @@ public final class IntentionManagerImpl extends IntentionManager implements Disp
   public void dispose() {
   }
 
-  private static @NotNull IntentionAction createFixAllIntentionInternal(@NotNull InspectionToolWrapper<?, ?> toolWrapper,
+  private static @Nullable IntentionAction createFixAllIntentionInternal(@NotNull InspectionToolWrapper<?, ?> toolWrapper,
                                                                         @NotNull IntentionAction action) {
     LocalQuickFix fix = QuickFixWrapper.unwrap(action);
+    if (fix != null && !fix.availableInBatchMode()) return null;
     PsiFile file = QuickFixWrapper.unwrapFile(action);
     return new CleanupInspectionIntention(toolWrapper, fix == null ? action : fix, file, action.getText());
   }


### PR DESCRIPTION
I'm not sure if this breaks anything else, but I was trying to write a LocalInspection. I didn't like the behavior of the Fix All action, so I was able to disable it by specifying `availableInBatchMode = false`. However, the Fix All action is still generated, and then it gives an error ("Unfortunately [action] is currently not available for batch mode User interaction is required for each problem found") when the user tries to use it. 