### PR TITLE
Fix encoding of project name in doc url

### DIFF
--- a/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
+++ b/java/java-impl/src/com/intellij/codeInsight/javadoc/JavaDocExternalFilter.java
@@ -103,8 +103,9 @@ public class JavaDocExternalFilter extends AbstractExternalFilter {
     String externalDoc = null;
     myElement = element;
 
+    String authority = "localhost:" + BuiltInServerOptions.getInstance().getEffectiveBuiltInServerPort();
     String projectPath = "/" + myProject.getName() + "/";
-    String builtInServer = "http://localhost:" + BuiltInServerOptions.getInstance().getEffectiveBuiltInServerPort() + projectPath;
+    String builtInServer = Urls.newHttpUrl(authority, projectPath).toExternalForm();
     if (docURL.startsWith(builtInServer)) {
       Url url = Urls.parseFromIdea(docURL);
       if (url != null) {


### PR DESCRIPTION
JavaDocExternalFilter.getExternalDocInfoForElement does a comparison to determine if the given doc URL is coming from the built in server. However, it does this using a constructed string that fails to correctly encode the project name, so the comparison does not work for any project names that contains characters needing encoding (like a space).

Using Urls.newHttpUrl() to make the comparison string fixes the issue, since this is the same API used in BuiltInWebBrowserUrlProvider to create the doc URL in the first place.