### PR TITLE
[JEWEL-792] Add slot-based API for InlineBanner

### DIFF
--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/dialog/ComponentShowcaseDialog.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/dialog/ComponentShowcaseDialog.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.samples.ideplugin.dialog
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
@@ -24,6 +25,7 @@ import org.jetbrains.jewel.bridge.theme.macOs
 import org.jetbrains.jewel.bridge.toDpSize
 import org.jetbrains.jewel.bridge.toPaddingValues
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.intui.markdown.bridge.ProvideMarkdownStyling
 import org.jetbrains.jewel.samples.showcase.views.ComponentsView
 import org.jetbrains.jewel.samples.showcase.views.ComponentsViewModel
 import org.jetbrains.jewel.ui.component.styling.IconButtonMetrics
@@ -43,7 +45,6 @@ internal class ComponentShowcaseDialog(project: Project) : DialogWrapper(project
 
     override fun createSouthPanel(): JComponent? = null
 
-    @OptIn(ExperimentalLayoutApi::class)
     override fun createCenterPanel(): JComponent {
         val viewModel =
             ComponentsViewModel(
@@ -54,31 +55,41 @@ internal class ComponentShowcaseDialog(project: Project) : DialogWrapper(project
         val dialogPanel = JewelComposePanel {
             val iconButtonMetrics = JewelTheme.iconButtonStyle.metrics
             val uiSettings = UISettings.Companion.getInstance()
-            ComponentsView(
-                viewModel = viewModel,
-                toolbarButtonMetrics =
-                    remember(uiSettings.compactMode, ResizeStripeManager.isShowNames()) {
-                        iconButtonMetrics.tweak(
-                            minSize = Toolbar.stripeToolbarButtonSize().toDpSize(),
-                            // See com.intellij.openapi.wm.impl.SquareStripeButtonLook.getButtonArc
-                            cornerSize =
-                                retrieveArcAsCornerSizeOrDefault(
-                                    "Button.ToolWindow.arc",
-                                    CornerSize(if (uiSettings.compactMode) 4.dp else 6.dp),
-                                ),
-                            padding =
-                                Toolbar.stripeToolbarButtonIconPadding(
-                                        uiSettings.compactMode, // compactMode
-                                        ResizeStripeManager.isShowNames(), // showNames
-                                    )
-                                    .toPaddingValues(),
-                            borderWidth = 0.dp,
-                        )
-                    },
-            )
+            ProvideMarkdownStyling { RootLayout(viewModel, uiSettings, iconButtonMetrics) }
         }
         dialogPanel.preferredSize = Dimension(800, 600)
         return dialogPanel
+    }
+
+    @OptIn(ExperimentalLayoutApi::class)
+    @Composable
+    private fun RootLayout(
+        viewModel: ComponentsViewModel,
+        uiSettings: UISettings,
+        iconButtonMetrics: IconButtonMetrics,
+    ) {
+        ComponentsView(
+            viewModel = viewModel,
+            toolbarButtonMetrics =
+                remember(uiSettings.compactMode, ResizeStripeManager.isShowNames()) {
+                    iconButtonMetrics.tweak(
+                        minSize = Toolbar.stripeToolbarButtonSize().toDpSize(),
+                        // See com.intellij.openapi.wm.impl.SquareStripeButtonLook.getButtonArc
+                        cornerSize =
+                            retrieveArcAsCornerSizeOrDefault(
+                                "Button.ToolWindow.arc",
+                                CornerSize(if (uiSettings.compactMode) 4.dp else 6.dp),
+                            ),
+                        padding =
+                            Toolbar.stripeToolbarButtonIconPadding(
+                                    uiSettings.compactMode, // compactMode
+                                    ResizeStripeManager.isShowNames(), // showNames
+                                )
+                                .toPaddingValues(),
+                        borderWidth = 0.dp,
+                    )
+                },
+        )
     }
 
     private fun IconButtonMetrics.tweak(

--- a/platform/jewel/samples/showcase/build.gradle.kts
+++ b/platform/jewel/samples/showcase/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 dependencies {
     implementation(project(":foundation"))
     implementation(project(":ui"))
+    implementation(projects.markdown.core)
     testImplementation(compose.desktop.uiTestJUnit4)
     testImplementation(compose.desktop.currentOs) { exclude(group = "org.jetbrains.compose.material") }
 }

--- a/platform/jewel/samples/showcase/intellij.platform.jewel.samples.showcase.iml
+++ b/platform/jewel/samples/showcase/intellij.platform.jewel.samples.showcase.iml
@@ -36,6 +36,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="intellij.platform.jewel.ui" />
     <orderEntry type="module" module-name="intellij.platform.jewel.foundation" />
+    <orderEntry type="module" module-name="intellij.platform.jewel.markdown.core" />
     <orderEntry type="module" module-name="intellij.libraries.skiko" />
     <orderEntry type="module" module-name="intellij.libraries.compose.foundation.desktop" />
   </component>

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.CheckboxRow
 import org.jetbrains.jewel.ui.component.ErrorDefaultBanner
 import org.jetbrains.jewel.ui.component.ErrorInlineBanner
 import org.jetbrains.jewel.ui.component.GroupHeader
@@ -108,16 +109,30 @@ public fun Banners() {
 
                 GroupHeader("Inline banner")
 
+                var showTitle by remember { mutableStateOf(false) }
+                var optionalTitle: String? by remember { mutableStateOf(null) }
+                CheckboxRow(
+                    checked = showTitle,
+                    onCheckedChange = {
+                        showTitle = it
+                        optionalTitle = if (showTitle) "I'm an optional title" + LONG_IPSUM else null
+                    },
+                ) {
+                    Text("Show optional title")
+                }
+
                 InformationInlineBanner(
                     icon = null,
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                    title = optionalTitle
                 )
 
                 InformationInlineBanner(
                     icon = null,
                     style = JewelTheme.inlineBannerStyle.information,
                     text = LONG_IPSUM,
+                    title = optionalTitle,
                     actionIcons = {
                         IconButton(onClick = { clickLabel = "Info inline no icon Action Icon clicked" }) {
                             Icon(AllIconsKeys.General.Close, "Close button")
@@ -129,6 +144,7 @@ public fun Banners() {
                     icon = null,
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                    title = optionalTitle,
                     actions = {
                         Link("Action A", onClick = { clickLabel = "Info inline no icon Action A clicked" })
                         Link("Action B", onClick = { clickLabel = "Info inline no icon Action B clicked" })
@@ -139,6 +155,7 @@ public fun Banners() {
                     icon = null,
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                    title = optionalTitle,
                     actionIcons = {
                         IconButton(onClick = { clickLabel = "Info inline no icon Action Icon clicked" }) {
                             Icon(AllIconsKeys.General.Close, "Close button")
@@ -153,10 +170,12 @@ public fun Banners() {
                 InformationInlineBanner(
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                    title = optionalTitle,
                 )
                 ErrorInlineBanner(
                     style = JewelTheme.inlineBannerStyle.error,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                    title = optionalTitle,
                     actionIcons = {
                         IconButton(onClick = { clickLabel = "Error Inline Action Icon clicked" }) {
                             Icon(AllIconsKeys.General.Close, "Close button")
@@ -166,6 +185,7 @@ public fun Banners() {
                 InformationInlineBanner(
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                    title = optionalTitle,
                     actions = {
                         Link("Action A", onClick = { clickLabel = "Information Inline Action A clicked" })
                         Link("Action B", onClick = { clickLabel = "Information Inline Action B clicked" })
@@ -174,6 +194,7 @@ public fun Banners() {
                 SuccessInlineBanner(
                     style = JewelTheme.inlineBannerStyle.success,
                     text = LONG_IPSUM,
+                    title = optionalTitle,
                     actions = {
                         Link("Action A", onClick = { clickLabel = "Success Inline Action A clicked" })
                         Link("Action B", onClick = { clickLabel = "Success Inline Action B clicked" })
@@ -190,6 +211,7 @@ public fun Banners() {
                 WarningInlineBanner(
                     style = JewelTheme.inlineBannerStyle.warning,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                    title = optionalTitle,
                     actions = { Link("Action A", onClick = { clickLabel = "Warning Inline Action A clicked" }) },
                     actionIcons = {
                         IconButton(onClick = { clickLabel = "Error Close Icon clicked" }) {

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
@@ -125,7 +125,7 @@ public fun Banners() {
                     icon = null,
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
-                    title = optionalTitle
+                    title = optionalTitle,
                 )
 
                 InformationInlineBanner(

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
@@ -115,7 +115,7 @@ public fun Banners() {
                     checked = showTitle,
                     onCheckedChange = {
                         showTitle = it
-                        optionalTitle = if (showTitle) "I'm an optional title" + LONG_IPSUM else null
+                        optionalTitle = if (showTitle) "I'm an optional title " + LONG_IPSUM else null
                     },
                 ) {
                     Text("Show optional title")

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.markdown.Markdown
 import org.jetbrains.jewel.ui.component.CheckboxRow
 import org.jetbrains.jewel.ui.component.ErrorDefaultBanner
 import org.jetbrains.jewel.ui.component.ErrorInlineBanner
@@ -131,14 +132,15 @@ public fun Banners() {
                 InformationInlineBanner(
                     icon = null,
                     style = JewelTheme.inlineBannerStyle.information,
-                    text = LONG_IPSUM,
                     title = optionalTitle,
                     actionIcons = {
                         IconButton(onClick = { clickLabel = "Info inline no icon Action Icon clicked" }) {
                             Icon(AllIconsKeys.General.Close, "Close button")
                         }
                     },
-                )
+                ) {
+                    Markdown("This is a **Markdown** banner — [watch](https://youtu.be/dQw4w9WgXcQ) `this` out ;)")
+                }
 
                 InformationInlineBanner(
                     icon = null,

--- a/platform/jewel/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
+++ b/platform/jewel/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
@@ -14,6 +14,7 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.decodeToSvgPainter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.util.JewelLogger
+import org.jetbrains.jewel.intui.markdown.standalone.ProvideMarkdownStyling
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.intui.standalone.theme.createDefaultTextStyle
 import org.jetbrains.jewel.intui.standalone.theme.createEditorTextStyle
@@ -77,7 +78,7 @@ public fun main() {
                 },
                 content = {
                     TitleBarView()
-                    currentView.content()
+                    ProvideMarkdownStyling { currentView.content() }
                 },
             )
         }

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -461,10 +461,10 @@ public final class org/jetbrains/jewel/ui/component/IconKt {
 }
 
 public final class org/jetbrains/jewel/ui/component/InlineBannerKt {
-	public static final fun ErrorInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
-	public static final fun InformationInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
-	public static final fun SuccessInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
-	public static final fun WarningInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ErrorInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun InformationInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SuccessInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun WarningInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/InputFieldState : org/jetbrains/jewel/foundation/state/FocusableComponentState {

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -307,11 +307,19 @@ public final class org/jetbrains/jewel/ui/component/ComposableSingletons$InlineB
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public static field lambda-6 Lkotlin/jvm/functions/Function2;
+	public static field lambda-7 Lkotlin/jvm/functions/Function2;
+	public static field lambda-8 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$ui ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$ui ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$ui ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-4$ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-6$ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-7$ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-8$ui ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class org/jetbrains/jewel/ui/component/ComposableSingletons$MenuKt {
@@ -461,9 +469,13 @@ public final class org/jetbrains/jewel/ui/component/IconKt {
 }
 
 public final class org/jetbrains/jewel/ui/component/InlineBannerKt {
+	public static final fun ErrorInlineBanner (Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ErrorInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun InformationInlineBanner (Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun InformationInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SuccessInlineBanner (Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun SuccessInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun WarningInlineBanner (Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun WarningInlineBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/InlineBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
@@ -41,43 +41,41 @@ import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.theme.inlineBannerStyle
 
 /**
- * Displays an informational inline banner providing subtle, non-intrusive context or feedback within a particular UI
- * section.
- *
- * The banner uses the inline "information" theme by default, featuring an optional icon, a context message, and
- * optional actions.
- *
- * @param text the primary content of the banner, briefly describing the information it conveys.
- * @param title an optional title, rendered in bold bold font, above the text
- * @param modifier a [Modifier] to customize the layout and appearance of the banner.
- * @param icon a composable representation of an optional 16x16 dp "information" icon displayed to the left of the
- *   banner. Pass `null` to hide the icon. By default, it shows the "information" icon.
- * @param actions a lambda defining optional interactive components (e.g., links, buttons) placed inside the banner for
- *   inline actions like "View More" or "Dismiss."
- * @param actionIcons a lambda defining composable icons representing secondary or quick actions, such as closing the
- *   banner. Icons are placed on the right side of the banner.
- * @param style a [InlineBannerStyle] that determines the visual styling of the banner, using the default “information”
- *   theme. This can be overridden for customization.
- * @param textStyle typography settings applied to the banner text, based on the default Jewel theme.
+ * Displays an informational inline banner providing subtle, non-intrusive context or feedback.
  *
  * Use this banner to provide relevant, non-critical information in a compact layout.
  *
- * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/balloon.html)
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
  *
  * **Swing equivalent:**
- * [`Notifications`](https://github.com/JetBrains/intellij-community/blob/idea/243.23654.153/platform/ide-core/src/com/intellij/notification/Notifications.java)
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
  *
  * **Usage example:**
  * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
  *
  * ```kotlin
  * InformationInlineBanner(
- *     text = "Project indexed successfully.",
+ *     text = "Project index up to date.",
  *     actions = {
  *         Link("View Logs", onClick = { /* handle click */ })
  *     }
  * )
  * ```
+ *
+ * @param text The primary content of the banner, briefly describing the information it conveys.
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [text].
+ * @param icon Slot for an optional icon displayed on the left of the [text] or [title]. If null, there is no icon. By
+ *   default, it is the [AllIconsKeys.General.BalloonInformation] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [text].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [text] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.information`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.information].
+ * @param textStyle The base [TextStyle] used by the [text] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
  */
 @Composable
 public fun InformationInlineBanner(
@@ -90,8 +88,7 @@ public fun InformationInlineBanner(
     style: InlineBannerStyle = JewelTheme.inlineBannerStyle.information,
     textStyle: TextStyle = JewelTheme.defaultTextStyle,
 ) {
-    InlineBannerImpl(
-        text = text,
+    InformationInlineBanner(
         title = title,
         style = style,
         textStyle = textStyle,
@@ -99,61 +96,119 @@ public fun InformationInlineBanner(
         actions = actions,
         modifier = modifier,
         actionIcons = actionIcons,
+    ) {
+        Text(text = text, style = textStyle)
+    }
+}
+
+/**
+ * Displays an informational inline banner providing subtle, non-intrusive context or feedback.
+ *
+ * Use this banner to provide relevant, non-critical information in a compact layout.
+ *
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
+ *
+ * **Swing equivalent:**
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
+ *
+ * **Usage example:**
+ * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
+ *
+ * ```kotlin
+ * InformationInlineBanner(
+ *     actions = {
+ *         Link("View Logs", onClick = { /* handle click */ })
+ *     }
+ * ) {
+ *     Markdown("Project index **up to date**.")
+ * }
+ * ```
+ *
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [content].
+ * @param icon Slot for an optional icon displayed on the left of the [content] or [title]. If null, there is no icon.
+ *   By default, it is the [AllIconsKeys.General.BalloonInformation] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [content].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [content] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.information`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.information].
+ * @param textStyle The base [TextStyle] used by the [content] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
+ * @param content The primary content of the banner, briefly describing the information it conveys.
+ */
+@Composable
+public fun InformationInlineBanner(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.General.BalloonInformation, null) },
+    actions: (@Composable FlowRowScope.() -> Unit)? = null,
+    actionIcons: (@Composable RowScope.() -> Unit)? = null,
+    style: InlineBannerStyle = JewelTheme.inlineBannerStyle.information,
+    textStyle: TextStyle = JewelTheme.defaultTextStyle,
+    content: @Composable () -> Unit,
+) {
+    InlineBannerImpl(
+        title = title,
+        style = style,
+        textStyle = textStyle,
+        icon = icon,
+        actions = actions,
+        modifier = modifier,
+        actionIcons = actionIcons,
+        content = content,
     )
 }
 
 /**
- * Displays an inline banner to confirm successful actions or state completions in compact UI sections without
- * interrupting the workflow.
+ * Displays a success inline banner providing information about the successful completion of an operation.
  *
- * The banner uses the inline "success" theme by default, featuring an optional icon, a success message, and optional
- * user actions.
- *
- * @param text the main content of the banner, succinctly describing the successful operation or state.
- * @param title an optional title, rendered in bold bold font, above the text
- * @param modifier a [Modifier] to customize the layout, padding, or size of the banner.
- * @param icon a composable for an optional 16x16 dp "success" icon displayed on the left side of the banner. The
- *   success icon is shown by default. Pass `null` to hide the icon.
- * @param actions a lambda defining optional interactive components, such as links or buttons, placed within the banner
- *   for additional user operations.
- * @param actionIcons a lambda defining composable icons for quick or secondary operations, such as dismissing the
- *   banner, placed on the banner's right side.
- * @param style a [InlineBannerStyle] defining the visual appearance of the banner. It uses the default "success" theme,
- *   but this can be customized if needed.
- * @param textStyle the style of the banner text, controlled by the Jewel theme's typography.
- *
- * Use this banner to provide visual feedback for completed actions.
- *
- * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/balloon.html)
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
  *
  * **Swing equivalent:**
- * [`Notifications`](https://github.com/JetBrains/intellij-community/blob/idea/243.23654.153/platform/ide-core/src/com/intellij/notification/Notifications.java)
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
  *
  * **Usage example:**
  * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
  *
  * ```kotlin
  * SuccessInlineBanner(
- *     text = "Build completed successfully.",
+ *     text = "Project indexed successfully.",
  *     actions = {
- *         Link("Details", onClick = { /* handle link */ })
+ *         Link("View Logs", onClick = { /* handle click */ })
  *     }
  * )
  * ```
+ *
+ * @param text The primary content of the banner, briefly describing the information it conveys.
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [text].
+ * @param icon Slot for an optional icon displayed on the left of the [text] or [title]. If null, there is no icon. By
+ *   default, it is the [AllIconsKeys.Status.Success] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [text].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [text] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.success`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.success].
+ * @param textStyle The base [TextStyle] used by the [text] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
  */
 @Composable
 public fun SuccessInlineBanner(
     text: String,
     modifier: Modifier = Modifier,
     title: String? = null,
-    icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.Debugger.ThreadStates.Idle, null) },
+    icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.Status.Success, null) },
     actions: (@Composable FlowRowScope.() -> Unit)? = null,
     actionIcons: (@Composable RowScope.() -> Unit)? = null,
     style: InlineBannerStyle = JewelTheme.inlineBannerStyle.success,
     textStyle: TextStyle = JewelTheme.defaultTextStyle,
 ) {
-    InlineBannerImpl(
-        text = text,
+    SuccessInlineBanner(
         title = title,
         style = style,
         textStyle = textStyle,
@@ -161,46 +216,108 @@ public fun SuccessInlineBanner(
         actions = actions,
         modifier = modifier,
         actionIcons = actionIcons,
+    ) {
+        Text(text = text, style = textStyle)
+    }
+}
+
+/**
+ * Displays a success inline banner providing information about the successful completion of an operation.
+ *
+ * Use this banner to provide relevant, non-critical information in a compact layout.
+ *
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
+ *
+ * **Swing equivalent:**
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
+ *
+ * **Usage example:**
+ * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
+ *
+ * ```kotlin
+ * SuccessInlineBanner(
+ *     actions = {
+ *         Link("View Logs", onClick = { /* handle click */ })
+ *     }
+ * ) {
+ *     Markdown("Project indexed **successfully**.")
+ * }
+ * ```
+ *
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [content].
+ * @param icon Slot for an optional icon displayed on the left of the [content] or [title]. If null, there is no icon.
+ *   By default, it is the [AllIconsKeys.Status.Success] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [content].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [content] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.success`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.success].
+ * @param textStyle The base [TextStyle] used by the [content] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
+ * @param content The primary content of the banner, briefly describing the information it conveys.
+ */
+@Composable
+public fun SuccessInlineBanner(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.Status.Success, null) },
+    actions: (@Composable FlowRowScope.() -> Unit)? = null,
+    actionIcons: (@Composable RowScope.() -> Unit)? = null,
+    style: InlineBannerStyle = JewelTheme.inlineBannerStyle.success,
+    textStyle: TextStyle = JewelTheme.defaultTextStyle,
+    content: @Composable () -> Unit,
+) {
+    InlineBannerImpl(
+        title = title,
+        style = style,
+        textStyle = textStyle,
+        icon = icon,
+        actions = actions,
+        modifier = modifier,
+        actionIcons = actionIcons,
+        content = content,
     )
 }
 
 /**
  * Shows a warning inline banner to draw attention to non-critical issues that require user awareness or resolution.
  *
- * The banner applies the inline "warning" theme by default, including an optional icon, a warning message, and
- * additional actions if provided.
+ * Use this banner to provide relevant, non-critical information in a compact layout.
  *
- * @param text the main content of the banner, describing the warning or potential issue.
- * @param title an optional title, rendered in bold bold font, above the text
- * @param modifier a [Modifier] for applying layout modifications to the banner, such as padding or size changes.
- * @param icon a composable element for an optional 16x16 dp "warning" icon displayed at the banner's left edge. The
- *   warning icon is shown by default. Set `null` to omit the icon.
- * @param actions a lambda defining interactive elements such as links or buttons, which provide additional user
- *   operations related to the warning.
- * @param actionIcons a lambda defining composable icons for secondary operations, like dismissing the banner, placed on
- *   the right side of the banner.
- * @param style an [InlineBannerStyle] defining the warning theme of the banner. The default warning theme is applied by
- *   default, but this can be customized.
- * @param textStyle typography used for the text content of the banner, inheriting from the Jewel theme.
- *
- * Use this banner for unobstructive warnings requiring user awareness.
- *
- * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/balloon.html)
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
  *
  * **Swing equivalent:**
- * [`Notifications`](https://github.com/JetBrains/intellij-community/blob/idea/243.23654.153/platform/ide-core/src/com/intellij/notification/Notifications.java)
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
  *
  * **Usage example:**
  * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
  *
  * ```kotlin
  * WarningInlineBanner(
- *     text = "This feature is deprecated and will be removed in the next version.",
+ *     text = "Project indexed with warnings.",
  *     actions = {
- *         Link("Learn More", onClick = { /* handle action */ })
+ *         Link("View Logs", onClick = { /* handle click */ })
  *     }
  * )
  * ```
+ *
+ * @param text The primary content of the banner, briefly describing the information it conveys.
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [text].
+ * @param icon Slot for an optional icon displayed on the left of the [text] or [title]. If null, there is no icon. By
+ *   default, it is the [AllIconsKeys.General.BalloonWarning] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [text].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [text] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.warning`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.warning].
+ * @param textStyle The base [TextStyle] used by the [text] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
  */
 @Composable
 public fun WarningInlineBanner(
@@ -213,8 +330,7 @@ public fun WarningInlineBanner(
     style: InlineBannerStyle = JewelTheme.inlineBannerStyle.warning,
     textStyle: TextStyle = JewelTheme.defaultTextStyle,
 ) {
-    InlineBannerImpl(
-        text = text,
+    WarningInlineBanner(
         title = title,
         style = style,
         textStyle = textStyle,
@@ -222,45 +338,108 @@ public fun WarningInlineBanner(
         actions = actions,
         modifier = modifier,
         actionIcons = actionIcons,
+    ) {
+        Text(text = text, style = textStyle)
+    }
+}
+
+/**
+ * Shows a warning inline banner to draw attention to non-critical issues that require user awareness or resolution.
+ *
+ * Use this banner to provide relevant, non-critical information in a compact layout.
+ *
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
+ *
+ * **Swing equivalent:**
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
+ *
+ * **Usage example:**
+ * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
+ *
+ * ```kotlin
+ * WarningInlineBanner(
+ *     actions = {
+ *         Link("View Logs", onClick = { /* handle click */ })
+ *     }
+ * ) {
+ *     Markdown("Project indexed **with warnings**.")
+ * }
+ * ```
+ *
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [content].
+ * @param icon Slot for an optional icon displayed on the left of the [content] or [title]. If null, there is no icon.
+ *   By default, it is the [AllIconsKeys.General.BalloonWarning] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [content].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [content] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.warning`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.warning].
+ * @param textStyle The base [TextStyle] used by the [content] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
+ * @param content The primary content of the banner, briefly describing the information it conveys.
+ */
+@Composable
+public fun WarningInlineBanner(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.General.BalloonWarning, null) },
+    actions: (@Composable FlowRowScope.() -> Unit)? = null,
+    actionIcons: (@Composable RowScope.() -> Unit)? = null,
+    style: InlineBannerStyle = JewelTheme.inlineBannerStyle.warning,
+    textStyle: TextStyle = JewelTheme.defaultTextStyle,
+    content: @Composable () -> Unit,
+) {
+    InlineBannerImpl(
+        title = title,
+        style = style,
+        textStyle = textStyle,
+        icon = icon,
+        actions = actions,
+        modifier = modifier,
+        actionIcons = actionIcons,
+        content = content,
     )
 }
 
 /**
- * Displays an inline banner highlighting critical errors or failures that require immediate user attention and action.
+ * Shows an error inline banner to draw attention to non-critical issues that require user awareness or resolution.
  *
- * This banner uses the inline "error" theme by default, featuring a message describing the error, and optional icons
- * and actions to assist the user in resolving it.
+ * Use this banner to provide relevant, non-critical information in a compact layout.
  *
- * @param text the main content of the banner, describing the error context or failure details.
- * @param title an optional title, rendered in bold bold font, above the text
- * @param modifier a [Modifier] for layout customization (e.g., padding, width).
- * @param icon a composable that displays an optional 16x16 dp "error" icon at the banner's left side. The error icon is
- *   displayed by default and can be omitted by passing `null`.
- * @param actions a lambda providing interactive options (e.g., retry, open settings) as part of the banner.
- * @param actionIcons a lambda defining composable icons for secondary operations, such as closing or dismissing the
- *   banner, rendered on the banner's right side.
- * @param style an [InlineBannerStyle] defining the banner's appearance under the error theme. It can be customized to
- *   override the default error styling.
- * @param textStyle typography settings for the text content, based on the default Jewel theme.
- *
- * Use this banner to convey high-priority errors affecting application behavior.
- *
- * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/balloon.html)
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
  *
  * **Swing equivalent:**
- * [`Notifications`](https://github.com/JetBrains/intellij-community/blob/idea/243.23654.153/platform/ide-core/src/com/intellij/notification/Notifications.java)
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
  *
  * **Usage example:**
  * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
  *
  * ```kotlin
  * ErrorInlineBanner(
- *     text = "Connection to the server failed.",
+ *     text = "Project indexed failed.",
  *     actions = {
- *         Link("Retry", onClick = { /* handle retry */ })
+ *         Link("View Logs", onClick = { /* handle click */ })
  *     }
  * )
  * ```
+ *
+ * @param text The primary content of the banner, briefly describing the information it conveys.
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [text].
+ * @param icon Slot for an optional icon displayed on the left of the [text] or [title]. If null, there is no icon. By
+ *   default, it is the [AllIconsKeys.General.BalloonError] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [text].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [text] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.error`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.error].
+ * @param textStyle The base [TextStyle] used by the [text] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
  */
 @Composable
 public fun ErrorInlineBanner(
@@ -273,8 +452,7 @@ public fun ErrorInlineBanner(
     style: InlineBannerStyle = JewelTheme.inlineBannerStyle.error,
     textStyle: TextStyle = JewelTheme.defaultTextStyle,
 ) {
-    InlineBannerImpl(
-        text = text,
+    ErrorInlineBanner(
         style = style,
         textStyle = textStyle,
         title = title,
@@ -282,13 +460,75 @@ public fun ErrorInlineBanner(
         actions = actions,
         modifier = modifier,
         actionIcons = actionIcons,
+    ) {
+        Text(text = text, style = textStyle)
+    }
+}
+
+/**
+ * Shows an error inline banner to draw attention to non-critical issues that require user awareness or resolution.
+ *
+ * Use this banner to provide relevant, non-critical information in a compact layout.
+ *
+ * **Guidelines:** [on IntelliJ Platform SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html) (note:
+ * there are no guidelines for inline banners)
+ *
+ * **Swing equivalent:**
+ * [`InlineBanner`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/InlineBanner.kt)
+ *
+ * **Usage example:**
+ * [`Banners.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt)
+ *
+ * ```kotlin
+ * ErrorInlineBanner(
+ *     actions = {
+ *         Link("View Logs", onClick = { /* handle click */ })
+ *     }
+ * ) {
+ *     Markdown("Project indexed **successfully**.")
+ * }
+ * ```
+ *
+ * @param modifier [Modifier] to apply to the banner.
+ * @param title An optional title, rendered in bold, that appears above the [content].
+ * @param icon Slot for an optional icon displayed on the left of the [content] or [title]. If null, there is no icon.
+ *   By default, it is the [AllIconsKeys.General.BalloonError] icon.
+ * @param actions Slot for optional primary actions (usually links) to show at the bottom of the banner, below the
+ *   [content].
+ * @param actionIcons Slot for secondary actions (usually icon buttons), such as closing the banner to show at the top
+ *   right of the banner, to the right of the [content] or [title].
+ * @param style An [InlineBannerStyle] used to style the banner. The default is the theme's
+ *   [`JewelTheme.inlineBannerStyle.error`][org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.error].
+ * @param textStyle The base [TextStyle] used by the [content] and [title]. Note that the [title] always has a
+ *   [`Bold` weight][androidx.compose.ui.text.font.FontWeight.Bold].
+ * @param content The primary content of the banner, briefly describing the information it conveys.
+ */
+@Composable
+public fun ErrorInlineBanner(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.General.BalloonError, null) },
+    actions: (@Composable FlowRowScope.() -> Unit)? = null,
+    actionIcons: (@Composable RowScope.() -> Unit)? = null,
+    style: InlineBannerStyle = JewelTheme.inlineBannerStyle.error,
+    textStyle: TextStyle = JewelTheme.defaultTextStyle,
+    content: @Composable () -> Unit,
+) {
+    InlineBannerImpl(
+        style = style,
+        textStyle = textStyle,
+        title = title,
+        icon = icon,
+        actions = actions,
+        modifier = modifier,
+        actionIcons = actionIcons,
+        content = content,
     )
 }
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun InlineBannerImpl(
-    text: String,
     style: InlineBannerStyle,
     textStyle: TextStyle,
     title: String?,
@@ -296,6 +536,7 @@ private fun InlineBannerImpl(
     actions: @Composable (FlowRowScope.() -> Unit)?,
     actionIcons: @Composable (RowScope.() -> Unit)?,
     modifier: Modifier,
+    content: @Composable (() -> Unit),
 ) {
     val borderColor = style.colors.border
     RoundedCornerBox(
@@ -323,7 +564,7 @@ private fun InlineBannerImpl(
                     Text(text = title, style = textStyle, fontWeight = Bold)
                     Spacer(Modifier.height(8.dp))
                 }
-                Text(text = text, style = textStyle)
+                content()
 
                 if (actions != null) {
                     Spacer(Modifier.height(8.dp))
@@ -345,7 +586,7 @@ private fun InlineBannerImpl(
 }
 
 @Composable
-internal fun RoundedCornerBox(
+private fun RoundedCornerBox(
     modifier: Modifier = Modifier,
     contentColor: Color,
     borderColor: Color,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.modifier.thenIf
@@ -47,6 +48,7 @@ import org.jetbrains.jewel.ui.theme.inlineBannerStyle
  * optional actions.
  *
  * @param text the primary content of the banner, briefly describing the information it conveys.
+ * @param title an optional title, rendered in bold bold font, above the text
  * @param modifier a [Modifier] to customize the layout and appearance of the banner.
  * @param icon a composable representation of an optional 16x16 dp "information" icon displayed to the left of the
  *   banner. Pass `null` to hide the icon. By default, it shows the "information" icon.
@@ -81,6 +83,7 @@ import org.jetbrains.jewel.ui.theme.inlineBannerStyle
 public fun InformationInlineBanner(
     text: String,
     modifier: Modifier = Modifier,
+    title: String? = null,
     icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.General.BalloonInformation, null) },
     actions: (@Composable FlowRowScope.() -> Unit)? = null,
     actionIcons: (@Composable RowScope.() -> Unit)? = null,
@@ -89,6 +92,7 @@ public fun InformationInlineBanner(
 ) {
     InlineBannerImpl(
         text = text,
+        title = title,
         style = style,
         textStyle = textStyle,
         icon = icon,
@@ -106,6 +110,7 @@ public fun InformationInlineBanner(
  * user actions.
  *
  * @param text the main content of the banner, succinctly describing the successful operation or state.
+ * @param title an optional title, rendered in bold bold font, above the text
  * @param modifier a [Modifier] to customize the layout, padding, or size of the banner.
  * @param icon a composable for an optional 16x16 dp "success" icon displayed on the left side of the banner. The
  *   success icon is shown by default. Pass `null` to hide the icon.
@@ -140,6 +145,7 @@ public fun InformationInlineBanner(
 public fun SuccessInlineBanner(
     text: String,
     modifier: Modifier = Modifier,
+    title: String? = null,
     icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.Debugger.ThreadStates.Idle, null) },
     actions: (@Composable FlowRowScope.() -> Unit)? = null,
     actionIcons: (@Composable RowScope.() -> Unit)? = null,
@@ -148,6 +154,7 @@ public fun SuccessInlineBanner(
 ) {
     InlineBannerImpl(
         text = text,
+        title = title,
         style = style,
         textStyle = textStyle,
         icon = icon,
@@ -164,6 +171,7 @@ public fun SuccessInlineBanner(
  * additional actions if provided.
  *
  * @param text the main content of the banner, describing the warning or potential issue.
+ * @param title an optional title, rendered in bold bold font, above the text
  * @param modifier a [Modifier] for applying layout modifications to the banner, such as padding or size changes.
  * @param icon a composable element for an optional 16x16 dp "warning" icon displayed at the banner's left edge. The
  *   warning icon is shown by default. Set `null` to omit the icon.
@@ -198,6 +206,7 @@ public fun SuccessInlineBanner(
 public fun WarningInlineBanner(
     text: String,
     modifier: Modifier = Modifier,
+    title: String? = null,
     icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.General.BalloonWarning, null) },
     actions: (@Composable FlowRowScope.() -> Unit)? = null,
     actionIcons: (@Composable RowScope.() -> Unit)? = null,
@@ -206,6 +215,7 @@ public fun WarningInlineBanner(
 ) {
     InlineBannerImpl(
         text = text,
+        title = title,
         style = style,
         textStyle = textStyle,
         icon = icon,
@@ -222,6 +232,7 @@ public fun WarningInlineBanner(
  * and actions to assist the user in resolving it.
  *
  * @param text the main content of the banner, describing the error context or failure details.
+ * @param title an optional title, rendered in bold bold font, above the text
  * @param modifier a [Modifier] for layout customization (e.g., padding, width).
  * @param icon a composable that displays an optional 16x16 dp "error" icon at the banner's left side. The error icon is
  *   displayed by default and can be omitted by passing `null`.
@@ -255,6 +266,7 @@ public fun WarningInlineBanner(
 public fun ErrorInlineBanner(
     text: String,
     modifier: Modifier = Modifier,
+    title: String? = null,
     icon: (@Composable () -> Unit)? = { Icon(AllIconsKeys.General.BalloonError, null) },
     actions: (@Composable FlowRowScope.() -> Unit)? = null,
     actionIcons: (@Composable RowScope.() -> Unit)? = null,
@@ -265,6 +277,7 @@ public fun ErrorInlineBanner(
         text = text,
         style = style,
         textStyle = textStyle,
+        title = title,
         icon = icon,
         actions = actions,
         modifier = modifier,
@@ -278,6 +291,7 @@ private fun InlineBannerImpl(
     text: String,
     style: InlineBannerStyle,
     textStyle: TextStyle,
+    title: String?,
     icon: @Composable (() -> Unit)?,
     actions: @Composable (FlowRowScope.() -> Unit)?,
     actionIcons: @Composable (RowScope.() -> Unit)?,
@@ -305,6 +319,10 @@ private fun InlineBannerImpl(
                         .padding(top = 12.dp, bottom = 12.dp) // kftmt plz behave
                         .thenIf(actionIcons == null) { padding(end = 12.dp) }
             ) {
+                if (title != null) {
+                    Text(text = title, style = textStyle, fontWeight = Bold)
+                    Spacer(Modifier.height(8.dp))
+                }
                 Text(text = text, style = textStyle)
 
                 if (actions != null) {


### PR DESCRIPTION
This adds a slot-based API to InlineBanner, in addition to the String-based API that already exists. It is a non-breaking change. The reason is to allow users to specify their own main content, e.g., to use Markdown. The title is unaffected as it remains plain text.

> [!IMPORTANT]
> This PR needs #2999 to be merged first

Additionally, this fixes the KDoc for InlineBanner by making sure there is no content after the tags section. Before this all the content after the last tag would be considered to be part of the tag itself's documentation, which is incorrect.

The KDocs have also been rewritten for correctness and to improve clarity, making them simpler and more readable.