### PR TITLE
Replace empty folder names in imported run configurations to null

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/settings/RunConfigurationHandler.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/settings/RunConfigurationHandler.kt
@@ -49,7 +49,7 @@ internal class RunConfigurationHandler : ConfigurationHandler {
       try {
         importer.process(project, runnerAndConfigurationSettings.configuration, cfg as Map<String, *>, modelsProvider)
         if (!isDefaults) {
-          runnerAndConfigurationSettings.folderName = cfg["folderName"] as? String ?: ""
+          runnerAndConfigurationSettings.folderName = (cfg["folderName"] as? String)?.ifEmpty { null }
           runManager.addConfiguration(runnerAndConfigurationSettings)
         }
 


### PR DESCRIPTION
So after some additional investigation, while "empty folder name" in the *UI* means no folder, the code still uses `null` to signify this.

With this fix, a folder name only containing whitespace is fine (this is also accepted by the UI)
![image](https://github.com/user-attachments/assets/549214fe-95b5-4909-be7c-946df98ff697)
![image](https://github.com/user-attachments/assets/8e8dfe2e-3084-4449-86d7-db0fe2f36916)

A folder name that is set to an empty string will be converted to null silently:
![image](https://github.com/user-attachments/assets/809ac032-f821-427c-87a5-3d53d5b8ccb7)
![image](https://github.com/user-attachments/assets/e76e22ea-0146-46e1-9b55-ee50b004c43e)

And null or no folderName set at all will also not set a folder:
![image](https://github.com/user-attachments/assets/5ee60a7d-30a0-42d9-ad97-349330b82eba)
![image](https://github.com/user-attachments/assets/bf2133fa-3b42-4768-b957-43ab6a4edfa3)

![image](https://github.com/user-attachments/assets/6381b71e-7063-4782-bf05-b247738d3cc9)
![image](https://github.com/user-attachments/assets/f51d8baf-69d8-4c81-9950-11eda9961fb3)
