### PR TITLE
Fix IDEA-372415 - Convert anonymous to inner refactoring doesn't copy generics when non-static

### DIFF
--- a/java/java-impl-refactorings/src/com/intellij/refactoring/anonymousToInner/AnonymousToInnerHandler.java
+++ b/java/java-impl-refactorings/src/com/intellij/refactoring/anonymousToInner/AnonymousToInnerHandler.java
@@ -33,7 +33,6 @@ import com.intellij.refactoring.util.RefactoringChangeUtil;
 import com.intellij.refactoring.util.VariableData;
 import com.intellij.refactoring.util.classMembers.ElementNeedsThis;
 import com.intellij.util.ArrayUtil;
-import com.intellij.util.CommonJavaRefactoringUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.siyeh.ig.jdk.VarargParameterInspection;
 import org.jetbrains.annotations.NonNls;
@@ -737,7 +736,7 @@ public class AnonymousToInnerHandler implements RefactoringActionHandlerOnPsiEle
         if (resolved instanceof PsiTypeParameter typeParameter) {
           final PsiTypeParameterListOwner owner = typeParameter.getOwner();
           if (owner != null && !PsiTreeUtil.isAncestor(myAnonOrLocalClass, owner, false) &&
-              (CommonJavaRefactoringUtil.isInStaticContext(owner, myTargetClass) || myMakeStatic)) {
+              (!PsiTreeUtil.isAncestor(owner, myTargetClass, false) || myMakeStatic)) {
             myTypeParametersToCreate.add(typeParameter);
           }
         }

--- a/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStatic.java
+++ b/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStatic.java
@@ -1,0 +1,18 @@
+import java.util.*;
+
+class A {
+    public <K, V> Iterator<Map.Entry<K, V>> iterator(long revision) {
+        return new <caret>Iterator<Map.Entry<K, V>>() {
+            public boolean hasNext() {
+                return false;
+            }
+
+            public Map.Entry<K, V> next() {
+                return null;
+            }
+
+            public void remove() {
+            }
+        };
+    }
+}

--- a/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStaticNoGenericsNeeded.java
+++ b/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStaticNoGenericsNeeded.java
@@ -1,0 +1,18 @@
+import java.util.*;
+
+class A<K, V> {
+    public Iterator<Map.Entry<K, V>> iterator(long revision) {
+        return new <caret>Iterator<Map.Entry<K, V>>() {
+            public boolean hasNext() {
+                return false;
+            }
+
+            public Map.Entry<K, V> next() {
+                return null;
+            }
+
+            public void remove() {
+            }
+        };
+    }
+}

--- a/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStaticNoGenericsNeeded_after.java
+++ b/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStaticNoGenericsNeeded_after.java
@@ -1,0 +1,20 @@
+import java.util.*;
+
+class A<K, V> {
+    public Iterator<Map.Entry<K, V>> iterator(long revision) {
+        return new MyIterator();
+    }
+
+    private class MyIterator implements Iterator<Map.Entry<K, V>> {
+        public boolean hasNext() {
+            return false;
+        }
+
+        public Map.Entry<K, V> next() {
+            return null;
+        }
+
+        public void remove() {
+        }
+    }
+}

--- a/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStatic_after.java
+++ b/java/java-tests/testData/refactoring/anonymousToInner/genericTypeParametersNonStatic_after.java
@@ -1,0 +1,20 @@
+import java.util.*;
+
+class A {
+    public <K, V> Iterator<Map.Entry<K, V>> iterator(long revision) {
+        return new MyIterator<>();
+    }
+
+    private class MyIterator<K, V> implements Iterator<Map.Entry<K, V>> {
+        public boolean hasNext() {
+            return false;
+        }
+
+        public Map.Entry<K, V> next() {
+            return null;
+        }
+
+        public void remove() {
+        }
+    }
+}

--- a/java/java-tests/testSrc/com/intellij/java/refactoring/AnonymousToInnerTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/refactoring/AnonymousToInnerTest.java
@@ -23,6 +23,14 @@ public class AnonymousToInnerTest extends LightJavaCodeInsightTestCase {
     doTest("MyIterator", true);
   }
 
+  public void testGenericTypeParametersNonStatic() {
+    doTest("MyIterator", false);
+  }
+
+  public void testGenericTypeParametersNonStaticNoGenericsNeeded() {
+    doTest("MyIterator", false);
+  }
+
   public void testInsideInterface() {  // IDEADEV-29446
     doTest("MyRunnable", true);
   }


### PR DESCRIPTION
In `AnonymousToInnerHandler.calculateTypeParametersToCreate`, I believe the faulty check is `CommonJavaRefactoringUtil.isInStaticContext`, this doesn't make much sense to me. Instead, when the new class is non-static, you should be checking if the type parameter would still be in the lexical scope. In this case, this is equivalent to checking if the type parameter owner is a (non-strict) ancestor of the target class (the class into which we are adding the inner class).