### PR TITLE
[JEWEL-823] Bumping compose to latest stable version

### DIFF
--- a/platform/jewel/gradle/libs.versions.toml
+++ b/platform/jewel/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 commonmark = "0.24.0"
-composeDesktop = "1.8.0-alpha04"
+composeDesktop = "1.8.1"
 detekt = "1.23.6"
 dokka = "2.0.0"
 filepicker = "3.1.0"


### PR DESCRIPTION
Updating compose to 1.8.1 as it includes a fix for the SKIA Svg Render