### PR TITLE
IJPL-178852 Make MatchBraceAction to work in injected code fragment

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/editorActions/MatchBraceAction.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/editorActions/MatchBraceAction.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 public final class MatchBraceAction extends EditorAction {
   public MatchBraceAction() {
     super(new MyHandler());
+    setInjectedContext(true);
   }
 
   private static final class MyHandler extends EditorActionHandler.ForEachCaret {


### PR DESCRIPTION
As described in [IJPL-178852](https://youtrack.jetbrains.com/issue/IJPL-178852), to make MatchBraceAction work in injected code fragment, we need to call `setInjectedContext(true)` on instantiation.

Confirmed the patch works with this build: https://github.com/ocadaruma/intellij-community/actions/runs/13458444458

https://github.com/user-attachments/assets/bf671916-b450-4654-8ecd-6c5483700b89