### PR TITLE
Allow import of run configuration folderName from Gradle / External Project Model

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/settings/RunConfigurationHandler.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/settings/RunConfigurationHandler.kt
@@ -49,6 +49,7 @@ internal class RunConfigurationHandler : ConfigurationHandler {
       try {
         importer.process(project, runnerAndConfigurationSettings.configuration, cfg as Map<String, *>, modelsProvider)
         if (!isDefaults) {
+          runnerAndConfigurationSettings.folderName = cfg["folderName"] as? String ?: ""
           runManager.addConfiguration(runnerAndConfigurationSettings)
         }
 


### PR DESCRIPTION
This enables https://github.com/JetBrains/gradle-idea-ext-plugin/issues/87 to be solved, by importing the `folderName` model property for run configurations.

Empty strings are converted to `null` here, since the IDE expects `null` for "no folder" and doesn't react nicely to empty strings being set.

Tested using an adapted idea-ext to work (these run configs were imported from Gradle, including the folders):
![image](https://github.com/user-attachments/assets/c7a6a70e-70bd-4072-ad05-0354e947db53)

No tests were adapted since I couldn't find any tests that actually tested this external model import.

---

Example on how to make use of this with idea-ext, without having to build a custom plugin:

```
var appRun = new Application("name", project) {
    @SuppressWarnings("unchecked")
    @Override
    public Map<String, ?> toMap() {
        var result = (Map<String, Object>) super.toMap();
        result.put("folderName", "RUN SUBFOLDER");
        return result;
    }
};
runConfigurations.add(appRun); // add as normal to the container
```