### PR TITLE
Avoid use of IdentityHashMap to future-proof implementation

### DIFF
--- a/plugins/gradle/java/src/service/project/JavaGradleProjectResolver.java
+++ b/plugins/gradle/java/src/service/project/JavaGradleProjectResolver.java
@@ -50,8 +50,8 @@ import static com.intellij.openapi.externalSystem.service.execution.ExternalSyst
 @Order(ExternalSystemConstants.UNORDERED)
 public final class JavaGradleProjectResolver extends AbstractProjectResolverExtension {
 
-  private final IdentityHashMap<GradleBuildScriptClasspathModel, List<BuildScriptClasspathData.ClasspathEntry>> buildScriptEntriesMap =
-    new IdentityHashMap<>();
+  private final HashMap<GradleBuildScriptClasspathModel, List<BuildScriptClasspathData.ClasspathEntry>> buildScriptEntriesMap =
+    new HashMap<>();
 
   @Override
   public void resolveFinished(@NotNull DataNode<ProjectData> projectDataNode) {

--- a/plugins/gradle/java/src/service/project/MavenRepositoriesProjectResolver.kt
+++ b/plugins/gradle/java/src/service/project/MavenRepositoriesProjectResolver.kt
@@ -16,7 +16,7 @@ import java.util.*
 
 class MavenRepositoriesProjectResolver: AbstractProjectResolverExtension() {
 
-  private val processedRepositoryModels = IdentityHashMap<RepositoryModels, Unit>()
+  private val processedRepositoryModels = HashMap<RepositoryModels, Unit>()
 
   override fun resolveFinished(projectDataNode: DataNode<ProjectData>) {
     processedRepositoryModels.clear()

--- a/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/buildScriptClasspathModel/DefaultGradleBuildScriptClasspathModel.java
+++ b/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/buildScriptClasspathModel/DefaultGradleBuildScriptClasspathModel.java
@@ -23,9 +23,11 @@ public class DefaultGradleBuildScriptClasspathModel implements GradleBuildScript
   private final List<ClasspathEntryModel> myClasspathEntries;
   private @Nullable File gradleHomeDir;
   private String myGradleVersion;
+  private int myClasspathEntriesHashCode;
 
   public DefaultGradleBuildScriptClasspathModel() {
     myClasspathEntries = new ArrayList<>(0);
+    myClasspathEntriesHashCode = 0;
   }
 
   @Override
@@ -44,6 +46,7 @@ public class DefaultGradleBuildScriptClasspathModel implements GradleBuildScript
 
   public void add(@NotNull ClasspathEntryModel classpathEntryModel) {
     myClasspathEntries.add(classpathEntryModel);
+    myClasspathEntriesHashCode = 31 * myClasspathEntriesHashCode + classpathEntryModel.hashCode();
   }
 
   public void setGradleVersion(@NotNull String gradleVersion) {
@@ -62,7 +65,7 @@ public class DefaultGradleBuildScriptClasspathModel implements GradleBuildScript
 
     DefaultGradleBuildScriptClasspathModel other = (DefaultGradleBuildScriptClasspathModel)o;
 
-    if (!myClasspathEntries.equals(other.myClasspathEntries)) return false;
+    if (myClasspathEntriesHashCode != other.myClasspathEntriesHashCode) return false;
     if (gradleHomeDir == null && other.gradleHomeDir != null ||
         gradleHomeDir != null && (other.gradleHomeDir == null || !gradleHomeDir.getPath().equals(other.gradleHomeDir.getPath()))) {
       return false;
@@ -74,7 +77,7 @@ public class DefaultGradleBuildScriptClasspathModel implements GradleBuildScript
 
   @Override
   public int hashCode() {
-    int result = myClasspathEntries.hashCode();
+    int result = myClasspathEntriesHashCode;
     result = 31 * result + (gradleHomeDir != null ? gradleHomeDir.hashCode() : 0);
     result = 31 * result + (myGradleVersion != null ? myGradleVersion.hashCode() : 0);
     return result;

--- a/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/DefaultRepositoryModels.java
+++ b/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/internal/DefaultRepositoryModels.java
@@ -11,9 +11,11 @@ import java.util.List;
 public class DefaultRepositoryModels implements RepositoryModels {
 
   private final @NotNull List<MavenRepositoryModel> myRepositories;
+  private final int myRepositoriesHashCode;
 
   public DefaultRepositoryModels(@NotNull List<MavenRepositoryModel> repositories) {
     myRepositories = Collections.unmodifiableList(repositories);
+    myRepositoriesHashCode = myRepositories.hashCode();
   }
 
   @Override
@@ -27,14 +29,12 @@ public class DefaultRepositoryModels implements RepositoryModels {
     if (o == null || getClass() != o.getClass()) return false;
 
     DefaultRepositoryModels model = (DefaultRepositoryModels)o;
-
-    if (!myRepositories.equals(model.myRepositories)) return false;
-
+    if (myRepositoriesHashCode != model.myRepositoriesHashCode) return false;
     return true;
   }
 
   @Override
   public int hashCode() {
-    return myRepositories.hashCode();
+    return myRepositoriesHashCode;
   }
 }


### PR DESCRIPTION
Storing the hash code for potentially long list of elements in models to make sure the performance is similar to the IdentityHashMap implementation.