### PR TITLE
Always use compiler version as the max value for api level when known

### DIFF
--- a/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/facet/KotlinFacetUtils.kt
+++ b/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/facet/KotlinFacetUtils.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.platform.IdePlatformKind
 import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.platform.idePlatformKind
 import org.jetbrains.kotlin.platform.impl.JvmIdePlatformKind
-import org.jetbrains.kotlin.platform.impl.isKotlinNative
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.NotNullableUserDataProperty
 import kotlin.reflect.KProperty1
@@ -84,29 +83,22 @@ fun IKotlinFacetSettings.initializeIfNeeded(
 
     if (shouldInferAPILevel) {
         apiLevel = when {
-            useProjectSettings -> {
-                LanguageVersion.fromVersionString(commonArguments.apiVersion) ?: languageLevel
-            }
-            /*
-            The below 'getLibraryVersion' call tries to figure out apiVersion by inspecting the stdlib available in dependencies.
-            This is not supported for K/N (07.2023), we therefore just fallback to the compiler version
-             */
-            targetPlatform?.idePlatformKind?.isKotlinNative == true && compilerVersion != null -> {
-                languageLevel?.coerceAtMostVersion(compilerVersion)
-            }
-
-            else -> run apiLevel@{
-                val maximumValue = getKotlinStdlibVersionOrNull(
-                    module,
-                    rootModel,
-                    this.targetPlatform?.idePlatformKind,
-                    coerceRuntimeLibraryVersionToReleased = compilerVersion == null
-                ) ?: compilerVersion ?: getDefaultVersion()
-                languageLevel?.coerceAtMostVersion(maximumValue)
-            }
+            useProjectSettings -> LanguageVersion.fromVersionString(commonArguments.apiVersion) ?: languageLevel
+            else -> languageLevel?.coerceAtMostVersion(getMaximumValueForApiLevel(module, rootModel, compilerVersion))
         }
     }
 }
+
+private fun IKotlinFacetSettings.getMaximumValueForApiLevel(
+    module: Module,
+    rootModel: ModuleRootModel?,
+    compilerVersion: IdeKotlinVersion?
+) = compilerVersion ?: getKotlinStdlibVersionOrNull(
+    module,
+    rootModel,
+    targetPlatform?.idePlatformKind,
+    coerceRuntimeLibraryVersionToReleased = true
+) ?: getDefaultVersion(explicitVersion = null, coerceRuntimeLibraryVersionToReleased = true)
 
 private fun getDefaultTargetPlatform(module: Module, rootModel: ModuleRootModel?): TargetPlatform {
     val platformKind = IdePlatformKind.ALL_KINDS.firstOrNull {


### PR DESCRIPTION
For figuring out the API level, we currently use the minimum of compiler version and the stdlib version module's library dependencies. This is an expensive operation and it can be avoided when we know the answer beforehand. My understanding is that we know the answer when compiler version is set explicitly (this is at least true for Gradle import case). In all other cases we can still use the old logic.