### PR TITLE
Optimize the url filter by using non-capturing regex groups

### DIFF
--- a/platform/util/src/com/intellij/util/io/URLUtil.java
+++ b/platform/util/src/com/intellij/util/io/URLUtil.java
@@ -29,10 +29,10 @@ public final class URLUtil {
   public static final String JRT_PROTOCOL = "jrt";
   public static final String JAR_SEPARATOR = "!/";
 
-  public static final Pattern DATA_URI_PATTERN = Pattern.compile("data:([^,;]+/[^,;]+)(;charset[=:][^,;]+)?(;base64)?,(.+)");
-  public static final Pattern URL_PATTERN = Pattern.compile("\\b(mailto:|(news|(ht|f)tp(s?))://|((?<![\\p{L}0-9_.])(www\\.)))[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
-  public static final Pattern URL_WITH_PARENS_PATTERN = Pattern.compile("\\b(mailto:|(news|(ht|f)tp(s?))://|((?<![\\p{L}0-9_.])(www\\.)))[-A-Za-z0-9+$&@#/%?=~_|!:,.;()]*[-A-Za-z0-9+$&@#/%=~_|()]");
-  public static final Pattern FILE_URL_PATTERN = Pattern.compile("\\b(file:///)[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
+  public static final Pattern DATA_URI_PATTERN = Pattern.compile("data:(?:[^,;]+/[^,;]+)(?:;charset[=:][^,;]+)?(;base64)?,(.+)");
+  public static final Pattern URL_PATTERN = Pattern.compile("\\b(?:mailto:|(?:news|(?:ht|f)tp(?:s?))://|(?:(?<![\\p{L}0-9_.])(?:www\\.)))[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
+  public static final Pattern URL_WITH_PARENS_PATTERN = Pattern.compile("\\b(?:mailto:|(?:news|(?:ht|f)tp(?:s?))://|(?:(?<![\\p{L}0-9_.])(?:www\\.)))[-A-Za-z0-9+$&@#/%?=~_|!:,.;()]*[-A-Za-z0-9+$&@#/%=~_|()]");
+  public static final Pattern FILE_URL_PATTERN = Pattern.compile("\\b(?:file:///)[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
 
   public static final Pattern HREF_PATTERN = Pattern.compile("<a(?:\\s+href\\s*=\\s*[\"']([^\"']*)[\"'])?\\s*>([^<]*)</a>");
 
@@ -203,8 +203,8 @@ public final class URLUtil {
     Matcher matcher = DATA_URI_PATTERN.matcher(StringUtilRt.unquoteString(dataUrl));
     if (matcher.matches()) {
       try {
-        String content = matcher.group(4);
-        return ";base64".equalsIgnoreCase(matcher.group(3))
+        String content = matcher.group(2);
+        return ";base64".equalsIgnoreCase(matcher.group(1))
                ? Base64.getDecoder().decode(content)
                : decode(content).getBytes(StandardCharsets.UTF_8);
       }


### PR DESCRIPTION
It seems especially the URL_PATTERN couldn't be optimized by the regex compiler because all groups are capturing.

I see this all over the cod ebase 