### PR TITLE
[PY-77792] Fix `No Conda environment selected` error

### DIFF
--- a/python/src/com/jetbrains/python/sdk/add/v2/conda/CondaExistingEnvironmentSelector.kt
+++ b/python/src/com/jetbrains/python/sdk/add/v2/conda/CondaExistingEnvironmentSelector.kt
@@ -62,6 +62,7 @@ internal class CondaExistingEnvironmentSelector(model: PythonAddInterpreterModel
                              scope = model.scope, uiContext = model.uiContext)
 
           .validationRequestor(validationRequestor and WHEN_PROPERTY_CHANGED(state.condaExecutable))
+          .validationRequestor(validationRequestor and WHEN_PROPERTY_CHANGED(state.selectedCondaEnv))
           .validationOnInput {
             return@validationOnInput if (it.isVisible && it.selectedItem == null) ValidationInfo(message("python.sdk.conda.no.env.selected.error")) else null
           }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/PY-77792/No-Conda-enviroment-selected

Tried to get the input validation to re-run when the selection changes.  Not familiar with kotlin but this change worked when I tested locally.

When I stepped through with the debugger the issue seemed to be that the input validation would run right after the conda exe was set so the selection was still null but after the `conda env list` was run in the background to populate the selection, changing what's selected didn't dismiss the error.