### PR TITLE
Fix json-schema pattern matcher

### DIFF
--- a/json/src/com/jetbrains/jsonSchema/impl/light/legacy/JsonSchemaObjectReadingUtils.java
+++ b/json/src/com/jetbrains/jsonSchema/impl/light/legacy/JsonSchemaObjectReadingUtils.java
@@ -354,7 +354,7 @@ public final class JsonSchemaObjectReadingUtils {
 
   public static boolean matchPattern(final @NotNull Pattern pattern, final @NotNull String s) {
     try {
-      return pattern.matcher(StringUtil.newBombedCharSequence(s, 300)).matches();
+      return pattern.matcher(StringUtil.newBombedCharSequence(s, 300)).find();
     }
     catch (ProcessCanceledException e) {
       // something wrong with the pattern, infinite cycle?
@@ -371,17 +371,10 @@ public final class JsonSchemaObjectReadingUtils {
 
   public static Pair<Pattern, String> compilePattern(final @NotNull String pattern) {
     try {
-      return Pair.create(Pattern.compile(adaptSchemaPattern(pattern)), null);
+      return Pair.create(Pattern.compile(pattern), null);
     }
     catch (PatternSyntaxException e) {
       return Pair.create(null, e.getMessage());
     }
-  }
-
-  private static @NotNull String adaptSchemaPattern(String pattern) {
-    pattern = pattern.startsWith("^") || pattern.startsWith("*") || pattern.startsWith(".") ? pattern : (".*" + pattern);
-    pattern = pattern.endsWith("+") || pattern.endsWith("*") || pattern.endsWith("$") ? pattern : (pattern + ".*");
-    pattern = pattern.replace("\\\\", "\\");
-    return pattern;
   }
 }

--- a/json/tests/test/com/jetbrains/jsonSchema/JsonSchemaHighlightingTest.java
+++ b/json/tests/test/com/jetbrains/jsonSchema/JsonSchemaHighlightingTest.java
@@ -453,6 +453,27 @@ public class JsonSchemaHighlightingTest extends JsonSchemaHighlightingTestBase {
     doTest(schema, wrongText);
   }
 
+  public void testPatternWithAlternation() {
+    @Language("JSON") final String schema = """
+      {
+        "properties": {
+          "withPattern": {
+            "pattern": "^v?\\\\d+(\\\\.\\\\d+){0,3}|^dev-"
+          }
+        }
+      }""";
+    @Language("JSON") final String correctText1 = """
+      {
+        "withPattern": "1.0.0-RC1"
+      }""";
+    @Language("JSON") final String correctText2 = """
+      {
+        "withPattern": "dev-master"
+      }""";
+    doTest(schema, correctText1);
+    doTest(schema, correctText2);
+  }
+
   public void testRootObjectRedefinedAdditionalPropertiesForbidden() {
     doTest(rootObjectRedefinedSchema(), "{<warning descr=\"Property 'a' is not allowed\">\"a\"</warning>: true," +
                                         "\"r1\": \"allowed!\"}");


### PR DESCRIPTION
Let's handle regexp pattern with alternation (eg. `^v?\d+(\.\d+){0,3}|^dev-`) in correct way.
See also: https://github.com/composer/composer/pull/12332