### PR TITLE
[JEWEL] Fix table inner blocks inheritance

### DIFF
--- a/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
+++ b/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
@@ -23,24 +23,28 @@ public fun List<MarkdownBlock>.assertEquals(vararg expected: MarkdownBlock) {
     )
 }
 
-public fun List<MarkdownBlock>.findDifferences(expected: List<MarkdownBlock>, indentSize: Int): List<String> = buildList {
-    val indent = " ".repeat(indentSize)
-    val thisSize = this@findDifferences.size
-    if (expected.size != thisSize) {
-        add("$indent * Content size mismatch. Was $thisSize, but we expected ${expected.size}")
-        add("$indent     Actual:   ${this@findDifferences}")
-        add("$indent     Expected: $expected\n")
-        add("$indent   ℹ️ Note: skipping cells comparison as it's meaningless")
-        return@buildList
-    }
+public fun List<MarkdownBlock>.findDifferences(expected: List<MarkdownBlock>, indentSize: Int): List<String> =
+    buildList {
+        val indent = " ".repeat(indentSize)
+        val thisSize = this@findDifferences.size
+        if (expected.size != thisSize) {
+            add("$indent * Content size mismatch. Was $thisSize, but we expected ${expected.size}")
+            add("$indent     Actual:   ${this@findDifferences}")
+            add("$indent     Expected: $expected\n")
+            add("$indent   ℹ️ Note: skipping cells comparison as it's meaningless")
+            return@buildList
+        }
 
-    for ((i, item) in this@findDifferences.withIndex()) {
-        val difference = item.findDifferenceWith(expected[i], indentSize + 2)
-        if (difference.isNotEmpty()) {
-            add("$indent * Item #$i is not the same as the expected value.\n\n" + "${difference.joinToString("\n")}\n")
+        for ((i, item) in this@findDifferences.withIndex()) {
+            val difference = item.findDifferenceWith(expected[i], indentSize + 2)
+            if (difference.isNotEmpty()) {
+                add(
+                    "$indent * Item #$i is not the same as the expected value.\n\n" +
+                        "${difference.joinToString("\n")}\n"
+                )
+            }
         }
     }
-}
 
 private fun MarkdownBlock.findDifferenceWith(expected: MarkdownBlock, indentSize: Int): List<String> {
     val indent = " ".repeat(indentSize)
@@ -168,19 +172,25 @@ private fun diffList(actual: ListBlock, expected: MarkdownBlock, indentSize: Int
 
 public fun paragraph(content: String): Paragraph = Paragraph(InlineMarkdown.Text(content))
 
-public fun heading(level: Int, vararg inlineContent: InlineMarkdown): Heading = Heading(inlineContent = inlineContent, level = level)
+public fun heading(level: Int, vararg inlineContent: InlineMarkdown): Heading =
+    Heading(inlineContent = inlineContent, level = level)
 
 public fun indentedCodeBlock(content: String): IndentedCodeBlock = IndentedCodeBlock(content)
 
-public fun fencedCodeBlock(content: String, mimeType: MimeType? = null): FencedCodeBlock = FencedCodeBlock(content, mimeType)
+public fun fencedCodeBlock(content: String, mimeType: MimeType? = null): FencedCodeBlock =
+    FencedCodeBlock(content, mimeType)
 
 public fun blockQuote(vararg contents: MarkdownBlock): BlockQuote = BlockQuote(contents.toList())
 
 public fun unorderedList(vararg items: ListItem, isTight: Boolean = true, marker: String = "-"): UnorderedList =
     UnorderedList(items.toList(), isTight, marker)
 
-public fun orderedList(vararg items: ListItem, isTight: Boolean = true, startFrom: Int = 1, delimiter: String = "."): OrderedList =
-    OrderedList(items.toList(), isTight, startFrom, delimiter)
+public fun orderedList(
+    vararg items: ListItem,
+    isTight: Boolean = true,
+    startFrom: Int = 1,
+    delimiter: String = ".",
+): OrderedList = OrderedList(items.toList(), isTight, startFrom, delimiter)
 
 public fun listItem(vararg items: MarkdownBlock): ListItem = ListItem(*items)
 

--- a/platform/jewel/markdown/extension/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
+++ b/platform/jewel/markdown/extension/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
@@ -147,13 +147,13 @@ internal data class TableBlock(val header: TableHeader, val rows: List<TableRow>
     }
 }
 
-internal data class TableHeader(val cells: List<TableCell>) : CustomBlock()
+internal data class TableHeader(val cells: List<TableCell>) : MarkdownBlock.CustomBlock
 
-internal data class TableRow(val rowIndex: Int, val cells: List<TableCell>) : CustomBlock()
+internal data class TableRow(val rowIndex: Int, val cells: List<TableCell>) : MarkdownBlock.CustomBlock
 
 internal data class TableCell(
     val rowIndex: Int,
     val columnIndex: Int,
     val content: List<InlineMarkdown>,
     val alignment: Alignment.Horizontal?,
-) : CustomBlock()
+) : MarkdownBlock.CustomBlock

--- a/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/BasicJewelUiTest.kt
+++ b/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/BasicJewelUiTest.kt
@@ -7,13 +7,13 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 
 public open class BasicJewelUiTest {
-    @get:Rule
-    public val composeRule: ComposeContentTestRule = createComposeRule()
+    @get:Rule public val composeRule: ComposeContentTestRule = createComposeRule()
 
     @Suppress("ImplicitUnitReturnType")
-    protected fun runComposeTest(composable: @Composable () -> Unit, block: suspend ComposeContentTestRule.() -> Unit): Unit =
+    protected fun runComposeTest(composable: @Composable () -> Unit, block: suspend ComposeContentTestRule.() -> Unit) {
         runBlocking {
             composeRule.setContent(composable)
             composeRule.block()
         }
+    }
 }

--- a/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/PainterHintTest.kt
+++ b/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/PainterHintTest.kt
@@ -29,7 +29,7 @@ import org.junit.Test
 @Suppress("ImplicitUnitReturnType")
 public class PainterHintTest : BasicJewelUiTest() {
     @Test
-    public fun `empty hint should be ignored`(): Unit =
+    public fun `empty hint should be ignored`() {
         runComposeTest({
             OverrideDarkMode(isDark = false) {
                 val provider = rememberResourcePainterProvider("icons/github.svg", PainterHintTest::class.java)
@@ -46,6 +46,7 @@ public class PainterHintTest : BasicJewelUiTest() {
         }) {
             awaitIdle()
         }
+    }
 
     private class TestPainterProviderScope(
         density: Density,


### PR DESCRIPTION
We were mistakenly extending CommonMark's CustomBlock instead of implementing Jewel's CustomBlock in TableHeader, TableRow, and TableCell.

Also includes a few fixes to make the CI happy