### PR TITLE
Add GH alerts support to Markdown, fix inline code font

### DIFF
--- a/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/ComposePanelProvider.kt
+++ b/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/ComposePanelProvider.kt
@@ -15,14 +15,13 @@ internal class ComposePanelProvider : MarkdownHtmlPanelProvider() {
     return MarkdownComposePanel()
   }
 
-  override fun createHtmlPanel(project: Project, virtualFile: VirtualFile): MarkdownHtmlPanel {
-    return MarkdownComposePanel(project, virtualFile)
-  }
+  override fun createHtmlPanel(project: Project, virtualFile: VirtualFile): MarkdownHtmlPanel = MarkdownComposePanel(project, virtualFile)
 
   override fun isAvailable(): AvailabilityInfo {
     if (Registry.`is`("enable.markdown.compose.preview.renderer.choice", false) && AppMode.isMonolith()) {
       return AvailabilityInfo.AVAILABLE
     }
+
     return AvailabilityInfo.UNAVAILABLE
   }
 

--- a/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/JcefLikeMarkdownStyling.kt
+++ b/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/JcefLikeMarkdownStyling.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.editor.colors.FontPreferences
 import com.intellij.util.ui.JBUI
 import org.intellij.plugins.markdown.ui.preview.PreviewStyleScheme
 import org.jetbrains.jewel.bridge.retrievePlatformTextStyle
+import org.jetbrains.jewel.bridge.theme.retrieveEditorTextStyle
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.rendering.InlinesStyling
@@ -64,8 +65,9 @@ internal fun JcefLikeMarkdownStyling(scheme: PreviewStyleScheme, fontSize: TextU
 
   val codeFont = Font(FontPreferences.JETBRAINS_MONO, Font.PLAIN, (fontSize.value * 0.9f).toInt()).asComposeFontFamily()
   val codeTextStyle = baseTextStyle.copy(fontFamily = codeFont)
+  val editorTextStyle = retrieveEditorTextStyle()
 
-  val inlinesStyling = createInlinesStyling(baseTextStyle, scheme, codeFont)
+  val inlinesStyling = createInlinesStyling(baseTextStyle, editorTextStyle, scheme, codeFont)
   val paragraph = createParagraphStyling(inlinesStyling)
   val heading = createHeadingStyling(scheme, baseTextStyle, fontSizeDp, codeFont)
   val blockQuote = createBlockQuoteStyling(scheme)
@@ -90,15 +92,16 @@ internal fun JcefLikeMarkdownStyling(scheme: PreviewStyleScheme, fontSize: TextU
 
 private fun createInlinesStyling(
   baseTextStyle: TextStyle,
+  editorTextStyle: TextStyle,
   scheme: PreviewStyleScheme,
   codeFont: FontFamily = FontFamily.Monospace,
   link: SpanStyle = baseTextStyle.copy(
     color = JBUI.CurrentTheme.Link.Foreground.ENABLED.toComposeColor(),
     textDecoration = TextDecoration.Underline,
-  ).toSpanStyle()
+  ).toSpanStyle(),
 ): InlinesStyling = InlinesStyling(
   textStyle = baseTextStyle,
-  inlineCode = baseTextStyle
+  inlineCode = editorTextStyle
     .copy(
       fontFamily = codeFont,
       fontSize = baseTextStyle.fontSize,
@@ -108,7 +111,7 @@ private fun createInlinesStyling(
   link = link,
   emphasis = baseTextStyle.copy(fontStyle = FontStyle.Italic).toSpanStyle(),
   strongEmphasis = baseTextStyle.copy(fontWeight = FontWeight.Bold).toSpanStyle(),
-  inlineHtml = baseTextStyle.toSpanStyle(),
+  inlineHtml = editorTextStyle.toSpanStyle(),
   linkDisabled = link.copy(color = JBUI.CurrentTheme.Link.Foreground.DISABLED.toComposeColor()),
   linkHovered = link.copy(color = JBUI.CurrentTheme.Link.Foreground.HOVERED.toComposeColor()),
   linkFocused = link.copy(
@@ -179,7 +182,7 @@ private fun headerInlinesStyling(scheme: PreviewStyleScheme, textStyle: TextStyl
     color = color ?: textStyle.color,
     fontSize = fontSize,
     lineHeight = fontSize * lineHeightMultiplier,
-  ), scheme, codeFont)
+  ), retrieveEditorTextStyle(), scheme, codeFont)
 }
 
 private fun createBlockQuoteStyling(scheme: PreviewStyleScheme): BlockQuote = BlockQuote(

--- a/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/MarkdownComposePanel.kt
+++ b/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/MarkdownComposePanel.kt
@@ -92,7 +92,7 @@ internal class MarkdownComposePanel(
   @Composable
   private fun MarkdownPanel() {
     val scheme = PreviewStyleScheme.fromCurrentTheme()
-    val fontSize = scheme.fontSize.sp
+    val fontSize = scheme.fontSize.sp / scheme.scale
     val scrollState = rememberScrollState(0)
     val scrollingSynchronizer = remember(scrollState) { ScrollingSynchronizer.create(scrollState) }
     val markdownStyling = remember(scheme, fontSize) { JcefLikeMarkdownStyling(scheme, fontSize) }
@@ -120,7 +120,7 @@ internal class MarkdownComposePanel(
     val coilContext = LocalPlatformContext.current
     val imageRendererExtension = remember(coilContext) { Coil3ImageRendererExtension.withDefaultLoader(coilContext) }
     val allRenderingExtensions = listOf(tableRenderer, alertRenderer, GitHubStrikethroughRendererExtension, imageRendererExtension)
-    val blockRenderer = remember(markdownStyling) {
+    val blockRenderer = remember(markdownStyling, allRenderingExtensions) {
       ScrollSyncMarkdownBlockRenderer(
         markdownStyling,
         allRenderingExtensions,


### PR DESCRIPTION
This adds support for GitHub alerts to the Compose Markdown renderer, and improves the styling setup to use the correct font for inline code (the one from the editor scheme instead of the system default font).

## Before
Inline code has the wrong font:
![image](https://github.com/user-attachments/assets/1b0dab18-fc0f-4c02-9250-ad0ce94eaa98)

GitHub alerts are rendered as normal blockquotes:
![image](https://github.com/user-attachments/assets/4a51b4a7-9e63-455b-b759-1147f1314c4c)

## After
![image](https://github.com/user-attachments/assets/868bd0af-8bb8-45a5-a0fc-d32a2b45de63)

![image](https://github.com/user-attachments/assets/fcc17cd3-319b-4247-8ed0-6f419eafac12)
