### PR TITLE
[JEWEL-809] Fix typo in macOS decorated window property

### DIFF
--- a/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.MacOS.kt
+++ b/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.MacOS.kt
@@ -65,15 +65,15 @@ internal fun DecoratedWindowScope.TitleBarOnMacOs(
         }
 
     if (newFullscreenControls) {
-        System.setProperty("apple.awt.newFullScreeControls", true.toString())
+        System.setProperty("apple.awt.newFullScreenControls", true.toString())
         System.setProperty(
-            "apple.awt.newFullScreeControls.background",
+            "apple.awt.newFullScreenControls.background",
             "${style.colors.fullscreenControlButtonsBackground.toArgb()}",
         )
         MacUtil.updateColors(window)
     } else {
-        System.clearProperty("apple.awt.newFullScreeControls")
-        System.clearProperty("apple.awt.newFullScreeControls.background")
+        System.clearProperty("apple.awt.newFullScreenControls")
+        System.clearProperty("apple.awt.newFullScreenControls.background")
     }
 
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -384,6 +384,7 @@ public final class org/jetbrains/jewel/ui/component/DropdownState$Companion {
 
 public final class org/jetbrains/jewel/ui/component/EditableComboBoxKt {
 	public static final fun EditableComboBox (Landroidx/compose/foundation/text/input/TextFieldState;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/ComboBoxStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/ui/component/PopupManager;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun detectPressAndCancel (Landroidx/compose/ui/input/pointer/PointerInputScope;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/jewel/ui/component/FixedCursorPoint : androidx/compose/foundation/TooltipPlacement {
@@ -4203,6 +4204,12 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Profiler {
 	public final fun getCollapseNode ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getExpandNode ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getRec ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+}
+
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Promo {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Promo;
+	public final fun getJavaDuke ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 }
 
 public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Providers {


### PR DESCRIPTION
In the decorated window module, on macOS, we are setting the `apple.awt.newFullScreeControls` system property (note the missing 'n'). It used to be spelled this way in IJP.

However, it was fixed in IJP in early 2024 to
`apple.awt.newFullScreenControls`. This PR updates the system property, fixing the window controls in fullscreen.

This also updates `ui.api`, as it seems to be out of date.

#### Before
![Screenshot showing "compat" fullscreen controls on macOS](https://github.com/user-attachments/assets/41479b8f-3139-4495-9cfc-94596f4c287f)

#### After
![Screenshot showing the "compat" controls are gone after the fix](https://github.com/user-attachments/assets/d2fbc57f-8cd7-45e5-824e-a546d00ad0d5)
