### PR TITLE
[IJPL-174685] Do not continue processing if kotlin data node is null

### DIFF
--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/KotlinGradleSourceSetDataService.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/KotlinGradleSourceSetDataService.kt
@@ -254,9 +254,9 @@ fun configureFacetByGradleModule(
 
     val platformKind = detectPlatformKindByPlugin(moduleNode) ?: detectPlatformByLibrary(moduleNode)
     val kotlinGradleSourceSetDataNode = kotlinGradleProjectDataNode.findAll(KotlinGradleSourceSetData.KEY)
-        .firstOrNull { it.data.sourceSetName == sourceSetName }
+        .firstOrNull { it.data.sourceSetName == sourceSetName } ?: return null
 
-    val compilerVersion = kotlinGradleSourceSetDataNode?.data?.kotlinPluginVersion?.let(IdeKotlinVersion::opt)
+    val compilerVersion = kotlinGradleSourceSetDataNode.data?.kotlinPluginVersion?.let(IdeKotlinVersion::opt)
     // required for GradleFacetImportTest.{testCommonImportByPlatformPlugin, testKotlinAndroidPluginDetection}
         ?: KotlinGradleFacade.getInstance()?.findKotlinPluginVersion(moduleNode)
 


### PR DESCRIPTION
the search for the dataNode uses a name comparison, and for the case of Android for example, the names won't match and we will end up finding nothing. The function should not continue processing data if the dataNode is null because it will just use fallbacks instead of configuring the right way. For the NAdroid case, we even have our own data service that actually passes the right name in this case.