### PR TITLE
IDEA-328157 Allow gradle installations to be read-only

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/ui/validation/validations.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/ui/validation/validations.kt
@@ -45,6 +45,14 @@ val CHECK_DIRECTORY: DialogValidation.WithParameter<() -> String> = validationPa
   }
 }
 
+val CHECK_SYSTEM_DIRECTORY: DialogValidation.WithParameter<() -> String> = validationPathErrorFor { path ->
+  when {
+    !path.exists() -> null
+    !path.isDirectory() -> UIBundle.message("label.project.wizard.new.project.file.not.directory.error", path.name)
+    else -> null
+  }
+}
+
 private val firstSymbolGroupIdPattern = "[a-zA-Z_].*".toRegex()
 private val CHECK_GROUP_ID_FORMAT = validationErrorFor<String> { text ->
   if (text.startsWith('.') || text.endsWith('.')) {

--- a/plugins/gradle/java/src/service/project/wizard/GradleNewProjectWizardStep.kt
+++ b/plugins/gradle/java/src/service/project/wizard/GradleNewProjectWizardStep.kt
@@ -35,8 +35,8 @@ import com.intellij.openapi.roots.ui.configuration.projectRoot.SdkDownloadTask
 import com.intellij.openapi.ui.*
 import com.intellij.openapi.ui.BrowseFolderDescriptor.Companion.withPathToTextConvertor
 import com.intellij.openapi.ui.BrowseFolderDescriptor.Companion.withTextToPathConvertor
-import com.intellij.openapi.ui.validation.CHECK_DIRECTORY
 import com.intellij.openapi.ui.validation.CHECK_NON_EMPTY
+import com.intellij.openapi.ui.validation.CHECK_SYSTEM_DIRECTORY
 import com.intellij.openapi.ui.validation.WHEN_GRAPH_PROPAGATION_FINISHED
 import com.intellij.openapi.util.NlsContexts
 import com.intellij.openapi.util.registry.Registry
@@ -196,7 +196,7 @@ abstract class GradleNewProjectWizardStep<ParentStep>(parent: ParentStep) :
               textFieldWithBrowseButton(fileChooserDescriptor, context.project)
                 .applyToComponent { setEmptyState(GradleBundle.message("gradle.project.settings.distribution.local.location.empty.state")) }
                 .bindText(gradleHomeProperty.toUiPathProperty())
-                .trimmedTextValidation(CHECK_NON_EMPTY, CHECK_DIRECTORY)
+                .trimmedTextValidation(CHECK_NON_EMPTY, CHECK_SYSTEM_DIRECTORY)
                 .validationOnInput { validateGradleHome(withDialog = false) }
                 .validationOnApply { validateGradleHome(withDialog = true) }
                 .align(AlignX.FILL)

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/settings/IdeaGradleDefaultProjectSettingsControl.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/settings/IdeaGradleDefaultProjectSettingsControl.kt
@@ -13,8 +13,8 @@ import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.ui.getCanonicalPath
 import com.intellij.openapi.ui.getPresentablePath
 import com.intellij.openapi.ui.setEmptyState
-import com.intellij.openapi.ui.validation.CHECK_DIRECTORY
 import com.intellij.openapi.ui.validation.CHECK_NON_EMPTY
+import com.intellij.openapi.ui.validation.CHECK_SYSTEM_DIRECTORY
 import com.intellij.openapi.ui.validation.WHEN_GRAPH_PROPAGATION_FINISHED
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
@@ -98,7 +98,7 @@ internal class IdeaGradleDefaultProjectSettingsControl : GradleSettingsControl()
                 textFieldWithBrowseButton(fileChooserDescriptor)
                   .applyToComponent { setEmptyState(GradleBundle.message("gradle.project.settings.distribution.local.location.empty.state")) }
                   .bindText(gradleHomeProperty.toUiPathProperty())
-                  .trimmedTextValidation(CHECK_NON_EMPTY, CHECK_DIRECTORY)
+                  .trimmedTextValidation(CHECK_NON_EMPTY, CHECK_SYSTEM_DIRECTORY)
                   .validationInfo { validateGradleHome(gradleHome) }
                   .align(AlignX.FILL)
               }


### PR DESCRIPTION
Currently, the Gradle tool window permits any directory containing the correct content to be configured as the Gradle installation home:
https://github.com/JetBrains/intellij-community/blob/0e71313b43b3880db8a7334ab9f29cb8db4864ed/plugins/gradle/src/org/jetbrains/plugins/gradle/service/settings/IdeaGradleProjectSettingsControlBuilder.java#L419-L421

The new project wizard and settings component on the other hand [use `CHECK_DIRECTORY`](https://github.com/JetBrains/intellij-community/blob/0e71313b43b3880db8a7334ab9f29cb8db4864ed/plugins/gradle/java/src/service/project/wizard/GradleNewProjectWizardStep.kt#L196-L199) in addition, which also checks whether the directory is writable, even though this is never needed here:
https://github.com/JetBrains/intellij-community/blob/0e71313b43b3880db8a7334ab9f29cb8db4864ed/platform/platform-impl/src/com/intellij/openapi/ui/validation/validations.kt#L39-L46

As a consequence, users that use a package manager first have to create their projects with gradlew, then manually delete the gradlew files and change the installation home in the tool window instead of just creating their project.

This PR fixes this by providing a variant of `CHECK_DIRECTORY` that does not check for writeability.