### PR TITLE
[launcher ]Check CARGO_CFG_TARGET_OS instead of 'target_os

### DIFF
--- a/native/XPlatLauncher/Cargo.toml
+++ b/native/XPlatLauncher/Cargo.toml
@@ -42,14 +42,12 @@ native-dialog = "0.7.0"
 
 [build-dependencies]
 anyhow = { version = "1.0.95", features = ["std", "backtrace"] }
-# these crates are used in separate build steps; uncomment them from time to time to check for updates
-#cargo-deny = "0.17.0"
-#cargo-about = "0.6.6"
-
-[target.'cfg(target_os = "windows")'.build-dependencies]
 curl = { version = "0.4.47", features = ["static-curl"] }
 sha1 = "0.10.6"
 winresource = "0.1.19"
+# these crates are used in separate build steps; uncomment them from time to time to check for updates
+#cargo-deny = "0.17.0"
+#cargo-about = "0.6.6"
 
 [package.metadata.winresource]
 CompanyName = "JetBrains s.r.o."

--- a/native/XPlatLauncher/build.rs
+++ b/native/XPlatLauncher/build.rs
@@ -1,9 +1,5 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 
-// technically we shouldn't use #cfg in build.rs due to cross-compilation,
-// but the only we do is windows x64 -> arm64, so it's fine for our purposes
-
-#[cfg(target_os = "windows")]
 use {
     anyhow::{bail, Context, Result},
     std::env,
@@ -11,7 +7,7 @@ use {
     winresource::WindowsResource,
 };
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 use {
     curl::easy::Easy,
     sha1::{Digest, Sha1},
@@ -20,14 +16,13 @@ use {
     std::process::Command,
 };
 
-#[cfg(target_os = "windows")]
+#[cfg(feature = "cef")]
 macro_rules! trace {
     ($($arg:tt)*) => {
         println!("TRACE: {}", format_args!($($arg)*));
     };
 }
 
-#[cfg(target_os = "windows")]
 macro_rules! cargo {
     ($($arg:tt)*) => {
         println!("cargo:{}", format_args!($($arg)*));
@@ -35,10 +30,9 @@ macro_rules! cargo {
 }
 
 fn main() {
-    #[cfg(target_os = "windows")]
-    {
-        cargo!("rerun-if-changed=build.rs");
+    cargo!("rerun-if-changed=build.rs");
 
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
         #[cfg(feature = "cef")]
         link_cef().expect("Failed to link with CEF");
 
@@ -46,8 +40,10 @@ fn main() {
     }
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn link_cef() -> Result<()> {
+    assert!(std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows");
+
     let cef_version = "122.1.9+gd14e051+chromium-122.0.6261.94";
 
     let cef_arch_string = match env::var("CARGO_CFG_TARGET_ARCH")?.as_str() {
@@ -65,7 +61,7 @@ fn link_cef() -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 pub fn download_cef(version: &str, platform: &str, working_dir: &Path) -> Result<PathBuf> {
     let cef_distribution = &format!("cef_binary_{version}_{platform}_minimal");
 
@@ -97,7 +93,7 @@ pub fn download_cef(version: &str, platform: &str, working_dir: &Path) -> Result
     Ok(extract_dir)
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn download_file(url: &str, file: &Path) -> Result<()> {
     trace!("Downloading {url} to {file:?}");
     let mut out = File::create(&file)?;
@@ -112,7 +108,7 @@ fn download_file(url: &str, file: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn verify_sha1_checksum(file: &Path, expected: &str) -> Result<()> {
     trace!("Verifying checksum of {file:?}");
 
@@ -133,7 +129,7 @@ fn verify_sha1_checksum(file: &Path, expected: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn extract_tar_bz2(archive: &Path, dest: &Path, extract_marker: &Path) -> Result<()> {
     trace!("Will extract {archive:?} to {dest:?}");
 
@@ -202,7 +198,6 @@ fn extract_tar_bz2(archive: &Path, dest: &Path, extract_marker: &Path) -> Result
     Ok(())
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
 fn is_7z_available_in_path() -> bool {
     let status = Command::new("7z")
         .arg("--help")
@@ -211,8 +206,10 @@ fn is_7z_available_in_path() -> bool {
     status.is_ok()
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn link_cef_sandbox(cef_dir: &Path) -> Result<()> {
+    assert!(std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows");
+
     let cef_lib_search_path = &cef_dir.join("Release").canonicalize()?;
     let cef_lib_search_path_string = get_non_unc_string(cef_lib_search_path)?;
     cargo!("rustc-link-search=native={cef_lib_search_path_string}");
@@ -257,7 +254,7 @@ fn link_cef_sandbox(cef_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn get_file_name(path: &Path) -> Result<String> {
     let result = path.file_name()
         .context(format!("Failed to get filename from {path:?}"))?
@@ -268,8 +265,9 @@ fn get_file_name(path: &Path) -> Result<String> {
     Ok(result)
 }
 
-#[cfg(target_os = "windows")]
 fn embed_metadata() -> Result<()> {
+    assert!(std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows");
+
     let cargo_root_env_var = env::var("CARGO_MANIFEST_DIR")?;
     let cargo_root = PathBuf::from(cargo_root_env_var);
 
@@ -286,7 +284,7 @@ fn embed_metadata() -> Result<()> {
     res.compile().context("Failed to embed resources")
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn get_non_unc_string(path: &Path) -> Result<String> {
     let result = path
         .to_str()
@@ -297,7 +295,7 @@ fn get_non_unc_string(path: &Path) -> Result<String> {
     Ok(result)
 }
 
-#[cfg(all(target_os = "windows", feature = "cef"))]
+#[cfg(feature = "cef")]
 fn fs_remove(path: &Path) -> Result<()> {
     trace!("Will remove {path:?}");
 
@@ -315,7 +313,6 @@ fn fs_remove(path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "windows")]
 fn assert_exists_and_file(path: &Path) -> Result<()> {
     if !path.exists() {
         bail!("File '{path:?}' does not exist")


### PR DESCRIPTION
`#[cfg]` refers to the environment in which the build.rs's executable will run, which will be the host (compiler) operating system. It is not the actual compilation target system.