### PR TITLE
[JEWEL-817] Fix iconClass defaults for *IconActionButton

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeResourceResolver.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeResourceResolver.kt
@@ -5,10 +5,12 @@ import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.painter.ResourcePainterProvider
 
 /** [ResourcePainterProvider] to resolve resources in Intellij Module and Bridge module. */
+@Deprecated("Use IconKeys and the Icon composable instead")
 public fun bridgePainterProvider(path: String): ResourcePainterProvider =
     ResourcePainterProvider(path, DirProvider::class.java.classLoader, SwingBridgeService::class.java.classLoader)
 
 /** [ResourcePainterProvider] to resolve resources in Intellij Module and Bridge module. */
+@Deprecated("Use the Icon composable instead")
 public fun bridgePainterProvider(iconKey: IconKey): ResourcePainterProvider {
     val isNewUi = isNewUiTheme()
     return ResourcePainterProvider(

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/PainterProvider.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/PainterProvider.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.intui.standalone
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.painter.ResourcePainterProvider
 
-/** Create a [PainterProvider][org.jetbrains.jewel.painter.PainterProvider] to load a resource from the classpath. */
+/** Create a [PainterProvider][org.jetbrains.jewel.ui.painter.PainterProvider] to load a resource from the classpath. */
+@Deprecated("Use IconKeys and the Icon composable instead")
 public fun standalonePainterProvider(path: String): ResourcePainterProvider =
     ResourcePainterProvider(path, JewelTheme::class.java.classLoader)

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
@@ -60,7 +60,7 @@ private val languageOptions =
     )
 
 @Composable
-public fun ComboBoxes() {
+fun ComboBoxes() {
     GroupHeader("List combo box (aka dropdown)")
     ListComboBoxes()
 
@@ -233,8 +233,8 @@ private fun CustomComboBoxes() {
                     SimpleListItem(
                         text = languageOptions[selectedIndex].name,
                         icon = languageOptions[selectedIndex].icon,
-                        isSelected = false,
-                        isActive = true,
+                        selected = false,
+                        active = true,
                     )
                 },
             )

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -384,6 +384,7 @@ public final class org/jetbrains/jewel/ui/component/DropdownState$Companion {
 
 public final class org/jetbrains/jewel/ui/component/EditableComboBoxKt {
 	public static final fun EditableComboBox (Landroidx/compose/foundation/text/input/TextFieldState;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/ComboBoxStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/ui/component/PopupManager;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun detectPressAndCancel (Landroidx/compose/ui/input/pointer/PointerInputScope;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/jewel/ui/component/FixedCursorPoint : androidx/compose/foundation/TooltipPlacement {
@@ -4203,6 +4204,12 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Profiler {
 	public final fun getCollapseNode ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getExpandNode ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getRec ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+}
+
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Promo {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Promo;
+	public final fun getJavaDuke ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 }
 
 public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Providers {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/IconActionButton.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/IconActionButton.kt
@@ -45,7 +45,7 @@ public fun IconActionButton(
     colorFilter: ColorFilter? = null,
     hint: PainterHint? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
 ) {
     BaseIconActionButton(
         key = key,
@@ -79,7 +79,7 @@ public fun IconActionButton(
     tooltipModifier: Modifier = Modifier,
     tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
     tooltip: @Composable () -> Unit,
 ) {
     Tooltip(tooltip, style = tooltipStyle, modifier = tooltipModifier, tooltipPlacement = tooltipPlacement) {
@@ -113,7 +113,7 @@ public fun IconActionButton(
     style: IconButtonStyle = JewelTheme.iconButtonStyle,
     colorFilter: ColorFilter? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
 ) {
     CoreIconActionButton(
         key = key,
@@ -147,7 +147,7 @@ public fun IconActionButton(
     tooltipModifier: Modifier = Modifier,
     tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
     tooltip: @Composable () -> Unit,
 ) {
     Tooltip(tooltip, style = tooltipStyle, modifier = tooltipModifier, tooltipPlacement = tooltipPlacement) {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/SelectableIconActionButton.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/SelectableIconActionButton.kt
@@ -32,7 +32,7 @@ public fun SelectableIconActionButton(
     colorFilter: ColorFilter? = null,
     extraHint: PainterHint? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
 ) {
     BaseSelectableIconActionButton(
         key = key,
@@ -68,7 +68,7 @@ public fun SelectableIconActionButton(
     tooltipModifier: Modifier = Modifier,
     tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
     tooltip: @Composable () -> Unit,
 ) {
     Tooltip(tooltip, style = tooltipStyle, modifier = tooltipModifier, tooltipPlacement = tooltipPlacement) {
@@ -104,7 +104,7 @@ public fun SelectableIconActionButton(
     style: IconButtonStyle = JewelTheme.iconButtonStyle,
     colorFilter: ColorFilter? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
 ) {
     CoreSelectableIconActionButton(
         key = key,
@@ -140,7 +140,7 @@ public fun SelectableIconActionButton(
     tooltipModifier: Modifier = Modifier,
     tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
     tooltip: @Composable () -> Unit,
 ) {
     Tooltip(tooltip, style = tooltipStyle, modifier = tooltipModifier, tooltipPlacement = tooltipPlacement) {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ToggleableIconActionButton.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ToggleableIconActionButton.kt
@@ -32,7 +32,7 @@ public fun ToggleableIconActionButton(
     colorFilter: ColorFilter? = null,
     extraHint: PainterHint? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
 ) {
     BaseToggleableIconActionButton(
         key = key,
@@ -68,7 +68,7 @@ public fun ToggleableIconActionButton(
     tooltipModifier: Modifier = Modifier,
     tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
     tooltip: @Composable () -> Unit,
 ) {
     Tooltip(tooltip, style = tooltipStyle, modifier = tooltipModifier, tooltipPlacement = tooltipPlacement) {
@@ -104,7 +104,7 @@ public fun ToggleableIconActionButton(
     style: IconButtonStyle = JewelTheme.iconButtonStyle,
     colorFilter: ColorFilter? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
 ) {
     CoreToggleableIconActionButton(
         key = key,
@@ -140,7 +140,7 @@ public fun ToggleableIconActionButton(
     tooltipModifier: Modifier = Modifier,
     tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    iconClass: Class<*> = key::class.java,
+    iconClass: Class<*> = key.iconClass,
     tooltip: @Composable () -> Unit,
 ) {
     Tooltip(tooltip, style = tooltipStyle, modifier = tooltipModifier, tooltipPlacement = tooltipPlacement) {


### PR DESCRIPTION
We were passing the `IconKey`'s class itself as key instead of the class it contains, causing issues in IDE release builds due to classloader isolation. Now we pass the correct class in by default.

We also deprecate a few now-unused APIs related to icon loading, and address a minor issue in the ComboBoxes showcase page.