### PR TITLE
Teach GradleAutoImportAware about .gradle/config.properties

### DIFF
--- a/build/dependencies/dependencies.properties
+++ b/build/dependencies/dependencies.properties
@@ -7,6 +7,6 @@ jdkBuild=17.0.14b1376.4
 launcherBuild=252.1165
 nsisBuild=1
 restarterBuild=243.6005
-runtimeBuild=21.0.6b924.19
+runtimeBuild=21.0.6b929.24
 snapDockerImage=registry.jetbrains.team/p/ij/docker-hub/jetbrains/snapcraft@sha256:0059496b7a941e27937bc523621a336bddc1327de8dcd03f6b0bd0b57892ce43
 toolboxBuild=2.6.0.38586

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleAutoImportAware.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/GradleAutoImportAware.java
@@ -126,6 +126,7 @@ public class GradleAutoImportAware implements ExternalSystemAutoImportAware {
       files.add(new File(gradleUserHome, "gradle.properties"));
       files.add(new File(gradleUserHome, "init.gradle"));
       files.add(new File(externalProjectPath, "gradle.properties"));
+      files.add(new File(new File(externalProjectPath, ".gradle"), "config.properties"));
       return files;
     }
   }


### PR DESCRIPTION
Handle it similarly to other Gradle-related properties files, in case the user is using the #GRADLE_LOCAL_JAVA_HOME macro.