### PR TITLE
Remove DummyVersionedEntityStorage, causing "cached values" not to be cached

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/SourceFolderManagerImpl.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/manage/SourceFolderManagerImpl.kt
@@ -228,8 +228,7 @@ class SourceFolderManagerImpl(
     val diffBuilder = WorkspaceModel.getInstance(project).currentSnapshot.toBuilder()
     val modifiableRootModels = modules.asSequence().filter { !it.isDisposed }.map { module ->
       val moduleRootComponentBridge = ModuleRootManager.getInstance(module) as ModuleRootComponentBridge
-      val modifiableRootModel = moduleRootComponentBridge.getModifiableModelForMultiCommit(ExternalSystemRootConfigurationAccessor(diffBuilder),
-                                                                                           false)
+      val modifiableRootModel = moduleRootComponentBridge.getModifiableModelForMultiCommit(ExternalSystemRootConfigurationAccessor(diffBuilder))
       modifiableRootModel as ModifiableRootModelBridge
       modifier.invoke(modifiableRootModel)
       modifiableRootModel.prepareForCommit()

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/LegacyBridgeModifiableBase.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/LegacyBridgeModifiableBase.kt
@@ -6,19 +6,17 @@ import com.intellij.model.SideEffectGuard
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.util.JDOMUtil
 import com.intellij.platform.workspace.storage.MutableEntityStorage
-import com.intellij.platform.workspace.storage.impl.DummyVersionedEntityStorage
 import com.intellij.platform.workspace.storage.impl.VersionedEntityStorageOnBuilder
 import org.jetbrains.annotations.ApiStatus
 
 //todo restore internal visibility for members of this class after other classes will be moved to this module
 @ApiStatus.Internal
-abstract class LegacyBridgeModifiableBase(val diff: MutableEntityStorage, cacheStorageResult: Boolean) {
+abstract class LegacyBridgeModifiableBase(val diff: MutableEntityStorage) {
   init {
     SideEffectGuard.checkSideEffectAllowed(SideEffectGuard.EffectType.PROJECT_MODEL)
   }
 
-  val entityStorageOnDiff = if (cacheStorageResult) VersionedEntityStorageOnBuilder(diff)
-  else DummyVersionedEntityStorage(diff)
+  val entityStorageOnDiff = VersionedEntityStorageOnBuilder(diff)
 
   private var committedOrDisposed = false
 

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/GlobalOrCustomModifiableLibraryTableBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/GlobalOrCustomModifiableLibraryTableBridgeImpl.kt
@@ -20,7 +20,7 @@ import com.intellij.workspaceModel.ide.impl.legacyBridge.library.ProjectLibraryT
 import org.jetbrains.jps.model.serialization.library.JpsLibraryTableSerializer
 
 internal class GlobalOrCustomModifiableLibraryTableBridgeImpl(private val libraryTable: LibraryTable, val descriptor: EelDescriptor, private val entitySource: EntitySource) :
-  LegacyBridgeModifiableBase(MutableEntityStorage.from(GlobalWorkspaceModel.getInstance(descriptor).currentSnapshot), true),
+  LegacyBridgeModifiableBase(MutableEntityStorage.from(GlobalWorkspaceModel.getInstance(descriptor).currentSnapshot)),
   LibraryTable.ModifiableModel {
 
   private val myAddedLibraries = mutableListOf<LibraryBridgeImpl>()

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/LibraryBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/LibraryBridgeImpl.kt
@@ -128,7 +128,7 @@ class LibraryBridgeImpl(
       is LibraryOrigin.OfDescriptor -> GlobalWorkspaceModel.getInstance(origin.descriptor).getVirtualFileUrlManager()
       is LibraryOrigin.OfProject -> WorkspaceModel.getInstance(origin.project).getVirtualFileUrlManager()
     }
-    return LibraryModifiableModelBridgeImpl(this, librarySnapshot, builder, targetBuilder, virtualFileUrlManager, false)
+    return LibraryModifiableModelBridgeImpl(this, librarySnapshot, builder, targetBuilder, virtualFileUrlManager)
   }
 
   override fun getSource(): Library? = null

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/LibraryModifiableModelBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/LibraryModifiableModelBridgeImpl.kt
@@ -34,8 +34,7 @@ internal class LibraryModifiableModelBridgeImpl(
   diff: MutableEntityStorage,
   private val targetBuilder: MutableEntityStorage?,
   private val virtualFileManager: VirtualFileUrlManager,
-  cacheStorageResult: Boolean = true
-) : LegacyBridgeModifiableBase(diff, cacheStorageResult), LibraryModifiableModelBridge, RootProvider {
+) : LegacyBridgeModifiableBase(diff), LibraryModifiableModelBridge, RootProvider {
 
   private var entityId = originalLibrarySnapshot.libraryEntity.symbolicId
   private var reloadKind = false

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/ProjectLibraryTableBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/ProjectLibraryTableBridgeImpl.kt
@@ -233,8 +233,7 @@ class ProjectLibraryTableBridgeImpl(
       libraryTable = this,
       project = project,
       originalStorage = entityStorage.current,
-      diff = diff,
-      cacheStorageResult = false
+      diff = diff
     )
 
   override fun addListener(listener: LibraryTable.Listener) {

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/ProjectModifiableLibraryTableBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/library/ProjectModifiableLibraryTableBridgeImpl.kt
@@ -28,9 +28,8 @@ internal class ProjectModifiableLibraryTableBridgeImpl(
   originalStorage: EntityStorage,
   private val libraryTable: ProjectLibraryTableBridgeImpl,
   private val project: Project,
-  diff: MutableEntityStorage = MutableEntityStorage.from(originalStorage.toSnapshot()),
-  cacheStorageResult: Boolean = true
-) : LegacyBridgeModifiableBase(diff, cacheStorageResult), ProjectModifiableLibraryTableBridge {
+  diff: MutableEntityStorage = MutableEntityStorage.from(originalStorage.toSnapshot())
+) : LegacyBridgeModifiableBase(diff), ProjectModifiableLibraryTableBridge {
 
   private val myAddedLibraries = mutableListOf<LibraryBridgeImpl>()
 

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/ModifiableModuleModelBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/ModifiableModuleModelBridgeImpl.kt
@@ -41,9 +41,8 @@ private val LOG: Logger
 internal class ModifiableModuleModelBridgeImpl(
   private val project: Project,
   private val moduleManager: ModuleManagerBridgeImpl,
-  diff: MutableEntityStorage,
-  cacheStorageResult: Boolean = true
-) : LegacyBridgeModifiableBase(diff, cacheStorageResult), ModifiableModuleModelBridge {
+  diff: MutableEntityStorage
+) : LegacyBridgeModifiableBase(diff), ModifiableModuleModelBridge {
   private val moduleTypes = ConcurrentFactoryMap.createMap<String, ModuleTypeId> { ModuleTypeId(it) }
 
   override fun getProject(): Project = project

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/ModuleManagerBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/ModuleManagerBridgeImpl.kt
@@ -277,7 +277,7 @@ abstract class ModuleManagerBridgeImpl(
   }
 
   fun getModifiableModel(diff: MutableEntityStorage): ModifiableModuleModel {
-    return ModifiableModuleModelBridgeImpl(project = project, moduleManager = this, diff = diff, cacheStorageResult = false)
+    return ModifiableModuleModelBridgeImpl(project = project, moduleManager = this, diff = diff)
   }
 
   override fun newModule(filePath: String, moduleTypeId: String): Module = newModuleTimeMs.addMeasuredTime {

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/roots/ModifiableRootModelBridgeImpl.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/roots/ModifiableRootModelBridgeImpl.kt
@@ -50,9 +50,8 @@ import java.util.concurrent.ConcurrentHashMap
 internal class ModifiableRootModelBridgeImpl(
   diff: MutableEntityStorage,
   override val moduleBridge: ModuleBridge,
-  override val accessor: RootConfigurationAccessor,
-  cacheStorageResult: Boolean = true
-) : LegacyBridgeModifiableBase(diff, cacheStorageResult), ModifiableRootModelBridge, ModuleRootModelBridge {
+  override val accessor: RootConfigurationAccessor
+) : LegacyBridgeModifiableBase(diff), ModifiableRootModelBridge, ModuleRootModelBridge {
 
   /*
     We save the module entity for the following case:

--- a/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/roots/ModuleRootComponentBridge.kt
+++ b/platform/projectModel-impl/src/com/intellij/workspaceModel/ide/impl/legacyBridge/module/roots/ModuleRootComponentBridge.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.roots.*
 import com.intellij.openapi.roots.impl.ModuleOrderEnumerator
 import com.intellij.openapi.roots.impl.RootConfigurationAccessor
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.workspace.storage.CachedValue
 import com.intellij.platform.workspace.storage.EntityStorage
 import com.intellij.platform.workspace.storage.ImmutableEntityStorage
 import com.intellij.platform.workspace.storage.MutableEntityStorage
@@ -32,7 +33,7 @@ class ModuleRootComponentBridge(
 
   private val orderRootsCache = OrderRootsCacheBridge(currentModule.project, currentModule)
 
-  private val modelValue = VersionedCache<RootModelBridgeImpl> {
+  private val modelValue = CachedValue {
     RootModelBridgeImpl(
       moduleEntity = moduleBridge.findModuleEntity(moduleBridge.entityStorage.current),
       storage = moduleBridge.entityStorage,
@@ -63,7 +64,7 @@ class ModuleRootComponentBridge(
   }
 
   private val model: RootModelBridgeImpl
-    get() = modelValue.getValue(moduleBridge.entityStorage.version)
+    get() = moduleBridge.entityStorage.cachedValue(modelValue)
 
   override val storage: EntityStorage
     get() = moduleBridge.entityStorage.current
@@ -86,7 +87,7 @@ class ModuleRootComponentBridge(
   }
 
   internal fun dropRootModelCache() {
-    modelValue.clear()
+    moduleBridge.entityStorage.clearCachedValue(modelValue)
   }
 
   override fun getModificationCountForTests(): Long = moduleBridge.entityStorage.version
@@ -102,28 +103,14 @@ class ModuleRootComponentBridge(
     moduleBridge,
     accessor)
 
-  /**
-   * This method is used in Project Structure dialog to ensure that changes made in {@link ModifiableModuleModel} after creation
-   * of this {@link ModifiableRootModel} are available in its storage and references in its {@link OrderEntry} can be resolved properly.
-   */
-  override fun getModifiableModelForMultiCommit(accessor: RootConfigurationAccessor): ModifiableRootModel =
-    getModifiableModelForMultiCommit(accessor, true)
-
-  @ApiStatus.Internal
-  fun getModifiableModelForMultiCommit(accessor: RootConfigurationAccessor, cacheStorageResult: Boolean): ModifiableRootModel = ModifiableRootModelBridgeImpl(
-    (moduleBridge.diff as? MutableEntityStorage) ?: (accessor as? RootConfigurationAccessorForWorkspaceModel)?.actualDiffBuilder
+  override fun getModifiableModelForMultiCommit(accessor: RootConfigurationAccessor): ModifiableRootModel = ModifiableRootModelBridgeImpl(
+    moduleBridge.diff ?: (accessor as? RootConfigurationAccessorForWorkspaceModel)?.actualDiffBuilder
     ?: MutableEntityStorage.from(moduleBridge.entityStorage.current.toSnapshot()),
     moduleBridge,
-    accessor,
-    cacheStorageResult)
-
-  @ApiStatus.Internal
-  fun getModifiableModelWithoutCaching(): ModifiableRootModel {
-    return getModifiableModel(MutableEntityStorage.from(moduleBridge.entityStorage.current.toSnapshot()), RootConfigurationAccessor.DEFAULT_INSTANCE)
-  }
+    accessor)
 
   fun getModifiableModel(diff: MutableEntityStorage, accessor: RootConfigurationAccessor): ModifiableRootModel {
-    return ModifiableRootModelBridgeImpl(diff, moduleBridge, accessor, false)
+    return ModifiableRootModelBridgeImpl(diff, moduleBridge, accessor)
   }
 
   override fun getDependencies(): Array<Module> = moduleDependencies
@@ -170,26 +157,5 @@ private fun EntityStorage.toSnapshot(): ImmutableEntityStorage {
     is ImmutableEntityStorage -> this
     is MutableEntityStorage -> this.toSnapshot()
     else -> error("Unexpected storage: $this")
-  }
-}
-
-private class VersionedCache<T>(val compute: () -> T) {
-  private var version: Long = -1
-  private var valueResult: T? = null
-
-  @Synchronized
-  fun getValue(currentVersion: Long): T {
-    var res = valueResult
-    if (res != null && version == currentVersion) return res
-
-    this.version = currentVersion
-    res = compute()
-    valueResult = res
-    return res
-  }
-
-  @Synchronized
-  fun clear() {
-    valueResult = null
   }
 }


### PR DESCRIPTION
 The storage field in StorageSnapshotCache is unused anyway and is deleted. As far as I understand, this should solve the memory concerns that caused this class to be introduced.