### PR TITLE
IDEA-366795: Set context when creating new declaration

### DIFF
--- a/java/java-impl-inspections/src/com/intellij/codeInspection/varScopeCanBeNarrowed/FieldCanBeLocalInspection.java
+++ b/java/java-impl-inspections/src/com/intellij/codeInspection/varScopeCanBeNarrowed/FieldCanBeLocalInspection.java
@@ -451,7 +451,8 @@ public final class FieldCanBeLocalInspection extends AbstractBaseJavaLocalInspec
         initializer = variable.getInitializer();
       }
       final PsiElementFactory psiFactory = JavaPsiFacade.getElementFactory(variable.getProject());
-      final PsiDeclarationStatement declaration = psiFactory.createVariableDeclarationStatement(localName, variable.getType(), initializer);
+      final PsiDeclarationStatement declaration =
+        psiFactory.createVariableDeclarationStatement(localName, variable.getType(), initializer, variable.getContainingFile());
       if (ContainerUtil.exists(references, PsiUtil::isAccessedForWriting)) {
         PsiUtil.setModifierProperty((PsiLocalVariable)declaration.getDeclaredElements()[0], PsiModifier.FINAL, false);
       }


### PR DESCRIPTION
When running in Android Studio against a non-physical type (eg, a data-binding or `R` class) that uses a scope enlarger, this inspection is producing a new variable declaration that uses a fully-qualified type name when in fact it should be a shortened name.

Creating the declaration with an appropriate context element will allow the correct form of the type name to be generated.