### PR TITLE
Improve AboutPopupDescriptionProvider API

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/AboutPopupDescriptionProvider.kt
+++ b/platform/platform-impl/src/com/intellij/ide/AboutPopupDescriptionProvider.kt
@@ -11,6 +11,13 @@ import com.intellij.openapi.util.NlsContexts.DetailedDescription
 interface AboutPopupDescriptionProvider {
   /**
    * Return additional info which should be shown in the "About" dialog.
+   * Plain text only. Only one line supported.
    */
   fun getDescription(): @DetailedDescription String?
+
+  /**
+   * Return additional info which should be only added to the text copied with the action in the "About" dialog.
+   * Plain text only, and defaults to the value returned by [getDescription].
+   */
+  fun getExtendedDescription(): @DetailedDescription String? = getDescription()
 }


### PR DESCRIPTION
The EP now offers a way to provide different text to append to the "extended text" that the dialog copies when the Copy button is clicked. Extended descriptions can provide multiple lines of plain text. This is useful e.g., to enumerate non-default flags in Android Studio's own flag system (similar to the IJP Registry).

By default, this is the same as what the existing `getDescription()` API returns, so the behaviour is not changed for existing EPs. The KDocs have been updated and improved to better reflect the contract of the EP.

In addition, the `AboutDialog` has been changed to:
 * Use `getExtendedDescription()` to build the "extended text"
 * Strip HTML that may be produced by the EP implementers, as it's supposed to be plaintext only, as per Yann's comment on https://youtrack.jetbrains.com/issue/IJPL-1813
 * Ensures the non-extended description only provides one line of text, as per Yan's comment on IJPL-1813