### PR TITLE
IDEA-358562 Fix error handling for Daemon toolchain no resolved URLs exception

### DIFF
--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/issues/checkers/GradleUndefinedToolchainRepositoriesIssueChecker.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/issues/checkers/GradleUndefinedToolchainRepositoriesIssueChecker.kt
@@ -15,14 +15,14 @@ import java.util.function.Consumer
 
 /**
  * An [GradleIssueChecker] handling Daemon JVM criteria exceptions like:
- * "Cannot find a Java installation on your machine (Mac OS X 14.7.1 aarch64) matching: {languageVersion=99, vendor=any vendor,
- * implementation=vendor-specific}. Toolchain download repositories have not been configured."
+ * "Toolchain resolvers did not return download URLs providing a JDK matching
+ * {languageVersion=21, vendor=Tencent, implementation=vendor-specific} for any of the requested platforms"
  */
 class GradleUndefinedToolchainRepositoriesIssueChecker : GradleIssueChecker {
 
     override fun check(issueData: GradleIssueData): BuildIssue? {
         val rootCause = getRootCauseAndLocation(issueData.error).first
-        if (rootCause.message?.contains("Toolchain download repositories have not been configured.") == true) {
+        if (rootCause.message?.contains("Toolchain resolvers did not return download URLs providing a JDK matching") == true) {
             return GradleUndefinedToolchainRepositoriesBuildIssue(rootCause, issueData.projectPath)
         }
         return null


### PR DESCRIPTION
The Daemon toolchain auto-provisioning will land in `Gradle 8.13`. However, as part of the latest changes the message in case the applied resolver plugins cannot return download URLs matching criteria has changed with the [following](https://github.com/gradle/gradle/pull/32253/files#diff-461468b1cd1e6067768f462b00162ddecca3097cda2765f241c642cd2fd80f27) making error handling to not catch the exception. 

```
Toolchain resolvers did not return download URLs providing a JDK matching {languageVersion=21, vendor=Tencent, implementation=vendor-specific} for any of the requested platforms
```

_NOTE: No exception was thrown before if empty download URLs was returned or even if no resolver plugin was applied to the project_