### PR TITLE
Android studio wrap floaty elephant

### DIFF
--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/autoimport/AutoImportProjectTracker.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/autoimport/AutoImportProjectTracker.kt
@@ -193,9 +193,8 @@ class AutoImportProjectTracker(
   private fun updateProjectNotification() {
     LOG.debug("Notification status update")
 
-    val isDisabledAutoReload = isDisabledAutoReload()
     for ((projectId, data) in projectDataMap) {
-      when (isDisabledAutoReload || data.isUpToDate()) {
+      when (data.isUpToDate()) {
         true -> notificationAware.notificationExpire(projectId)
         else -> notificationAware.notificationNotify(data.projectAware)
       }

--- a/platform/external-system-impl/src/com/intellij/openapi/externalSystem/autoimport/ProjectRefreshFloatingProvider.kt
+++ b/platform/external-system-impl/src/com/intellij/openapi/externalSystem/autoimport/ProjectRefreshFloatingProvider.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.editor.toolbar.floating.AbstractFloatingToolbarProvider
 import com.intellij.openapi.editor.toolbar.floating.FloatingToolbarComponent
 import com.intellij.openapi.editor.toolbar.floating.FloatingToolbarProvider
+import com.intellij.openapi.editor.toolbar.floating.FloatingToolbarProvider.Companion.EP_NAME
 import com.intellij.openapi.editor.toolbar.floating.isInsideMainEditor
 import com.intellij.openapi.project.Project
 import com.intellij.util.containers.DisposableWrapperList
@@ -15,7 +16,7 @@ import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.ApiStatus
 
 @ApiStatus.Internal
-internal class ProjectRefreshFloatingProvider : AbstractFloatingToolbarProvider(ACTION_GROUP) {
+class ProjectRefreshFloatingProvider : AbstractFloatingToolbarProvider(ACTION_GROUP) {
   override val autoHideable = false
 
   private val toolbarComponents = DisposableWrapperList<Pair<Project, FloatingToolbarComponent>>()
@@ -24,7 +25,7 @@ internal class ProjectRefreshFloatingProvider : AbstractFloatingToolbarProvider(
     return isInsideMainEditor(dataContext)
   }
 
-  private fun updateToolbarComponents(project: Project) {
+  fun updateToolbarComponents(project: Project) {
     // init service outside of EDT if not initialized yet
     ExternalSystemProjectNotificationAware.getInstance(project)
 
@@ -55,8 +56,8 @@ internal class ProjectRefreshFloatingProvider : AbstractFloatingToolbarProvider(
 
   internal class Listener : ExternalSystemProjectNotificationAware.Listener {
     override fun onNotificationChanged(project: Project) {
-      FloatingToolbarProvider.getProvider<ProjectRefreshFloatingProvider>()
-        .updateToolbarComponents(project)
+      EP_NAME.findExtension(ProjectRefreshFloatingProvider::class.java)
+        ?.updateToolbarComponents(project)
     }
   }
 


### PR DESCRIPTION
I think these are the minimal changes that allow Android Studio to wrap the ProjectRefresh floating toolbar to disable it for Android Gradle projects (but continue to allow it for non-Android projects), and to display its own UI (an editor notification banner) for out-of-date Android Gradle projects