### PR TITLE
[JEWEL] Update Jewel's VCS settings

### DIFF
--- a/platform/jewel/.idea/vcs.xml
+++ b/platform/jewel/.idea/vcs.xml
@@ -12,5 +12,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
This allows opening the Jewel Gradle sub-project in the IDE and still being able to use the VCS integration. Without this, the Jewel sub-project has no VCS enabled in the IDE.