### PR TITLE
IDEA-358562 Fix build output 'Starting Daemon' event using Daemon JVM criteria

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleProgressListener.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleProgressListener.java
@@ -28,9 +28,7 @@ import org.jetbrains.plugins.gradle.tooling.Message;
 import org.jetbrains.plugins.gradle.tooling.MessageReporter;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import static com.intellij.openapi.util.text.StringUtil.formatDuration;
 
@@ -46,6 +44,7 @@ public class GradleProgressListener implements ProgressListener, org.gradle.tool
   private final ExternalSystemTaskId myTaskId;
   private final Map<Object, Long> myStatusEventIds = new HashMap<>();
   private final String myOperationId;
+  private static final String EXECUTING_BUILD = "Build";
   private static final String STARTING_GRADLE_DAEMON_EVENT = "Starting Gradle Daemon";
   private ExternalSystemTaskNotificationEvent myLastStatusChange = null;
   private final boolean sendProgressEventsToOutput;
@@ -211,18 +210,26 @@ public class GradleProgressListener implements ProgressListener, org.gradle.tool
     }
   }
 
+  /**
+   * Report Gradle Daemon starting event based on the fact that multiple 'Starting Gradle Daemon' might be received when new
+   * ProgressLoggerFactory.newOperation are nested within the 'Starting Gradle Daemon' operation reporting always the parent on
+   * completion. Based on that, the Build event will be used to calculate when Daemon was started. Those are the events returned:
+   *  - Build
+   *  - Starting Gradle Daemon
+   *  - Discovering toolchains
+   *  - Starting Gradle Daemon
+   *  - Connecting to Gradle Daemon
+   *  - Starting Gradle Daemon
+   *  - Build
+   */
   private void reportGradleDaemonStartingEvent(String eventDescription) {
-    if (StringUtil.equals(STARTING_GRADLE_DAEMON_EVENT, eventDescription)) {
-      long eventTime = System.currentTimeMillis();
-      Long startTime = myStatusEventIds.remove(eventDescription);
-      if (startTime == null) {
-        myListener.onTaskOutput(myTaskId, STARTING_GRADLE_DAEMON_EVENT + "...\n", true);
-        myStatusEventIds.put(eventDescription, eventTime);
-      }
-      else {
-        String duration = formatDuration(eventTime - startTime);
-        myListener.onTaskOutput(myTaskId, "\rGradle Daemon started in " + duration + "\n", true);
-      }
+    if (StringUtil.equals(STARTING_GRADLE_DAEMON_EVENT, eventDescription) && !myStatusEventIds.containsKey(STARTING_GRADLE_DAEMON_EVENT)) {
+      myListener.onTaskOutput(myTaskId, STARTING_GRADLE_DAEMON_EVENT + "...\n", true);
+      myStatusEventIds.put(STARTING_GRADLE_DAEMON_EVENT, System.currentTimeMillis());
+    } else if (StringUtil.equals(EXECUTING_BUILD, eventDescription) && myStatusEventIds.containsKey(STARTING_GRADLE_DAEMON_EVENT)) {
+      Long startTime = myStatusEventIds.remove(STARTING_GRADLE_DAEMON_EVENT);
+      String duration = formatDuration(System.currentTimeMillis() - startTime);
+      myListener.onTaskOutput(myTaskId, "\rGradle Daemon started in " + duration + "\n", true);
     }
   }
 


### PR DESCRIPTION
### Context
The `Daemon toolchain` was introduced in [Gradle 8.8](https://docs.gradle.org/8.8/release-notes.html#daemon-toolchains) and the motivation behind it and other technical details can be found on the public [spec document](https://docs.google.com/document/d/1CU1e4QjPs2yj_SmJuykPUXutynvn4X_SF0BPXVnAlKI/edit?usp=drive_link). The implementation follows the agreed details on [spec document](https://docs.google.com/document/d/1TjI-gGDcTQdIZP-cz38bBdV0jX2wRXmu3DJNUbvVG-o/edit?usp=sharing&resourcekey=0-iAyVFbna4gxtug_JVF0tJw) and [UI/UX document](https://docs.google.com/document/d/1MHkyJGQtNGevlRGBfx4-lDQLte1kjM2qHOjuMVMuEoM/edit?usp=sharing).

#### Summary
Given a project using `Daemon JVM criteria` when starting a daemon the event is captured multiple times on `GradleProgressListener` due to the fact that a new  `ProgressLoggerFactory.newOperation` was nested on the original `Starting Gradle Daemon` as part of Daemon toolchain implementation. However, Gradle triggers always the parent event on completion resulting on the following:
```
Build
Starting Gradle Daemon
Discovering toolchains
Starting Gradle Daemon
Connecting to Gradle Daemon
Starting Gradle Daemon
Build
```
Before we had only `Connecting to Gradle Daemon` expecting only 2 `Starting Gradle Daemon` events, however, this isn't longer the case. For this reason, until a better way is provided by Gradle we are going to relay on the fact that latest `Starting Gradle Daemon` is always proceeded by `Build`, representing his parent. 

Reported Gradle issue: https://github.com/gradle/gradle/issues/31777

#### Tests

- [GradleOutputParsersMessagesImportingTest.kt](https://github.com/JetBrains/intellij-community/pull/2888/files#diff-07d52dc49a9bb6d911ae869223c0a9e57315e1ad95f7350da9a3560fa14d0fca)

#### Overview

<img width="389" alt="Starting Gradle Daemon" src="https://github.com/user-attachments/assets/7963fdd8-8dfa-46e8-9fb7-4e4f43e3ca53">


