### PR TITLE
[JEWEL-821] Fix Jewel publishing

### DIFF
--- a/build/src/org/jetbrains/intellij/build/IdeaCommunityProperties.kt
+++ b/build/src/org/jetbrains/intellij/build/IdeaCommunityProperties.kt
@@ -78,17 +78,23 @@ open class IdeaCommunityProperties(private val communityHomeDir: Path) : BaseIde
     ))
     mavenArtifacts.patchCoordinates = { module, coordinates ->
       when {
-        JewelMavenArtifacts.isJewel(module) -> JewelMavenArtifacts.patchCoordinates(module, coordinates)
+        JewelMavenArtifacts.isPublishedJewelModule(module) -> JewelMavenArtifacts.patchCoordinates(module, coordinates)
         else -> coordinates
+      }
+    }
+    mavenArtifacts.patchDependencies = { module, dependencies ->
+      when {
+        JewelMavenArtifacts.isPublishedJewelModule(module) -> JewelMavenArtifacts.patchDependencies(module, dependencies)
+        else -> dependencies
       }
     }
     mavenArtifacts.addPomMetadata = { module, model ->
       when {
-        JewelMavenArtifacts.isJewel(module) -> JewelMavenArtifacts.addPomMetadata(module, model)
+        JewelMavenArtifacts.isPublishedJewelModule(module) -> JewelMavenArtifacts.addPomMetadata(module, model)
       }
     }
     mavenArtifacts.isJavadocJarRequired = {
-      JewelMavenArtifacts.isJewel(it)
+      JewelMavenArtifacts.isPublishedJewelModule(it)
     }
     mavenArtifacts.validate = { context, artifacts ->
       JewelMavenArtifacts.validate(context, artifacts)

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/MavenArtifactsProperties.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/MavenArtifactsProperties.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.persistentListOf
 import org.apache.maven.model.Model
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.intellij.build.impl.maven.GeneratedMavenArtifacts
+import org.jetbrains.intellij.build.impl.maven.MavenArtifactDependency
 import org.jetbrains.intellij.build.impl.maven.MavenCoordinates
 import org.jetbrains.jps.model.module.JpsModule
 import org.jetbrains.jps.util.JpsPathUtil
@@ -54,6 +55,9 @@ class MavenArtifactsProperties {
 
   @ApiStatus.Internal
   var patchCoordinates: (JpsModule, MavenCoordinates) -> MavenCoordinates = { _, coordinates -> coordinates }
+
+  @ApiStatus.Internal
+  var patchDependencies: (JpsModule, List<MavenArtifactDependency>) -> List<MavenArtifactDependency> = { _, dependencies -> dependencies }
 
   @ApiStatus.Internal
   var addPomMetadata: (JpsModule, Model) -> Unit = { _, _ -> }

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/maven/MavenArtifactsBuilder.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/maven/MavenArtifactsBuilder.kt
@@ -299,13 +299,14 @@ open class MavenArtifactsBuilder(protected val context: BuildContext) {
         }
       }
     }
+    val patchedDependencies = context.productProperties.mavenArtifacts.patchDependencies(module, dependencies)
     computationInProgress.remove(module)
     if (!mavenizable) {
       nonMavenizableModules.add(module)
       return null
     }
 
-    val artifactData = MavenArtifactData(module, generateMavenCoordinatesForModule(module), dependencies)
+    val artifactData = MavenArtifactData(module, generateMavenCoordinatesForModule(module), patchedDependencies)
     if (!module.isLibraryModule()) {
       results[module] = artifactData
     }
@@ -328,7 +329,7 @@ open class MavenArtifactsBuilder(protected val context: BuildContext) {
   }
 }
 
-internal enum class DependencyScope {
+enum class DependencyScope {
   COMPILE, RUNTIME
 }
 
@@ -353,7 +354,7 @@ internal data class MavenArtifactData(
   val dependencies: List<MavenArtifactDependency>
 )
 
-internal data class MavenArtifactDependency(
+data class MavenArtifactDependency(
   val coordinates: MavenCoordinates,
   val includeTransitiveDeps: Boolean,
   val excludedDependencies: List<String>,


### PR DESCRIPTION
This adds a `patchDependencies` capability to `MavenArtifactsBuilder`, which is used by `JewelMavenArtifacts` to change the dependencies that are added to the POM files. 

This way, we set up the correct scopes and exclusions, cleaning up unnecessary dependencies that only exist in the JPS build to accommodate IJP quirks. This makes the artefacts usable for standalone builds.

In particular, the patching:
 * Drops unneeded/undesirable IJP-only dependencies (e.g., `skiko-awt-runtime-all` and the forked coroutines-core)
 * Omits dependencies that are brought in transitively, letting Maven/Gradle do it
 * Ensures proper scoping for all dependencies (mostly "compile"; only Markdown extensions in the Markdown styling module are supposed to be "runtime")
 * Removes exclusions that only make sense in the JPS build, restoring proper transitivity