### PR TITLE
[JEWEL] Fix log paths in run configs

### DIFF
--- a/platform/jewel/.idea/runConfigurations/IDE_sample.xml
+++ b/platform/jewel/.idea/runConfigurations/IDE_sample.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="IDE sample" type="GradleRunConfiguration" factoryName="Gradle" show_console_on_std_err="true" show_console_on_std_out="true">
-    <log_file alias="IDE Logs" path="$PROJECT_DIR$/samples/ide-plugin/build/idea-sandbox/IC-2024.2/log/idea.log" show_all="true" />
+    <log_file alias="IDE Logs" path="$PROJECT_DIR$/build/idea-sandbox/*/log/idea.log" show_all="true" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$/samples/ide-plugin" />

--- a/platform/jewel/.idea/runConfigurations/Run_checks.xml
+++ b/platform/jewel/.idea/runConfigurations/Run_checks.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run checks" type="GradleRunConfiguration" factoryName="Gradle" folderName="Checks">
+    <log_file alias="IDE Logs" path="$PROJECT_DIR$/build/idea-sandbox/*/log/idea.log" show_all="true" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />


### PR DESCRIPTION
This commit updates the log paths in run configs to be independent of the target IJP version. This way when you run the IDE sample, the logs will show up in the host IDE regardless of the target IJ version used.