### PR TITLE
[JEWEL-797] Tooltip automatic disappearance improvements

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTooltip.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTooltip.kt
@@ -19,6 +19,8 @@ internal fun readTooltipStyle(): TooltipStyle {
                 contentPadding = JBUI.CurrentTheme.HelpTooltip.smallTextBorderInsets().toPaddingValues(),
                 showDelay = Registry.intValue("ide.tooltip.initialReshowDelay").milliseconds,
                 cornerSize = CornerSize(JBUI.CurrentTheme.Tooltip.CORNER_RADIUS.dp),
+                regularDisappearDelay = Registry.intValue("ide.helptooltip.regular.dismissDelay").milliseconds,
+                fullDisappearDelay = Registry.intValue("ide.helptooltip.full.dismissDelay").milliseconds,
             ),
         colors =
             TooltipColors(

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tooltips.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tooltips.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
+import org.jetbrains.jewel.ui.component.AutoHideBehavior
 import org.jetbrains.jewel.ui.component.CheckboxRow
 import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.Text
@@ -35,7 +36,11 @@ public fun Tooltips() {
     }
 
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-        Tooltip(tooltip = { Text("This is a tooltip") }, enabled = enabled, neverHide = neverHide) {
+        Tooltip(
+            tooltip = { Text("This is a tooltip") },
+            enabled = enabled,
+            autoHideBehavior = if (neverHide) AutoHideBehavior.Never else AutoHideBehavior.Normal,
+        ) {
             // Any content works — this is a button just because it's focusable
             DefaultButton({}) { Text("Hover me!") }
         }

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tooltips.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tooltips.kt
@@ -12,17 +12,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import org.jetbrains.jewel.ui.component.CheckboxRow
 import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.Tooltip
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 public fun Tooltips() {
     var toggleEnabled by remember { mutableStateOf(true) }
     var enabled by remember { mutableStateOf(true) }
+    var neverHide by remember { mutableStateOf(false) }
+    
     LaunchedEffect(toggleEnabled) {
         if (!toggleEnabled) return@LaunchedEffect
 
@@ -33,7 +35,11 @@ public fun Tooltips() {
     }
 
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-        Tooltip(tooltip = { Text("This is a tooltip") }, enabled = enabled) {
+        Tooltip(
+            tooltip = { Text("This is a tooltip") },
+            enabled = enabled,
+            neverHide = neverHide
+        ) {
             // Any content works — this is a button just because it's focusable
             DefaultButton({}) { Text("Hover me!") }
         }
@@ -41,5 +47,7 @@ public fun Tooltips() {
         CheckboxRow("Enabled", enabled, { enabled = it })
 
         CheckboxRow("Toggle enabled every 1s", toggleEnabled, { toggleEnabled = it })
+
+        CheckboxRow("Never hide", neverHide, { neverHide = it })
     }
 }

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tooltips.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Tooltips.kt
@@ -12,19 +12,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import org.jetbrains.jewel.ui.component.CheckboxRow
 import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.Tooltip
-import kotlin.time.Duration.Companion.seconds
 
 @Composable
 public fun Tooltips() {
     var toggleEnabled by remember { mutableStateOf(true) }
     var enabled by remember { mutableStateOf(true) }
     var neverHide by remember { mutableStateOf(false) }
-    
+
     LaunchedEffect(toggleEnabled) {
         if (!toggleEnabled) return@LaunchedEffect
 
@@ -35,11 +35,7 @@ public fun Tooltips() {
     }
 
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-        Tooltip(
-            tooltip = { Text("This is a tooltip") },
-            enabled = enabled,
-            neverHide = neverHide
-        ) {
+        Tooltip(tooltip = { Text("This is a tooltip") }, enabled = enabled, neverHide = neverHide) {
             // Any content works — this is a button just because it's focusable
             DefaultButton({}) { Text("Hover me!") }
         }

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -105,6 +105,15 @@ public final class org/jetbrains/jewel/ui/component/ActionButtonKt {
 	public static final fun ActionButton (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/ui/component/styling/IconButtonStyle;Landroidx/compose/foundation/layout/PaddingValues;Lorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
+public final class org/jetbrains/jewel/ui/component/AutoHideBehavior : java/lang/Enum {
+	public static final field Long Lorg/jetbrains/jewel/ui/component/AutoHideBehavior;
+	public static final field Never Lorg/jetbrains/jewel/ui/component/AutoHideBehavior;
+	public static final field Normal Lorg/jetbrains/jewel/ui/component/AutoHideBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/jewel/ui/component/AutoHideBehavior;
+	public static fun values ()[Lorg/jetbrains/jewel/ui/component/AutoHideBehavior;
+}
+
 public final class org/jetbrains/jewel/ui/component/BannerKt {
 	public static final fun ErrorDefaultBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/DefaultBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
 	public static final fun InformationDefaultBanner (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lorg/jetbrains/jewel/ui/component/styling/DefaultBannerStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
@@ -1096,7 +1105,8 @@ public final class org/jetbrains/jewel/ui/component/ToggleableIconButtonState$Co
 }
 
 public final class org/jetbrains/jewel/ui/component/TooltipKt {
-	public static final fun Tooltip-k8zXyTc (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;ZJLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lorg/jetbrains/jewel/ui/component/AutoHideBehavior;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun rememberPopupPositionProviderAtFixedPosition-7KAyTs4 (JJLandroidx/compose/ui/Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -384,6 +384,7 @@ public final class org/jetbrains/jewel/ui/component/DropdownState$Companion {
 
 public final class org/jetbrains/jewel/ui/component/EditableComboBoxKt {
 	public static final fun EditableComboBox (Landroidx/compose/foundation/text/input/TextFieldState;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/ComboBoxStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/ui/component/PopupManager;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun detectPressAndCancel (Landroidx/compose/ui/input/pointer/PointerInputScope;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/jewel/ui/component/FixedCursorPoint : androidx/compose/foundation/TooltipPlacement {
@@ -1095,7 +1096,7 @@ public final class org/jetbrains/jewel/ui/component/ToggleableIconButtonState$Co
 }
 
 public final class org/jetbrains/jewel/ui/component/TooltipKt {
-	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Tooltip-k8zXyTc (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;ZJLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun rememberPopupPositionProviderAtFixedPosition-7KAyTs4 (JJLandroidx/compose/ui/Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 
@@ -2933,12 +2934,14 @@ public final class org/jetbrains/jewel/ui/component/styling/TooltipColors$Compan
 public final class org/jetbrains/jewel/ui/component/styling/TooltipMetrics {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/styling/TooltipMetrics$Companion;
-	public synthetic fun <init> (Landroidx/compose/foundation/layout/PaddingValues;JLandroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/layout/PaddingValues;JLandroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/TooltipPlacement;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBorderWidth-D9Ej5fM ()F
 	public final fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
 	public final fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public final fun getFullDisappearDelay-UwyO8pc ()J
 	public final fun getPlacement ()Landroidx/compose/foundation/TooltipPlacement;
+	public final fun getRegularDisappearDelay-UwyO8pc ()J
 	public final fun getShadowSize-D9Ej5fM ()F
 	public final fun getShowDelay-UwyO8pc ()J
 	public fun hashCode ()I
@@ -2946,8 +2949,8 @@ public final class org/jetbrains/jewel/ui/component/styling/TooltipMetrics {
 }
 
 public final class org/jetbrains/jewel/ui/component/styling/TooltipMetrics$Companion {
-	public final fun defaults-8qf-r9M (Landroidx/compose/foundation/layout/PaddingValues;JLandroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/TooltipPlacement;)Lorg/jetbrains/jewel/ui/component/styling/TooltipMetrics;
-	public static synthetic fun defaults-8qf-r9M$default (Lorg/jetbrains/jewel/ui/component/styling/TooltipMetrics$Companion;Landroidx/compose/foundation/layout/PaddingValues;JLandroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/TooltipPlacement;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TooltipMetrics;
+	public final fun defaults-L5TaK9c (Landroidx/compose/foundation/layout/PaddingValues;JJJLandroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/TooltipPlacement;)Lorg/jetbrains/jewel/ui/component/styling/TooltipMetrics;
+	public static synthetic fun defaults-L5TaK9c$default (Lorg/jetbrains/jewel/ui/component/styling/TooltipMetrics$Companion;Landroidx/compose/foundation/layout/PaddingValues;JJJLandroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/TooltipPlacement;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TooltipMetrics;
 }
 
 public final class org/jetbrains/jewel/ui/component/styling/TooltipStyle {
@@ -4203,6 +4206,12 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Profiler {
 	public final fun getCollapseNode ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getExpandNode ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getRec ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+}
+
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Promo {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Promo;
+	public final fun getJavaDuke ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 }
 
 public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Providers {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TooltipStyling.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TooltipStyling.kt
@@ -92,6 +92,8 @@ public class TooltipMetrics(
     public val borderWidth: Dp,
     public val shadowSize: Dp,
     public val placement: TooltipPlacement,
+    public val regularDisappearDelay: Duration,
+    public val fullDisappearDelay: Duration,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -105,6 +107,8 @@ public class TooltipMetrics(
         if (borderWidth != other.borderWidth) return false
         if (shadowSize != other.shadowSize) return false
         if (placement != other.placement) return false
+        if (regularDisappearDelay != other.regularDisappearDelay) return false
+        if (fullDisappearDelay != other.fullDisappearDelay) return false
 
         return true
     }
@@ -116,6 +120,8 @@ public class TooltipMetrics(
         result = 31 * result + borderWidth.hashCode()
         result = 31 * result + shadowSize.hashCode()
         result = 31 * result + placement.hashCode()
+        result = 31 * result + regularDisappearDelay.hashCode()
+        result = 31 * result + fullDisappearDelay.hashCode()
         return result
     }
 
@@ -127,6 +133,8 @@ public class TooltipMetrics(
             "borderWidth=$borderWidth, " +
             "shadowSize=$shadowSize, " +
             "placement=$placement" +
+            "regularDisappearDelay=$regularDisappearDelay, " +
+            "fullDisappearDelay=$fullDisappearDelay" +
             ")"
     }
 
@@ -134,11 +142,23 @@ public class TooltipMetrics(
         public fun defaults(
             contentPadding: PaddingValues = PaddingValues(vertical = 9.dp, horizontal = 12.dp),
             showDelay: Duration = 500.milliseconds, // ide.tooltip.initialReshowDelay
+            regularDisappearDelay: Duration = 10000.milliseconds, // ide.helptooltip.regular.dismissDelay
+            fullDisappearDelay: Duration = 30000.milliseconds, // ide.helptooltip.full.dismissDelay
             cornerSize: CornerSize = CornerSize(4.dp),
             borderWidth: Dp = 1.dp,
             shadowSize: Dp = 12.dp,
             placement: TooltipPlacement = FixedCursorPoint(DpOffset(4.dp, 24.dp)),
-        ): TooltipMetrics = TooltipMetrics(contentPadding, showDelay, cornerSize, borderWidth, shadowSize, placement)
+        ): TooltipMetrics =
+            TooltipMetrics(
+                contentPadding,
+                showDelay,
+                cornerSize,
+                borderWidth,
+                shadowSize,
+                placement,
+                regularDisappearDelay,
+                fullDisappearDelay,
+            )
     }
 }
 


### PR DESCRIPTION
# Prologue

> In IJP, tooltips also disappear automatically after a duration from the registry
The default duration is 10s or 30s, depending on whether the text content is single- or multi-line (defined not by the actual layout but by counting if there are any tags)
You can also set tooltips to never hide explicitly in their builder.
Tooltips attached to help buttons (the round ones with the ? symbol) also never hide by default.
We should separately track this behaviour and implement it at some point.

Reference https://youtrack.jetbrains.com/issue/JEWEL-645/Tooltip-default-delay-is-too-long

# Overview

This PR introduces two new values to the `TooltipMetrics`:

* `regularDisappearDelay` based on the Registry key `ide.helptooltip.regular.dismissDelay`
* `fullDisappearDelay` based on the Registry key `ide.helptooltip.full.dismissDelay`

These new values can be used with the new `autoHideDelay` parameter on `Tooltip`.

We also have a new `neverHide` parameter.