### PR TITLE
Don't call updateEditors when there are no editors on that file

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/EditorNotificationsImpl.kt
+++ b/platform/platform-impl/src/com/intellij/ui/EditorNotificationsImpl.kt
@@ -203,7 +203,9 @@ class EditorNotificationsImpl(private val project: Project,
         visible
       }
     }
-    updateEditors(file = file, fileEditors = editors.toList())
+    if (editors.any()) {
+      updateEditors(file = file, fileEditors = editors.toList())
+    }
   }
 
   private fun getEditors(file: VirtualFile): Sequence<FileEditor> {


### PR DESCRIPTION
Callees from updateEditors, including arbitrary third-party notification providers, can have side-effects, such as instantiating PsiFile instances for the VirtualFiles.  These PsiFiles can then be spurious: if there is more than one project open, we might end up with a PsiFile with PsiFile.project = ProjectA, where the VirtualFile in fact belongs to ProjectB.