### PR TITLE
[javafx] IDEA-343577 Make Kotlin DSL the default for new Java/Kotlin …

### DIFF
--- a/plugins/javaFX/resources/fileTemplates/j2ee/javafx-build.gradle.ft
+++ b/plugins/javaFX/resources/fileTemplates/j2ee/javafx-build.gradle.ft
@@ -95,8 +95,12 @@ dependencies {
 }
 
 test {
-  #if ($context.testRunnerId == "junit")useJUnitPlatform()#end
-  #if ($context.testRunnerId == "testng")useTestNG()#end
+#if ($context.testRunnerId == "junit")
+  useJUnitPlatform()
+#end
+#if($context.testRunnerId == "testng")
+  useTestNG()
+#end
 }
 
 jlink {

--- a/plugins/javaFX/resources/fileTemplates/j2ee/javafx-build.gradle.kts.ft
+++ b/plugins/javaFX/resources/fileTemplates/j2ee/javafx-build.gradle.kts.ft
@@ -1,0 +1,105 @@
+#set ($D = '$')
+plugins {
+  java
+  application
+#if ($context.hasLanguage("kotlin"))
+  id("org.jetbrains.kotlin.jvm" version "${context.getVersion("org.jetbrains.kotlin", "kotlin-gradle-plugin")}"
+#end
+  id("org.javamodularity.moduleplugin") version "${context.getBomProperty("javamodularity.version")}"
+  id("org.openjfx.javafxplugin") version "${context.getVersion("org.openjfx", "javafxplugin")}"
+  id("org.beryx.jlink") version "${context.getVersion("org.beryx", "badass-jlink-plugin")}"
+}
+
+group = "${context.group}"
+version = "${context.version}"
+
+repositories {
+  mavenCentral()
+}
+
+#if ($context.testRunnerId == "junit")
+val junitVersion = "${context.getVersion("org.junit.jupiter", "junit-jupiter-engine")}"
+#end
+
+#if ($context.sdkFeatureVersion > 0 && !$context.hasLanguage("kotlin"))
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(${context.sdkFeatureVersion})
+  }
+}
+#end
+
+tasks.withType<JavaCompile> {
+  options.encoding = "UTF-8"
+}
+
+application {
+  mainModule.set("${context.rootPackage}")
+  mainClass.set("${context.rootPackage}.HelloApplication")
+}
+#if ($context.hasLanguage("kotlin"))
+kotlin {
+  jvmToolchain(#if ($context.sdkFeatureVersion < 17) 11 #else 17 #end)
+}
+#end
+
+javafx {
+  version = "${context.getProperty("javafx.version")}"
+  modules = listOf("javafx.controls", "javafx.fxml"#if ($context.hasLibrary("tilesfx")), "javafx.web", "javafx.swing" #end#if ($context.hasLibrary("fxgl")), "javafx.media"#end)
+}
+
+dependencies {
+#if ($context.hasLanguage("groovy"))
+  implementation("org.apache.groovy:groovy:${context.getVersion("org.apache.groovy", "groovy")}")
+#end
+#if ($context.hasLibrary("controlsfx"))
+  implementation("org.controlsfx:controlsfx:${context.getVersion("org.controlsfx", "controlsfx")}")
+#end
+#if ($context.hasLibrary("formsfx"))
+  implementation("com.dlsc.formsfx:formsfx-core:${context.getVersion("com.dlsc.formsfx", "formsfx-core")}") {
+    exclude(group = "org.openjfx")
+  }
+#end
+#if ($context.hasLibrary("validatorfx"))
+  implementation("net.synedra:validatorfx:${context.getVersion("net.synedra", "validatorfx")}") {
+    exclude(group = "org.openjfx")
+  }
+#end
+#if ($context.hasLibrary("ikonli"))
+  implementation("org.kordamp.ikonli:ikonli-javafx:${context.getVersion("org.kordamp.ikonli", "ikonli-javafx")}")
+#end
+#if ($context.hasLibrary("bootstrapfx"))
+  implementation("org.kordamp.bootstrapfx:bootstrapfx-core:${context.getVersion("org.kordamp.bootstrapfx", "bootstrapfx-core")}")
+#end
+#if ($context.hasLibrary("tilesfx"))
+  implementation("eu.hansolo:tilesfx:${context.getVersion("eu.hansolo", "tilesfx")}") {
+    exclude(group = "org.openjfx")
+  }
+#end
+#if ($context.hasLibrary("fxgl"))
+  implementation("com.github.almasb:fxgl:#if ($context.sdkFeatureVersion >= 17)${context.getBomProperty("fxgl17.version")}#else${context.getBomProperty("fxgl11.version")}#end") {
+    exclude(group = "org.openjfx")
+    exclude(group = "org.jetbrains.kotlin")
+  }
+#end
+
+#if ($context.testRunnerId == "junit")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:${context.asPlaceholder("junitVersion")}")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${context.asPlaceholder("junitVersion")}")
+#end
+#if ($context.testRunnerId == "testng")
+  testImplementation("org.testng:testng:${context.getVersion("org.testng", "testng")}")
+#end
+}
+tasks.withType<Test> {
+    #if ($context.testRunnerId == "junit")useJUnitPlatform()#end
+    #if ($context.testRunnerId == "testng")useTestNG()#end
+}
+
+jlink {
+  imageZip.set(layout.buildDirectory.file("/distributions/app-${D}{javafx.platform.classifier}.zip"))
+  options.set(listOf("--strip-debug", "--compress", "2", "--no-header-files", "--no-man-pages"))
+  launcher {
+    name = "app"
+  }
+}

--- a/plugins/javaFX/resources/fileTemplates/j2ee/javafx-settings.gradle.kts.ft
+++ b/plugins/javaFX/resources/fileTemplates/j2ee/javafx-settings.gradle.kts.ft
@@ -1,0 +1,1 @@
+rootProject.name = "${context.artifact}"

--- a/plugins/javaFX/src/org/jetbrains/plugins/javaFX/wizard/JavaFxModuleBuilder.kt
+++ b/plugins/javaFX/src/org/jetbrains/plugins/javaFX/wizard/JavaFxModuleBuilder.kt
@@ -79,7 +79,11 @@ internal class JavaFxModuleBuilder : StarterModuleBuilder() {
       files.add("pom.xml")
     }
     else if (starterContext.projectType == GRADLE_PROJECT) {
-      files.add("build.gradle")
+      if(starterContext.language.id == "groovy") {
+        files.add("build.gradle")
+      } else {
+        files.add("build.gradle.kts")
+      }
     }
 
     val packagePath = getPackagePath(starterContext.group, starterContext.artifact)
@@ -126,8 +130,13 @@ internal class JavaFxModuleBuilder : StarterModuleBuilder() {
 
     val assets = mutableListOf<GeneratorAsset>()
     if (starterContext.projectType == GRADLE_PROJECT) {
-      assets.add(GeneratorTemplateFile("build.gradle", ftManager.getJ2eeTemplate(JavaFxModuleTemplateGroup.JAVAFX_BUILD_GRADLE)))
-      assets.add(GeneratorTemplateFile("settings.gradle", ftManager.getJ2eeTemplate(JavaFxModuleTemplateGroup.JAVAFX_SETTINGS_GRADLE)))
+      if(starterContext.language.id == "groovy") {
+        assets.add(GeneratorTemplateFile("build.gradle", ftManager.getJ2eeTemplate(JavaFxModuleTemplateGroup.JAVAFX_BUILD_GRADLE)))
+        assets.add(GeneratorTemplateFile("settings.gradle", ftManager.getJ2eeTemplate(JavaFxModuleTemplateGroup.JAVAFX_SETTINGS_GRADLE)))
+      } else {
+        assets.add(GeneratorTemplateFile("build.gradle.kts", ftManager.getJ2eeTemplate(JavaFxModuleTemplateGroup.JAVAFX_BUILD_GRADLE_KTS)))
+        assets.add(GeneratorTemplateFile("settings.gradle.kts", ftManager.getJ2eeTemplate(JavaFxModuleTemplateGroup.JAVAFX_SETTINGS_GRADLE_KTS)))
+      }
       assets.add(GeneratorTemplateFile(standardAssetsProvider.gradleWrapperPropertiesLocation,
                                        ftManager.getJ2eeTemplate(JavaFxModuleTemplateGroup.JAVAFX_GRADLEW_PROPERTIES)))
       assets.addAll(standardAssetsProvider.getGradlewAssets())

--- a/plugins/javaFX/src/org/jetbrains/plugins/javaFX/wizard/JavaFxModuleTemplateGroup.kt
+++ b/plugins/javaFX/src/org/jetbrains/plugins/javaFX/wizard/JavaFxModuleTemplateGroup.kt
@@ -31,9 +31,11 @@ internal class JavaFxModuleTemplateGroup : FileTemplateGroupDescriptorFactory {
 
   companion object {
     const val JAVAFX_BUILD_GRADLE = "javafx-build.gradle"
+    const val JAVAFX_BUILD_GRADLE_KTS = "javafx-build.gradle.kts"
     const val JAVAFX_POM_XML = "javafx-pom.xml"
     const val JAVAFX_MVNW_PROPERTIES = "javafx-maven-wrapper.properties"
     const val JAVAFX_SETTINGS_GRADLE = "javafx-settings.gradle"
+    const val JAVAFX_SETTINGS_GRADLE_KTS = "javafx-settings.gradle.kts"
     const val JAVAFX_GRADLEW_PROPERTIES = "javafx-gradle-wrapper.properties"
 
     const val JAVAFX_HELLO_VIEW_FXML = "javafx-hello-view.fxml"


### PR DESCRIPTION
…JavaFX Projects

With this commit Kotlin DSL becomes the default for new JavaFX projects that use gradle as the build tool. Groovy projects still use the Groovy DSL