### PR TITLE
fix: replace "Mozzila" with "Mozilla"

### DIFF
--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/Css.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/Css.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/DomEvents.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/DomEvents.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/GlobalObjects.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/GlobalObjects.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/Html.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/Html.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/MathML.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/MathML.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/Svg.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/Svg.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-a.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-a.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-e.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-e.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-l.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-l.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-r.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-r.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-u.json
+++ b/xml/xml-psi-impl/gen/com/intellij/documentation/mdn/WebApi-u.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/mdn-doc-gen/src/GenerateMdnDocumentation.kt
+++ b/xml/xml-psi-impl/mdn-doc-gen/src/GenerateMdnDocumentation.kt
@@ -340,7 +340,7 @@ class GenerateMdnDocumentation : BasePlatformTestCase() {
         "url" to "https://creativecommons.org/licenses/by-sa/2.5/",
       ),
       "author" to mapOf(
-        "name" to "Mozzila Contributors",
+        "name" to "Mozilla Contributors",
         "url" to "https://github.com/mdn/content"
       ),
       "lang" to BUILT_LANG,

--- a/xml/xml-psi-impl/src/com/intellij/documentation/mdn/Css-obsolete.json
+++ b/xml/xml-psi-impl/src/com/intellij/documentation/mdn/Css-obsolete.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/src/com/intellij/documentation/mdn/DomEvents-obsolete.json
+++ b/xml/xml-psi-impl/src/com/intellij/documentation/mdn/DomEvents-obsolete.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/src/com/intellij/documentation/mdn/Html-obsolete.json
+++ b/xml/xml-psi-impl/src/com/intellij/documentation/mdn/Html-obsolete.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",

--- a/xml/xml-psi-impl/src/com/intellij/documentation/mdn/Svg-obsolete.json
+++ b/xml/xml-psi-impl/src/com/intellij/documentation/mdn/Svg-obsolete.json
@@ -4,7 +4,7 @@
     "url": "https://creativecommons.org/licenses/by-sa/2.5/"
   },
   "author": {
-    "name": "Mozzila Contributors",
+    "name": "Mozilla Contributors",
     "url": "https://github.com/mdn/content"
   },
   "lang": "en-us",


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Attrib_copyright_license