### PR TITLE
chore: fix typo README.md

### DIFF
--- a/python/helpers/pydev/README.md
+++ b/python/helpers/pydev/README.md
@@ -19,7 +19,7 @@ any other variant which properly supports the Python structure for debuggers -- 
 
 Recent versions contain speedup modules using Cython, which are generated with a few changes in the regular files
 to `cythonize` the files. To update and compile the cython sources (and generate some other auto-generated files),
-`build_tools/build.py` should be run -- note that the resulting .pyx and .c files should be commited.
+`build_tools/build.py` should be run -- note that the resulting .pyx and .c files should be committed.
 
 To generate a distribution with the precompiled binaries for the IDE, `build_binaries_windows.py` should be run (
 note that the environments must be pre-created as specified in that file).


### PR DESCRIPTION
## Pull Request: Fix Typo in `README.md`

### Summary
This pull request addresses a typo in the `README.md` file. The word "commited" has been corrected to "committed" for proper spelling.
