### PR TITLE
IJPL-189791 add patterns to GradleConsoleFilter

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/GradleConsoleFilter.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/execution/GradleConsoleFilter.java
@@ -38,8 +38,9 @@ public class GradleConsoleFilter implements Filter {
 
   @Override
   public @Nullable Result applyFilter(final @NotNull String line, final int entireLength) {
-    String[] filePrefixes = new String[]{"Build file '", "build file '", "Settings file '", "settings file '"};
-    String[] linePrefixes = new String[]{"' line: ", "': ", "' line: ", "': "};
+    String[] filePrefixes =
+      new String[]{"Build file '", "build file '", "Settings file '", "settings file '", "Initialization script '", "Script '"};
+    String[] linePrefixes = new String[]{"' line: ", "': ", "' line: ", "': ", "' line: ", "' line: "};
     String filePrefix = null;
     String linePrefix = null;
     for (int i = 0; i < filePrefixes.length; i++) {

--- a/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/GradleConsoleFilterTest.java
+++ b/plugins/gradle/testSources/org/jetbrains/plugins/gradle/execution/GradleConsoleFilterTest.java
@@ -31,6 +31,8 @@ public class GradleConsoleFilterTest extends CodeInsightFixtureTestCase {
     doTest("build file 'C:\\project\\build.gradle': 49: unexpected token: 5 @ line 49, column 28.", "C:\\project\\build.gradle", 49);
     doTest("Settings file 'C:\\project\\settings.gradle' line: 7", "C:\\project\\settings.gradle", 7);
     doTest("Settings file '/project/settings.gradle' line: 7", "/project/settings.gradle", 7);
+    doTest("Initialization script '/user/.gradle/init.d/offline.gradle' line: 19", "/user/.gradle/init.d/offline.gradle", 19);
+    doTest("Script '/project/script.gradle' line: 7", "/project/script.gradle", 7);
     doTestExpectingNull("Build file '/home/ezm/projects/intellij/one.com/commons-webservice-utils/build.gradle' line: ");
     doTestExpectingNull("Garbage");
   }


### PR DESCRIPTION
Adding patterns to recognise the following lines as locations:
```
Initialization script '$path' line: 19
Script '$path' line: 19
```