### PR TITLE
 Avoid compiler argument serialization in KotlinFacetSettingsWorkspac…

### DIFF
--- a/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/serialization/KotlinFacetSettingsWorkspaceModel.kt
+++ b/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/serialization/KotlinFacetSettingsWorkspaceModel.kt
@@ -49,29 +49,11 @@ class KotlinFacetSettingsWorkspaceModel(val entity: KotlinSettingsEntity.Builder
         }
 
     private var _compilerArguments: CommonCompilerArguments? = null
-    private var _lastKnownCompilerArguments: String? = null
     override var compilerArguments: CommonCompilerArguments?
-        get() {
-            val currentSerializedArguments = entity.compilerArguments
-            if (_compilerArguments != null && currentSerializedArguments == _lastKnownCompilerArguments) {
-                // Cache is valid, return the cached value
-                return _compilerArguments
-            }
-
-            // Deserialize and update the cache
-            _compilerArguments = currentSerializedArguments?.let {
-                CompilerArgumentsSerializer.deserializeFromString(it)
-            }
-            _lastKnownCompilerArguments = currentSerializedArguments
-
-            return _compilerArguments
-        }
+        get() = _compilerArguments
         set(value) {
-            val serializedValue = CompilerArgumentsSerializer.serializeToString(value)
-            entity.compilerArguments = serializedValue
             updateMergedArguments()
             _compilerArguments = value?.unfrozen()
-            _lastKnownCompilerArguments = serializedValue
         }
 
     override val mergedCompilerArguments: CommonCompilerArguments?

--- a/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/workspaceModel/KotlinFacetBridge.kt
+++ b/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/workspaceModel/KotlinFacetBridge.kt
@@ -25,6 +25,7 @@ class KotlinFacetBridge(
         val moduleEntity = mutableStorage.resolve(existingFacetEntity.moduleId)!!
         mutableStorage.modifyModuleEntity(moduleEntity) module@{
             val kotlinSettingsEntity = config.getEntityBuilder(this@module)
+            val compilerArgumentsString = CompilerArgumentsSerializer.serializeToString((configuration as KotlinFacetConfigurationBridge).compilerArguments)
             mutableStorage.modifyKotlinSettingsEntity(existingFacetEntity) {
                 if (kotlinSettingsEntity.flushNeeded) flushNeeded = false
                 name = kotlinSettingsEntity.name
@@ -44,7 +45,7 @@ class KotlinFacetBridge(
                 isHmppEnabled = kotlinSettingsEntity.isHmppEnabled
                 pureKotlinSourceFolders = kotlinSettingsEntity.pureKotlinSourceFolders.toMutableList()
                 kind = kotlinSettingsEntity.kind
-                compilerArguments = kotlinSettingsEntity.compilerArguments
+                compilerArguments = compilerArgumentsString
                 compilerSettings = kotlinSettingsEntity.compilerSettings
                 targetPlatform = kotlinSettingsEntity.targetPlatform
                 externalSystemRunTasks = kotlinSettingsEntity.externalSystemRunTasks.toMutableList()

--- a/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/workspaceModel/KotlinFacetConfigurationBridge.kt
+++ b/plugins/kotlin/base/facet/src/org/jetbrains/kotlin/idea/workspaceModel/KotlinFacetConfigurationBridge.kt
@@ -13,9 +13,12 @@ import org.jetbrains.kotlin.idea.facet.KotlinFacetType
 import org.jetbrains.kotlin.idea.serialization.KotlinFacetSettingsWorkspaceModel
 
 class KotlinFacetConfigurationBridge : KotlinFacetConfiguration, FacetConfigurationBridge<KotlinSettingsEntity, KotlinSettingsEntity.Builder> {
-    override val settings: IKotlinFacetSettings by lazy { KotlinFacetSettingsWorkspaceModel(kotlinSettingsEntity) }
-
+    private val kotlinFacetSettingsWorkspaceModel by lazy { KotlinFacetSettingsWorkspaceModel(kotlinSettingsEntity) }
     private val kotlinSettingsEntity: KotlinSettingsEntity.Builder
+
+    override val settings: IKotlinFacetSettings by lazy { kotlinFacetSettingsWorkspaceModel }
+
+    val compilerArguments get() = kotlinFacetSettingsWorkspaceModel.compilerArguments
 
     private constructor(kotlinSettingsEntity: KotlinSettingsEntity.Builder) : super() {
         this.kotlinSettingsEntity = kotlinSettingsEntity


### PR DESCRIPTION
…eModel.

 This gets rid of using the entity as the underlying data storage for this, and instead updates the entity in the commit time instead.