### PR TITLE
Remove gutter icon for pytest fixtures

### DIFF
--- a/python/testData/pyTestLineMarker/fixtureTest.py
+++ b/python/testData/pyTestLineMarker/fixtureTest.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.fixture
+def test_fixture():
+    return 42
+
+def test_actual():
+    assert True

--- a/python/testSrc/com/jetbrains/python/testing/PyTestRunLineMarkerTest.kt
+++ b/python/testSrc/com/jetbrains/python/testing/PyTestRunLineMarkerTest.kt
@@ -12,6 +12,7 @@ open class PyTestRunLineMarkerTest : PyTestCase() {
   companion object {
     const val TESTS_DIR = "/pyTestLineMarker/"
     const val PYTHON_FILE = "pythonFile.py"
+    const val FIXTURE_FILE = "fixtureTest.py"
   }
 
   override fun getTestDataPath(): String = super.getTestDataPath() + TESTS_DIR
@@ -53,5 +54,24 @@ open class PyTestRunLineMarkerTest : PyTestCase() {
     if (element != null) {
       assertInfoFound(element, lineMarkerContributor)
     }
+  }
+
+  fun testFixtureWithTestPrefix() {
+    val lineMarkerContributor = PyTestLineMarkerContributor()
+
+    myFixture.configureByText(FIXTURE_FILE, """
+      import pytest
+
+      @pytest.fixture
+      def <caret>test_fixture():
+          return 42
+
+      def test_actual():
+          assert True
+    """.trimIndent())
+
+    val fixtureElement = myFixture.file.findElementAt(myFixture.caretOffset)
+    assertNotNull(fixtureElement)
+    assertInfoNotFound(fixtureElement!!, lineMarkerContributor)
   }
 }


### PR DESCRIPTION
Fixes [PY-59322](https://youtrack.jetbrains.com/issue/PY-59322) Don't add gutter icon to pytest fixtures with `test_*` prefix