### PR TITLE
[JEWEL-609] Remove hardcoded styles in TabStrip

### DIFF
--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tabs.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tabs.kt
@@ -79,7 +79,7 @@ private fun DefaultTabShowcase() {
             }
         }
 
-    TabStripWithAddButton(tabs, JewelTheme.defaultTabStyle) {
+    TabStripWithAddButton(tabs = tabs, style = JewelTheme.defaultTabStyle) {
         val insertionIndex = (selectedTabIndex + 1).coerceIn(0..tabIds.size)
         val nextTabId = maxId + 1
 
@@ -138,7 +138,7 @@ private fun EditorTabShowcase() {
             }
         }
 
-    TabStripWithAddButton(tabs, JewelTheme.editorTabStyle) {
+    TabStripWithAddButton(tabs = tabs, style = JewelTheme.editorTabStyle) {
         val insertionIndex = (selectedTabIndex + 1).coerceIn(0..tabIds.size)
         val nextTabId = maxId + 1
 
@@ -150,7 +150,7 @@ private fun EditorTabShowcase() {
 @Composable
 private fun TabStripWithAddButton(tabs: List<TabData>, style: TabStyle, onAddClick: () -> Unit) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        TabStrip(tabs, style, modifier = Modifier.weight(1f))
+        TabStrip(tabs = tabs, style = style, modifier = Modifier.weight(1f))
 
         IconButton(onClick = onAddClick, modifier = Modifier.size(JewelTheme.defaultTabStyle.metrics.tabHeight)) {
             Icon(key = AllIconsKeys.General.Add, contentDescription = "Add a tab")

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
@@ -78,7 +78,7 @@ public fun TabStrip(tabs: List<TabData>, style: TabStyle, modifier: Modifier = M
                     )
                     .selectableGroup()
         ) {
-            tabs.forEach { TabImpl(isActive = tabStripState.isActive, tabData = it) }
+            tabs.forEach { tabData -> TabImpl(isActive = tabStripState.isActive, tabData = tabData, tabStyle = style) }
         }
 
         AnimatedVisibility(

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
@@ -43,6 +43,7 @@ import org.jetbrains.jewel.foundation.state.CommonStateBitMask.Selected
 import org.jetbrains.jewel.foundation.state.SelectableComponentState
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
+import org.jetbrains.jewel.ui.component.styling.TabStyle
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.painter.PainterHint
 import org.jetbrains.jewel.ui.painter.hints.Stateful
@@ -111,15 +112,10 @@ public fun TabContentScope.SimpleTabContent(
 internal fun TabImpl(
     isActive: Boolean,
     tabData: TabData,
+    tabStyle: TabStyle,
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
-    val tabStyle =
-        when (tabData) {
-            is TabData.Default -> JewelTheme.defaultTabStyle
-            is TabData.Editor -> JewelTheme.editorTabStyle
-        }
-
     var tabState by remember { mutableStateOf(TabState.of(selected = tabData.selected, active = isActive)) }
     remember(tabData.selected, isActive) { tabState = tabState.copy(selected = tabData.selected, active = isActive) }
 


### PR DESCRIPTION
The main focus of this PR is improving `Tabs`. We had a report from a user about hardcoded style: [JEWEL-609](https://youtrack.jetbrains.com/issue/JEWEL-609/TabStyle-is-mostly-ignored-by-TabStrip-and-ultimately-TabImpl-implementation).

I removed the hardcoded styles, exposed a new internal parameter `style`, named a couple of parameters in the showcase for clarity. It's a minor change, but enables the user to _drive_ the style. 

I didn't want to push too much, so if you have further refinements we could add, leave a comment, please.

⚠️ Build status
The CI is failing because of the Gradle build issue we are facing lately. Tweaking the build locally produces a successful build, so once the issues on `master` are resolved, we can revisit this and get it ready to merge.