### PR TITLE
Add handling for opening existing pull requests and merge request from notifications

### DIFF
--- a/plugins/github/github-core/resources/messages/GithubBundle.properties
+++ b/plugins/github/github-core/resources/messages/GithubBundle.properties
@@ -165,6 +165,7 @@ pull.request.create.creating=Creating a pull request
 pull.request.create.setting.metadata=Updating pull request fields
 pull.request.create.error.details=Details
 pull.request.notification.create.action=Create pull request
+pull.request.notification.open.action=Open pull request
 
 # TW content
 toolwindow.stripe.Pull_Requests=Pull Requests

--- a/plugins/github/github-core/src/org/jetbrains/plugins/github/notification/GHPushNotificationCustomizer.kt
+++ b/plugins/github/github-core/src/org/jetbrains/plugins/github/notification/GHPushNotificationCustomizer.kt
@@ -1,4 +1,5 @@
-// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code
+// is governed by the Apache 2.0 license.
 package org.jetbrains.plugins.github.notification
 
 import com.intellij.dvcs.push.VcsPushOptionValue
@@ -16,11 +17,13 @@ import org.jetbrains.plugins.github.api.GithubApiRequestExecutor
 import org.jetbrains.plugins.github.api.GithubApiRequests.Repos.PullRequests
 import org.jetbrains.plugins.github.api.data.GithubIssueState
 import org.jetbrains.plugins.github.api.data.pullrequest.GHPullRequestRestIdOnly
+import org.jetbrains.plugins.github.api.data.pullrequest.toPRIdentifier
 import org.jetbrains.plugins.github.api.executeSuspend
 import org.jetbrains.plugins.github.authentication.accounts.GHAccountManager
 import org.jetbrains.plugins.github.authentication.accounts.GithubAccount
 import org.jetbrains.plugins.github.authentication.accounts.GithubProjectDefaultAccountHolder
 import org.jetbrains.plugins.github.pullrequest.GHRepositoryConnectionManager
+import org.jetbrains.plugins.github.pullrequest.action.GHOpenPullRequestExistingTabNotificationAction
 import org.jetbrains.plugins.github.pullrequest.action.GHPRCreatePullRequestNotificationAction
 import org.jetbrains.plugins.github.pullrequest.config.GithubPullRequestsProjectUISettings
 import org.jetbrains.plugins.github.util.GHGitRepositoryMapping
@@ -35,9 +38,11 @@ internal class GHPushNotificationCustomizer(private val project: Project) : GitP
     pushResult: GitPushRepoResult,
     customParams: Map<String, VcsPushOptionValue>,
   ): List<AnAction> {
+
     if (!pushResult.isSuccessful) return emptyList()
     val remoteBranch = pushResult.findRemoteBranch(repository) ?: return emptyList()
 
+    // If we already have a GH connection open, make sure it matches
     val connection = project.serviceAsync<GHRepositoryConnectionManager>().connectionState.value
     if (connection != null && (connection.repo.gitRepository != repository || connection.repo.gitRemote != remoteBranch.remote)) {
       return emptyList()
@@ -45,70 +50,94 @@ internal class GHPushNotificationCustomizer(private val project: Project) : GitP
 
     val (projectMapping, account) = connection?.let {
       it.repo to it.account
-    } ?: GitPushNotificationUtil.findRepositoryAndAccount(
-      project.serviceAsync<GHHostedRepositoriesManager>().knownRepositories,
-      repository, remoteBranch.remote,
-      serviceAsync<GHAccountManager>().accountsState.value,
-      project.serviceAsync<GithubPullRequestsProjectUISettings>().selectedUrlAndAccount?.second,
-      project.serviceAsync<GithubProjectDefaultAccountHolder>().account
-    ) ?: return emptyList()
+    }
+                                    ?: GitPushNotificationUtil.findRepositoryAndAccount(project.serviceAsync<GHHostedRepositoriesManager>().knownRepositories, repository, remoteBranch.remote, project.serviceAsync<GHAccountManager>().accountsState.value, project.serviceAsync<GithubPullRequestsProjectUISettings>().selectedUrlAndAccount?.second, project.serviceAsync<GithubProjectDefaultAccountHolder>().account)
+                                    ?: return emptyList()
 
-    val canCreate = canCreateReview(projectMapping, account, remoteBranch)
-    if (!canCreate) return emptyList()
 
-    return listOf(GHPRCreatePullRequestNotificationAction(project, projectMapping, account))
+    if (!canCreateReview(projectMapping, account, remoteBranch)) {
+      return emptyList()
+    }
+
+    val existingPrs = findExistingPullRequests(projectMapping, account, remoteBranch)
+    return when (existingPrs.size) {
+      0 -> {
+        listOf(GHPRCreatePullRequestNotificationAction(project, projectMapping, account))
+      }
+      1 -> {
+        val singlePr = existingPrs.first()
+        listOf(GHOpenPullRequestExistingTabNotificationAction(project, projectMapping, account, singlePr.toPRIdentifier()))
+      }
+      else -> {
+        emptyList()
+      }
+    }
   }
 
-  private suspend fun canCreateReview(repositoryMapping: GHGitRepositoryMapping, account: GithubAccount, branch: GitRemoteBranch): Boolean {
+  /**
+   * Checks if it's even valid to create a PR.
+   * For instance:
+   * - The repository must exist
+   * - The branch cannot be the default branch (we don't allow creating a PR from default -> default)
+   */
+  private suspend fun canCreateReview(
+    repositoryMapping: GHGitRepositoryMapping,
+    account: GithubAccount,
+    branch: GitRemoteBranch,
+  ): Boolean {
     val accountManager = serviceAsync<GHAccountManager>()
     val token = accountManager.findCredentials(account) ?: return false
     val executor = GithubApiRequestExecutor.Factory.getInstance().create(account.server, token)
 
     val repository = repositoryMapping.repository
     val repositoryInfo = getRepositoryInfo(executor, repository) ?: run {
-      LOG.warn("Repository not found $repository")
+      LOG.warn("Repository not found: $repository")
       return false
     }
 
+    // Don't allow creating PRs targeting the default branch
     val remoteBranchName = branch.nameForRemoteOperations
-    if (repositoryInfo.defaultBranch == remoteBranchName) {
-      return false
-    }
-
-    if (findExistingPullRequests(executor, repository, remoteBranchName).isNotEmpty()) {
-      return false
-    }
-
-    return true
+    return repositoryInfo.defaultBranch != remoteBranchName
   }
 
-  private suspend fun getRepositoryInfo(executor: GithubApiRequestExecutor, repository: GHRepositoryCoordinates) =
-    try {
-      executor.executeSuspend(GHGQLRequests.Repo.find(repository))
-    }
-    catch (ce: CancellationException) {
-      throw ce
-    }
-    catch (e: Exception) {
-      LOG.warn("Failed to lookup a repository $repository", e)
-      null
-    }
-
-  private suspend fun findExistingPullRequests(
+  private suspend fun getRepositoryInfo(
     executor: GithubApiRequestExecutor,
     repository: GHRepositoryCoordinates,
-    remoteBranchName: String,
-  ): List<GHPullRequestRestIdOnly> = try {
-    executor.executeSuspend(PullRequests.find(repository,
-                                              GithubIssueState.open,
-                                              null,
-                                              repository.repositoryPath.owner + ":" + remoteBranchName)).items
+  ) = try {
+    executor.executeSuspend(GHGQLRequests.Repo.find(repository))
   }
   catch (ce: CancellationException) {
     throw ce
   }
   catch (e: Exception) {
-    LOG.warn("Failed to lookup an existing pull request for $remoteBranchName in $repository", e)
-    emptyList()
+    LOG.warn("Failed to lookup repository $repository", e)
+    null
+  }
+
+  /**
+   * Look up any existing open pull requests on the given remote branch.
+   */
+  private suspend fun findExistingPullRequests(
+    repositoryMapping: GHGitRepositoryMapping,
+    account: GithubAccount,
+    branch: GitRemoteBranch,
+  ): List<GHPullRequestRestIdOnly> {
+    val accountManager = serviceAsync<GHAccountManager>()
+    val token = accountManager.findCredentials(account) ?: return emptyList()
+    val executor = GithubApiRequestExecutor.Factory.getInstance().create(account.server, token)
+
+    val repository = repositoryMapping.repository
+    val remoteBranchName = branch.nameForRemoteOperations
+
+    return try {
+      executor.executeSuspend(PullRequests.find(repository, GithubIssueState.open, baseRef = null, headRef = repository.repositoryPath.owner + ":" + remoteBranchName)).items
+    }
+    catch (ce: CancellationException) {
+      throw ce
+    }
+    catch (e: Exception) {
+      LOG.warn("Failed to lookup existing pull requests for branch $remoteBranchName in $repository", e)
+      emptyList()
+    }
   }
 }

--- a/plugins/gitlab/gitlab-core/resources/messages/GitLabBundle.properties
+++ b/plugins/gitlab/gitlab-core/resources/messages/GitLabBundle.properties
@@ -199,3 +199,4 @@ snippet.create.error.log-in=Log In
 snippet.create.error.no-contents=No non-empty contents selected
 snippet.create.error.some-empty-contents=Some files have empty contents
 snippet.create.error.some-empty-contents.tooltip=Empty files are excluded from snippet: {0}
+merge.request.notification.open.action=Open merge request

--- a/plugins/gitlab/gitlab-core/src/org/jetbrains/plugins/gitlab/mergerequest/ui/create/action/GitLabMergeRequestOpenCreateTabAction.kt
+++ b/plugins/gitlab/gitlab-core/src/org/jetbrains/plugins/gitlab/mergerequest/ui/create/action/GitLabMergeRequestOpenCreateTabAction.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import org.jetbrains.plugins.gitlab.GitlabIcons
 import org.jetbrains.plugins.gitlab.authentication.accounts.GitLabAccount
+import org.jetbrains.plugins.gitlab.mergerequest.ui.toolwindow.GitLabReviewTab
 import org.jetbrains.plugins.gitlab.mergerequest.ui.toolwindow.model.GitLabToolWindowViewModel
 import org.jetbrains.plugins.gitlab.util.GitLabBundle
 import org.jetbrains.plugins.gitlab.util.GitLabProjectMapping
@@ -40,11 +41,30 @@ internal class GitLabMergeRequestOpenCreateTabAction : DumbAwareAction() {
   }
 
   override fun actionPerformed(e: AnActionEvent) {
-    val place = if (e.place == ActionPlaces.TOOLWINDOW_TITLE)
-      GitLabStatistics.ToolWindowOpenTabActionPlace.TOOLWINDOW
-    else
-      GitLabStatistics.ToolWindowOpenTabActionPlace.ACTION
+    val place = if (e.place == ActionPlaces.TOOLWINDOW_TITLE) GitLabStatistics.ToolWindowOpenTabActionPlace.TOOLWINDOW
+    else GitLabStatistics.ToolWindowOpenTabActionPlace.ACTION
     openCreationTab(e, place)
+  }
+}
+
+internal class GitLabOpenMergeRequestExistingTabNotificationAction(
+  private val project: Project,
+  private val projectMapping: GitLabProjectMapping,
+  private val account: GitLabAccount,
+  private val existingMrOrNull: String,
+) : NotificationAction(GitLabBundle.message("merge.request.notification.open.action")) {
+  override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+    val twVm = project.service<GitLabToolWindowViewModel>()
+    val selectorVm = twVm.selectorVm.value ?: error("Tool window has not been initialized")
+    selectorVm.selectRepoAndAccount(projectMapping, account)
+    selectorVm.submitSelection()
+    openExistingTab(e, existingMrOrNull)
+  }
+}
+
+private fun openExistingTab(event: AnActionEvent, mrId: String) {
+  event.project!!.service<GitLabToolWindowViewModel>().activateAndAwaitProject {
+    selectTab(GitLabReviewTab.ReviewSelected(mrId))
   }
 }
 
@@ -52,10 +72,8 @@ internal class GitLabMergeRequestOpenCreateTabAction : DumbAwareAction() {
 internal class GitLabMergeRequestOpenCreateTabNotificationAction(
   private val project: Project,
   private val projectMapping: GitLabProjectMapping,
-  private val account: GitLabAccount
-) : NotificationAction(
-  GitLabBundle.message("merge.request.create.notification.action.text")
-) {
+  private val account: GitLabAccount,
+) : NotificationAction(GitLabBundle.message("merge.request.create.notification.action.text")) {
   override fun actionPerformed(e: AnActionEvent, notification: Notification) {
     val twVm = project.service<GitLabToolWindowViewModel>()
     val selectorVm = twVm.selectorVm.value ?: error("Tool window has not been initialized")


### PR DESCRIPTION
Introduce actions for opening existing pull/merge requests directly in the respective tool windows. This improves usability by allowing users to interact with existing requests if detected, avoiding duplicate creation workflows.
This pull request introduces several new features and improvements to the GitHub and GitLab plugins, focusing on enhanced notification actions for pull and merge requests. The key changes include adding actions for opening existing pull requests and merge requests, as well as improving code readability and maintainability.

### GitHub Plugin Changes:

* **Notification Actions:**
  - Added `GHOpenPullRequestExistingTabNotificationAction` to open existing pull requests in a new tab if one exists. [[1]](diffhunk://#diff-f4872f625e7937d49c52575e2804ddcce245d81e832288dcf822a5a87f78379eR20-R26) [[2]](diffhunk://#diff-e97caf5236276490a0a1f873896cc1d4d23ecbf836d301f596a9e8ff5693dfa8R45-R73)
  - Modified `GHPushNotificationCustomizer` to check for existing pull requests and provide appropriate actions based on the number of existing pull requests.

* **Code Improvements:**
  - Improved readability of the `canCreateReview` and `findExistingPullRequests` methods by adding comments and restructuring the code.

### GitLab Plugin Changes:

* **Notification Actions:**
  - Added `GitLabOpenMergeRequestExistingTabNotificationAction` to open existing merge requests in a new tab if one exists.
  - Modified `GitLabPushNotificationCustomizer` to check for existing merge requests and provide appropriate actions based on the number of existing merge requests.

* **Code Improvements:**
  - Improved readability of the `canCreateReview` and `findExistingMergeRequests` methods by adding comments and restructuring the code.

### Additional Changes:

* **Properties Files:**
  - Added new message keys for opening pull requests and merge requests in the `GithubBundle.properties` and `GitLabBundle.properties` files. [[1]](diffhunk://#diff-c26f2c2704d2747ec2768e766633d5fde1061b85c2fc82635d2f6aff4af847baR168) [[2]](diffhunk://#diff-4e679904ebe0f31820133a98e7ed3f07bdae39d71ff510e3359817dc6c6c140bR202)

These changes enhance the user experience by providing more intuitive actions for handling existing pull and merge requests, while also improving the maintainability of the codebase.