### PR TITLE
Show Correct Message When There Are No Properties

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/render/KotlinClassRenderer.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/render/KotlinClassRenderer.kt
@@ -6,6 +6,7 @@ package org.jetbrains.kotlin.idea.debugger
 import com.intellij.debugger.JavaDebuggerBundle
 import com.intellij.debugger.engine.DebuggerManagerThreadImpl
 import com.intellij.debugger.engine.DebuggerUtils
+import com.intellij.debugger.engine.FieldVisibilityProvider
 import com.intellij.debugger.engine.JVMNameUtil
 import com.intellij.debugger.engine.evaluation.EvaluationContext
 import com.intellij.debugger.impl.DebuggerUtilsAsync
@@ -54,7 +55,7 @@ class KotlinClassRenderer : ClassRenderer() {
         val gettersFuture = DebuggerUtilsAsync.allMethods(refType)
             .thenApply { methods -> methods.getters().createNodes(value, parentDescriptor.project, evaluationContext, nodeManager) }
         DebuggerUtilsAsync.allFields(refType).thenCombine(gettersFuture) { fields, getterNodes ->
-            if (fields.isEmpty() && getterNodes.isEmpty()) {
+            if (fields.none { FieldVisibilityProvider.shouldDisplayField(it) } && getterNodes.isEmpty()) {
                 builder.setChildren(listOf(nodeManager.createMessageNode(KotlinDebuggerCoreBundle.message("message.class.has.no.properties"))))
                 return@thenCombine
             }


### PR DESCRIPTION
This is a followup to previous change:
https://github.com/alonalbert/intellij-community/commit/c38063f59b6d06df15cf1beceadc4144c108510f

On JVM, if an object has not fields or getters, the debugger displays:
```
Class has no properties
```

On android after the above cl is applied, the debugger displays:
```
No fields to display
```

This happens because the shadow fields removed by the Android FieldVisibilityProvider are not accounted for yet.

JVM:
![image](https://github.com/user-attachments/assets/db220b9c-d3de-410c-aba6-5a3c8c498a0e)

Android:
![image](https://github.com/user-attachments/assets/61aa8fed-2a2d-4eee-a2d8-bd2424271436)

https://youtrack.jetbrains.com/issue/IDEA-361349/Debugger-Shows-Internal-Android-Fields