### PR TITLE
IDEA-358562 Created projects via wizard defines Daemon JVM criteria by default

### DIFF
--- a/plugins/gradle/java/src/service/project/wizard/GradleNewProjectWizardStep.kt
+++ b/plugins/gradle/java/src/service/project/wizard/GradleNewProjectWizardStep.kt
@@ -473,7 +473,7 @@ abstract class GradleNewProjectWizardStep<ParentStep>(parent: ParentStep) :
     builder.contentEntryPath = parentStep.path + "/" + parentStep.name
 
     builder.isCreatingNewProject = context.isCreatingNewProject
-    builder.isUsingDaemonToolchain = Registry.`is`("gradle.daemon.jvm.criteria.new.projects") && isDaemonJvmCriteriaSupported(gradleVersion)
+    builder.isUsingDaemonToolchain = context.isCreatingNewProject && Registry.`is`("gradle.daemon.jvm.criteria.new.projects") && isDaemonJvmCriteriaSupported(gradleVersion)
 
     builder.parentProject = parentData
     builder.projectId = ProjectId(groupId, artifactId, version)

--- a/plugins/gradle/resources/messages/GradleBundle.properties
+++ b/plugins/gradle/resources/messages/GradleBundle.properties
@@ -199,6 +199,7 @@ column.name.daemon.timestamp=Timestamp
 column.name.daemon.info=Info
 gradle.execution.name.build.project.=Build {0}
 grable.execution.name.upgrade.wrapper=Upgrade Gradle wrapper
+gradle.execution.name.config.daemon.jvm.criteria=Configure Daemon JVM Criteria
 
 gradle.target.configure.label=Gradle configuration
 gradle.target.run.label=Run Gradle task

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/frameworkSupport/settingsScript/GradleSettingScriptBuilder.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/frameworkSupport/settingsScript/GradleSettingScriptBuilder.kt
@@ -28,6 +28,12 @@ interface GradleSettingScriptBuilder<Self: GradleSettingScriptBuilder<Self>> : S
 
   fun addCode(configure: ScriptTreeBuilder.() -> Unit): Self
 
+  fun withPlugin(configure: ScriptTreeBuilder.() -> Unit): Self
+
+  fun withPlugin(id: String, version: String?): Self
+
+  fun withFoojayPlugin()
+
   fun generateTree(): BlockElement
 
   fun generate(): String

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/frameworkSupport/settingsScript/GradleSettingsScriptBuilderUtil.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/frameworkSupport/settingsScript/GradleSettingsScriptBuilderUtil.kt
@@ -1,0 +1,6 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.frameworkSupport.settingsScript
+
+fun getFoojayResolverVersion(): String {
+  return "0.8.0"
+}

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleJvmVendorUtil.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/util/GradleJvmVendorUtil.kt
@@ -8,15 +8,15 @@ fun String.toJvmVendor(): JvmVendor {
   return JvmVendor.fromString(this)
 }
 
-fun Variant.toJvmVendor(): JvmVendor {
+fun Variant.toJvmVendor(): JvmVendor? {
   val knownVendor = toKnownJvmVendor()
   if (knownVendor != JvmVendor.KnownJvmVendor.UNKNOWN) {
-    return knownVendor.asJvmVendor()
+    return knownVendor?.asJvmVendor()
   }
   return name.toJvmVendor()
 }
 
-private fun Variant.toKnownJvmVendor(): JvmVendor.KnownJvmVendor {
+private fun Variant.toKnownJvmVendor(): JvmVendor.KnownJvmVendor? {
   return when (this) {
     Variant.AdoptOpenJdk_HS -> JvmVendor.KnownJvmVendor.ADOPTOPENJDK
     Variant.Corretto -> JvmVendor.KnownJvmVendor.AMAZON
@@ -30,13 +30,13 @@ private fun Variant.toKnownJvmVendor(): JvmVendor.KnownJvmVendor {
     Variant.Temurin -> JvmVendor.KnownJvmVendor.ADOPTIUM
     Variant.Zulu -> JvmVendor.KnownJvmVendor.AZUL
 
-    Variant.AdoptOpenJdk_J9 -> JvmVendor.KnownJvmVendor.UNKNOWN
-    Variant.BiSheng -> JvmVendor.KnownJvmVendor.UNKNOWN
-    Variant.Dragonwell -> JvmVendor.KnownJvmVendor.UNKNOWN
-    Variant.GraalVMCE -> JvmVendor.KnownJvmVendor.UNKNOWN
-    Variant.Homebrew -> JvmVendor.KnownJvmVendor.UNKNOWN
-    Variant.Kona -> JvmVendor.KnownJvmVendor.UNKNOWN
-    Variant.Semeru -> JvmVendor.KnownJvmVendor.UNKNOWN
-    Variant.Unknown -> JvmVendor.KnownJvmVendor.UNKNOWN
+    Variant.AdoptOpenJdk_J9 -> null
+    Variant.BiSheng -> null
+    Variant.Dragonwell -> null
+    Variant.GraalVMCE -> null
+    Variant.Homebrew -> null
+    Variant.Kona -> null
+    Variant.Semeru -> null
+    Variant.Unknown -> null
   }
 }

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/GradleBaseTestCase.kt
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/GradleBaseTestCase.kt
@@ -26,6 +26,7 @@ abstract class GradleBaseTestCase {
 
   val testRoot: VirtualFile get() = gradleTestFixture.testRoot
   val gradleJvm: String get() = gradleTestFixture.gradleJvm
+  val gradleJvmPath: String get() = gradleTestFixture.gradleJvmPath
   val gradleVersion: GradleVersion get() = gradleTestFixture.gradleVersion
 
   @BeforeEach

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/fixtures/GradleTestFixture.kt
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/fixtures/GradleTestFixture.kt
@@ -13,6 +13,8 @@ interface GradleTestFixture : IdeaTestFixture {
 
   val gradleJvm: String
 
+  val gradleJvmPath: String
+
   val gradleVersion: GradleVersion
 
   suspend fun openProject(relativePath: String, numProjectSyncs: Int = 1): Project

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/fixtures/impl/GradleJvmTestFixture.kt
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/fixtures/impl/GradleJvmTestFixture.kt
@@ -31,6 +31,9 @@ class GradleJvmTestFixture(
   val gradleJvm: String
     get() = sdk.name
 
+  val gradleJvmPath: String
+    get() = sdk.homePath.orEmpty()
+
   override fun setUp() {
     fixtureDisposable = Disposer.newDisposable()
     sdk = GradleJvmResolver.resolveGradleJvm(gradleVersion, fixtureDisposable, javaVersionRestriction)

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/fixtures/impl/GradleTestFixtureImpl.kt
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/testFramework/fixtures/impl/GradleTestFixtureImpl.kt
@@ -47,6 +47,8 @@ class GradleTestFixtureImpl(
 
   override lateinit var gradleJvm: String
 
+  override lateinit var gradleJvmPath: String
+
   override fun setUp() {
     reloadLeakTracker = OperationLeakTracker { getGradleProjectReloadOperation(it) }
     reloadLeakTracker.setUp()
@@ -57,6 +59,7 @@ class GradleTestFixtureImpl(
     gradleJvmFixture.setUp()
     gradleJvmFixture.installProjectSettingsConfigurator()
     gradleJvm = gradleJvmFixture.gradleJvm
+    gradleJvmPath = gradleJvmFixture.gradleJvmPath
 
     fileFixture = IdeaTestFixtureFactory.getFixtureFactory().createTempDirTestFixture()
     fileFixture.setUp()

--- a/plugins/kotlin/gradle/gradle-java/resources/kotlin.gradle.gradle-java.xml
+++ b/plugins/kotlin/gradle/gradle-java/resources/kotlin.gradle.gradle-java.xml
@@ -120,6 +120,10 @@
             key="gradle.daemon.jvm.criteria.suggest.migration"
             description="Enable to recommend migrate project from existing Gradle JDK configuration to Gradle Daemon JVM criteria"
             defaultValue="false"/>
+    <registryKey
+            key="gradle.daemon.jvm.criteria.new.projects"
+            description="Enable to allow new projects to be created with the Gradle Daemon JVM criteria"
+            defaultValue="false"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonJvmCriteriaMigrationHelper.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/toolchain/GradleDaemonJvmCriteriaMigrationHelper.kt
@@ -1,8 +1,8 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package org.jetbrains.kotlin.idea.gradleJava.toolchain
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
-import com.intellij.openapi.command.writeCommandAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil.USE_PROJECT_JDK
@@ -14,15 +14,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
-import org.jetbrains.jps.model.java.JdkVersionDetector
 import org.jetbrains.kotlin.idea.gradleCodeInsightCommon.GradleBuildScriptSupport
 import org.jetbrains.kotlin.idea.gradleCodeInsightCommon.getTopLevelBuildScriptSettingsPsiFile
-import org.jetbrains.plugins.gradle.service.GradleInstallationManager
-import org.jetbrains.plugins.gradle.service.execution.GradleDaemonJvmCriteria
+import org.jetbrains.kotlin.idea.util.application.executeWriteCommand
 import org.jetbrains.plugins.gradle.service.execution.GradleDaemonJvmHelper
 import org.jetbrains.plugins.gradle.settings.GradleSettings
 import org.jetbrains.plugins.gradle.util.GradleBundle
-import org.jetbrains.plugins.gradle.util.toJvmVendor
 import java.util.concurrent.CompletableFuture
 
 object GradleDaemonJvmCriteriaMigrationHelper {
@@ -34,25 +31,9 @@ object GradleDaemonJvmCriteriaMigrationHelper {
     }
 
     private suspend fun migrateToDaemonJvmCriteriaImpl(project: Project, externalProjectPath: String): Boolean {
-        val gradleJvmPath = GradleInstallationManager.getInstance().getGradleJvmPath(project, externalProjectPath)
-        if (gradleJvmPath == null) {
-            displayMigrationFailureMessage(project)
-            return false
-        }
-        val gradleJvmInfo = JdkVersionDetector.getInstance().detectJdkVersionInfo(gradleJvmPath)
-        if (gradleJvmInfo == null) {
-            displayMigrationFailureMessage(project)
-            return false
-        }
-        val gradleJvmCriteria = GradleDaemonJvmCriteria(
-            version = gradleJvmInfo.version.feature.toString(),
-            vendor = gradleJvmInfo.variant.toJvmVendor()
-        )
-
-        applyDefaultToolchainResolverPlugin(project)
-
-        val isSuccess = GradleDaemonJvmHelper.updateProjectDaemonJvmCriteria(project, externalProjectPath, gradleJvmCriteria)
-            .await()
+        val isSuccess = GradleDaemonJvmHelper.setUpProjectDaemonJvmCriteria(project, externalProjectPath) {
+            applyDefaultToolchainResolverPlugin(project)
+        }.await()
 
         if (!isSuccess) {
             displayMigrationFailureMessage(project)
@@ -63,13 +44,15 @@ object GradleDaemonJvmCriteriaMigrationHelper {
         return true
     }
 
-    suspend fun applyDefaultToolchainResolverPlugin(project: Project) {
-        writeCommandAction(project, GradleBundle.message("gradle.notifications.daemon.toolchain.migration.apply.plugin.command.name")) {
-            project.getTopLevelBuildScriptSettingsPsiFile()?.let { topLevelBuildScript ->
-                val buildScriptSupport = GradleBuildScriptSupport.getManipulator(topLevelBuildScript)
-                buildScriptSupport.addFoojayPlugin(topLevelBuildScript)
-            } ?: run {
-                // TODO create settings.gradle file with Foojay Plugin
+    fun applyDefaultToolchainResolverPlugin(project: Project) {
+        ApplicationManager.getApplication().invokeAndWait {
+            project.executeWriteCommand(GradleBundle.message("gradle.notifications.daemon.toolchain.migration.apply.plugin.command.name")) {
+                project.getTopLevelBuildScriptSettingsPsiFile()?.let { topLevelBuildScript ->
+                    val buildScriptSupport = GradleBuildScriptSupport.getManipulator(topLevelBuildScript)
+                    buildScriptSupport.addFoojayPlugin(topLevelBuildScript)
+                } ?: run {
+                    // TODO create settings.gradle file with Foojay Plugin
+                }
             }
         }
     }

--- a/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/idea/toolchain/gradle/GradleDaemonToolchainMigrationHelperTest.kt
+++ b/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/idea/toolchain/gradle/GradleDaemonToolchainMigrationHelperTest.kt
@@ -51,6 +51,6 @@ class GradleDaemonToolchainMigrationHelperTest: GradleProjectSdkResolverTestCase
     private fun assertDaemonJvmProperties(expectedVersion: JavaVersion, expectedVendor: Variant) {
         val properties = GradleDaemonJvmPropertiesFile.getProperties(Path(projectPath))!!
         assertEquals(expectedVersion.feature.toString(), properties.version?.value)
-        assertEquals(expectedVendor.toJvmVendor().rawVendor, properties.vendor?.value?.toJvmVendor()?.rawVendor)
+        assertEquals(expectedVendor.toJvmVendor()?.rawVendor, properties.vendor?.value?.toJvmVendor()?.rawVendor)
     }
 }

--- a/plugins/kotlin/project-wizard/tests/testData/gradleNewProjectWizard/simpleProjectUsingDaemonJvmCriteria/build.gradle
+++ b/plugins/kotlin/project-wizard/tests/testData/gradleNewProjectWizard/simpleProjectUsingDaemonJvmCriteria/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version 'KOTLIN_VERSION'
+}
+
+group = 'org.testcase'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
+}
+
+test {
+    useJUnitPlatform()
+}
+kotlin {
+    jvmToolchain(JDK_VERSION)
+}

--- a/plugins/kotlin/project-wizard/tests/testData/gradleNewProjectWizard/simpleProjectUsingDaemonJvmCriteria/gradle.properties
+++ b/plugins/kotlin/project-wizard/tests/testData/gradleNewProjectWizard/simpleProjectUsingDaemonJvmCriteria/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.code.style=official

--- a/plugins/kotlin/project-wizard/tests/testData/gradleNewProjectWizard/simpleProjectUsingDaemonJvmCriteria/settings.gradle
+++ b/plugins/kotlin/project-wizard/tests/testData/gradleNewProjectWizard/simpleProjectUsingDaemonJvmCriteria/settings.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version 'FOOJAY_VERSION'
+}
+rootProject.name = 'project'


### PR DESCRIPTION
### Context
The `Daemon toolchain` was introduced in [Gradle 8.8](https://docs.gradle.org/8.8/release-notes.html#daemon-toolchains) and the motivation behind it and other technical details can be found on the public [spec document](https://docs.google.com/document/d/1CU1e4QjPs2yj_SmJuykPUXutynvn4X_SF0BPXVnAlKI/edit?usp=drive_link). The implementation follows the agreed details on [spec document](https://docs.google.com/document/d/1TjI-gGDcTQdIZP-cz38bBdV0jX2wRXmu3DJNUbvVG-o/edit?usp=sharing&resourcekey=0-iAyVFbna4gxtug_JVF0tJw) and [UI/UX document](https://docs.google.com/document/d/1MHkyJGQtNGevlRGBfx4-lDQLte1kjM2qHOjuMVMuEoM/edit?usp=sharing).

#### Summary
When creating a new project via wizard, in case of using a Gradle version compatible with `Daemon JVM criteria` then specified JDK from the dropdown will be used to invoke `updateDaemonJvm` Gradle task with the resolved `version` and `vendor` from JDK. The vendor will only be specified if is known by [foojay-plugin](https://github.com/gradle/foojay-toolchains) being able to generate the different toolchain download URLs for the `auto-provisioning` mechanism.

_NOTE: For now this option will be disabled until `Daemon JVM criteria` supports the `auto-provisioning` but also until the feature is stable enough to be considered as a default for projects, keeping it as a opt-in option_. 

_NOTE: This PR was build on top of https://github.com/JetBrains/intellij-community/pull/2882 to avoid conflicts._

###### Tasks

- https://github.com/vmadalin/intellij-community/issues/12

#### Tests

- [GradleDaemonJvmPropertiesFileTest.kt](https://github.com/JetBrains/intellij-community/pull/2883/files#diff-483c4039fdab8efcab5707f5212b1e2a304c16bfc313e5f2b002ecc33907cb5a)
- [GradleKotlinNewProjectWizardTest.kt](https://github.com/JetBrains/intellij-community/pull/2883/files#diff-9e0f7b1558c25ecf74ad728ccb7ce57d4b279106d1bcac05505bc50be65a40c9)


#### Demo

https://github.com/user-attachments/assets/6b0598b6-849e-4a33-ba2e-58888d7f069b


