### PR TITLE
[xml] Fix pubIdChars

### DIFF
--- a/xml/xml-psi-impl/resources/standardSchemas/catalog.xsd
+++ b/xml/xml-psi-impl/resources/standardSchemas/catalog.xsd
@@ -10,7 +10,7 @@
 
   <xs:simpleType name="pubIdChars">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[a-zA-Z0-9\-'\(\)+,./:=?;!*#@$_% ]*"/>
+      <xs:pattern value="[a-zA-Z0-9\-'\(\)+,./:=?;!*#@$_% \r\n]*"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
This PR adds the missing line terminator characters that are according to the
specification valid pub id characters but are missing from the schema definition.
