### PR TITLE
IDEA-364738 Add multiple build failure line to task output end markers

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/build/output/GradleOutputDispatcherFactory.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/build/output/GradleOutputDispatcherFactory.kt
@@ -83,6 +83,8 @@ class GradleOutputDispatcherFactory : ExternalSystemOutputDispatcherFactory {
           }
           else if (cleanLine.startsWith("> Configure") ||
                    cleanLine.startsWith("FAILURE: Build failed") ||
+                   cleanLine.startsWith("FAILURE: Build completed") ||
+                   cleanLine.startsWith("[Incubating] Problems report is available at:") ||
                    cleanLine.startsWith("CONFIGURE SUCCESSFUL") ||
                    cleanLine.startsWith("BUILD SUCCESSFUL")) {
             myCurrentReader = myRootReader


### PR DESCRIPTION
'FAILURE: Build completed with 2 failures.' happens regularly now, e.g. when several tasks failed, but this line is not recognized currently. As a result all this build failure message is appended to last task's and is not parsed by the root parser resulting in completely broken presentation on the Build Output UI.

'[Incubating] Problems report...' also does not belong to any task so add it as well.