### PR TITLE
eclipse keymap: ctrl+f shortcut  for search in non-editor texts

### DIFF
--- a/plugins/keymaps/eclipse-keymap/resources/keymaps/Eclipse.xml
+++ b/plugins/keymaps/eclipse-keymap/resources/keymaps/Eclipse.xml
@@ -135,7 +135,9 @@
     <keyboard-shortcut first-keystroke="control F3"/>
     <keyboard-shortcut first-keystroke="control O"/>
   </action>
-  <action id="Find"/>
+  <action id="Find">
+    <keyboard-shortcut first-keystroke="ctrl f" />
+  </action>
   <action id="FindInPath">
     <keyboard-shortcut first-keystroke="control H"/>
   </action>


### PR DESCRIPTION
ctrl+f it worked in editor windows, because replace is assigned to ctrl f. This fixes "find" in application output/ mvn logs