### PR TITLE
[JEWEL-706] Clean EditableListComboBox selection on input not present in the item list

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
@@ -205,7 +205,7 @@ public fun EditableListComboBox(
             onSelectedItemChange(index, items[index])
             scope.launch { listState.lazyListState.scrollToIndex(index) }
         } else {
-            JewelLogger.getInstance("EditableListComboBox").trace("Ignoring item index $index as it's invalid")
+            listState.selectedKeys = emptySet()
         }
     }
 
@@ -251,9 +251,7 @@ public fun EditableListComboBox(
         },
         onEnterPress = {
             val indexOfSelected = items.indexOf(textFieldState.text)
-            if (indexOfSelected != -1) {
-                setSelectedItem(indexOfSelected)
-            }
+            setSelectedItem(indexOfSelected)
         },
         popupManager =
             remember {


### PR DESCRIPTION
Reference https://youtrack.jetbrains.com/issue/JEWEL-706/Editable-ListComboBox-clear-list-selection-when-the-input-field-contains-something-not-present-in-the-list-presets

Manually tested in Standalone and IDE Sample:
![20250225-1149-31 4309205-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/45e29dea-d3fd-426f-848c-3c78b4ce2998)
