### PR TITLE
[JEWEL] Add modifiers to Markdown block renderer APIs

### DIFF
--- a/platform/jewel/markdown/core/api/core.api
+++ b/platform/jewel/markdown/core/api/core.api
@@ -262,7 +262,7 @@ public abstract interface class org/jetbrains/jewel/markdown/extensions/Markdown
 
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension {
 	public abstract fun canRender (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;)Z
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownDelimitedInlineProcessorExtension {
@@ -353,22 +353,21 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer
 	public fun getRendererExtensions ()Ljava/util/List;
 	public fun getRootStyling ()Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;
 	public fun plus (Lorg/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension;)Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;
-	public fun render (Ljava/util/List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;Landroidx/compose/runtime/Composer;I)V
-	public fun renderWithMimeType-EWr_ITI (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Ljava/lang/String;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Ljava/util/List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer {
@@ -411,21 +410,21 @@ public abstract interface class org/jetbrains/jewel/markdown/rendering/MarkdownB
 	public abstract fun getRendererExtensions ()Ljava/util/List;
 	public abstract fun getRootStyling ()Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;
 	public abstract fun plus (Lorg/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension;)Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;
-	public abstract fun render (Ljava/util/List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Ljava/util/List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer$Companion {
@@ -803,10 +802,9 @@ public final class org/jetbrains/jewel/markdown/scrolling/AutoScrollingUtilKt {
 public class org/jetbrains/jewel/markdown/scrolling/ScrollSyncMarkdownBlockRenderer : org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer {
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Ljava/util/List;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun renderWithMimeType-EWr_ITI (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Ljava/lang/String;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 }
 
 public abstract class org/jetbrains/jewel/markdown/scrolling/ScrollingSynchronizer {

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/Markdown.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/Markdown.kt
@@ -77,10 +77,10 @@ public fun Markdown(
     blockRenderer: MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(markdownStyling),
 ) {
     if (selectable) {
-        SelectionContainer(modifier.semantics { rawMarkdown = markdown }) {
-            Column(verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing)) {
+        SelectionContainer(Modifier.semantics { rawMarkdown = markdown }) {
+            Column(modifier, verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing)) {
                 for (block in markdownBlocks) {
-                    blockRenderer.render(block, enabled, onUrlClick, onTextClick)
+                    blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier)
                 }
             }
         }
@@ -90,7 +90,7 @@ public fun Markdown(
             verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
         ) {
             for (block in markdownBlocks) {
-                blockRenderer.render(block, enabled, onUrlClick, onTextClick)
+                blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier)
             }
         }
     }
@@ -117,7 +117,9 @@ public fun LazyMarkdown(
                 contentPadding = contentPadding,
                 verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
             ) {
-                items(markdownBlocks) { block -> blockRenderer.render(block, enabled, onUrlClick, onTextClick) }
+                items(markdownBlocks) { block ->
+                    blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier)
+                }
             }
         }
     } else {
@@ -127,7 +129,7 @@ public fun LazyMarkdown(
             contentPadding = contentPadding,
             verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
         ) {
-            items(markdownBlocks) { block -> blockRenderer.render(block, enabled, onUrlClick, onTextClick) }
+            items(markdownBlocks) { block -> blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier) }
         }
     }
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.jewel.markdown.extensions
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CustomBlock
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
@@ -8,12 +9,25 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 
 /** An extension for [MarkdownBlockRenderer] that can render one or more [MarkdownBlock.CustomBlock]s. */
 public interface MarkdownBlockRendererExtension {
-    /** Check whether the provided [block] can be rendered by this extension. */
+    /**
+     * Check whether the provided [block] can be rendered by this extension.
+     *
+     * @param block The block to check for renderability.
+     * @return `true` if this extension can render the given [block], `false` otherwise.
+     */
     public fun canRender(block: CustomBlock): Boolean
 
     /**
      * Render a [MarkdownBlock.CustomBlock] as a native Composable. Note that if [canRender] returns `false` for
      * [block], the implementation might throw.
+     *
+     * @param block The [MarkdownBlock.CustomBlock] to render.
+     * @param blockRenderer The [MarkdownBlockRenderer] to use to render other blocks if necessary.
+     * @param inlineRenderer The [InlineMarkdownRenderer] to use to render inline elements if necessary.
+     * @param enabled Whether The rendered content should be enabled.
+     * @param modifier The modifier to be applied to the composable.
+     * @param onUrlClick The callback to invoke when an URL is clicked.
+     * @param onTextClick The callback to invoke when a text part is clicked.
      */
     @Composable
     public fun render(
@@ -21,6 +35,7 @@ public interface MarkdownBlockRendererExtension {
         blockRenderer: MarkdownBlockRenderer,
         inlineRenderer: InlineMarkdownRenderer,
         enabled: Boolean,
+        modifier: Modifier,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
@@ -38,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter
+import org.jetbrains.jewel.foundation.modifier.thenIf
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.BlockQuote
@@ -76,32 +78,47 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing)) {
+        Column(modifier, verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing)) {
             for (block in blocks) {
-                render(block, enabled, onUrlClick, onTextClick)
+                render(block, enabled, onUrlClick, onTextClick, Modifier)
             }
         }
     }
 
     @Composable
-    override fun render(block: MarkdownBlock, enabled: Boolean, onUrlClick: (String) -> Unit, onTextClick: () -> Unit) {
+    override fun render(
+        block: MarkdownBlock,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
+        onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
         when (block) {
-            is BlockQuote -> render(block, rootStyling.blockQuote, enabled, onUrlClick, onTextClick)
-            is FencedCodeBlock -> render(block, rootStyling.code.fenced)
-            is IndentedCodeBlock -> render(block, rootStyling.code.indented)
-            is Heading -> render(block, rootStyling.heading, enabled, onUrlClick, onTextClick)
-            is HtmlBlock -> render(block, rootStyling.htmlBlock)
-            is OrderedList -> render(block, rootStyling.list.ordered, enabled, onUrlClick, onTextClick)
-            is UnorderedList -> render(block, rootStyling.list.unordered, enabled, onUrlClick, onTextClick)
-            is ListItem -> render(block, enabled, onUrlClick, onTextClick)
-            is Paragraph -> render(block, rootStyling.paragraph, enabled, onUrlClick, onTextClick)
-            ThematicBreak -> renderThematicBreak(rootStyling.thematicBreak)
+            is BlockQuote -> render(block, rootStyling.blockQuote, enabled, onUrlClick, onTextClick, modifier)
+            is FencedCodeBlock -> render(block, rootStyling.code.fenced, enabled, modifier)
+            is IndentedCodeBlock -> render(block, rootStyling.code.indented, enabled, modifier)
+            is Heading -> render(block, rootStyling.heading, enabled, onUrlClick, onTextClick, modifier)
+            is HtmlBlock -> render(block, rootStyling.htmlBlock, enabled, modifier)
+            is OrderedList -> render(block, rootStyling.list.ordered, enabled, onUrlClick, onTextClick, modifier)
+            is UnorderedList -> render(block, rootStyling.list.unordered, enabled, onUrlClick, onTextClick, modifier)
+            is ListItem -> render(block, enabled, onUrlClick, onTextClick, modifier)
+            is Paragraph -> render(block, rootStyling.paragraph, enabled, onUrlClick, onTextClick, modifier)
+            ThematicBreak -> renderThematicBreak(rootStyling.thematicBreak, enabled, modifier)
             is CustomBlock -> {
                 rendererExtensions
                     .find { it.blockRenderer?.canRender(block) == true }
                     ?.blockRenderer
-                    ?.render(block, blockRenderer = this, inlineRenderer, enabled, onUrlClick, onTextClick)
+                    ?.render(
+                        block = block,
+                        blockRenderer = this,
+                        inlineRenderer = inlineRenderer,
+                        enabled = enabled,
+                        modifier = modifier,
+                        onUrlClick = onUrlClick,
+                        onTextClick = onTextClick,
+                    )
             }
         }
     }
@@ -113,6 +130,7 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         val renderedContent = rememberRenderedContent(block, styling.inlinesStyling, enabled, onUrlClick)
         val textColor =
@@ -124,7 +142,8 @@ public open class DefaultMarkdownBlockRenderer(
 
         Text(
             modifier =
-                Modifier.focusProperties { canFocus = false }
+                modifier
+                    .focusProperties { canFocus = false }
                     .clickable(interactionSource = interactionSource, indication = null, onClick = onTextClick),
             text = renderedContent,
             style = mergedStyle,
@@ -138,14 +157,15 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         when (block.level) {
-            1 -> render(block, styling.h1, enabled, onUrlClick, onTextClick)
-            2 -> render(block, styling.h2, enabled, onUrlClick, onTextClick)
-            3 -> render(block, styling.h3, enabled, onUrlClick, onTextClick)
-            4 -> render(block, styling.h4, enabled, onUrlClick, onTextClick)
-            5 -> render(block, styling.h5, enabled, onUrlClick, onTextClick)
-            6 -> render(block, styling.h6, enabled, onUrlClick, onTextClick)
+            1 -> render(block, styling.h1, enabled, onUrlClick, onTextClick, modifier)
+            2 -> render(block, styling.h2, enabled, onUrlClick, onTextClick, modifier)
+            3 -> render(block, styling.h3, enabled, onUrlClick, onTextClick, modifier)
+            4 -> render(block, styling.h4, enabled, onUrlClick, onTextClick, modifier)
+            5 -> render(block, styling.h5, enabled, onUrlClick, onTextClick, modifier)
+            6 -> render(block, styling.h6, enabled, onUrlClick, onTextClick, modifier)
             else -> error("Heading level ${block.level} not supported:\n$block")
         }
     }
@@ -157,6 +177,7 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         val renderedContent = rememberRenderedContent(block, styling.inlinesStyling, enabled, onUrlClick)
         Heading(
@@ -166,6 +187,7 @@ public open class DefaultMarkdownBlockRenderer(
             styling.underlineWidth,
             styling.underlineColor,
             styling.underlineGap,
+            modifier,
         )
     }
 
@@ -177,8 +199,9 @@ public open class DefaultMarkdownBlockRenderer(
         underlineWidth: Dp,
         underlineColor: Color,
         underlineGap: Dp,
+        modifier: Modifier,
     ) {
-        Column(modifier = Modifier.padding(paddingValues)) {
+        Column(modifier = modifier.padding(paddingValues)) {
             val textColor = textStyle.color.takeOrElse { LocalContentColor.current.takeOrElse { textStyle.color } }
             val mergedStyle = textStyle.merge(TextStyle(color = textColor))
             Text(text = renderedContent, style = mergedStyle, modifier = Modifier.focusProperties { canFocus = false })
@@ -202,9 +225,11 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         Column(
-            Modifier.drawBehind {
+            modifier
+                .drawBehind {
                     val isLtr = layoutDirection == Ltr
                     val lineWidthPx = styling.lineWidth.toPx()
                     val x = if (isLtr) lineWidthPx / 2 else size.width - lineWidthPx / 2
@@ -222,7 +247,7 @@ public open class DefaultMarkdownBlockRenderer(
             verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing),
         ) {
             CompositionLocalProvider(LocalContentColor provides styling.textColor) {
-                render(block.children, enabled, onUrlClick, onTextClick)
+                render(block.children, enabled, onUrlClick, onTextClick, Modifier)
             }
         }
     }
@@ -234,10 +259,11 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         when (block) {
-            is OrderedList -> render(block, styling.ordered, enabled, onUrlClick, onTextClick)
-            is UnorderedList -> render(block, styling.unordered, enabled, onUrlClick, onTextClick)
+            is OrderedList -> render(block, styling.ordered, enabled, onUrlClick, onTextClick, modifier)
+            is UnorderedList -> render(block, styling.unordered, enabled, onUrlClick, onTextClick, modifier)
         }
     }
 
@@ -248,6 +274,7 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         val itemSpacing =
             if (block.isTight) {
@@ -256,7 +283,7 @@ public open class DefaultMarkdownBlockRenderer(
                 styling.itemVerticalSpacing
             }
 
-        Column(modifier = Modifier.padding(styling.padding), verticalArrangement = Arrangement.spacedBy(itemSpacing)) {
+        Column(modifier = modifier.padding(styling.padding), verticalArrangement = Arrangement.spacedBy(itemSpacing)) {
             for ((index, item) in block.children.withIndex()) {
                 Row {
                     val number = block.startFrom + index
@@ -273,7 +300,7 @@ public open class DefaultMarkdownBlockRenderer(
 
                     Spacer(Modifier.width(styling.numberContentGap))
 
-                    render(item, enabled, onUrlClick, onTextClick)
+                    render(item, enabled, onUrlClick, onTextClick, Modifier)
                 }
             }
         }
@@ -286,6 +313,7 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         val itemSpacing =
             if (block.isTight) {
@@ -294,7 +322,7 @@ public open class DefaultMarkdownBlockRenderer(
                 styling.itemVerticalSpacing
             }
 
-        Column(modifier = Modifier.padding(styling.padding), verticalArrangement = Arrangement.spacedBy(itemSpacing)) {
+        Column(modifier = modifier.padding(styling.padding), verticalArrangement = Arrangement.spacedBy(itemSpacing)) {
             for (item in block.children) {
                 Row {
                     Text(
@@ -308,34 +336,47 @@ public open class DefaultMarkdownBlockRenderer(
 
                     Spacer(Modifier.width(styling.bulletContentGap))
 
-                    render(item, enabled, onUrlClick, onTextClick)
+                    render(item, enabled, onUrlClick, onTextClick, Modifier)
                 }
             }
         }
     }
 
     @Composable
-    override fun render(block: ListItem, enabled: Boolean, onUrlClick: (String) -> Unit, onTextClick: () -> Unit) {
-        Column(verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing)) {
-            render(block.children, enabled, onUrlClick, onTextClick)
+    override fun render(
+        block: ListItem,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
+        onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        Column(modifier, verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing)) {
+            render(block.children, enabled, onUrlClick, onTextClick, Modifier)
         }
     }
 
     @Composable
-    override fun render(block: CodeBlock, styling: MarkdownStyling.Code) {
+    override fun render(block: CodeBlock, styling: MarkdownStyling.Code, enabled: Boolean, modifier: Modifier) {
         when (block) {
-            is FencedCodeBlock -> render(block, styling.fenced)
-            is IndentedCodeBlock -> render(block, styling.indented)
+            is FencedCodeBlock -> render(block, styling.fenced, enabled, modifier)
+            is IndentedCodeBlock -> render(block, styling.indented, enabled, modifier)
         }
     }
 
     @Composable
-    override fun render(block: IndentedCodeBlock, styling: MarkdownStyling.Code.Indented) {
+    override fun render(
+        block: IndentedCodeBlock,
+        styling: MarkdownStyling.Code.Indented,
+        enabled: Boolean,
+        modifier: Modifier,
+    ) {
         MaybeScrollingContainer(
             isScrollable = styling.scrollsHorizontally,
-            Modifier.background(styling.background, styling.shape)
+            modifier
+                .background(styling.background, styling.shape)
                 .border(styling.borderWidth, styling.borderColor, styling.shape)
-                .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
+                .thenIf(styling.fillWidth) { fillMaxWidth() }
+                .thenIf(!enabled) { alpha(.5f) },
         ) {
             Text(
                 text = block.content,
@@ -350,13 +391,20 @@ public open class DefaultMarkdownBlockRenderer(
     }
 
     @Composable
-    override fun render(block: FencedCodeBlock, styling: MarkdownStyling.Code.Fenced) {
+    override fun render(
+        block: FencedCodeBlock,
+        styling: MarkdownStyling.Code.Fenced,
+        enabled: Boolean,
+        modifier: Modifier,
+    ) {
         val mimeType = block.mimeType ?: MimeType.Known.UNKNOWN
         MaybeScrollingContainer(
             isScrollable = styling.scrollsHorizontally,
-            Modifier.background(styling.background, styling.shape)
+            modifier
+                .background(styling.background, styling.shape)
                 .border(styling.borderWidth, styling.borderColor, styling.shape)
-                .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
+                .thenIf(styling.fillWidth) { fillMaxWidth() }
+                .thenIf(!enabled) { alpha(.5f) },
         ) {
             Column(Modifier.padding(styling.padding)) {
                 if (styling.infoPosition.verticalAlignment == Alignment.Top) {
@@ -369,7 +417,7 @@ public open class DefaultMarkdownBlockRenderer(
                     )
                 }
 
-                renderWithMimeType(block, mimeType, styling)
+                renderCodeWithMimeType(block, mimeType, styling, enabled)
 
                 if (styling.infoPosition.verticalAlignment == Alignment.Bottom) {
                     FencedBlockInfo(
@@ -385,14 +433,15 @@ public open class DefaultMarkdownBlockRenderer(
     }
 
     @Composable
-    public open fun renderWithMimeType(
+    internal open fun renderCodeWithMimeType(
         block: FencedCodeBlock,
         mimeType: MimeType,
         styling: MarkdownStyling.Code.Fenced,
+        enabled: Boolean,
     ) {
         val content = block.content
-        val highlightedCode by
-            LocalCodeHighlighter.current.highlight(content, mimeType).collectAsState(AnnotatedString(content))
+        val highlighter = LocalCodeHighlighter.current
+        val highlightedCode by highlighter.highlight(content, mimeType).collectAsState(AnnotatedString(content))
         Text(
             text = highlightedCode,
             style = styling.editorTextStyle,
@@ -422,17 +471,17 @@ public open class DefaultMarkdownBlockRenderer(
     }
 
     @Composable
-    override fun renderThematicBreak(styling: MarkdownStyling.ThematicBreak) {
+    override fun renderThematicBreak(styling: MarkdownStyling.ThematicBreak, enabled: Boolean, modifier: Modifier) {
         Divider(
             orientation = Orientation.Horizontal,
-            modifier = Modifier.padding(styling.padding).fillMaxWidth(),
+            modifier = modifier.padding(styling.padding).fillMaxWidth(),
             color = styling.lineColor,
             thickness = styling.lineWidth,
         )
     }
 
     @Composable
-    override fun render(block: HtmlBlock, styling: MarkdownStyling.HtmlBlock) {
+    override fun render(block: HtmlBlock, styling: MarkdownStyling.HtmlBlock, enabled: Boolean, modifier: Modifier) {
         // HTML blocks are intentionally not rendered
     }
 

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.jewel.markdown.rendering
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.BlockQuote
@@ -31,17 +32,55 @@ public interface MarkdownBlockRenderer {
     public val rendererExtensions: List<MarkdownRendererExtension>
     public val inlineRenderer: InlineMarkdownRenderer
 
+    /**
+     * Renders a list of [MarkdownBlock]s into a Compose UI.
+     *
+     * @param blocks The list of blocks to render.
+     * @param enabled True if the blocks should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the root composable (usually, a `Column` or `LazyColumn`).
+     * @see render
+     */
     @Composable
     public fun render(
         blocks: List<MarkdownBlock>,
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [MarkdownBlock] into a Compose UI.
+     *
+     * @param block The block to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
-    public fun render(block: MarkdownBlock, enabled: Boolean, onUrlClick: (String) -> Unit, onTextClick: () -> Unit)
+    public fun render(
+        block: MarkdownBlock,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
+        onTextClick: () -> Unit,
+        modifier: Modifier,
+    )
 
+    /**
+     * Renders a [Paragraph] into a Compose UI.
+     *
+     * @param block The paragraph to render.
+     * @param styling The [`Paragraph`][MarkdownStyling.Paragraph] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
     public fun render(
         block: Paragraph,
@@ -49,8 +88,20 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [MarkdownBlock.Heading] into a Compose UI.
+     *
+     * @param block The heading to render.
+     * @param styling The [`Heading`][MarkdownStyling.Heading] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
     public fun render(
         block: MarkdownBlock.Heading,
@@ -58,8 +109,20 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [MarkdownBlock.Heading] into a Compose UI, using a specific [`HN`][MarkdownStyling.Heading.HN] styling.
+     *
+     * @param block The heading to render.
+     * @param styling The [`Heading.HN`][MarkdownStyling.Heading.HN] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
     public fun render(
         block: MarkdownBlock.Heading,
@@ -67,8 +130,20 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [BlockQuote] into a Compose UI.
+     *
+     * @param block The blockquote to render.
+     * @param styling The [`BlockQuote`][MarkdownStyling.BlockQuote] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
     public fun render(
         block: BlockQuote,
@@ -76,8 +151,20 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [ListBlock] into a Compose UI.
+     *
+     * @param block The list to render.
+     * @param styling The [`List`][MarkdownStyling.List] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
     public fun render(
         block: ListBlock,
@@ -85,8 +172,20 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [OrderedList] into a Compose UI.
+     *
+     * @param block The ordered list to render.
+     * @param styling The [`List.Ordered`][MarkdownStyling.List.Ordered] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
     public fun render(
         block: OrderedList,
@@ -94,8 +193,20 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [UnorderedList] into a Compose UI.
+     *
+     * @param block The unordered list to render.
+     * @param styling The [`List.Unordered`][MarkdownStyling.List.Unordered] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
     public fun render(
         block: UnorderedList,
@@ -103,23 +214,105 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     )
 
+    /**
+     * Renders a [ListItem] into a Compose UI.
+     *
+     * @param block The list item to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
     @Composable
-    public fun render(block: ListItem, enabled: Boolean, onUrlClick: (String) -> Unit, onTextClick: () -> Unit)
+    public fun render(
+        block: ListItem,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
+        onTextClick: () -> Unit,
+        modifier: Modifier,
+    )
 
-    @Composable public fun render(block: CodeBlock, styling: MarkdownStyling.Code)
+    /**
+     * Renders a [CodeBlock] into a Compose UI.
+     *
+     * @param block The heading to render.
+     * @param styling The [`Code`][MarkdownStyling.Code] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
+    @Composable public fun render(block: CodeBlock, styling: MarkdownStyling.Code, enabled: Boolean, modifier: Modifier)
 
-    @Composable public fun render(block: IndentedCodeBlock, styling: MarkdownStyling.Code.Indented)
+    /**
+     * Renders a [IndentedCodeBlock] into a Compose UI.
+     *
+     * @param block The heading to render.
+     * @param styling The [`Code.Indented`][MarkdownStyling.Code.Indented] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
+    @Composable
+    public fun render(
+        block: IndentedCodeBlock,
+        styling: MarkdownStyling.Code.Indented,
+        enabled: Boolean,
+        modifier: Modifier,
+    )
 
-    @Composable public fun render(block: FencedCodeBlock, styling: MarkdownStyling.Code.Fenced)
+    /**
+     * Renders a [FencedCodeBlock] into a Compose UI. If the fenced block defines a language, it can be
+     * syntax-highlighted by the the [org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter].
+     *
+     * @param block The heading to render.
+     * @param styling The [`Code.Fenced`][MarkdownStyling.Code.Fenced] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     * @see org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
+     */
+    @Composable
+    public fun render(
+        block: FencedCodeBlock,
+        styling: MarkdownStyling.Code.Fenced,
+        enabled: Boolean,
+        modifier: Modifier,
+    )
 
-    @Composable public fun renderThematicBreak(styling: MarkdownStyling.ThematicBreak)
+    /**
+     * Renders a thematic break (horizontal divider) into a Compose UI.
+     *
+     * @param styling The [`ThematicBreak`][MarkdownStyling.ThematicBreak] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
+    @Composable
+    public fun renderThematicBreak(styling: MarkdownStyling.ThematicBreak, enabled: Boolean, modifier: Modifier)
 
-    @Composable public fun render(block: HtmlBlock, styling: MarkdownStyling.HtmlBlock)
+    /**
+     * Renders a [HtmlBlock] into a Compose UI. Since Compose can't render HTML out of the box, this might result in a
+     * no-op (e.g., in [DefaultMarkdownBlockRenderer.render]).
+     *
+     * @param block The heading to render.
+     * @param styling The [`Code`][MarkdownStyling.Code] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
+     * @see render
+     */
+    @Composable
+    public fun render(block: HtmlBlock, styling: MarkdownStyling.HtmlBlock, enabled: Boolean, modifier: Modifier)
 
     /**
      * Creates a copy of this instance, using the provided non-null parameters, or the current values for the null ones.
+     *
+     * @param rootStyling The [MarkdownStyling] to use to render the Markdown into composables.
+     * @param rendererExtensions The [MarkdownRendererExtension]s used to render [MarkdownBlock.CustomBlock]s.
+     * @param inlineRenderer The [InlineMarkdownRenderer] used to render inline content.
      */
     public fun createCopy(
         rootStyling: MarkdownStyling? = null,
@@ -127,8 +320,13 @@ public interface MarkdownBlockRenderer {
         inlineRenderer: InlineMarkdownRenderer? = null,
     ): MarkdownBlockRenderer
 
-    /** Creates a copy of this [MarkdownBlockRenderer] with the same properties, plus the provided [extension]. */
+    /**
+     * Creates a copy of this [MarkdownBlockRenderer] with the same properties, plus the provided [extension].
+     *
+     * @see createCopy
+     */
     @ExperimentalJewelApi public operator fun plus(extension: MarkdownRendererExtension): MarkdownBlockRenderer
 
+    /** The companion object for [MarkdownBlockRenderer]. */
     public companion object
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollSyncMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollSyncMarkdownBlockRenderer.kt
@@ -46,14 +46,17 @@ public open class ScrollSyncMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         val synchronizer =
             (JewelTheme.markdownMode as? MarkdownMode.EditorPreview)?.scrollingSynchronizer
                 ?: run {
-                    super.render(block, styling, enabled, onUrlClick, onTextClick)
+                    super.render(block, styling, enabled, onUrlClick, onTextClick, modifier)
                     return
                 }
-        AutoScrollableBlock(block, synchronizer) { super.render(block, styling, enabled, onUrlClick, onTextClick) }
+        AutoScrollableBlock(block, synchronizer) {
+            super.render(block, styling, enabled, onUrlClick, onTextClick, modifier)
+        }
     }
 
     @Composable
@@ -63,22 +66,30 @@ public open class ScrollSyncMarkdownBlockRenderer(
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
     ) {
         val synchronizer =
             (JewelTheme.markdownMode as? MarkdownMode.EditorPreview)?.scrollingSynchronizer
                 ?: run {
-                    super.render(block, styling, enabled, onUrlClick, onTextClick)
+                    super.render(block, styling, enabled, onUrlClick, onTextClick, modifier)
                     return
                 }
-        AutoScrollableBlock(block, synchronizer) { super.render(block, styling, enabled, onUrlClick, onTextClick) }
+        AutoScrollableBlock(block, synchronizer) {
+            super.render(block, styling, enabled, onUrlClick, onTextClick, modifier)
+        }
     }
 
     @Composable
-    override fun renderWithMimeType(block: FencedCodeBlock, mimeType: MimeType, styling: MarkdownStyling.Code.Fenced) {
+    override fun renderCodeWithMimeType(
+        block: FencedCodeBlock,
+        mimeType: MimeType,
+        styling: MarkdownStyling.Code.Fenced,
+        enabled: Boolean,
+    ) {
         val synchronizer =
             (JewelTheme.markdownMode as? MarkdownMode.EditorPreview)?.scrollingSynchronizer
                 ?: run {
-                    super.renderWithMimeType(block, mimeType, styling)
+                    super.renderCodeWithMimeType(block, mimeType, styling, enabled)
                     return
                 }
 
@@ -100,16 +111,22 @@ public open class ScrollSyncMarkdownBlockRenderer(
     }
 
     @Composable
-    override fun render(block: IndentedCodeBlock, styling: MarkdownStyling.Code.Indented) {
+    override fun render(
+        block: IndentedCodeBlock,
+        styling: MarkdownStyling.Code.Indented,
+        enabled: Boolean,
+        modifier: Modifier,
+    ) {
         val scrollingSynchronizer =
             (JewelTheme.markdownMode as? MarkdownMode.EditorPreview)?.scrollingSynchronizer
                 ?: run {
-                    super.render(block, styling)
+                    super.render(block, styling, enabled, modifier)
                     return
                 }
         MaybeScrollingContainer(
             isScrollable = styling.scrollsHorizontally,
-            Modifier.background(styling.background, styling.shape)
+            modifier
+                .background(styling.background, styling.shape)
                 .border(styling.borderWidth, styling.borderColor, styling.shape)
                 .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
         ) {

--- a/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollingSynchronizerTest.kt
+++ b/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollingSynchronizerTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.StrokeCap
@@ -21,7 +22,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import java.util.Arrays
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -635,7 +635,7 @@ public class ScrollingSynchronizerTest {
     private fun assertSameDistance(distance: Int, vararg elements: Int) {
         assertTrue(elements.size > 1)
         for (i in 0..<elements.lastIndex) {
-            assertEquals(Arrays.toString(elements), distance, elements[i + 1] - elements[i])
+            assertEquals(elements.contentToString(), distance, elements[i + 1] - elements[i])
         }
     }
 
@@ -685,7 +685,7 @@ public class ScrollingSynchronizerTest {
             ) {
                 JewelTheme(createThemeDefinition()) {
                     val blocks = processor.yieldBlocks()
-                    renderer.render(blocks, true, {}, {})
+                    renderer.render(blocks, true, {}, {}, Modifier)
                 }
             }
         }

--- a/platform/jewel/markdown/extension/gfm-alerts/api/gfm-alerts.api
+++ b/platform/jewel/markdown/extension/gfm-alerts/api/gfm-alerts.api
@@ -116,7 +116,7 @@ public final class org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubA
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/markdown/extensions/github/alerts/AlertStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;)V
 	public fun canRender (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;)Z
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertIcons {

--- a/platform/jewel/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
+++ b/platform/jewel/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
@@ -39,6 +39,7 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
         blockRenderer: MarkdownBlockRenderer,
         inlineRenderer: InlineMarkdownRenderer,
         enabled: Boolean,
+        modifier: Modifier,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     ) {
@@ -48,11 +49,11 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
         val alert = block as? Alert
 
         when (alert) {
-            is Caution -> Alert(alert, styling.caution, enabled, blockRenderer, onUrlClick, onTextClick)
-            is Important -> Alert(alert, styling.important, enabled, blockRenderer, onUrlClick, onTextClick)
-            is Note -> Alert(alert, styling.note, enabled, blockRenderer, onUrlClick, onTextClick)
-            is Tip -> Alert(alert, styling.tip, enabled, blockRenderer, onUrlClick, onTextClick)
-            is Warning -> Alert(alert, styling.warning, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Caution -> Alert(alert, modifier, styling.caution, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Important -> Alert(alert, modifier, styling.important, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Note -> Alert(alert, modifier, styling.note, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Tip -> Alert(alert, modifier, styling.tip, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Warning -> Alert(alert, modifier, styling.warning, enabled, blockRenderer, onUrlClick, onTextClick)
             else -> error("Unsupported block of type ${block.javaClass.name} cannot be rendered")
         }
     }
@@ -60,6 +61,7 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
     @Composable
     private fun Alert(
         block: Alert,
+        modifier: Modifier,
         styling: BaseAlertStyling,
         enabled: Boolean,
         blockRenderer: MarkdownBlockRenderer,
@@ -67,7 +69,8 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
         onTextClick: () -> Unit,
     ) {
         Column(
-            Modifier.drawBehind {
+            modifier
+                .drawBehind {
                     val isLtr = layoutDirection == Ltr
                     val lineWidthPx = styling.lineWidth.toPx()
                     val x = if (isLtr) lineWidthPx / 2 else size.width - lineWidthPx / 2
@@ -108,7 +111,7 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
             CompositionLocalProvider(
                 LocalContentColor provides styling.textColor.takeOrElse { LocalContentColor.current }
             ) {
-                blockRenderer.render(block.content, enabled, onUrlClick, onTextClick)
+                blockRenderer.render(block.content, enabled, onUrlClick, onTextClick, Modifier)
             }
         }
     }

--- a/platform/jewel/markdown/extension/gfm-tables/api/gfm-tables.api
+++ b/platform/jewel/markdown/extension/gfm-tables/api/gfm-tables.api
@@ -50,7 +50,7 @@ public final class org/jetbrains/jewel/markdown/extensions/github/tables/GitHubT
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/extensions/github/tables/GfmTableStyling;)V
 	public fun canRender (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;)Z
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension : org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension {

--- a/platform/jewel/markdown/extension/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
+++ b/platform/jewel/markdown/extension/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
@@ -34,6 +34,7 @@ public class GitHubTableBlockRenderer(
         blockRenderer: MarkdownBlockRenderer,
         inlineRenderer: InlineMarkdownRenderer,
         enabled: Boolean,
+        modifier: Modifier,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     ) {
@@ -121,6 +122,7 @@ public class GitHubTableBlockRenderer(
             cellBorderColor = tableStyling.colors.borderColor,
             cellBorderWidth = tableStyling.metrics.borderWidth,
             rows = rows,
+            modifier = modifier,
         )
     }
 
@@ -162,6 +164,7 @@ public class GitHubTableBlockRenderer(
                 enabled = enabled,
                 onUrlClick = onUrlClick,
                 onTextClick = onTextClick,
+                modifier = Modifier,
             )
         }
     }

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
@@ -38,6 +38,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.List.Ordered
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.List.Unordered
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.Paragraph
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.ThematicBreak
+import org.jetbrains.jewel.ui.component.Typography
 
 public fun MarkdownStyling.Companion.light(
     baseTextStyle: TextStyle = defaultTextStyle,
@@ -664,10 +665,18 @@ private val blockContentColorDark = Color(0xFFBCBEC4)
 private val defaultTextSize = 13.sp
 
 private val defaultTextStyle
-    get() = JewelTheme.createDefaultTextStyle(fontSize = defaultTextSize, lineHeight = defaultTextSize * 1.5)
+    get() =
+        JewelTheme.createDefaultTextStyle(
+            fontSize = defaultTextSize,
+            lineHeight = defaultTextSize * Typography.DefaultLineHeightMultiplier,
+        )
 
 private val defaultEditorTextStyle
-    get() = JewelTheme.createEditorTextStyle(fontSize = defaultTextSize, lineHeight = defaultTextSize * 1.2)
+    get() =
+        JewelTheme.createEditorTextStyle(
+            fontSize = defaultTextSize,
+            lineHeight = defaultTextSize * Typography.EditorLineHeightMultiplier,
+        )
 
 private val inlineCodeBackgroundColorLight = Color(red = 212, green = 222, blue = 231, alpha = 255 / 4)
 private val inlineCodeBackgroundColorDark = Color(red = 212, green = 222, blue = 231, alpha = 25)

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -424,6 +424,8 @@ private fun MarkdownExample(project: Project) {
                 |```kotlin
                 |fun hello() = "World"
                 |```
+                |
+                |    Indented code here!
                 """
                     .trimMargin(),
                 Modifier.fillMaxWidth()

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Typography.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Typography.kt
@@ -66,8 +66,11 @@ public object Typography {
      *     lineHeight = newFontSize * Typography.DefaultLineHeightMultiplier,
      * )
      * ```
+     *
+     * You should use [TextStyle.copyWithSize] to create copies of a [TextStyle] with a changed font size, as that
+     * function will automatically apply the correct line height, too.
      */
-    public const val EditorLineHeightMultiplier: Float = 1.2f
+    public const val EditorLineHeightMultiplier: Float = 1.5f
 
     /** The text style to use for h0 titles. Derived from [JewelTheme.defaultTextStyle]. */
     @Composable


### PR DESCRIPTION
This allows implementers of custom renderers to pass in a modifier to the default renderer. This is particularly convenient when the customization solely consists in aspects expressible by a modifier.

Also in this, we fix the Markdown code blocks not looking disabled when the rest of the rendered Markdown does (JEWEL-465), and tweaks the default editor text style line height to better match the IDE's.

![Screen Recording 2025-03-16 at 19 44 25](https://github.com/user-attachments/assets/05b8283f-2571-4d74-bcbb-e73787aea698)
