### PR TITLE
[JEWEL-773] Fix EditableComboBox not closing popup on click

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.onClick
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldLineLimits
@@ -193,8 +194,9 @@ public fun EditableComboBox(
                 modifier =
                     popupModifier
                         .testTag("Jewel.ComboBox.Popup")
-                        .semantics { contentDescription = "Jewel.ComboBox.Popup" }
-                        .width(comboBoxWidth),
+                        .semantics { contentDescription = "Jewel.EditableComboBox.Popup" }
+                        .width(comboBoxWidth)
+                        .onClick { popupManager.setPopupVisible(false) },
                 horizontalAlignment = Alignment.Start,
                 popupProperties = PopupProperties(focusable = false),
                 content = popupContent,


### PR DESCRIPTION
reference https://youtrack.jetbrains.com/issue/JEWEL-773/EditableListComboBox-Clicking-an-item-does-not-close-the-popup