### PR TITLE
Introduce JdiHelperClassLoader extension point

### DIFF
--- a/java/debugger/impl/resources/META-INF/java-debugger.xml
+++ b/java/debugger/impl/resources/META-INF/java-debugger.xml
@@ -35,6 +35,8 @@
                     interface="com.intellij.debugger.actions.JvmSmartStepIntoHandler" dynamic="true"/>
     <extensionPoint qualifiedName="com.intellij.debugger.jvmSteppingCommandProvider"
                     interface="com.intellij.debugger.impl.JvmSteppingCommandProvider" dynamic="true"/>
+    <extensionPoint qualifiedName="com.intellij.debugger.jdiHelperClassLoader"
+                    interface="com.intellij.debugger.impl.JdiHelperClassLoader" dynamic="true"/>
 
     <extensionPoint qualifiedName="com.intellij.debugger.frameExtraVarsProvider"
                     interface="com.intellij.debugger.engine.FrameExtraVariablesProvider" dynamic="true"/>
@@ -97,6 +99,7 @@
     <projectService serviceInterface="com.intellij.debugger.DebuggerManager"
                     serviceImplementation="com.intellij.debugger.impl.DebuggerManagerImpl"/>
     <debugger.additionalContextProvider implementation="com.intellij.debugger.engine.evaluation.MarkedObjectAdditionalContextProvider"/>
+    <debugger.jdiHelperClassLoader implementation="com.intellij.debugger.impl.JdiHelperClassLoaderImpl"/>
     <debuggerEditorTextProvider language="JAVA" implementationClass="com.intellij.debugger.impl.JavaEditorTextProviderImpl"/>
     <javaExpressionSurrounder implementation="com.intellij.debugger.codeinsight.JavaWithRuntimeCastSurrounder"/>
 

--- a/java/debugger/impl/src/com/intellij/debugger/impl/ClassLoadingUtils.java
+++ b/java/debugger/impl/src/com/intellij/debugger/impl/ClassLoadingUtils.java
@@ -9,15 +9,11 @@ import com.intellij.debugger.engine.evaluation.EvaluateException;
 import com.intellij.debugger.engine.evaluation.EvaluationContext;
 import com.intellij.debugger.engine.evaluation.EvaluationContextImpl;
 import com.intellij.debugger.jdi.VirtualMachineProxyImpl;
-import com.intellij.openapi.util.registry.Registry;
-import com.intellij.util.containers.ContainerUtil;
+import com.intellij.openapi.diagnostic.Logger;
 import com.jetbrains.jdi.MethodImpl;
 import com.sun.jdi.*;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -81,72 +77,19 @@ public final class ClassLoadingUtils {
    * May modify class loader in evaluationContext
    */
   public static @Nullable ClassType getHelperClass(Class<?> cls, EvaluationContextImpl evaluationContext,
-                                         String... additionalClassesToLoad) throws EvaluateException {
-    String name = cls.getName();
-    evaluationContext = evaluationContext.withAutoLoadClasses(true);
-    DebugProcess process = evaluationContext.getDebugProcess();
-    ClassLoaderReference currentClassLoader = evaluationContext.getClassLoader();
-    try {
-      return (ClassType)process.findClass(evaluationContext, name, currentClassLoader);
-    }
-    catch (EvaluateException e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof InvocationException) {
-        if ("java.lang.ClassNotFoundException".equals(((InvocationException)cause).exception().type().name())) {
-          // need to define
-          boolean newClassLoader = Registry.is("debugger.evaluate.load.helper.in.separate.classloader") || currentClassLoader == null;
-          ClassLoaderReference classLoaderForDefine = newClassLoader ? getClassLoader(evaluationContext, process)
-                                                                     : getTopClassloader(evaluationContext, currentClassLoader);
-
-          for (String fqn : ContainerUtil.prepend(Arrays.asList(additionalClassesToLoad), name)) {
-            if (!defineClass(fqn, cls, evaluationContext, classLoaderForDefine)) return null;
-          }
-
-          ClassLoaderReference classLoaderForFind = newClassLoader ? classLoaderForDefine : currentClassLoader;
-          if (newClassLoader) {
-            evaluationContext.setClassLoader(classLoaderForDefine);
-          }
-          return (ClassType)process.findClass(evaluationContext, name, classLoaderForFind);
+                                         String... additionalClassesToLoad) {
+    for (JdiHelperClassLoader loader : JdiHelperClassLoader.EP_NAME.getExtensionList()) {
+      try {
+        ClassType classType = loader.getHelperClass(cls, evaluationContext, additionalClassesToLoad);
+        if (classType != null) {
+          return classType;
         }
+      } catch (EvaluateException ex) {
+        Logger.getInstance(ClassLoadingUtils.class).error(
+          String.format("Failed to load %s with %s: %s", cls, loader, ex)
+        );
       }
-      throw e;
     }
-  }
-
-  /**
-   * Determines the top-level class loader in a hierarchy, starting from the given {@code currentClassLoader}.
-   * <p>
-   * It is used to define the helper class to avoid defining it in every classloader for performance reasons
-   */
-  private static @NotNull ClassLoaderReference getTopClassloader(EvaluationContextImpl evaluationContext,
-                                                                 ClassLoaderReference currentClassLoader) throws EvaluateException {
-    DebugProcessImpl process = evaluationContext.getDebugProcess();
-    ReferenceType classLoaderClass = process.findClass(evaluationContext, "java.lang.ClassLoader", currentClassLoader);
-    Method parentMethod = DebuggerUtils.findMethod(classLoaderClass, "getParent", "()Ljava/lang/ClassLoader;");
-    Objects.requireNonNull(parentMethod, "getParent method is not available");
-
-    ClassLoaderReference classLoader = currentClassLoader;
-
-    while (true) {
-      Value parent = process.invokeInstanceMethod(evaluationContext, classLoader, parentMethod, Collections.emptyList(), 0, true);
-      if (!(parent instanceof ClassLoaderReference classLoaderReference)) {
-        return classLoader;
-      }
-      classLoader = classLoaderReference;
-    }
-  }
-
-  private static boolean defineClass(String name,
-                                     Class<?> cls,
-                                     EvaluationContextImpl evaluationContext,
-                                     ClassLoaderReference classLoader) throws EvaluateException {
-    try (InputStream stream = cls.getResourceAsStream('/' + name.replace('.', '/') + ".class")) {
-      if (stream == null) return false;
-      defineClass(name, stream.readAllBytes(), evaluationContext, evaluationContext.getDebugProcess(), classLoader);
-      return true;
-    }
-    catch (IOException ioe) {
-      throw new EvaluateException("Unable to read " + name + " class bytes", ioe);
-    }
+    return null;
   }
 }

--- a/java/debugger/impl/src/com/intellij/debugger/impl/JdiHelperClassLoader.java
+++ b/java/debugger/impl/src/com/intellij/debugger/impl/JdiHelperClassLoader.java
@@ -1,0 +1,16 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.debugger.impl;
+
+import com.intellij.debugger.engine.evaluation.EvaluateException;
+import com.intellij.debugger.engine.evaluation.EvaluationContextImpl;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.sun.jdi.ClassType;
+import org.jetbrains.annotations.Nullable;
+
+public interface JdiHelperClassLoader {
+  ExtensionPointName<JdiHelperClassLoader> EP_NAME =
+    ExtensionPointName.create("com.intellij.debugger.jdiClassLoader");
+
+  @Nullable ClassType getHelperClass(Class<?> cls, EvaluationContextImpl evaluationContext,
+                                     String... additionalClassesToLoad) throws EvaluateException;
+}

--- a/java/debugger/impl/src/com/intellij/debugger/impl/JdiHelperClassLoaderImpl.java
+++ b/java/debugger/impl/src/com/intellij/debugger/impl/JdiHelperClassLoaderImpl.java
@@ -1,0 +1,97 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.debugger.impl;
+
+import com.intellij.debugger.engine.DebugProcess;
+import com.intellij.debugger.engine.DebugProcessImpl;
+import com.intellij.debugger.engine.DebuggerUtils;
+import com.intellij.debugger.engine.evaluation.EvaluateException;
+import com.intellij.debugger.engine.evaluation.EvaluationContextImpl;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.util.containers.ContainerUtil;
+import com.sun.jdi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+
+public class JdiHelperClassLoaderImpl implements JdiHelperClassLoader {
+  @Override
+  public @Nullable ClassType getHelperClass(Class<?> cls, EvaluationContextImpl evaluationContext,
+                                            String... additionalClassesToLoad) throws EvaluateException {
+    String name = cls.getName();
+    evaluationContext = evaluationContext.withAutoLoadClasses(true);
+    DebugProcess process = evaluationContext.getDebugProcess();
+    ClassLoaderReference currentClassLoader = evaluationContext.getClassLoader();
+    try {
+      return (ClassType)process.findClass(evaluationContext, name, currentClassLoader);
+    }
+    catch (EvaluateException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof InvocationException) {
+        if ("java.lang.ClassNotFoundException".equals(((InvocationException)cause).exception().type().name())) {
+          // need to define
+          boolean newClassLoader = Registry.is("debugger.evaluate.load.helper.in.separate.classloader") || currentClassLoader == null;
+          ClassLoaderReference classLoaderForDefine = newClassLoader ? ClassLoadingUtils.getClassLoader(evaluationContext, process)
+                                                                     : getTopClassloader(evaluationContext, currentClassLoader);
+
+          for (String fqn : ContainerUtil.prepend(Arrays.asList(additionalClassesToLoad), name)) {
+            if (!defineClass(fqn, cls, evaluationContext, classLoaderForDefine)) return null;
+          }
+
+          ClassLoaderReference classLoaderForFind = newClassLoader ? classLoaderForDefine : currentClassLoader;
+          if (newClassLoader) {
+            evaluationContext.setClassLoader(classLoaderForDefine);
+          }
+          return (ClassType)process.findClass(evaluationContext, name, classLoaderForFind);
+        }
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Determines the top-level class loader in a hierarchy, starting from the given {@code currentClassLoader}.
+   * <p>
+   * It is used to define the helper class to avoid defining it in every classloader for performance reasons
+   */
+  private static @NotNull ClassLoaderReference getTopClassloader(EvaluationContextImpl evaluationContext,
+                                                                 ClassLoaderReference currentClassLoader) throws EvaluateException {
+    DebugProcessImpl process = evaluationContext.getDebugProcess();
+    ReferenceType classLoaderClass = process.findClass(evaluationContext, "java.lang.ClassLoader", currentClassLoader);
+    Method parentMethod = DebuggerUtils.findMethod(classLoaderClass, "getParent", "()Ljava/lang/ClassLoader;");
+    Objects.requireNonNull(parentMethod, "getParent method is not available");
+
+    ClassLoaderReference classLoader = currentClassLoader;
+
+    while (true) {
+      Value parent = process.invokeInstanceMethod(
+        evaluationContext, classLoader, parentMethod,
+        Collections.emptyList(), 0, true
+      );
+      if (!(parent instanceof ClassLoaderReference classLoaderReference)) {
+        return classLoader;
+      }
+      classLoader = classLoaderReference;
+    }
+  }
+
+  private static boolean defineClass(String name,
+                                     Class<?> cls,
+                                     EvaluationContextImpl evaluationContext,
+                                     ClassLoaderReference classLoader) throws EvaluateException {
+    try (InputStream stream = cls.getResourceAsStream('/' + name.replace('.', '/') + ".class")) {
+      if (stream == null) return false;
+      ClassLoadingUtils.defineClass(
+        name, stream.readAllBytes(), evaluationContext, evaluationContext.getDebugProcess(), classLoader
+      );
+      return true;
+    }
+    catch (IOException ioe) {
+      throw new EvaluateException("Unable to read " + name + " class bytes", ioe);
+    }
+  }
+}


### PR DESCRIPTION
Currently some functionality of Intellij Kotlin and Java debuggers rely on helper classes, that are located in the `com.intellij.rt.debugger` module. The debugger loads these classes to the debuggee VM and then invokes corresponding helper methods to implement some of its functionality.

Unfortunately, when debugging Android applications these classes are not loaded. The reason is that you simply can't load a .class file on ART, because it only understands DEX files. Because of that Android Studio users are missing out on the  functionality provided by these helper classes.

For example, the `com.intellij.rt.debugger.coroutines.CoroutinesDebugHelper` class significantly speeds up async stack trace fetching time. The time difference is even more noticeable when debugging Android applications, because JDI communication with a phone is very expensive: 

![Async stack trace fetching time between different implementations and devices](https://github.com/user-attachments/assets/2c814b8f-d40a-4f76-9279-a1737e38f6be)

This pull request introduces an extension point that would allow the Android Studio debugger to implement its own helper class loading functionality.

@zuevmaxim 
@gorrus 