### PR TITLE
IDEA-164593: make 'Kill the debug process immediately'=true by default

### DIFF
--- a/java/debugger/shared/src/com/intellij/debugger/settings/DebuggerSettings.java
+++ b/java/debugger/shared/src/com/intellij/debugger/settings/DebuggerSettings.java
@@ -88,7 +88,7 @@ public final class DebuggerSettings implements Cloneable, PersistentStateCompone
   public volatile boolean WATCH_RETURN_VALUES = false;
   public volatile boolean AUTO_VARIABLES_MODE = false;
 
-  public volatile boolean KILL_PROCESS_IMMEDIATELY = false;
+  public volatile boolean KILL_PROCESS_IMMEDIATELY = true;
   public volatile boolean ALWAYS_DEBUG = true;
 
   public String EVALUATE_FINALLY_ON_POP_FRAME = EVALUATE_FINALLY_ASK;


### PR DESCRIPTION
PR to resolve https://youtrack.jetbrains.com/issue/IDEA-164593. The default value "Kill the debug process immediately" = true is the safe choice for individual developers and large teams because:
1. As a developer I need predictability. If I want to stop the program but it will continue to run, then it’s hard to predict what code will be executed and how it affects me and other team members. For example, the application might break shared data such as database, data in the cloud, call other API and corrupt testing data etc.
2. During the debugging session I can modify local variables, skip method calls etc. If the program flow and(or) data were modified but the program continues to run without my consent, then then the behavior might be undefined and it’s hard to guess what the outcome will be. In the worst case it might lead to memory leaks, intensive CPU usage, corrupt local files etc.
3. If I debug and understand that programs will do something wrong (for example, call expensive API or attempt to call a function which will spoil hardware device etc.) then I need a reliable way to stop it and DON’T execute subsequent code.
4. This is the default behavior in other IDEs for Java and other languages.