### PR TITLE
Use correct mise directories for all platforms

### DIFF
--- a/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
+++ b/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java
@@ -308,11 +308,18 @@ public class JavaHomeFinderBasic {
     Path miseDataDir = getPathInEnvironmentVariable("MISE_DATA_DIR", "installs");
     if (miseDataDir != null) return miseDataDir;
 
-    Path xdgDataDir = getPathInEnvironmentVariable("XDG_DATA_DIR", "mise/installs");
-    if (xdgDataDir != null) return xdgDataDir;
+    Path xdgDataHome = getPathInEnvironmentVariable("XDG_DATA_HOME", "mise/installs");
+    if (xdgDataHome != null) return xdgDataHome;
 
-    // finally, try the usual location in Unix or macOS
-    if (!(this instanceof JavaHomeFinderWindows) && !(this instanceof JavaHomeFinderWsl)) {
+    // finally, try the usual system-specific directories
+    if (this instanceof JavaHomeFinderWindows) {
+      // Windows
+      Path localAppData = getPathInEnvironmentVariable("LOCALAPPDATA", "mise/installs");
+      if (localAppData != null) return localAppData;
+      localAppData = getPathInUserHome("AppData/Local/mise/installs");
+      if (localAppData != null && safeIsDirectory(localAppData)) return localAppData;
+    } else if (!(this instanceof JavaHomeFinderWsl)) {
+      // Unix and macOS
       Path installsDir = getPathInUserHome(".local/share/mise/installs");
       if (installsDir != null && safeIsDirectory(installsDir)) return installsDir;
     }


### PR DESCRIPTION
This tries to follow mise's logic for all platforms (See
https://github.com/jdx/mise/blob/31bd9ba54cf887f7e2fd4d9e7c18f498181d1e13/src/env.rs#L58-L66),
so mise-installed JDKs are found on Windows.

This also fixes the XDG variable name (`XDG_DATA_DIR` does not exist, it's
called `XDG_DATA_HOME`)
