### PR TITLE
[JEWEL-796] [JEWEL-645] Fix wrong registry key for TooltipMetrics delay

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTooltip.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTooltip.kt
@@ -17,7 +17,7 @@ internal fun readTooltipStyle(): TooltipStyle {
         metrics =
             TooltipMetrics.defaults(
                 contentPadding = JBUI.CurrentTheme.HelpTooltip.smallTextBorderInsets().toPaddingValues(),
-                showDelay = Registry.intValue("ide.tooltip.initialDelay").milliseconds,
+                showDelay = Registry.intValue("ide.tooltip.initialReshowDelay").milliseconds,
                 cornerSize = CornerSize(JBUI.CurrentTheme.Tooltip.CORNER_RADIUS.dp),
             ),
         colors =

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TooltipStyling.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TooltipStyling.kt
@@ -133,7 +133,7 @@ public class TooltipMetrics(
     public companion object {
         public fun defaults(
             contentPadding: PaddingValues = PaddingValues(vertical = 9.dp, horizontal = 12.dp),
-            showDelay: Duration = 1200.milliseconds,
+            showDelay: Duration = 500.milliseconds, // ide.tooltip.initialReshowDelay
             cornerSize: CornerSize = CornerSize(4.dp),
             borderWidth: Dp = 1.dp,
             shadowSize: Dp = 12.dp,


### PR DESCRIPTION
One of our users noticed an inconsistency with tooltip delays. This PR addresses the first and most immediate to fix one.
With about 3x faster delay, the tooltip feels indeed _snappier_.

Tested in IDE:

![20250331-1508-07 3874485-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/3bb22e98-2676-433c-abb5-1c6eb214ac05)

Tested in Standalone:

![20250331-1511-06 6036174-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e477bf1d-5871-468e-a488-c0188f8b3f1a)

*UPDATE*

*Some context from the original ticket*
> After looking into this, it is clear that the tooltip delay should be set to the value of the ide.tooltip.initialReshowDelay registry key (can we recompose when that changes? Do we use rememberUpdatedState for this?), which defaults to 500 ms. This is what HelpTooltip does at a basic level. The Bridge uses ide.tooltip.initialDelay, which is the wrong value. The same check needs to be done in the standalone style, aligning on 500 ms.

Reference on YouTrack [JEWEL-796](https://youtrack.jetbrains.com/issue/JEWEL-796)