### PR TITLE
IJPL-175783 Revert enforcement of AboutDialog EP contract

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/AboutPopupDescriptionProvider.kt
+++ b/platform/platform-impl/src/com/intellij/ide/AboutPopupDescriptionProvider.kt
@@ -5,19 +5,23 @@ import com.intellij.openapi.util.NlsContexts.DetailedDescription
 
 /**
  * Allows plugins to add additional details to display in *Help | About* popup.
- * 
+ *
  * Register in `com.intellij.aboutPopupDescriptionProvider` extension point.
  */
 interface AboutPopupDescriptionProvider {
   /**
-   * Return additional info which should be shown in the "About" dialog.
-   * Plain text only. Only one line supported.
+   * Return additional info which should be shown in the "About" dialog. Can be HTML and multiple lines.
+   *
+   * Note that if you provide HTML here, you should also implement [getExtendedDescription] and provide a plain text version of the content
+   * there.
+   *
+   * @see getExtendedDescription
    */
   fun getDescription(): @DetailedDescription String?
 
   /**
-   * Return additional info which should be only added to the text copied with the action in the "About" dialog.
-   * Plain text only, and defaults to the value returned by [getDescription].
+   * Return additional info which should be only added to the text copied with the action in the "About" dialog. Defaults to the value
+   * returned by [getDescription]. Should be plain text, since it's not going to be shown in the UI but only copied to the clipboard.
    */
   fun getExtendedDescription(): @DetailedDescription String? = getDescription()
 }

--- a/platform/platform-impl/src/com/intellij/ide/actions/AboutDialog.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/AboutDialog.java
@@ -49,7 +49,6 @@ import com.jetbrains.cef.JCefAppConfig;
 import com.jetbrains.cef.JCefVersionDetails;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jsoup.Jsoup;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
@@ -209,7 +208,7 @@ public final class AboutDialog extends DialogWrapper {
     for (AboutPopupDescriptionProvider aboutInfoProvider : EP_NAME.getExtensionList()) {
       String description = aboutInfoProvider.getDescription();
       if (description != null) {
-        lines.add(cleanupDescriptionText(description, false));
+        lines.add(description);
         lines.add("");
       }
     }
@@ -300,7 +299,7 @@ public final class AboutDialog extends DialogWrapper {
     for (var aboutInfoProvider : EP_NAME.getExtensionList()) {
       var description = aboutInfoProvider.getExtendedDescription();
       if (description != null) {
-        text.append(cleanupDescriptionText(description, true)).append('\n');
+        text.append(description).append('\n');
       }
     }
 
@@ -341,17 +340,6 @@ public final class AboutDialog extends DialogWrapper {
     }
 
     return text.toString();
-  }
-
-  private static @NotNull String cleanupDescriptionText(@NotNull String description, boolean allowMultiline) {
-    var textOnly = Jsoup.parse(description).text().trim();
-    if (allowMultiline) {
-      return textOnly;
-    } else {
-      return textOnly.replace("\r\n", " ")
-        .replace("\r", " ")
-        .replace("\n", " ");
-    }
   }
 
   private static void showOssInfo(JComponent component) {


### PR DESCRIPTION
Turns out that the lack of enforcement and documentation of the contract of this EP is relied upon by some plugins, so we need to avoid enforcing it. The EP KDoc has also been updated to match the actual behaviour.