### PR TITLE
[PY-76681] Add id for PyClassNameCompletionContributor

### DIFF
--- a/python/python-psi-impl/resources/META-INF/PythonPsiImpl.xml
+++ b/python/python-psi-impl/resources/META-INF/PythonPsiImpl.xml
@@ -147,7 +147,7 @@
     <completion.contributor language="Python"
                             implementationClass="com.jetbrains.python.codeInsight.completion.PyStringFormatCompletionContributor" />
 
-    <completion.contributor language="Python" order="first"
+    <completion.contributor language="Python" order="first" id="pyClassNameCompletionContributor"
                             implementationClass="com.jetbrains.python.codeInsight.completion.PyClassNameCompletionContributor"/>
     <completion.contributor language="Python" order="last"
                             implementationClass="com.jetbrains.python.codeInsight.completion.PyModulePackageCompletionContributor"/>


### PR DESCRIPTION
Hello @avokin,

I noticed that you recently made a [experiment with extended completion](https://github.com/JetBrains/intellij-community/commit/63487fda41d442471d55e67fc7af7288ca1bf710). This change accidentally affected my plugin for PyCharm (https://plugins.jetbrains.com/plugin/13499-odoo). My plugin has a completion contributor which needs to take priority over other Python completion contributors to provide applicable completion items in injected Python expressions in XML. Because `PyClassNameCompletionContributor` now has `order="first"`, adding a id for it will help other contributors to take priority over it if needed.

I have also created [a similar PR for PyModuleNameCompletionContributor](https://github.com/JetBrains/intellij-community/pull/2197) before.

<img width="953" alt="image" src="https://github.com/user-attachments/assets/0ca0f1a5-f592-417e-a661-fbc4d15a0bc6">
