### PR TITLE
IDEA-358562 Suggest migrating existing projects to Daemon JVM criteria

### DIFF
--- a/plugins/gradle/plugin-resources/META-INF/plugin.xml
+++ b/plugins/gradle/plugin-resources/META-INF/plugin.xml
@@ -194,6 +194,8 @@
 
     <registryKey key="gradle.daemon.jvm.criteria" defaultValue="true"
                  description="Enable the Gradle Daemon JVM criteria allowing to detect provisioning required toolchain for the build"/>
+    <registryKey key="gradle.daemon.jvm.criteria.suggest.migration" defaultValue="false"
+                 description="Enable to recommend migrate project from existing Gradle JDK configuration to Gradle Daemon JVM criteria"/>
     <registryKey key="gradle.phased.sync.enabled" defaultValue="true"
                  description="Enable the phased Gradle sync execution"/>
     <registryKey defaultValue="https://download.jetbrains.com/resources/intellij/plugins/gradle/v1/compatibility.json"
@@ -257,6 +259,7 @@
     <action id="Gradle.DownloadSources" class="org.jetbrains.plugins.gradle.action.GradleDownloadSourcesAction"
             icon="AllIcons.Actions.Download"/>
     <action id="Gradle.OpenProjectCompositeConfiguration" class="org.jetbrains.plugins.gradle.action.GradleOpenProjectCompositeConfigurationAction"/>
+    <action id="Gradle.MigrateToDaemonJvmCriteria" class="org.jetbrains.kotlin.idea.gradleJava.actions.GradleDaemonToolchainMigrateAction"/>
 
     <action id="Gradle.RefreshDependencies" class="org.jetbrains.plugins.gradle.action.GradleRefreshProjectDependenciesAction"/>
 

--- a/plugins/gradle/resources/messages/GradleBundle.properties
+++ b/plugins/gradle/resources/messages/GradleBundle.properties
@@ -144,6 +144,7 @@ action.Gradle.ToggleOfflineAction.description=Toggle offline mode for Gradle bui
 action.Gradle.DownloadSources.text=Download Sources
 action.Gradle.DownloadSources.description=Download the source code of all libraries used in the project
 action.Gradle.ExecuteTask.text=Execute Gradle Task
+action.Gradle.MigrateToDaemonJvmCriteria.text=Migrate Project to Daemon JVM Criteria
 
 gradle.settings.wizard.add.as.module.to=Add as module to
 gradle.settings.composite.selector.description=Please select participant projects to include in the Gradle composite.

--- a/plugins/gradle/resources/messages/GradleBundle.properties
+++ b/plugins/gradle/resources/messages/GradleBundle.properties
@@ -289,6 +289,26 @@ notification.group.gradle=Gradle
 gradle.build.quick.fix.gradle.jvm=Use Java {1} as Gradle JVM: <a href="{0}">Open Gradle settings</a>
 gradle.build.quick.fix.gradle.version=<a href="{0}">Upgrade to Gradle {1} and re-sync</a>
 
+gradle.build.quick.fix.add.toolchain.repository=Add default toolchain download repository plugin
+gradle.build.quick.fix.add.toolchain.criteria=Add default Daemon JVM criteria
+gradle.build.quick.fix.modify.gradle.jvm.criteria=Modify Daemon JVM criteria
+gradle.build.quick.fix.install.missing.toolchain=Install required toolchain
+gradle.build.quick.fix.recreate.download.urls=Recreate toolchain download URLs
+
+gradle.notifications.daemon.toolchain.migration.title=Migrate to Gradle Daemon toolchain
+gradle.notifications.daemon.toolchain.migration.description=Projects using Daemon toolchain allow builds to automatically detect \
+  installed toolchains given the defined JVM criteria or download a compatible one if cannot be found locally. In addition, using \
+  the Daemon toolchain aligns the selection between CLI and IDE, avoiding spawning multiple Daemons improving performance but also \
+  makes it simple to handle the required toolchain on different machines.
+gradle.notifications.daemon.toolchain.migration.accept.action.text=Migrate
+gradle.notifications.daemon.toolchain.migration.cancel.action.text=Ignore
+gradle.notifications.daemon.toolchain.migration.info.action.text=Learn more
+gradle.notifications.daemon.toolchain.migration.info.url=https://docs.gradle.org/current/userguide/gradle_daemon.html#daemon_jvm_criteria
+gradle.notifications.daemon.toolchain.migration.apply.plugin.command.name=Applying Foojay Resolver Plugin
+gradle.notifications.daemon.toolchain.migration.error.title=Project Migration Error
+gradle.notifications.daemon.toolchain.migration.error.message=Failed to migrate project ''{0}'' to Daemon JVM criteria. Consider migrate \
+  manually following the guidelines.
+
 advanced.settings.gradle=Build Tools. Gradle
 advanced.setting.gradle.download.sources=Download sources
 advanced.setting.gradle.download.sources.description=Download sources for project dependencies during the project import. A project sync is required to download the sources after selecting this option.

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleDaemonJvmHelper.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleDaemonJvmHelper.kt
@@ -5,6 +5,7 @@ import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.openapi.externalSystem.model.execution.ExternalSystemTaskExecutionSettings
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
 import com.intellij.openapi.externalSystem.service.execution.ProgressExecutionMode
+import com.intellij.openapi.externalSystem.task.TaskCallback
 import com.intellij.openapi.externalSystem.util.ExternalSystemUtil
 import com.intellij.openapi.externalSystem.util.task.TaskExecutionSpec
 import com.intellij.openapi.project.Project
@@ -75,6 +76,7 @@ object GradleDaemonJvmHelper {
     project: Project,
     externalProjectPath: String,
     daemonJvmCriteria: GradleDaemonJvmCriteria?,
+    taskCallback: TaskCallback? = null,
     executionMode: ProgressExecutionMode = ProgressExecutionMode.START_IN_FOREGROUND_ASYNC,
   ) {
     val taskSettings = ExternalSystemTaskExecutionSettings().apply {
@@ -94,6 +96,7 @@ object GradleDaemonJvmHelper {
       .withProgressExecutionMode(executionMode)
       .withActivateToolWindowBeforeRun(true)
       .withUserData(taskUserData)
+      .withCallback(taskCallback)
       .build()
 
     ExternalSystemUtil.runTask(executionSpec)

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleNotificationIdsHolder.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleNotificationIdsHolder.kt
@@ -8,6 +8,7 @@ class GradleNotificationIdsHolder : NotificationIdsHolder {
     const val jvmConfigured = "gradle.jvm.configured"
     const val jvmInvalid = "gradle.jvm.invalid"
     const val configurationError = "gradle.configuration.error"
+    const val daemonToolchainMigration = "gradle.daemon.toolchain.migration"
   }
 
   override fun getNotificationIds(): List<String> {

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleDaemonJvmCriteriaTest.kt
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleDaemonJvmCriteriaTest.kt
@@ -17,7 +17,7 @@ class GradleDaemonJvmCriteriaTest : GradleImportingTestCase() {
     importProject("")
     val projectDir = project.guessProjectDir()!!
     GradleDaemonJvmHelper.updateProjectDaemonJvmCriteria(
-      project, projectDir.path, GradleDaemonJvmCriteria("17", "JETBRAINS"), ProgressExecutionMode.NO_PROGRESS_SYNC
+      project, projectDir.path, GradleDaemonJvmCriteria("17", "JETBRAINS"), null, ProgressExecutionMode.NO_PROGRESS_SYNC
     )
 
     GradleDaemonJvmPropertiesFile.getProperties(projectDir.toNioPath())!!.run {

--- a/plugins/kotlin/gradle/code-insight-common/src/org/jetbrains/kotlin/idea/gradleCodeInsightCommon/KotlinGradleCodeInsightUtils.kt
+++ b/plugins/kotlin/gradle/code-insight-common/src/org/jetbrains/kotlin/idea/gradleCodeInsightCommon/KotlinGradleCodeInsightUtils.kt
@@ -63,6 +63,12 @@ fun Module.getTopLevelBuildScriptSettingsPsiFile(): PsiFile? {
         ?.getPsiFile(project)
 }
 
+fun Project.getTopLevelBuildScriptSettingsPsiFile(): PsiFile? {
+    val projectDir = this.guessProjectDir() ?: return null
+    return findBuildGradleFile(projectDir.path, SETTINGS_FILE_NAME, KOTLIN_SETTINGS_SCRIPT_NAME)
+        ?.getPsiFile(this)
+}
+
 private fun Module.getBuildScriptFile(vararg fileNames: String): Path? {
     moduleNioFile.parent?.let { moduleDir ->
         findBuildGradleFile(moduleDir.pathString, *fileNames)?.let {

--- a/plugins/kotlin/gradle/gradle-java/resources/kotlin.gradle.gradle-java.xml
+++ b/plugins/kotlin/gradle/gradle-java/resources/kotlin.gradle.gradle-java.xml
@@ -94,6 +94,7 @@
     <externalProjectDataService implementation="org.jetbrains.kotlin.idea.gradleJava.configuration.kpm.KotlinFragmentDataService"/>
 
     <externalSystemTaskNotificationListener implementation="org.jetbrains.kotlin.idea.gradleJava.scripting.importing.KotlinDslSyncListener"/>
+    <externalSystemTaskNotificationListener implementation="org.jetbrains.kotlin.idea.gradleJava.toolchain.GradleDaemonToolchainMigrateNotificationListener"/>
 
     <editorNotificationProvider implementation="org.jetbrains.kotlin.idea.gradleJava.scripting.GradleScriptNotificationProvider"/>
 

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/actions/GradleDaemonToolchainMigrateAction.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/actions/GradleDaemonToolchainMigrateAction.kt
@@ -1,0 +1,30 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.gradleJava.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.externalSystem.action.ExternalSystemAction
+import com.intellij.openapi.util.registry.Registry
+import org.jetbrains.kotlin.idea.gradleJava.toolchain.GradleDaemonToolchainMigrationService
+import org.jetbrains.plugins.gradle.service.execution.GradleDaemonJvmHelper
+import org.jetbrains.plugins.gradle.settings.GradleSettings
+
+class GradleDaemonToolchainMigrateAction : ExternalSystemAction() {
+
+    override fun isEnabled(e: AnActionEvent) = Registry.`is`("gradle.daemon.jvm.criteria.suggest.migration")
+
+    override fun isVisible(e: AnActionEvent) = Registry.`is`("gradle.daemon.jvm.criteria.suggest.migration")
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+
+        GradleSettings.getInstance(project)
+            .linkedProjectsSettings
+            .mapNotNull { it.externalProjectPath }
+            .forEach {
+                val projectSettings = GradleSettings.getInstance(project).getLinkedProjectSettings(it) ?: return@forEach
+                if (!GradleDaemonJvmHelper.isDaemonJvmCriteriaSupported(projectSettings.resolveGradleVersion())) return@forEach
+                if (GradleDaemonJvmHelper.isProjectUsingDaemonJvmCriteria(projectSettings)) return@forEach
+                GradleDaemonToolchainMigrationService(project).startMigration(it)
+            }
+    }
+}

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonToolchainMigrateNotification.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonToolchainMigrateNotification.kt
@@ -1,0 +1,47 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.gradleJava.toolchain
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.gradle.service.project.GradleNotification
+import org.jetbrains.plugins.gradle.service.project.GradleNotificationIdsHolder
+import org.jetbrains.plugins.gradle.util.GradleBundle
+import java.awt.Desktop
+import java.net.URI
+
+private const val IGNORE_DAEMON_TOOLCHAIN_MIGRATION = "IGNORE_DAEMON_TOOLCHAIN_MIGRATION"
+
+object GradleDaemonToolchainMigrateNotification {
+
+    fun show(project: Project, externalProjectPath: String) {
+        if (isDaemonToolchainMigrationIgnored) return
+
+        GradleNotification.gradleNotificationGroup.createNotification(
+            title = GradleBundle.message("gradle.notifications.daemon.toolchain.migration.title", project.name),
+            content = GradleBundle.message("gradle.notifications.daemon.toolchain.migration.description"),
+            type = NotificationType.INFORMATION
+        ).addAction(
+            NotificationAction.create(GradleBundle.message("gradle.notifications.daemon.toolchain.migration.info.action.text")) { _, _ ->
+                if (Desktop.isDesktopSupported()) {
+                    val url = GradleBundle.message("gradle.notifications.daemon.toolchain.migration.info.url")
+                    Desktop.getDesktop().browse(URI(url))
+                }
+            }
+        ).addAction(NotificationAction.create(GradleBundle.message("gradle.notifications.daemon.toolchain.migration.accept.action.text")) { _, notification ->
+            isDaemonToolchainMigrationIgnored = true
+            notification.expire()
+            GradleDaemonToolchainMigrationService(project).startMigration(externalProjectPath)
+        }).addAction(NotificationAction.create(GradleBundle.message("gradle.notifications.daemon.toolchain.migration.cancel.action.text")) { _, notification ->
+            isDaemonToolchainMigrationIgnored = true
+            notification.expire()
+        }).setDisplayId(GradleNotificationIdsHolder.daemonToolchainMigration)
+            .notify(project)
+    }
+
+    private var isDaemonToolchainMigrationIgnored: Boolean
+        get() = PropertiesComponent.getInstance().getBoolean(IGNORE_DAEMON_TOOLCHAIN_MIGRATION, false)
+        set(value) = PropertiesComponent.getInstance().setValue(IGNORE_DAEMON_TOOLCHAIN_MIGRATION, value)
+
+}

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonToolchainMigrateNotificationListener.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonToolchainMigrateNotificationListener.kt
@@ -1,0 +1,26 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.gradleJava.toolchain
+
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType
+import com.intellij.openapi.util.registry.Registry
+import org.jetbrains.plugins.gradle.service.execution.GradleDaemonJvmHelper
+import org.jetbrains.plugins.gradle.settings.GradleSettings
+import org.jetbrains.plugins.gradle.util.GradleConstants
+
+class GradleDaemonToolchainMigrateNotificationListener: ExternalSystemTaskNotificationListener {
+
+    override fun onSuccess(projectPath: String, id: ExternalSystemTaskId) {
+        if (!Registry.`is`("gradle.daemon.jvm.criteria.suggest.migration")) return
+        if (GradleConstants.SYSTEM_ID.id != id.projectSystemId.id || id.type != ExternalSystemTaskType.RESOLVE_PROJECT) return
+
+        val project = id.findProject() ?: return
+        val projectSettings = GradleSettings.getInstance(project).getLinkedProjectSettings(projectPath) ?: return
+
+        if (!GradleDaemonJvmHelper.isDaemonJvmCriteriaSupported(projectSettings.resolveGradleVersion())) return
+        if (GradleDaemonJvmHelper.isProjectUsingDaemonJvmCriteria(projectSettings)) return
+
+        GradleDaemonToolchainMigrateNotification.show(project, projectPath)
+    }
+}

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonToolchainMigrationService.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonToolchainMigrationService.kt
@@ -1,0 +1,78 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.gradleJava.toolchain
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil.USE_PROJECT_JDK
+import com.intellij.openapi.externalSystem.task.TaskCallback
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import org.jetbrains.jps.model.java.JdkVersionDetector
+import org.jetbrains.kotlin.idea.gradle.extensions.nameSupportedByFoojayPlugin
+import org.jetbrains.kotlin.idea.gradleCodeInsightCommon.GradleBuildScriptSupport
+import org.jetbrains.kotlin.idea.gradleCodeInsightCommon.getTopLevelBuildScriptSettingsPsiFile
+import org.jetbrains.plugins.gradle.service.GradleInstallationManager
+import org.jetbrains.plugins.gradle.service.execution.GradleDaemonJvmCriteria
+import org.jetbrains.plugins.gradle.service.execution.GradleDaemonJvmHelper
+import org.jetbrains.plugins.gradle.settings.GradleSettings
+import org.jetbrains.plugins.gradle.util.GradleBundle
+
+@Service(Service.Level.PROJECT)
+class GradleDaemonToolchainMigrationService(private val project: Project) {
+
+    fun startMigration(externalProjectPath: String) {
+        val currentJdkInfo = GradleInstallationManager.getInstance().getGradleJvmPath(project, externalProjectPath)?.let {
+            JdkVersionDetector.getInstance().detectJdkVersionInfo(it)
+        }
+        if (currentJdkInfo?.version == null) {
+            displayMigrationFailureMessage()
+            return
+        }
+
+        applyDefaultToolchainResolverPlugin()
+
+        GradleDaemonJvmHelper.updateProjectDaemonJvmCriteria(
+            project,
+            externalProjectPath,
+            GradleDaemonJvmCriteria(
+                version = currentJdkInfo.version.feature.toString(),
+                vendor = currentJdkInfo.variant.nameSupportedByFoojayPlugin
+            ), object : TaskCallback {
+                override fun onSuccess() {
+                    overrideGradleJvmReferenceWithDefault(externalProjectPath)
+                }
+
+                override fun onFailure() {
+                    displayMigrationFailureMessage()
+                }
+            }
+        )
+    }
+
+    private fun applyDefaultToolchainResolverPlugin() {
+        CommandProcessor.getInstance().executeCommand(project, {
+            ApplicationManager.getApplication().runWriteAction {
+                project.getTopLevelBuildScriptSettingsPsiFile()?.let {
+                    val buildScriptSupport = GradleBuildScriptSupport.getManipulator(it)
+                    buildScriptSupport.addFoojayPlugin(it)
+                }
+            }
+        }, GradleBundle.message("gradle.notifications.daemon.toolchain.migration.apply.plugin.command.name"), null)
+    }
+
+    private fun overrideGradleJvmReferenceWithDefault(externalProjectPath: String) {
+        val projectSettings = GradleSettings.getInstance(project).getLinkedProjectSettings(externalProjectPath)
+        projectSettings?.gradleJvm = USE_PROJECT_JDK
+    }
+
+    private fun displayMigrationFailureMessage() {
+        ApplicationManager.getApplication().invokeLater {
+            Messages.showErrorDialog(
+                project,
+                GradleBundle.message("gradle.notifications.daemon.toolchain.migration.error.message", project.name),
+                GradleBundle.message("gradle.notifications.daemon.toolchain.migration.error.title")
+            )
+        }
+    }
+}

--- a/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/idea/toolchain/gradle/GradleDaemonToolchainMigrationServiceTest.kt
+++ b/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/idea/toolchain/gradle/GradleDaemonToolchainMigrationServiceTest.kt
@@ -1,0 +1,55 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.toolchain.gradle
+
+import com.intellij.openapi.application.invokeAndWaitIfNeeded
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil.JAVA_HOME
+import com.intellij.openapi.roots.ui.configuration.SdkTestCase.Companion.withRegisteredSdks
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.jps.model.java.JdkVersionDetector
+import org.jetbrains.kotlin.idea.gradle.extensions.nameSupportedByFoojayPlugin
+import org.jetbrains.kotlin.idea.gradleCodeInsightCommon.getTopLevelBuildScriptSettingsPsiFile
+import org.jetbrains.kotlin.idea.gradleJava.toolchain.GradleDaemonToolchainMigrationService
+import org.jetbrains.plugins.gradle.importing.GradleProjectSdkResolverTestCase
+import org.jetbrains.plugins.gradle.properties.GradleDaemonJvmPropertiesFile
+import org.jetbrains.plugins.gradle.tooling.annotation.TargetVersions
+import org.junit.Test
+import kotlin.io.path.Path
+
+class GradleDaemonToolchainMigrationServiceTest: GradleProjectSdkResolverTestCase() {
+
+    @Test
+    @TargetVersions("8.8+")
+    fun `test Given project When migrate to Daemon toolchain Then criteria is maintained`() = runBlocking {
+        val jdk = resolveRealTestSdk()
+        val jdkInfo = JdkVersionDetector.getInstance().detectJdkVersionInfo(jdk.homePath!!)
+        check(jdkInfo != null)
+        createGradleSubProject()
+
+        environment.withVariables(JAVA_HOME to jdk.homePath) {
+            withRegisteredSdks(jdk) {
+                loadProject()
+                check(GradleDaemonJvmPropertiesFile.getProperties(Path(projectPath)) == null)
+
+                invokeAndWaitIfNeeded {
+                    GradleDaemonToolchainMigrationService(project).startMigration(projectPath)
+                }
+                assertFoojayPluginIsApplied()
+                assertDaemonJvmProperties(jdkInfo.version.feature, jdkInfo.variant.nameSupportedByFoojayPlugin)
+            }
+        }
+    }
+
+    private suspend fun assertFoojayPluginIsApplied() {
+        readAction {
+            project.getTopLevelBuildScriptSettingsPsiFile()!!.text.contains("org.gradle.toolchains.foojay-resolver-convention")
+        }
+    }
+
+    private fun assertDaemonJvmProperties(expectedVersion: Int, expectedVendor: String?) {
+        GradleDaemonJvmPropertiesFile.getProperties(Path(projectPath))!!.run {
+            assertEquals(expectedVersion.toString(), version?.value)
+            assertEquals(expectedVendor, vendor?.value)
+        }
+    }
+}

--- a/plugins/kotlin/gradle/gradle/src/org/jetbrains/kotlin/idea/gradle/extensions/VariantExtensions.kt
+++ b/plugins/kotlin/gradle/gradle/src/org/jetbrains/kotlin/idea/gradle/extensions/VariantExtensions.kt
@@ -1,0 +1,19 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.gradle.extensions
+
+import org.jetbrains.jps.model.java.JdkVersionDetector.Variant
+
+/**
+ * Transform [Variant.name] into expected vendors name by [foojay-plugin](https://github.com/gradle/foojay-toolchains) being the default
+ * [plugin resolver](https://docs.gradle.org/current/userguide/toolchain_plugins.html) applied to projects when Gradle
+ * toolchains are configured
+ */
+val Variant.nameSupportedByFoojayPlugin: String?
+    get() = when(this) {
+        Variant.AdoptOpenJdk_HS -> "AOJ"
+        Variant.AdoptOpenJdk_J9 -> "AOJ OpenJ9"
+        Variant.JBR -> "JetBrains"
+        Variant.IBM -> Variant.Semeru.name
+        Variant.Unknown, Variant.GraalVMCE, Variant.Homebrew -> null
+        else -> name
+    }

--- a/plugins/kotlin/gradle/gradle/tests/kotlin.gradle.gradle.tests.iml
+++ b/plugins/kotlin/gradle/gradle/tests/kotlin.gradle.gradle.tests.iml
@@ -55,5 +55,8 @@
     <orderEntry type="module" module-name="kotlin.completion.tests.shared" scope="TEST" />
     <orderEntry type="module" module-name="kotlin.completion.tests.k1" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="TestNG" level="project" />
+    <orderEntry type="library" scope="TEST" name="mockito" level="project" />
+    <orderEntry type="library" scope="TEST" name="mockito-kotlin" level="project" />
+    <orderEntry type="module" module-name="intellij.platform.testFramework.junit5" scope="TEST" />
   </component>
 </module>

--- a/plugins/kotlin/gradle/gradle/tests/test/org/jetbrains/kotlin/idea/gradle/externsions/VariantExtensionsTest.kt
+++ b/plugins/kotlin/gradle/gradle/tests/test/org/jetbrains/kotlin/idea/gradle/externsions/VariantExtensionsTest.kt
@@ -1,0 +1,39 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.gradle.externsions
+
+import com.intellij.testFramework.junit5.TestApplication
+import org.jetbrains.jps.model.java.JdkVersionDetector.Variant
+import org.jetbrains.kotlin.idea.gradle.extensions.nameSupportedByFoojayPlugin
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@TestApplication
+class VariantExtensionsTest {
+
+    @Test
+    fun testVariantNameSupportedByFoojayPlugin() {
+        Variant.entries.forEach { variant ->
+            assertEquals(variant.expectedNameSupportedByFoojayPlugin, variant.nameSupportedByFoojayPlugin)
+        }
+    }
+
+    private val Variant.expectedNameSupportedByFoojayPlugin: String?
+        get() = when (this) {
+            Variant.AdoptOpenJdk_HS -> "AOJ"
+            Variant.AdoptOpenJdk_J9 -> "AOJ OpenJ9"
+            Variant.IBM, Variant.Semeru -> "Semeru"
+            Variant.JBR -> "JetBrains"
+            Variant.BiSheng -> "BiSheng"
+            Variant.Corretto -> "Corretto"
+            Variant.Dragonwell -> "Dragonwell"
+            Variant.GraalVM -> "GraalVM"
+            Variant.Kona -> "Kona"
+            Variant.Liberica -> "Liberica"
+            Variant.Microsoft -> "Microsoft"
+            Variant.Oracle -> "Oracle"
+            Variant.SapMachine -> "SapMachine"
+            Variant.Temurin -> "Temurin"
+            Variant.Zulu -> "Zulu"
+            Variant.Unknown, Variant.GraalVMCE, Variant.Homebrew -> null
+        }
+}


### PR DESCRIPTION
### Context
The `Daemon toolchain` was introduced in [Gradle 8.8](https://docs.gradle.org/8.8/release-notes.html#daemon-toolchains) and the motivation behind it and other technical details can be found on the public [spec document](https://docs.google.com/document/d/1CU1e4QjPs2yj_SmJuykPUXutynvn4X_SF0BPXVnAlKI/edit?usp=drive_link). The implementation follows the agreed details on [spec document](https://docs.google.com/document/d/1TjI-gGDcTQdIZP-cz38bBdV0jX2wRXmu3DJNUbvVG-o/edit?usp=sharing&resourcekey=0-iAyVFbna4gxtug_JVF0tJw) and [UI/UX document](https://docs.google.com/document/d/1MHkyJGQtNGevlRGBfx4-lDQLte1kjM2qHOjuMVMuEoM/edit?usp=sharing).

#### Summary
This PR creates a info dialog suggesting users to migrate their project to `Daemon JVM criteria`. The migration process will take into consideration the existing `Gradle JDK configuration` and creating the criteria based on it. In case of `vendor` is important to highlight that must be known by [foojay plugin](https://github.com/gradle/foojay-toolchains) otherwise the download URL are not going to returned for this reason if that's not the case its value will not be specified.

_NOTE: For now any suggestion to migrate projects will be disabled until Daemon JVM criteria supports the auto-provisioning_

###### Tasks

- https://github.com/vmadalin/intellij-community/issues/7
- https://github.com/vmadalin/intellij-community/issues/3
- https://github.com/vmadalin/intellij-community/issues/4

#### Tests

- [GradleDaemonToolchainMigrationServiceTest.kt](https://github.com/JetBrains/intellij-community/pull/2882/files#diff-3ec299fb0b4e67ad56951438557c2b65678ff98b5274c50f92ab8b00f9010f50)
- [VariantExtensionsTest.kt](https://github.com/JetBrains/intellij-community/pull/2882/files#diff-ffd4b97e6595da5896c6f4b4c5467223123ee01d042460dfea2919ae69e56507)


#### Demo



https://github.com/user-attachments/assets/52c87809-f2fd-4c96-a7fc-77b765021228





