### PR TITLE
Pin tooltip popups for keypress actions

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/GotoNextErrorHandler.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/GotoNextErrorHandler.java
@@ -71,7 +71,7 @@ public class GotoNextErrorHandler implements CodeInsightActionHandler {
             HighlightInfo fullInfo = ((DaemonCodeAnalyzerImpl)DaemonCodeAnalyzer.getInstance(project))
               .findHighlightByOffset(editor.getDocument(), editor.getCaretModel().getOffset(), false);
             HighlightInfo info = fullInfo != null ? fullInfo : infoToGo;
-            EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editor, info, editor.getCaretModel().getOffset(), false, true);
+            EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editor, info, editor.getCaretModel().getOffset(), false, true, false, true);
           }
         });
         return;

--- a/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/actions/ShowErrorDescriptionHandler.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/daemon/impl/actions/ShowErrorDescriptionHandler.java
@@ -24,7 +24,7 @@ final class ShowErrorDescriptionHandler implements CodeInsightActionHandler {
   public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
     HighlightInfo info = findInfoUnderCaret(project, editor);
     if (info != null) {
-      EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editor, info, editor.getCaretModel().getOffset(), myRequestFocus, true);
+      EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editor, info, editor.getCaretModel().getOffset(), myRequestFocus, true, false, true);
     }
   }
 

--- a/platform/lang-impl/src/com/intellij/openapi/editor/actions/ShowHoverInfoAction.kt
+++ b/platform/lang-impl/src/com/intellij/openapi/editor/actions/ShowHoverInfoAction.kt
@@ -41,7 +41,7 @@ class ShowHoverInfoAction: AnAction(), ActionToIgnore, PopupAction, DumbAware, P
       }
       withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
         if (highlightInfo != null) {
-          EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editor, highlightInfo, editor.caretModel.offset, false, true, true)
+          EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editor, highlightInfo, editor.caretModel.offset, false, true, true, true)
         }
         else {
           // No errors, just show doc


### PR DESCRIPTION
When hovering the mouse cursor over a code element, the resulting tooltip/popup is opened in a temporary window which closes automatically when the mouse cursor moves away from it.  However, the behavior for popups activated via hotkey is inconsistent.

For example, the Quick Documentation action (Ctrl + Q) pins the tooltip and requires pressing Esc or clicking elsewhere to close (simply moving the mouse away isn't enough).  But other actions, such as Error Description (Ctrl + F1), don't pin the popup window and function like the normal mouse hover.  This patch changes the behavior of the following keypress actions to also pin their windows:

Next Highlighted Error (F2)
Previous Highlighted Error (Shift + F2)
Error Description (Ctrl + F1)
Hover Info

Before:
![before](https://github.com/user-attachments/assets/b5bdee6f-2828-4090-bc6e-3005fdf47c88)

After:
![after](https://github.com/user-attachments/assets/f0342650-88ac-47c2-a0e8-4c2075674966)


