### PR TITLE
KTIJ-10950 Language injection only works for the first argument to a vararg parameter

### DIFF
--- a/plugins/kotlin/injection/base/src/org/jetbrains/kotlin/idea/base/injection/KotlinLanguageInjectionContributorBase.kt
+++ b/plugins/kotlin/injection/base/src/org/jetbrains/kotlin/idea/base/injection/KotlinLanguageInjectionContributorBase.kt
@@ -408,7 +408,14 @@ abstract class KotlinLanguageInjectionContributorBase : LanguageInjectionContrib
 
     private fun injectionForKotlinCall(argument: KtValueArgument, ktFunction: KtFunction, reference: PsiReference): InjectionInfo? {
         val argumentName = argument.getArgumentName()?.asName
-        val argumentIndex = (argument.parent as KtValueArgumentList).arguments.indexOf(argument)
+        val argumentListIndex = (argument.parent as KtValueArgumentList).arguments.indexOf(argument)
+        val varargIndex = argumentName?.let { // Skip vararg check if name is present
+            (argumentListIndex downTo 0).firstNotNullOfOrNull { f ->
+                ktFunction.valueParameters.getOrNull(f)?.takeIf { it.isVarArg }?.let { f }
+            }
+        }
+        val argumentIndex = varargIndex ?: argumentListIndex
+
         // Prefer using argument name if present
         val ktParameter = if (argumentName != null) {
             ktFunction.valueParameters.firstOrNull { it.nameAsName == argumentName }

--- a/plugins/kotlin/injection/base/src/org/jetbrains/kotlin/idea/base/injection/KotlinLanguageInjectionContributorBase.kt
+++ b/plugins/kotlin/injection/base/src/org/jetbrains/kotlin/idea/base/injection/KotlinLanguageInjectionContributorBase.kt
@@ -409,11 +409,11 @@ abstract class KotlinLanguageInjectionContributorBase : LanguageInjectionContrib
     private fun injectionForKotlinCall(argument: KtValueArgument, ktFunction: KtFunction, reference: PsiReference): InjectionInfo? {
         val argumentName = argument.getArgumentName()?.asName
         val argumentListIndex = (argument.parent as KtValueArgumentList).arguments.indexOf(argument)
-        val varargIndex = argumentName?.let { // Skip vararg check if name is present
+        val varargIndex = if (argumentName != null) null else // Skip vararg check if name is present
             (argumentListIndex downTo 0).firstNotNullOfOrNull { f ->
                 ktFunction.valueParameters.getOrNull(f)?.takeIf { it.isVarArg }?.let { f }
             }
-        }
+
         val argumentIndex = varargIndex ?: argumentListIndex
 
         // Prefer using argument name if present

--- a/plugins/kotlin/injection/base/tests/test/org/jetbrains/kotlin/idea/base/injection/KotlinInjectionTestBase.kt
+++ b/plugins/kotlin/injection/base/tests/test/org/jetbrains/kotlin/idea/base/injection/KotlinInjectionTestBase.kt
@@ -330,7 +330,7 @@ abstract class KotlinInjectionTestBase : AbstractInjectionTest() {
         languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false
     )
 
-    fun testInjectionOffVarargParameterWithAnnotation() = doInjectionPresentTest(
+    fun testInjectionOfVarargParameterWithAnnotation() = doInjectionPresentTest(
         """
         import org.intellij.lang.annotations.Language
 
@@ -343,7 +343,7 @@ abstract class KotlinInjectionTestBase : AbstractInjectionTest() {
         languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false
     )
 
-    fun testInjectionOffVarargParameterWithOutAnnotation() = doInjectionPresentTest(
+    fun testNoFalseInjectionOfVarargParameter() = doInjectionPresentTest(
         """
         import org.intellij.lang.annotations.Language
 

--- a/plugins/kotlin/injection/base/tests/test/org/jetbrains/kotlin/idea/base/injection/KotlinInjectionTestBase.kt
+++ b/plugins/kotlin/injection/base/tests/test/org/jetbrains/kotlin/idea/base/injection/KotlinInjectionTestBase.kt
@@ -330,6 +330,33 @@ abstract class KotlinInjectionTestBase : AbstractInjectionTest() {
         languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false
     )
 
+    fun testInjectionOffVarargParameterWithAnnotation() = doInjectionPresentTest(
+        """
+        import org.intellij.lang.annotations.Language
+
+        fun bar(@Language("HTML") vararg s: String){}
+
+        val a = bar(
+        "some","some","<caret>some"
+        )
+        """,
+        languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = false
+    )
+
+    fun testInjectionOffVarargParameterWithOutAnnotation() = doInjectionPresentTest(
+        """
+        import org.intellij.lang.annotations.Language
+
+        fun bar(vararg s: String,@Language("HTML") s2 : String){}
+
+        val a = bar(
+        "some","<caret>some","some",s2 = "some"
+        )
+        """,
+        languageId = HTMLLanguage.INSTANCE.id, unInjectShouldBePresent = true
+    )
+
+
     fun testInjectionOfCustomParameterJavaWithAnnotation() = doInjectionPresentTest(
         """
         fun bar() { Test.foo("<caret>some") }


### PR DESCRIPTION
## Tracker
[KTIJ-10950](https://youtrack.jetbrains.com/issue/KTIJ-10950/Language-injection-only-works-for-the-first-argument-to-a-vararg-parameter)
## Issue
The issue was that in ```injectionForKotlinCall``` the index of the argument gets misaligned with the index of the ktFunction valueParameters.

## Solution
if the argumentIndex > index of the vararg then it needs to be the vararg. This works, since the Kotlin spec only allows for one vararg and any parameter after a vararg needs to be named, which means it does not need the index.

## Improvement
It would be better to save the varargIndex to the KtFunction object. But that change needs to be on the kotlin compiler side.