### PR TITLE
[JEWEL-812] Implement `JewelBridgeClipboard`

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/clipboard/JewelBridgeClipboard.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/clipboard/JewelBridgeClipboard.kt
@@ -1,0 +1,63 @@
+package org.jetbrains.jewel.bridge.clipboard
+
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.NativeClipboard
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.ide.CopyPasteManager
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
+
+/**
+ * A [Clipboard] implementation, similar to Compose's internal `AwtPlatformClipboard`, that delegates to the IJP's
+ * [CopyPasteManager] instead of to the AWT [`Clipboard`][java.awt.datatransfer.Clipboard].
+ */
+internal class JewelBridgeClipboard : Clipboard {
+    private val logger = thisLogger()
+
+    @Suppress("TooGenericExceptionCaught") // Just guarding against IJP/AWT weirdness
+    private val copyPasteManager by lazy {
+        logger.info("Initializing CopyPasteManager...")
+        if (ApplicationManager.getApplication() == null) {
+            logger.error("CopyPasteManager is not available when the IJP is not initialized.")
+            return@lazy null
+        }
+
+        try {
+            CopyPasteManager.getInstance()
+        } catch (e: RuntimeException) {
+            logger.error("CopyPasteManager is not available.", e)
+            null
+        }
+    }
+
+    override val nativeClipboard: NativeClipboard
+        get() = copyPasteManager ?: error("CopyPasteManager is not available")
+
+    override suspend fun getClipEntry(): ClipEntry? {
+        logger.debug("getClipEntry called. CopyPasteManager available: ${copyPasteManager != null}")
+
+        val transferable = copyPasteManager?.contents ?: return null
+        val flavors = transferable.transferDataFlavors
+        if (flavors?.size == 0) return null
+        return ClipEntry(transferable)
+    }
+
+    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+        logger.debug("setClipEntry called: $clipEntry. CopyPasteManager available: ${copyPasteManager != null}")
+        val transferable = clipEntry?.nativeClipEntry as? Transferable
+        copyPasteManager?.setContents(transferable ?: EmptyTransferable)
+    }
+
+    private object EmptyTransferable : Transferable {
+        override fun getTransferDataFlavors(): Array<DataFlavor> = emptyArray()
+
+        override fun isDataFlavorSupported(flavor: DataFlavor?): Boolean = false
+
+        override fun getTransferData(flavor: DataFlavor?): Any {
+            throw UnsupportedFlavorException(flavor)
+        }
+    }
+}

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
@@ -4,9 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
 import org.jetbrains.jewel.bridge.BridgePainterHintsProvider
 import org.jetbrains.jewel.bridge.SwingBridgeReader
+import org.jetbrains.jewel.bridge.clipboard.JewelBridgeClipboard
 import org.jetbrains.jewel.bridge.icon.BridgeNewUiChecker
 import org.jetbrains.jewel.bridge.scaleDensityWithIdeScale
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
@@ -31,6 +34,7 @@ public fun SwingBridgeTheme(content: @Composable () -> Unit) {
             LocalPainterHintsProvider provides BridgePainterHintsProvider(themeData.themeDefinition.isDark),
             LocalNewUiChecker provides BridgeNewUiChecker,
             LocalDensity provides scaleDensityWithIdeScale(LocalDensity.current),
+            LocalClipboard provides remember { JewelBridgeClipboard() },
         ) {
             content()
         }


### PR DESCRIPTION
In the bridge only, this change adds a new `Clipboard` implementation that delegates to the IJP's `ClipboardManager` instead of the AWT `Clipboard` (which is what CMP does).

This allows us to directly integrate in the clipboard history feature in IJP, and take advantage of a number of improvements around pasting from the clipboard. For more details see IJP's `ClipboardSynchronizer`.

## Release notes

### New features
 * **JEWEL-812** Hook clipboard into IJP's in the bridge ([#3050](https://github.com/JetBrains/intellij-community/pull/3050))