### PR TITLE
[JEWEL-829] Fix the bridge not reading the LaF

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/SwingBridgeService.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/SwingBridgeService.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onStart
 import org.jetbrains.jewel.bridge.theme.createBridgeComponentStyling
 import org.jetbrains.jewel.bridge.theme.createBridgeThemeDefinition
 import org.jetbrains.jewel.foundation.theme.ThemeDefinition
@@ -23,14 +24,15 @@ import org.jetbrains.jewel.ui.component.copyWithSize
 internal class SwingBridgeService {
     private val scrollbarHelper = ScrollbarHelper.getInstance()
     private val settingsFlow: Flow<UISettings> =
-        ApplicationManager.getApplication().messageBus.subscribeAsFlow(UISettingsListener.TOPIC) {
-            UISettingsListener { uiSettings -> trySend(uiSettings) }
-        }
+        ApplicationManager.getApplication()
+            .messageBus
+            .subscribeAsFlow(UISettingsListener.TOPIC) { UISettingsListener { uiSettings -> trySend(uiSettings) } }
+            .onStart { emit(UISettings.getInstance()) }
 
     internal val currentBridgeThemeData: StateFlow<BridgeThemeData> =
-        LafFlowService.getInstance().customLafFlowState(BridgeThemeData.DEFAULT) { flow ->
+        LafFlowService.getInstance().customLafFlowState(BridgeThemeData.DEFAULT) { lafChangeFlow ->
             combine(
-                flow,
+                lafChangeFlow,
                 scrollbarHelper.scrollbarVisibilityStyleFlow,
                 scrollbarHelper.trackClickBehaviorFlow,
                 settingsFlow,


### PR DESCRIPTION
In JEWEL-558, a change was made to add a new flow to the combine in `SwingBridgeService`. However, that new flow never emitted, causing the whole `combine` to stall until it did. This in turn causes only the theme defaults to be loaded, until the user changes the "contrast scrollbars" option, making the faulty flow emit and unblocking the `combine`.

The fix is to ensure the flow emits on start, like all other flows in the `combine` do.