### PR TITLE
Fixes for interactive matplotlib & PySide6

### DIFF
--- a/python/helpers/pydev/pydev_ipython/inputhook.py
+++ b/python/helpers/pydev/pydev_ipython/inputhook.py
@@ -27,6 +27,7 @@ GUI_QT = 'qt'
 GUI_QT4 = 'qt4'
 GUI_QT5 = 'qt5'
 GUI_QT6 = 'qt6'
+GUI_PYSIDE = 'pyside'
 GUI_GTK = 'gtk'
 GUI_TK = 'tk'
 GUI_OSX = 'osx'
@@ -180,9 +181,11 @@ class InputHookManager(object):
         self.clear_inputhook()
 
     def enable_qt(self, app=None):
-        from pydev_ipython.qt_for_kernel import QT_API, QT_API_PYQT5, QT_API_PYQT6
+        from pydev_ipython.qt_for_kernel import QT_API, QT_API_PYQT5, QT_API_PYQT6, QT_API_PYSIDE
         if QT_API == QT_API_PYQT6:
             self.enable_qt6(app)
+        elif QT_API == QT_API_PYSIDE:
+            self.enable_pyside(app)
         elif QT_API == QT_API_PYQT5:
             self.enable_qt5(app)
         else:
@@ -245,12 +248,22 @@ class InputHookManager(object):
 
     def enable_qt6(self, app=None):
         from pydev_ipython.inputhookqt6 import create_inputhook_qt6
-        app, inputhook_qt6 = create_inputhook_qt6(self, app)
+        app, inputhook_qt6 = create_inputhook_qt6(self, app, GUI_QT6)
         self.set_inputhook(inputhook_qt6)
 
         self._current_gui = GUI_QT6
         app._in_event_loop = True
         self._apps[GUI_QT6] = app
+        return app
+
+    def enable_pyside(self, app=None):
+        from pydev_ipython.inputhookqt6 import create_inputhook_qt6
+        app, inputhook_pyside = create_inputhook_qt6(self, app, GUI_PYSIDE)
+        self.set_inputhook(inputhook_pyside)
+
+        self._current_gui = GUI_PYSIDE
+        app._in_event_loop = True
+        self._apps[GUI_PYSIDE] = app
         return app
 
     def disable_qt6(self):

--- a/python/helpers/pydev/pydev_ipython/inputhookqt6.py
+++ b/python/helpers/pydev/pydev_ipython/inputhookqt6.py
@@ -22,8 +22,7 @@ import signal
 import threading
 
 
-from PyQt6 import QtCore, QtGui
-from pydev_ipython.inputhook import allow_CTRL_C, ignore_CTRL_C, stdin_ready
+from pydev_ipython.inputhook import allow_CTRL_C, ignore_CTRL_C, stdin_ready, GUI_QT6, GUI_PYSIDE
 
 # To minimise future merging complexity, rather than edit the entire code base below
 # we fake InteractiveShell here
@@ -51,7 +50,7 @@ sigint_timer = None
 # Code
 #-----------------------------------------------------------------------------
 
-def create_inputhook_qt6(mgr, app=None):
+def create_inputhook_qt6(mgr, app=None, gui=GUI_QT6):
     """Create an input hook for running the Qt6 application event loop.
 
     Parameters
@@ -79,10 +78,18 @@ def create_inputhook_qt6(mgr, app=None):
     """
 
     if app is None:
-        app = QtCore.QCoreApplication.instance()
-        if app is None:
-            from PyQt6 import QtWidgets
-            app = QtWidgets.QApplication([" "])
+        if gui == GUI_QT6:
+            from PyQt6 import QtCore
+            app = QtCore.QCoreApplication.instance()
+            if app is None:
+                from PyQt6 import QtWidgets
+                app = QtWidgets.QApplication([" "])
+        elif gui == GUI_PYSIDE:
+            from PySide6 import QtCore
+            app = QtCore.QCoreApplication.instance()
+            if app is None:
+                from PySide6 import QtWidgets
+                app = QtWidgets.QApplication([" "])
 
     # Re-use previously created inputhook if any
     ip = InteractiveShell.instance()

--- a/python/helpers/pydev/pydev_ipython/matplotlibtools.py
+++ b/python/helpers/pydev/pydev_ipython/matplotlibtools.py
@@ -63,11 +63,11 @@ def is_interactive_backend(backend):
     )
 
     if installed_version >= required_version:
-        interactive_bk = matplotlib.backends.backend_registry.list_builtin(matplotlib.backends.BackendFilter.INTERACTIVE)
-        non_interactive_bk = matplotlib.backends.backend_registry.list_builtin(matplotlib.backends.BackendFilter.NON_INTERACTIVE)
-        if backend in interactive_bk:
+        interactive_bk = [bk.lower() for bk in matplotlib.backends.backend_registry.list_builtin(matplotlib.backends.BackendFilter.INTERACTIVE)]
+        non_interactive_bk = [bk.lower() for bk in matplotlib.backends.backend_registry.list_builtin(matplotlib.backends.BackendFilter.NON_INTERACTIVE)]
+        if backend.lower() in interactive_bk:
             return True
-        elif backend in non_interactive_bk:
+        elif backend.lower() in non_interactive_bk:
             return False
         else:
             return matplotlib.is_interactive()


### PR DESCRIPTION
These two patches

1) fix interactive backends with matplotlib 3.9 broken by case-sensitive backend name matching ('PyQt' vs 'pyqt')

2) move from PySide (unsupported in inputhook anyway) to PySide6 and add PySide6 support to inputhookqt6

This makes recent Python + PySide6 + matplotlib 3.9 from anaconda.org usable again in the Python Console.