### PR TITLE
IDEA-369696 Fix update DaemonJvmCriteria with invalid or undefined ProjectSDK

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleDaemonJvmHelper.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleDaemonJvmHelper.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.UserDataHolderBase
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.text.StringUtil
+import com.intellij.util.SystemProperties
 import org.gradle.internal.buildconfiguration.DaemonJvmPropertiesConfigurator
 import org.gradle.util.GradleVersion
 import org.jetbrains.annotations.ApiStatus
@@ -73,10 +74,10 @@ object GradleDaemonJvmHelper {
   }
 
   @JvmStatic
-  fun getGradleJvmForUpdateDaemonJvmTask(id: ExternalSystemTaskId): String? {
-    val project = id.findProject() ?: return null
-    val projectRootManager = ProjectRootManager.getInstance(project)
-    return projectRootManager.projectSdk?.homePath
+  fun getGradleJvmForUpdateDaemonJvmTask(id: ExternalSystemTaskId): String {
+    return id.findProject()?.let { project ->
+      ProjectRootManager.getInstance(project).projectSdk?.homePath
+    } ?: SystemProperties.getJavaHome()
   }
 
   @JvmStatic

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleDaemonJvmCriteriaTest.kt
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/importing/GradleDaemonJvmCriteriaTest.kt
@@ -1,6 +1,9 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package org.jetbrains.plugins.gradle.importing
 
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.testFramework.VfsTestUtil
 import org.gradle.internal.jvm.inspection.JvmVendor.KnownJvmVendor.JETBRAINS
 import org.jetbrains.plugins.gradle.properties.GradleDaemonJvmPropertiesFile
 import org.jetbrains.plugins.gradle.service.execution.GradleDaemonJvmCriteria
@@ -18,6 +21,31 @@ class GradleDaemonJvmCriteriaTest : GradleImportingTestCase() {
       it.withFoojayPlugin()
     })
     importProject()
+
+    val criteria = GradleDaemonJvmCriteria("17", JETBRAINS.asJvmVendor())
+    GradleDaemonJvmHelper.updateProjectDaemonJvmCriteria(project, projectRoot.path, criteria)
+      .get(1, TimeUnit.MINUTES)
+
+    val properties = GradleDaemonJvmPropertiesFile.getProperties(projectRoot.toNioPath())
+    assertNotNull(properties)
+    assertEquals(criteria, properties!!.criteria)
+  }
+
+  @Test
+  @TargetVersions("8.8+")
+  fun testUpdatingDaemonJvmCriteriaWithAlreadyExistingInvalidProperties() {
+    createSettingsFile(settingsScript {
+      it.withFoojayPlugin()
+    })
+    importProject()
+    VfsTestUtil.createFile(projectRoot, "gradle/gradle-daemon-jvm.properties", """
+      toolchainVersion=17
+      toolchainVendor=invalid
+    """.trimIndent()
+    )
+    ExternalSystemApiUtil.executeProjectChangeAction(project) {
+      ProjectRootManager.getInstance(project).projectSdk = null
+    }
 
     val criteria = GradleDaemonJvmCriteria("17", JETBRAINS.asJvmVendor())
     GradleDaemonJvmHelper.updateProjectDaemonJvmCriteria(project, projectRoot.path, criteria)


### PR DESCRIPTION
### Context
The `Modify Daemon JVM` option end up invoking the `updateDaemonJvm` task to update `gradle-daemon-jvm.properties` file since with `8.13` that file also contain download URLs for the toolchains being resolved based on the applied project [resolver toolchain plugins](https://docs.gradle.org/current/userguide/toolchain_plugins.html#toolchain_plugins), meaning that cannot be modified directly by the IDE and must be delegated to Gradle. To archive running a Gradle task bypassing a potential JVM criteria not matching with any locally installed toolchain the `Project SDK` is used instead. However, in your case the `project-jdk-name` under `.idea/misc.xml`  isn't defined or points to invalid `jdk.table` entry. 

For sure the `Project SDK` might be updated after a successful sync to point to the Daemon used `java.home` to run the sync (this was already raised on [IDEA-367680](https://youtrack.jetbrains.com/issue/IDEA-367680/The-module-SDK-isnt-always-specified) after discussing [#2947](https://github.com/JetBrains/intellij-community/pull/2947) draft PR). However, there's no guarantee that users don't manually modified it or  end up in this case given not having previously synced project (i.e. import project). For this reason we should consider fallback to `bundled JBR` in those cases using `SystemProperties.getJavaHome()`. All of that is possible given that toolchain version used by `updateDaemonJvm` is less important given that will be used just to evaluate project Gradle settings but not actually compile anything.