### PR TITLE
[JEWEL] Tiny Checkbox code cleanup

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Checkbox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Checkbox.kt
@@ -487,7 +487,7 @@ private fun CheckboxImpl(
     val toggleableModifier =
         modifier.triStateToggleable(
             state = state,
-            onClick = { onClick() },
+            onClick = onClick,
             enabled = enabled,
             role = Role.Checkbox,
             interactionSource = interactionSource,


### PR DESCRIPTION
Use onClick directly when possible instead of creating another lambda.