### PR TITLE
[toml] add `uv.lock`

### DIFF
--- a/plugins/toml/resources/META-INF/plugin.xml
+++ b/plugins/toml/resources/META-INF/plugin.xml
@@ -25,7 +25,7 @@
                   implementationClass="org.toml.lang.psi.TomlFileType"
                   fieldName="INSTANCE"
                   extensions="toml"
-                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile;poetry.lock,uv.lock"/>
+                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile;poetry.lock;uv.lock"/>
         <lang.parserDefinition language="TOML" implementationClass="org.toml.lang.parse.TomlParserDefinition"/>
         <lang.ast.factory language="TOML" implementationClass="org.toml.lang.psi.impl.TomlASTFactory"/>
         <lang.syntaxHighlighter language="TOML" implementationClass="org.toml.ide.TomlHighlighter"/>

--- a/plugins/toml/resources/META-INF/plugin.xml
+++ b/plugins/toml/resources/META-INF/plugin.xml
@@ -25,7 +25,7 @@
                   implementationClass="org.toml.lang.psi.TomlFileType"
                   fieldName="INSTANCE"
                   extensions="toml"
-                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile;poetry.lock"/>
+                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile;poetry.lock,uv.lock"/>
         <lang.parserDefinition language="TOML" implementationClass="org.toml.lang.parse.TomlParserDefinition"/>
         <lang.ast.factory language="TOML" implementationClass="org.toml.lang.psi.impl.TomlASTFactory"/>
         <lang.syntaxHighlighter language="TOML" implementationClass="org.toml.ide.TomlHighlighter"/>

--- a/plugins/toml/tests/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
+++ b/plugins/toml/tests/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
@@ -18,6 +18,7 @@ class TomlFileTypeTest : TomlTestBase() {
     fun `test Gopkg lock`() = doTest("Gopkg.lock")
     fun `test Pipfile`() = doTest("Pipfile")
     fun `test Poetry lock file`() = doTest("poetry.lock")
+    fun `test uv lock file`() = doTest("uv.lock")
     fun `test Cargo config`() = doTest(".cargo/config")
 
     private fun doTest(path: String) {


### PR DESCRIPTION
Add support for [uv.lock](https://docs.astral.sh/uv/concepts/projects/#project-lockfile) from [uv Python package manager](https://docs.astral.sh/uv/) in TOML plugin.