### PR TITLE
IDEA-358562 Ensure project SDK uses resolved Daemon toolchain

### DIFF
--- a/platform/external-system-impl/resources/META-INF/ExternalSystemExtensions.xml
+++ b/platform/external-system-impl/resources/META-INF/ExternalSystemExtensions.xml
@@ -84,6 +84,8 @@
 
     <registryKey key="external.system.substitute.library.dependencies" defaultValue="true"
                  description="Replace library dependencies with module dependencies imported from external build systems like Maven/Gradle"/>
+    <registryKey key="external.system.project.sdk.matches.build.config" defaultValue="false"
+                 description="Ensure project SDK always matches the build configuration after sync if possible"/>
 
     <externalProjectDataService implementation="com.intellij.openapi.externalSystem.service.project.manage.ProjectDataServiceImpl"/>
     <externalProjectDataService implementation="com.intellij.openapi.externalSystem.service.project.manage.LibraryDataService"/>


### PR DESCRIPTION
### Context
The `Daemon toolchain` was introduced in [Gradle 8.8](https://docs.gradle.org/8.8/release-notes.html#daemon-toolchains) and the motivation behind it and other technical details can be found on the public [spec document](https://docs.google.com/document/d/1CU1e4QjPs2yj_SmJuykPUXutynvn4X_SF0BPXVnAlKI/edit?usp=drive_link). The implementation follows the agreed details on [spec document](https://docs.google.com/document/d/1TjI-gGDcTQdIZP-cz38bBdV0jX2wRXmu3DJNUbvVG-o/edit?usp=sharing&resourcekey=0-iAyVFbna4gxtug_JVF0tJw) and [UI/UX document](https://docs.google.com/document/d/1MHkyJGQtNGevlRGBfx4-lDQLte1kjM2qHOjuMVMuEoM/edit?usp=sharing).

Until now, the IDE was responsible for indicating to Gradle which toolchain to use after resolving the `Gradle JDK configuration`, using the same to create the `project SDK`, if required. However, this will no longer be the case when using `Daemon toolchain`, since Gradle internally will need to find based on the defined criteria the installed toolchain or download a compatible one. For this reason, IDE will use the `IdeaProject` model to obtain the resolved JDK and use it for the `SdkDataService`. In addition, in studio we want the `project SDK` to always be aligned with the ` Daemon JVM criteria` since the `Project Structure > SDK` isn't exposed, for this reason a registry flag was created to allow this behavior. 

#### Tasks

- https://github.com/vmadalin/intellij-community/issues/8

### Before
<img width="1303" alt="Screenshot 2025-02-14 at 23 23 28" src="https://github.com/user-attachments/assets/0a78adbc-7c1d-4341-9424-f1e93925736b" />

### After
https://github.com/user-attachments/assets/8b92b72d-7476-4882-9b6c-7612538693a1

