### PR TITLE
Print import errors and exceptions when starting django_test_manage.py

### DIFF
--- a/python/helpers/pycharm/django_test_manage.py
+++ b/python/helpers/pycharm/django_test_manage.py
@@ -32,9 +32,9 @@ try:
   sys.path.append(os.path.join(project_directory, os.pardir))
   project_name = os.path.basename(os.path.normpath(project_directory))
   __import__(project_name)
-except ImportError:
-  # project has custom structure (project directory is not importable)
-  pass
+except ImportError as e:
+  print("Exception while importing project directory {}: {}".format(project_directory, e))
+  traceback.print_tb(e.__traceback__)
 finally:
   sys.path.pop()
 

--- a/python/helpers/pycharm/django_test_manage.py
+++ b/python/helpers/pycharm/django_test_manage.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import traceback
 
 from django.core.management import ManagementUtility
 
@@ -20,7 +21,8 @@ try:
     from django.conf import settings
     apps = settings.INSTALLED_APPS
 except:
-    pass
+    print("Exception while installing apps: {}".format(str(e)))
+    traceback.print_tb(e.__traceback__)
 
 from django.core import management
 

--- a/python/helpers/pycharm/django_test_manage.py
+++ b/python/helpers/pycharm/django_test_manage.py
@@ -21,7 +21,7 @@ try:
     from django.conf import settings
     apps = settings.INSTALLED_APPS
 except:
-    print("Exception while installing apps: {}".format(str(e)))
+    print("Exception while importing settings: {}".format(str(e)))
     traceback.print_tb(e.__traceback__)
 
 from django.core import management


### PR DESCRIPTION
Pycharm uses djang_manage_test.py as the default django test running command.
However when there are issues such as local settings can't be loaded correctly, the `django_manage_test.py` silently swallows the reasons.

For example: If importing the settings had an issue today, because we `pass` in the `except` section, this is the output we get

```
<path_to_bin>/python /Applications/PyCharm.app/Contents/plugins/python-ce/helpers/pycharm/django_test_manage.py test path_to_test
Testing started at 3:24 PM ...
There is no such settings file settings.__init__

..... Some error in downstream code start showing up here which is not often implying that there was an issue with loading the settings....
```


**After making the changes:**

```/var/lib/conda/envs/org3/bin/python /Applications/PyCharm.app/Contents/plugins/python-ce/helpers/pycharm/django_test_manage.py test --keepdb org.scheduler.management.commands.change_enabled_release_v2_test.ChangeEnabledReleaseV2TestCase /Users/<username>/src/org/apps 
Testing started at 3:30 PM ...
Exception while importing settings: No module named 'distutil'
  File "/Applications/PyCharm.app/Contents/plugins/python-ce/helpers/pycharm/django_test_manage.py", line 23, in <module>
    apps = settings.INSTALLED_APPS
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/conda/envs/org3/lib/python3.12/site-packages/django/conf/__init__.py", line 102, in __getattr__
    self._setup(name)
  File "/var/lib/conda/envs/org3/lib/python3.12/site-packages/django/conf/__init__.py", line 89, in _setup
    self._wrapped = Settings(settings_module)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/conda/envs/org3/lib/python3.12/site-packages/django/conf/__init__.py", line 217, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/conda/envs/org3/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/Users/<username>/src/org/apps/org/settings/__init__.py", line 16, in <module>
    from org.settings.local_dev import *
  File "/Users/<username>/src/org/apps/org/settings/local_dev.py", line 12, in <module>
    from org.settings.default import *
  File "/Users/<username>/src/org/apps/org/settings/default.py", line 9, in <module>
    from distutil import util
```


This clearly shows us that when importing settings, a library `dsutil` couldn't be loaded.

