### PR TITLE
Use compiler arguments before iterating jars to figure out platform kind

### DIFF
--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/KotlinGradleSourceSetDataService.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/KotlinGradleSourceSetDataService.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.config.IKotlinFacetSettings
 import org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor
 import org.jetbrains.kotlin.idea.base.codeInsight.tooling.tooling
 import org.jetbrains.kotlin.idea.base.externalSystem.KotlinGradleFacade
+import org.jetbrains.kotlin.idea.base.externalSystem.NodeWithData
 import org.jetbrains.kotlin.idea.base.externalSystem.find
 import org.jetbrains.kotlin.idea.base.externalSystem.findAll
 import org.jetbrains.kotlin.idea.base.platforms.*
@@ -51,6 +52,7 @@ import org.jetbrains.kotlin.idea.gradleJava.inspections.getResolvedVersionByModu
 import org.jetbrains.kotlin.idea.gradleJava.migrateNonJvmSourceFolders
 import org.jetbrains.kotlin.library.KLIB_FILE_EXTENSION
 import org.jetbrains.kotlin.platform.IdePlatformKind
+import org.jetbrains.kotlin.platform.idePlatformKind
 import org.jetbrains.kotlin.platform.impl.isCommon
 import org.jetbrains.kotlin.platform.impl.isJavaScript
 import org.jetbrains.kotlin.platform.impl.isJvm
@@ -254,9 +256,12 @@ fun configureFacetByGradleModule(
         return null
     }
 
-    val platformKind = detectPlatformKindByPlugin(moduleNode) ?: detectPlatformByLibrary(moduleNode)
     val kotlinGradleSourceSetDataNode = kotlinGradleProjectDataNode.findAll(KotlinGradleSourceSetData.KEY)
         .firstOrNull { it.data.sourceSetName == sourceSetName } ?: return null
+
+    val platformKind = detectPlatformKindByPlugin(moduleNode)
+        ?: detectPlatformKindByCompilerArguments(kotlinGradleSourceSetDataNode)
+        ?: detectPlatformByLibrary(moduleNode)
 
     val compilerVersion = kotlinGradleSourceSetDataNode.data?.kotlinPluginVersion?.let(IdeKotlinVersion::opt)
     // required for GradleFacetImportTest.{testCommonImportByPlatformPlugin, testKotlinAndroidPluginDetection}
@@ -310,6 +315,9 @@ fun configureFacetByGradleModule(
 
     return kotlinFacet
 }
+
+private fun detectPlatformKindByCompilerArguments(kotlinGradleSourceSetDataNode: NodeWithData<KotlinGradleSourceSetData>?) : IdePlatformKind? =
+    kotlinGradleSourceSetDataNode?.data?.compilerArguments?.let { IdePlatformKind.platformByCompilerArguments(it) }?.idePlatformKind
 
 private fun IKotlinFacetSettings.configureOutputPaths(moduleNode: DataNode<ModuleData>, platformKind: IdePlatformKind?) {
     if (!platformKind.isJavaScript) {


### PR DESCRIPTION
Jar iteration is expensive so we should avoid it as much as we can.