### PR TITLE
Remove invalid function 'getargspec' references in hg4idea library

### DIFF
--- a/plugins/hg4idea/resources/python/prompthooks.py
+++ b/plugins/hg4idea/resources/python/prompthooks.py
@@ -171,8 +171,6 @@ def find_user_password(self, realm, authuri):
     except error.Abort:
         def read_hgrc_authtoken(ui, authuri):
             from mercurial.httpconnection import readauthforuri
-            from inspect import getargspec
-            args, _, _, _ = getargspec(readauthforuri)
             res = readauthforuri(self.ui, authuri, "")
             if res:
                 group, auth = res


### PR DESCRIPTION
function 'getargspec' has been deprecated in python 3 and has been removed in python 3.11. Since invalid functions are used here, methods like 'hg pull, hg push and hg update' fails from Intellij UI.

Reference Link: https://docs.python.org/3.0/library/inspect.html?highlight=getargspec#inspect.getargspec