### PR TITLE
IJPL 173473: fix ArrayIndexOutOfBoundsException when using ContainerUtil.concat()

### DIFF
--- a/platform/platform-tests/testSrc/com/intellij/util/containers/ContainerUtilTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/util/containers/ContainerUtilTest.java
@@ -18,6 +18,7 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 
 public class ContainerUtilTest extends TestCase {
@@ -91,6 +92,67 @@ public class ContainerUtilTest extends TestCase {
       fail();
     }
     catch (ConcurrentModificationException ignore) {
+    }
+  }
+
+  private static Future<?> modifyListUntilStopped(List<Integer> list, AtomicBoolean stopped) {
+
+    return AppExecutorUtil.getAppExecutorService().submit(()-> {
+
+       // simple random generator (may overflow)
+       for (int seed = 13; !stopped.get(); seed += 907) {
+         // random [0-31] (sign clipped)
+         int rand = (seed^(seed>>5)) & 0x1f;
+
+         // grow or shrink the list randomly.
+         if (rand < list.size()) {
+           list.remove(rand);
+         }
+         else {
+           list.add(seed);
+         }
+       }
+     });
+  }
+
+  private static List<Integer> createFilledList(int size) {
+    List<Integer> list = ContainerUtil.createLockFreeCopyOnWriteList();
+
+    for(int i=0; i<size; ++i) {
+       list.add(i);
+    }
+
+    return list;
+  }
+
+  public void testConcatenatedDynamicListsAreIterable() throws Exception {
+    List<Integer> list1 = createFilledList(32);
+    List<Integer> list2 = createFilledList(32);
+    List<Integer> values = ContainerUtil.concat(list1, list2);
+
+    AtomicBoolean stop = new AtomicBoolean(false);
+    Future<?> future1 = modifyListUntilStopped(list1, stop);
+    Future<?> future2 = modifyListUntilStopped(list2, stop);
+
+    try {
+      long count = 0;
+      int n=0;
+      long until = System.currentTimeMillis() + 1000;
+      while (System.currentTimeMillis() < until) {
+
+        for (Integer value : values) {
+           count += value;
+        }
+
+        // must work on streams (even parallel), too.
+        count += values.parallelStream().count();
+        ++n;
+      }
+      stop.set(true);
+    } finally {
+      stop.set(true); // finally stop even in case of an error
+      future1.get();
+      future2.get();
     }
   }
 

--- a/platform/util/src/com/intellij/util/containers/ContainerUtil.java
+++ b/platform/util/src/com/intellij/util/containers/ContainerUtil.java
@@ -1441,6 +1441,24 @@ public final class ContainerUtil {
       public int size() {
         return size;
       }
+
+      /**
+       * Returns an iterator over the <em>actual elements</em> in this list based on the underlying lists.
+       *
+       * @implNote
+       * This implementation replaces the straightforward implementation based on index operations.
+       * Those fail badly, if the underlying lists change since creation of this concatenated list:
+       * either by an {@link IndexOutOfBoundsException} if any list shrinks unexpectedly,
+       * or by missing all elements added later on.
+       *
+       * @return Returns an iterator over the <em>actual elements</em> of both lists.
+       */
+      @Override
+      public Iterator<T> iterator() {
+        final Iterable<? extends T> it1 = list1;
+        final Iterable<? extends T> it2 = list2;
+        return concat(it1, it2).iterator();
+      }
     };
   }
 


### PR DESCRIPTION
### Context

The method [ContainerUtil.concat(list1, list2)](https://github.com/JetBrains/intellij-community/blob/7b91998a9b35422db4ed6aeb85669ae1ee0dd22e/platform/util/src/com/intellij/util/containers/ContainerUtil.java#L1450) works fine with immutable lists. However, if the lists are modified concurrently, iteration may fail. see: [IJPL-173473](https://youtrack.jetbrains.com/issue/IJPL-173473)

This fix contains a unit test `ContainerUtilTest.testConcatenatedDynamicListsAreIterable` to disclose the problem.
Surprisingly it does not indicate any problem, if you start joining two empty lists. This is, because the size of the composed list is calculated in advance and never change. So, while an underlying `List` is growing, the composed `List` just does nothing. But I think this is also not the expected behavior. But if any `List` shrinks, the concatenated `List` throws an `IndexOutOfBoundsException`.

To fix this, I introduced an `iterator()` method for the concatenated `List` to get the actual elements from both lists.

Other utility methods here, using a straightforward `new AbstractList<T>`, may suffer from the same problem but are not fixed so far.