### PR TITLE
Allow the user to set order of prefixes

### DIFF
--- a/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/lombokconfig/ConfigDiscovery.java
+++ b/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/lombokconfig/ConfigDiscovery.java
@@ -160,7 +160,7 @@ public class ConfigDiscovery {
 
     Collections.reverse(properties);
 
-    Set<String> result = new HashSet<>();
+    Set<String> result = new LinkedHashSet<>();
 
     for (String configProperty : properties) {
       if (StringUtil.isNotEmpty(configProperty)) {


### PR DESCRIPTION
Current implementation used HashSet which sorts prefixes by their hash, and empty string "" was put before probably any other prefix (at least before very common "_"). Then, it matched first and underscore never matched so it was not possible to automatically remove _ prefixes from property names.
There is a need to include this empty string if you want prefixes only for underscore prefix removal and not for filtering properties.

This will allow workaround for this bug: [IDEA-363722](https://youtrack.jetbrains.com/issue/IDEA-363722/empty-lombok.accessors.prefix-is-not-supported-in-lombok.config)