### PR TITLE
IJPL-43725: New UI: allow showing expanded menu and other toolbar wid…

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/customFrameDecorations/header/toolbar/ExpandableMenu.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/customFrameDecorations/header/toolbar/ExpandableMenu.kt
@@ -70,10 +70,19 @@ internal class ExpandableMenu(
         updateBounds()
       }
     })
+    if (isSticky()) {
+      SwingUtilities.invokeLater {
+        switchState();
+      }
+    }
   }
 
   fun isEnabled(): Boolean {
     return !SystemInfoRt.isMac && Registry.`is`("ide.main.menu.expand.horizontal")
+  }
+
+  fun isSticky(): Boolean {
+    return isEnabled() && !SystemInfoRt.isMac && Registry.`is`("ide.main.menu.expand.horizontal.sticky")
   }
 
   private fun isShowing(): Boolean {
@@ -112,9 +121,12 @@ internal class ExpandableMenu(
     updateColor()
     layeredPane.add(expandedMenuBar!!, (JLayeredPane.DEFAULT_LAYER - 2) as Any)
 
-    // The first menu usage has no selection in the menu. Fix it by invokeLater
-    ApplicationManager.getApplication().invokeLater {
-      selectMenu(actionMenuToShow)
+    if (!isSticky()) {
+      // Keep original behavior
+      // The first menu usage has no selection in the menu. Fix it by invokeLater
+      ApplicationManager.getApplication().invokeLater {
+        selectMenu(actionMenuToShow)
+      }
     }
   }
 
@@ -167,11 +179,13 @@ internal class ExpandableMenu(
 
   private fun hideExpandedMenuBar() {
     if (isShowing()) {
-      rootPane?.layeredPane?.remove(expandedMenuBar)
-      expandedMenuBar = null
-      headerColorfulPanel = null
+      if (!isSticky()) {
+        rootPane?.layeredPane?.remove(expandedMenuBar)
+        expandedMenuBar = null
+        headerColorfulPanel = null
 
-      rootPane?.repaint()
+        rootPane?.repaint()
+      }
     }
   }
 

--- a/platform/util/resources/misc/registry.properties
+++ b/platform/util/resources/misc/registry.properties
@@ -258,6 +258,9 @@ ide.tree.show.expand.with.single.click.setting.description=Adds a global Expand 
 ide.main.menu.expand.horizontal=true
 ide.main.menu.expand.horizontal.description=Expands hamburger menu horizontally (Windows and Linux only)
 
+ide.main.menu.expand.horizontal.sticky=false
+ide.main.menu.expand.horizontal.sticky.description=Leave Expands hamburger menu horizontally (Windows and Linux only) expanded (Opt-in)
+
 ide.macos.main.menu.alignment.options=[Native*|Aligned|Aligned in group|No icons]
 ide.macos.main.menu.alignment.options.description=Native - align menu items as macOS does, Aligned - align menu items vertically inside a group, No icons - hide icons
 ide.splitter.mouseZone=6


### PR DESCRIPTION
…gets in window header

The idea is to add an opt-in feature controlled by a property:

```
ide.main.menu.expand.horizontal.sticky=false
```

to fix the issue IJPL-43725

By default the property value is false and thus the existing behavior is maintained. If set to true the menu bar is always shown and does not hide.

Obviously this works best on wide screen monitors and no actions have been added to the `left` section of the toolbar.
