### PR TITLE
[JEWEL-743] Expose position provider in PopupContainer

### DIFF
--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -647,7 +647,7 @@ public final class org/jetbrains/jewel/ui/component/PlatformIconKt {
 }
 
 public final class org/jetbrains/jewel/ui/component/PopupContainerKt {
-	public static final fun PopupContainer (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/PopupContainerStyle;Landroidx/compose/ui/window/PopupProperties;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun PopupContainer (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/PopupContainerStyle;Landroidx/compose/ui/window/PopupProperties;Landroidx/compose/ui/window/PopupPositionProvider;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/PopupManager {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PopupContainer.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PopupContainer.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.jewel.foundation.Stroke
 import org.jetbrains.jewel.foundation.modifier.border
@@ -24,15 +25,15 @@ public fun PopupContainer(
     modifier: Modifier = Modifier,
     style: PopupContainerStyle = JewelTheme.popupContainerStyle,
     popupProperties: PopupProperties = PopupProperties(focusable = true),
-    content: @Composable () -> Unit,
-) {
-    val popupPositionProvider =
+    popupPositionProvider: PopupPositionProvider =
         AnchorVerticalMenuPositionProvider(
             contentOffset = style.metrics.offset,
             contentMargin = style.metrics.menuMargin,
             alignment = horizontalAlignment,
             density = LocalDensity.current,
-        )
+        ),
+    content: @Composable () -> Unit,
+) {
     Popup(
         popupPositionProvider = popupPositionProvider,
         onDismissRequest = onDismissRequest,


### PR DESCRIPTION
This allows users to specify where the popup should show. The default behaviour remains unvaried.

Closes https://github.com/JetBrains/jewel/issues/743