### PR TITLE
[JEWEL-636] Remove context receivers from KeyActions

### DIFF
--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/BasicLazyTree.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/BasicLazyTree.kt
@@ -184,7 +184,6 @@ public fun <T> BasicLazyTree(
                         }
                         .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
                             val item = flattenedTree[index] as Tree.Element<T>
-                            JewelLogger.getInstance("BasicLazyTree").warn("Clicky clicky: ${item.data}")
                             (pointerEventScopedActions as? DefaultTreeViewPointerEventAction)?.notifyItemClicked(
                                 item = item,
                                 scope = scope,

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
@@ -280,21 +280,28 @@ public open class DefaultSelectableLazyColumnKeyActions(
         state.lastKeyEventUsedMouse = false
         state.isKeyboardNavigating = true
 
-        with(keybindings) { with(actions) { execute(keys, state, selectionMode) } }
+        execute(
+            keys = keys,
+            state = state,
+            selectionMode = selectionMode,
+            keyEvent = actions,
+            keyBindings = keybindings,
+        )
     }
 
-    context(SelectableColumnKeybindings, SelectableColumnOnKeyEvent)
     private fun KeyEvent.execute(
         keys: List<SelectableLazyListKey>,
         state: SelectableLazyListState,
         selectionMode: SelectionMode,
+        keyEvent: SelectableColumnOnKeyEvent,
+        keyBindings: SelectableColumnKeybindings,
     ): Boolean {
-        val singleSelectionEventHandled = handleSingleSelectionEvents(keys, state)
+        val singleSelectionEventHandled = handleSingleSelectionEvents(keys, state, keyEvent, keyBindings)
         if (singleSelectionEventHandled) {
             return true
         }
         if (selectionMode == SelectionMode.Multiple) {
-            val multipleSelectionEventHandled = handleMultipleSelectionEvents(keys, state)
+            val multipleSelectionEventHandled = handleMultipleSelectionEvents(keys, state, keyEvent, keyBindings)
             if (multipleSelectionEventHandled) {
                 return true
             }
@@ -302,39 +309,45 @@ public open class DefaultSelectableLazyColumnKeyActions(
         return false
     }
 
-    context(SelectableColumnKeybindings, SelectableColumnOnKeyEvent)
     private fun KeyEvent.handleSingleSelectionEvents(
         keys: List<SelectableLazyListKey>,
         state: SelectableLazyListState,
+        keyEvent: SelectableColumnOnKeyEvent,
+        keybindings: SelectableColumnKeybindings,
     ): Boolean {
-        when {
-            isSelectNextItem -> onSelectNextItem(keys, state)
-            isSelectPreviousItem -> onSelectPreviousItem(keys, state)
-            isSelectFirstItem -> onSelectFirstItem(keys, state)
-            isSelectLastItem -> onSelectLastItem(keys, state)
-            isEdit -> onEdit()
-            else -> return false
+        with(keybindings) {
+            when {
+                isSelectNextItem -> keyEvent.onSelectNextItem(keys, state)
+                isSelectPreviousItem -> keyEvent.onSelectPreviousItem(keys, state)
+                isSelectFirstItem -> keyEvent.onSelectFirstItem(keys, state)
+                isSelectLastItem -> keyEvent.onSelectLastItem(keys, state)
+                isEdit -> keyEvent.onEdit()
+                else -> return false
+            }
+            return true
         }
-        return true
     }
 
-    context(SelectableColumnKeybindings, SelectableColumnOnKeyEvent)
     private fun KeyEvent.handleMultipleSelectionEvents(
         keys: List<SelectableLazyListKey>,
         state: SelectableLazyListState,
+        keyEvent: SelectableColumnOnKeyEvent,
+        keyBindings: SelectableColumnKeybindings,
     ): Boolean {
-        when {
-            isExtendSelectionToFirstItem -> onExtendSelectionToFirst(keys, state)
-            isExtendSelectionToLastItem -> onExtendSelectionToLastItem(keys, state)
-            isExtendSelectionWithNextItem -> onExtendSelectionWithNextItem(keys, state)
-            isExtendSelectionWithPreviousItem -> onExtendSelectionWithPreviousItem(keys, state)
-            isScrollPageDownAndExtendSelection -> onScrollPageDownAndExtendSelection(keys, state)
-            isScrollPageDownAndSelectItem -> onScrollPageDownAndSelectItem(keys, state)
-            isScrollPageUpAndExtendSelection -> onScrollPageUpAndExtendSelection(keys, state)
-            isScrollPageUpAndSelectItem -> onScrollPageUpAndSelectItem(keys, state)
-            isSelectAll -> onSelectAll(keys, state)
-            else -> return false
+        with(keyBindings) {
+            when {
+                isExtendSelectionToFirstItem -> keyEvent.onExtendSelectionToFirst(keys, state)
+                isExtendSelectionToLastItem -> keyEvent.onExtendSelectionToLastItem(keys, state)
+                isExtendSelectionWithNextItem -> keyEvent.onExtendSelectionWithNextItem(keys, state)
+                isExtendSelectionWithPreviousItem -> keyEvent.onExtendSelectionWithPreviousItem(keys, state)
+                isScrollPageDownAndExtendSelection -> keyEvent.onScrollPageDownAndExtendSelection(keys, state)
+                isScrollPageDownAndSelectItem -> keyEvent.onScrollPageDownAndSelectItem(keys, state)
+                isScrollPageUpAndExtendSelection -> keyEvent.onScrollPageUpAndExtendSelection(keys, state)
+                isScrollPageUpAndSelectItem -> keyEvent.onScrollPageUpAndSelectItem(keys, state)
+                isSelectAll -> keyEvent.onSelectAll(keys, state)
+                else -> return false
+            }
+            return true
         }
-        return true
     }
 }


### PR DESCRIPTION
`KeyActions` was triggering a warning during build time:

> Experimental context receivers are deprecated and will be superseded by context parameters.
Please don't use context receivers. You can either pass parameters explicitly or use members with extensions.

I investigated it a bit, and it looks like we are luckily not using Context Receivers heavily. We should be OK with a couple of passed-in parameters and a couple of `with(...) {...}`.

Tested building the Standalone sample using Gradle and building the whole IJC with JPS.