### PR TITLE
Fix incorrect index assignment in toggleKeySelection by adding .key comparison

### DIFF
--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
@@ -105,7 +105,7 @@ public open class DefaultSelectableLazyColumnEventAction : PointerEventActions {
                 }
             }
         }
-        selectableLazyListState.lastActiveItemIndex = allKeys.indexOfFirst { it == key }
+        selectableLazyListState.lastActiveItemIndex = allKeys.indexOfFirst { it.key == key }
     }
 
     override fun onExtendSelectionToKey(


### PR DESCRIPTION
Missing .key caused the index check to always be -1, resulting in lastActiveItemIndex being set to -1 after Ctrl + left mouse click selecting an item. This led to an array out-of-bounds error in the onExtendSelectionToKey method when using Shift to select items.

- Corrected the logic in toggleKeySelection to properly compare keys.
- Changed `selectableLazyListState.lastActiveItemIndex = allKeys.indexOfFirst { it == key }` to `selectableLazyListState.lastActiveItemIndex = allKeys.indexOfFirst { it.key == key }`.