### PR TITLE
[JEWEL] Restore strikethrough dep in standalone sample

### DIFF
--- a/platform/jewel/samples/standalone/build.gradle.kts
+++ b/platform/jewel/samples/standalone/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(projects.intUi.intUiDecoratedWindow)
     implementation(projects.markdown.intUiStandaloneStyling)
     implementation(projects.markdown.extension.gfmAlerts)
-    //    implementation(projects.markdown.extension.gfmStrikethrough)
+    implementation(projects.markdown.extension.gfmStrikethrough)
     implementation(projects.markdown.extension.gfmTables)
     implementation(projects.markdown.extension.autolink)
     implementation(compose.desktop.currentOs) { exclude(group = "org.jetbrains.compose.material") }


### PR DESCRIPTION
I'm not sure why someone commented it out as part of an entirely unrelated change elsewhere in IJP... this change makes the standalone sample Gradle target build again.