### PR TITLE
A fix for IDEA-283250: CommandLineWrapper does not defer to the system ClassLoader

### DIFF
--- a/java/java-runtime/src/com/intellij/rt/execution/CommandLineWrapper.java
+++ b/java/java-runtime/src/com/intellij/rt/execution/CommandLineWrapper.java
@@ -176,7 +176,7 @@ public final class CommandLineWrapper {
     }
 
     String mainClassName = args[startArgsIdx - 1];
-    ClassLoader loader = new URLClassLoader(classpathUrls.toArray(new URL[0]), null);
+    ClassLoader loader = new URLClassLoader(classpathUrls.toArray(new URL[0]), ClassLoader.getSystemClassLoader());
     String systemLoaderName = System.getProperty("java.system.class.loader");
     if (systemLoaderName != null) {
       try {


### PR DESCRIPTION
Some time ago I submitted a bug report that was initially attributed to GWT but is actually more fundamental than that. My report appears to have been ignored after a couple of initial back-and-forth messages.

In order to continue to debug our application using IntelliJ, I have been manually patching the java-runtime library (idea_rt.jar) in my own installs after each upgrade. I would like to include this change in the baseline so that it continues to work out of the box.

At issue is the fact that the GWT plugin uses `CommandLineWrapper` from the java-runtime module to get around an issue with a long classpath. `CommandLineWrapper` creates a new instance of `URLClassLoader` and passes in an array of URLs but does not link it to the system ClassLoader.

This was previously not an issue, however an update to the default behavior of the JVM starting with JDK 8u171 caused unexpected and breaking behavior in our application. We use a serialized JCEKS keystore in our application and deserializing said keystore fails when debugging our application using IntelliJ. See https://stackoverflow.com/a/52593341 for more details about the core issue.

This fix simply joins the URLClassLoader created within `CommandLineWrapper.java` to `ClassLoader.getSystemClassLoader()`.