### PR TITLE
Bugfix on crash while debugging with matplotlib versions containing non-numerals

### DIFF
--- a/python/helpers/pydev/pydev_ipython/matplotlibtools.py
+++ b/python/helpers/pydev/pydev_ipython/matplotlibtools.py
@@ -1,6 +1,6 @@
 
 import sys
-from pkg_resources import packaging
+from packaging.version import Version
 
 backends = {'tk': 'TkAgg',
             'gtk': 'GTKAgg',


### PR DESCRIPTION
See https://github.com/JetBrains/intellij-community/commit/2abc99f0b67ba5853a68cb2df11095f29776bb66#r148100178