### PR TITLE
Fix py 54482: Show True/False/None in decorator argument list completions

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/codeInsight/completion/PyKeywordCompletionContributor.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/codeInsight/completion/PyKeywordCompletionContributor.java
@@ -307,6 +307,7 @@ public final class PyKeywordCompletionContributor extends CompletionContributor 
 
   private static final PsiElementPattern.Capture<PsiElement> IN_PARAM_LIST = psiElement().inside(PyParameterList.class);
   private static final PsiElementPattern.Capture<PsiElement> IN_ARG_LIST = psiElement().inside(PyArgumentList.class);
+  private static final PsiElementPattern.Capture<PsiElement> IN_DECORATOR_ARG_LIST = psiElement().inside(PyArgumentList.class).inside(PyDecorator.class);
 
   private static final PsiElementPattern.Capture<PsiElement> IN_DEF_BODY =
     psiElement().inside(false, psiElement(PyFunction.class), psiElement(PyClass.class));
@@ -647,6 +648,7 @@ public final class PyKeywordCompletionContributor extends CompletionContributor 
   }
 
   private void addPy3kLiterals() {
+    // Add literals in normal contexts
     extend(
       CompletionType.BASIC, psiElement()
       .withLanguage(PythonLanguage.getInstance())
@@ -659,6 +661,17 @@ public final class PyKeywordCompletionContributor extends CompletionContributor 
       .andNot(TARGET_AFTER_QUALIFIER)
       ,
       new PyKeywordCompletionProvider(TailTypes.noneType(), PyNames.TRUE, PyNames.FALSE, PyNames.NONE));
+
+    // Add literals specifically in decorator argument lists
+    extend(
+      CompletionType.BASIC, psiElement()
+      .withLanguage(PythonLanguage.getInstance())
+      .and(IN_DECORATOR_ARG_LIST)
+      .andNot(IN_COMMENT)
+      .andNot(IN_STRING_LITERAL)
+      ,
+      new PyKeywordCompletionProvider(TailTypes.noneType(), PyNames.TRUE, PyNames.FALSE, PyNames.NONE));
+
     extend(CompletionType.BASIC,
            psiElement()
              .withLanguage(PythonLanguage.getInstance())

--- a/python/testData/keywordCompletion/literalsInDecoratorArgumentList.py
+++ b/python/testData/keywordCompletion/literalsInDecoratorArgumentList.py
@@ -1,0 +1,12 @@
+#  Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+def decorator(arg):
+    def wrapper(func):
+        return func
+
+    return wrapper
+
+
+@decorator([Tr<caret>])
+def foo():
+    pass

--- a/python/testSrc/com/jetbrains/python/PythonKeywordCompletionTest.java
+++ b/python/testSrc/com/jetbrains/python/PythonKeywordCompletionTest.java
@@ -335,4 +335,10 @@ public class PythonKeywordCompletionTest extends PyTestCase {
   public void testNonLiteralExpressionKeywordsInCaseClauseBody() {
     assertContainsElements(doTestByTestName(), PyNames.ASYNC, PyNames.NOT, PyNames.LAMBDA);
   }
+
+  // PY-54482
+  public void testLiteralsInDecoratorArgumentList() {
+    List<String> variants = doTestByTestName();
+    assertContainsElements(variants, PyNames.TRUE);
+  }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/PY-54482/Booleans-missing-in-auto-complete-in-pytest-parametrization