### PR TITLE
Fix wrong intention when referencing parameters in static fields

### DIFF
--- a/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightFixUtil.java
+++ b/java/java-analysis-impl/src/com/intellij/codeInsight/daemon/impl/analysis/HighlightFixUtil.java
@@ -199,7 +199,7 @@ public final class HighlightFixUtil {
     if (place instanceof PsiReferenceExpression && place.getParent() instanceof PsiMethodCallExpression) {
       ReplaceGetClassWithClassLiteralFix.registerFix((PsiMethodCallExpression)place.getParent(), info);
     }
-    if (refElement instanceof PsiJvmModifiersOwner) {
+    if (refElement instanceof PsiJvmModifiersOwner && !(refElement instanceof PsiParameter)) {
       List<IntentionAction> fixes =
         JvmElementActionFactories.createModifierActions((PsiJvmModifiersOwner)refElement, MemberRequestsKt.modifierRequest(JvmModifier.STATIC, true));
       QuickFixAction.registerQuickFixActions(info, null, fixes);

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/modifier/beforeLocalClassReferencingParameterInStaticContext.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/quickFix/modifier/beforeLocalClassReferencingParameterInStaticContext.java
@@ -1,0 +1,10 @@
+// "Make 'p' static" "false"
+import java.io.*;
+
+class a {
+  void m(int p) {
+    class C {
+      static int P = <caret>p;
+    }
+  }
+}


### PR DESCRIPTION
Local classes (and interfaces) can reference parameters from the enclosing method, however not in static contexts.
However, IntelliJ currently incorrectly suggests making the parameter static. This should be avoided.

As `PsiParameter` also covers variables in for-each loops, pattern variables, and catch variables, those were affected too.

Example:
```java
public class StaticReference {

    void m(int p) {
        int lv;
        if (null instanceof Object tp) {
            for (Object ef : new Object[0]) {
                class C {
                    static int LV = lv; // works for local variables correctly, everything else gets the wrong intention
                    static int P = p;
                    static Object TP = tp;
                    static Object EF = ef;
                }
            }
        }
    }
}
```