### PR TITLE
[JEWEL-803] Replace get() with safer getOrNull() in ThemeColorPalette

### DIFF
--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/ThemeColorPalette.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/ThemeColorPalette.kt
@@ -55,8 +55,8 @@ public class ThemeColorPalette(
 
     public fun lookup(colorKey: String): Color? {
         val result = colorKeyRegex.matchEntire(colorKey.trim())
-        val colorGroup = result?.groupValues?.get(1)?.lowercase()
-        val colorIndex = result?.groupValues?.get(2)?.toIntOrNull()
+        val colorGroup = result?.groupValues?.getOrNull(1)?.lowercase()
+        val colorIndex = result?.groupValues?.getOrNull(2)?.toIntOrNull()
 
         if (colorGroup == null || colorIndex == null) {
             return rawMap[colorKey]
@@ -64,14 +64,14 @@ public class ThemeColorPalette(
 
         return when (colorGroup) {
             "grey",
-            "gray" -> gray(colorIndex)
-            "blue" -> blue(colorIndex)
-            "green" -> green(colorIndex)
-            "red" -> red(colorIndex)
-            "yellow" -> yellow(colorIndex)
-            "orange" -> orange(colorIndex)
-            "purple" -> purple(colorIndex)
-            "teal" -> teal(colorIndex)
+            "gray" -> grayOrNull(colorIndex)
+            "blue" -> blueOrNull(colorIndex)
+            "green" -> greenOrNull(colorIndex)
+            "red" -> redOrNull(colorIndex)
+            "yellow" -> yellowOrNull(colorIndex)
+            "orange" -> orangeOrNull(colorIndex)
+            "purple" -> purpleOrNull(colorIndex)
+            "teal" -> tealOrNull(colorIndex)
             else -> null
         }
     }

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Borders.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Borders.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -102,8 +103,18 @@ public fun Borders() {
     Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
         val isDark = JewelTheme.isDark
         val colorPalette = JewelTheme.colorPalette
-        val borderColor = remember(isDark) { if (isDark) colorPalette.blue(6) else colorPalette.blue(4) }
-        val backgroundColor = remember(isDark) { if (isDark) colorPalette.gray(4) else colorPalette.gray(11) }
+        val borderColor =
+            if (isDark) {
+                colorPalette.blueOrNull(6) ?: Color(0xFF3574F0)
+            } else {
+                colorPalette.blueOrNull(4) ?: Color(0xFF3574F0)
+            }
+        val backgroundColor =
+            if (isDark) {
+                colorPalette.grayOrNull(4) ?: Color(0xFF43454A)
+            } else {
+                colorPalette.grayOrNull(11) ?: Color(0xFFDFE1E5)
+            }
 
         Box(
             Modifier.size(28.dp, 28.dp)

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ChipsAndTree.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ChipsAndTree.kt
@@ -173,9 +173,9 @@ public fun TreeSample(modifier: Modifier = Modifier) {
 
     val borderColor =
         if (JewelTheme.isDark) {
-            JewelTheme.colorPalette.gray(3)
+            JewelTheme.colorPalette.grayOrNull(3) ?: Color(0xFF393B40)
         } else {
-            JewelTheme.colorPalette.gray(12)
+            JewelTheme.colorPalette.grayOrNull(12) ?: Color(0xFFEBECF0)
         }
 
     Box(modifier.border(1.dp, borderColor, RoundedCornerShape(2.dp))) {

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Icons.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Icons.kt
@@ -61,14 +61,20 @@ public fun Icons() {
                 hint = Badge(Color.Red, DotBadgeShape.Default),
             )
         }
+        val backgroundColor =
+            if (JewelTheme.isDark) {
+                JewelTheme.colorPalette.blueOrNull(4) ?: Color(0xFF375FAD)
+            } else {
+                JewelTheme.colorPalette.blueOrNull(4) ?: Color(0xFF3574F0)
+            }
         Box(
-            Modifier.size(24.dp).background(JewelTheme.colorPalette.blue(4), shape = RoundedCornerShape(4.dp)),
+            Modifier.size(24.dp).background(backgroundColor, shape = RoundedCornerShape(4.dp)),
             contentAlignment = Alignment.Center,
         ) {
             Icon(key = AllIconsKeys.Nodes.ConfigFolder, contentDescription = "taskGroup", hint = Stroke(Color.White))
         }
         Box(
-            Modifier.size(24.dp).background(JewelTheme.colorPalette.blue(4), shape = RoundedCornerShape(4.dp)),
+            Modifier.size(24.dp).background(backgroundColor, shape = RoundedCornerShape(4.dp)),
             contentAlignment = Alignment.Center,
         ) {
             Icon(

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Scrollbars.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Scrollbars.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import java.util.Locale
@@ -245,19 +246,23 @@ private fun AlignedContentExample(scrollbarStyle: ScrollbarStyle, modifier: Modi
                 Modifier.fillMaxWidth().border(Stroke.Alignment.Outside, 1.dp, JewelTheme.globalColors.borders.normal),
         ) {
             val shape = RoundedCornerShape(4.dp)
+            val borderColor =
+                if (JewelTheme.isDark) {
+                    JewelTheme.colorPalette.blueOrNull(2) ?: Color(0xFF2E436E)
+                } else {
+                    JewelTheme.colorPalette.blueOrNull(2) ?: Color(0xFF315FBD)
+                }
+            val backgroundColor =
+                if (JewelTheme.isDark) {
+                    JewelTheme.colorPalette.grayOrNull(1) ?: Color(0xFF1E1F22)
+                } else {
+                    JewelTheme.colorPalette.grayOrNull(14) ?: Color(0xFFFFFFFF)
+                }
             Column(
                 modifier =
                     Modifier.align(Alignment.Center)
-                        .background(
-                            color =
-                                if (JewelTheme.isDark) {
-                                    JewelTheme.colorPalette.gray(1)
-                                } else {
-                                    JewelTheme.colorPalette.gray(14)
-                                },
-                            shape,
-                        )
-                        .border(1.dp, JewelTheme.colorPalette.blue(2), shape)
+                        .background(color = backgroundColor, shape)
+                        .border(1.dp, borderColor, shape)
                         .padding(8.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(4.dp),


### PR DESCRIPTION
This PR addresses an unfortunate lack of warning for methods that can throw exceptions.

`ThemeColorPalette` was using a nullable chain containing also `get(index)` and then acting on missing values using the Elvis operator `.?`. Unfortunately, `get(index)` is an unsafe method that throws, preventing the `.?` from doing any rescue.

We switched to a safer variant, and properly managing the `null`.