### PR TITLE
maven: honor user-specified dependency collector implementation

### DIFF
--- a/plugins/maven/maven36-server-impl/src/org/jetbrains/idea/maven/server/Maven36ServerEmbedderImpl.java
+++ b/plugins/maven/maven36-server-impl/src/org/jetbrains/idea/maven/server/Maven36ServerEmbedderImpl.java
@@ -56,7 +56,15 @@ public class Maven36ServerEmbedderImpl extends Maven3XServerEmbedder {
         DependencyCollector dependencyCollector;
         if (VersionComparatorUtil.compare(getMavenVersion(), "3.9.0") >= 0) {
           // depth-first dependency collector, available since maven 3.9.0
-          dependencyCollector = getComponentIfExists(DependencyCollector.class, "df");
+          if (System.getProperty("aether.dependencyCollector.impl") != null) {
+            // honor user-specified dependency collector, if it exists
+            dependencyCollector = getComponentIfExists(DependencyCollector.class, System.getProperty("aether.dependencyCollector.impl"));
+            if (dependencyCollector == null) {
+              dependencyCollector = getComponentIfExists(DependencyCollector.class, "df");
+            }
+          } else {
+            dependencyCollector = getComponentIfExists(DependencyCollector.class, "df");
+          }
         }
         else {
           // default dependency collector, maven 3.8


### PR DESCRIPTION
one may pass `-Daether.dependencyCollector.impl=bf` to maven importer options and remain confused that it does "nothing".

---

i have validated this by hex editing df to bf and repackaging maven36-server.jar into my IntelliJ IDEA.
i have not found a way to build this yet, sadly (stuck in some exponential backoff while fetching dependencies with `./installers.cmd`).
