### PR TITLE
[IDEA-367321] Find new custom handlers on recursive dependency discovery

### DIFF
--- a/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/OrderEnumeratorBase.java
+++ b/platform/projectModel-impl/src/com/intellij/openapi/roots/impl/OrderEnumeratorBase.java
@@ -302,7 +302,7 @@ public abstract class OrderEnumeratorBase extends OrderEnumerator implements Ord
         continue;
       }
       if (action.type == ProcessEntryActionType.RECURSE) {
-        doProcessEntries(getRootModel(action.recurseOnModule), processed, false, customHandlers, processor);
+        doProcessEntries(getRootModel(action.recurseOnModule), processed, false, getCustomHandlers(action.recurseOnModule), processor);
         continue;
       }
       assert action.type == ProcessEntryActionType.PROCESS;

--- a/plugins/gradle/java/testSources/importing/GradleMiscImportingTest.java
+++ b/plugins/gradle/java/testSources/importing/GradleMiscImportingTest.java
@@ -17,9 +17,8 @@ import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.module.StdModuleTypes;
 import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.ModifiableRootModel;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.TestModuleProperties;
+import com.intellij.openapi.roots.*;
+import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.platform.backend.workspace.WorkspaceModel;
 import com.intellij.platform.workspace.jps.entities.ModuleId;
 import com.intellij.pom.java.AcceptedLanguageLevelsSettings;
@@ -443,6 +442,33 @@ public class GradleMiscImportingTest extends GradleJavaImportingTestCase {
     var javaSettings = JavaModuleSettingsKt.getJavaSettings(moduleEntity);
     var automaticModuleName = javaSettings.getManifestAttributes().get(PsiJavaModule.AUTO_MODULE_NAME);
     assertEquals("my.module.name", automaticModuleName);
+  }
+
+  @Test
+  public void testJavaModuleCompileOutputPathFromGradleDependency() throws Exception {
+    createProjectSubFile("src/main/java/A.java");
+    createProjectSubFile("src/main/resources/resource.properties");
+    importProject("apply plugin: 'java'");
+
+    IdeModifiableModelsProvider modelsProvider = ProjectDataManager.getInstance().createModifiableModelsProvider(myProject);
+    var appModule = modelsProvider.newModule(getProjectPath() + "/app.iml", StdModuleTypes.JAVA.getId());
+    ModuleRootModificationUtil.addDependency(appModule, getModule("project.main"));
+    edt(() -> ApplicationManager.getApplication().runWriteAction(modelsProvider::commit));
+
+    assertModules("app", "project", "project.main", "project.test");
+
+    assertNull(ExternalSystemApiUtil.getExternalProjectPath(getModule("app")));
+    assertEquals(getProjectPath(), ExternalSystemApiUtil.getExternalProjectPath(getModule("project")));
+    assertEquals(getProjectPath(), ExternalSystemApiUtil.getExternalProjectPath(getModule("project.main")));
+    assertEquals(getProjectPath(), ExternalSystemApiUtil.getExternalProjectPath(getModule("project.test")));
+
+    String[] outputPathsFromEnumerator = ContainerUtil.map2Array(
+      OrderEnumerator.orderEntries(appModule).recursively().withoutSdk().withoutLibraries().classes().getUrls(),
+      String.class,
+      VfsUtilCore::urlToPath
+    );
+
+    assertUnorderedElementsAreEqual(outputPathsFromEnumerator, path("build/classes/java/main"), path("build/resources/main"));
   }
 
   private static void assertExternalProjectIds(Map<String, ExternalProject> projectMap, String projectId, String... sourceSetModulesIds) {


### PR DESCRIPTION
The `GradleOrderEnumeratorHandler` would not be present in the root module as its not managed by Gradle. When the Gradle dependency is visited, we begin to recursively add its dependencies and pass in the old set of handlers from the original module. This leads to Gradle specific behavior not lighting up and resulting to incomplete classpath.

Fixes this by discovering the new set of handlers before we start recursively adding the dependencies.