### PR TITLE
Implement `MetaPathFinder.find_spec` method in `MyFinder` subclass

### DIFF
--- a/python/helpers/generator3/core.py
+++ b/python/helpers/generator3/core.py
@@ -592,6 +592,11 @@ def imported_names_collected():
             imported_names.add(fullname)
             return None
 
+        # noinspection PyMethodMayBeStatic
+        def find_spec(self, fullname, path, target=None):
+            imported_names.add(fullname)
+            return None
+
     my_finder = MyFinder()
     sys.meta_path.insert(0, my_finder)
     try:


### PR DESCRIPTION
The `MyFinder` subclass of [`MetaPathFinder`](https://docs.python.org/3.11/library/importlib.html#importlib.abc.MetaPathFinder) currently only implements the deprecated `find_module` method. That deprecated method was [removed](https://github.com/python/cpython/pull/98059) in Python 3.12. This change adds an implementation for its replacement method called `find_spec`.