### PR TITLE
IJPL-156693 list local or global git-bash in `Tools | Terminal` settings

### DIFF
--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalSettingsPanel.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/TerminalSettingsPanel.java
@@ -394,8 +394,10 @@ public final class TerminalSettingsPanel {
       if (pwsh != null && StringUtil.startsWithIgnoreCase(pwsh.getAbsolutePath(), "C:\\Program Files\\PowerShell\\")) {
         shells.add(pwsh.getAbsolutePath());
       }
-      File gitBash = new File("C:\\Program Files\\Git\\bin\\bash.exe");
-      if (gitBash.isFile()) {
+      File gitBashGlobal = new File("C:\\Program Files\\Git\\bin\\bash.exe");
+      File gitBashLocal = new File(System.getenv("LocalAppData") + "\\Programs\\Git\\bin\\bash.exe");
+      File gitBash = gitBashLocal.isFile() ? gitBashLocal : (gitBashGlobal.isFile() ? gitBashGlobal : null);
+      if (gitBash != null) {
         shells.add(gitBash.getAbsolutePath());
       }
       String cmderRoot = EnvironmentUtil.getValue("CMDER_ROOT");


### PR DESCRIPTION
Detects Git for Windows installed in either `machine` or `user` scope (using `winget install Git.Git --scope user` for non-admin accounts), enabling the "Git Bash" shell to appear in the `Shell Paths` list under `Tools | Terminal` settings.

More details: https://youtrack.jetbrains.com/issue/IJPL-156693#focus=Comments-27-11392437.0-0

Refs: #2817