### PR TITLE
[JEWEL-827] Improving TabStrip implementation 

### DIFF
--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/TabStripTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/TabStripTest.kt
@@ -1,0 +1,171 @@
+package org.jetbrains.jewel.ui.component
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import kotlin.math.max
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.ui.component.interactions.performKeyPress
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+import org.jetbrains.jewel.ui.painter.hints.Stateful
+import org.jetbrains.jewel.ui.painter.rememberResourcePainterProvider
+import org.jetbrains.jewel.ui.theme.defaultTabStyle
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TabStripTest {
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun `clicking on a tab selects it`() = runComposeTest {
+        onNodeWithText("Test Tab 1").assertIsSelected()
+        onNodeWithText("Test Tab 2").assertIsNotSelected()
+
+        onNodeWithText("Test Tab 2").performClick()
+
+        onNodeWithText("Test Tab 1").assertIsNotSelected()
+        onNodeWithText("Test Tab 2").assertIsSelected()
+    }
+
+    @Test
+    fun `on press arrow right, moves focus to next tab`() = runComposeTest {
+        onNodeWithText("Test Tab 1").assertIsSelected()
+
+        onRoot().performKeyPress(Key.Companion.DirectionRight)
+
+        onNodeWithText("Test Tab 2").assertIsSelected()
+    }
+
+    @Test
+    fun `on press arrow right, in the last tab, moves focus to the first tab`() =
+        runComposeTest(initiallySelectedTabIndex = 11) {
+            onNodeWithText("Test Tab 12").assertIsSelected()
+
+            onRoot().performKeyPress(Key.Companion.DirectionRight)
+
+            onNodeWithText("Test Tab 1").assertIsSelected()
+        }
+
+    @Test
+    fun `when keeping arrow right pressed, keeps moving the selected tab`() = runComposeTest {
+        onNodeWithText("Test Tab 1").assertIsSelected()
+
+        onRoot().performKeyPress(Key.Companion.DirectionRight, duration = 3_000)
+
+        onNodeWithText("Test Tab 5").assertIsSelected()
+    }
+
+    @Test
+    fun `on press arrow left, moves focus to previous tab`() =
+        runComposeTest(initiallySelectedTabIndex = 1) {
+            onNodeWithText("Test Tab 2").assertIsSelected()
+
+            onRoot().performKeyPress(Key.Companion.DirectionLeft)
+
+            onNodeWithText("Test Tab 1").assertIsSelected()
+        }
+
+    @Test
+    fun `on press arrow left, in the first tab, moves focus to the last tab`() = runComposeTest {
+        onNodeWithText("Test Tab 1").assertIsSelected()
+
+        onRoot().performKeyPress(Key.Companion.DirectionLeft)
+
+        onNodeWithText("Test Tab 12").assertIsSelected()
+    }
+
+    @Test
+    fun `on press end, moves focus to last tab`() = runComposeTest {
+        onNodeWithText("Test Tab 1").assertIsSelected()
+
+        onRoot().performKeyPress(Key.Companion.MoveEnd)
+
+        onNodeWithText("Test Tab 12").assertIsSelected()
+    }
+
+    @Test
+    fun `on press home, moves focus to first tab`() =
+        runComposeTest(initiallySelectedTabIndex = 11) {
+            onNodeWithText("Test Tab 12").assertIsSelected()
+
+            onRoot().performKeyPress(Key.Companion.MoveHome)
+
+            onNodeWithText("Test Tab 1").assertIsSelected()
+        }
+
+    @Test
+    fun `on scroll to tab, set it in focus`() = runComposeTest {
+        onNodeWithText("Test Tab 12").assertIsNotDisplayed()
+
+        onRoot().performKeyPress(Key.Companion.MoveEnd)
+
+        onNodeWithText("Test Tab 12").assertIsDisplayed()
+    }
+
+    private fun runComposeTest(
+        closeable: Boolean = true,
+        initiallyOpenTabs: List<Int> = (1..12).toList(),
+        initiallySelectedTabIndex: Int = 0,
+        block: ComposeContentTestRule.() -> Unit,
+    ) {
+        rule.setContent {
+            val focusRequester = remember { FocusRequester() }
+            var selectedTabIndex by remember { mutableIntStateOf(initiallySelectedTabIndex) }
+            val tabIds = remember { initiallyOpenTabs.toMutableStateList() }
+
+            val tabs =
+                remember(tabIds, selectedTabIndex) {
+                    tabIds.mapIndexed { index, id ->
+                        TabData.Default(
+                            selected = index == selectedTabIndex,
+                            content = { tabState ->
+                                val iconProvider = rememberResourcePainterProvider(AllIconsKeys.Actions.Find)
+                                val icon by iconProvider.getPainter(Stateful(tabState))
+                                SimpleTabContent(label = "Test Tab $id", state = tabState, icon = icon)
+                            },
+                            onClose = {
+                                tabIds.removeAt(index)
+                                if (selectedTabIndex >= index) {
+                                    val maxPossibleIndex = max(0, tabIds.lastIndex)
+                                    selectedTabIndex = (selectedTabIndex - 1).coerceIn(0..maxPossibleIndex)
+                                }
+                            },
+                            onClick = { selectedTabIndex = index },
+                            closable = closeable,
+                        )
+                    }
+                }
+
+            IntUiTheme {
+                TabStrip(
+                    tabs = tabs,
+                    style = JewelTheme.Companion.defaultTabStyle,
+                    modifier = Modifier.Companion.focusRequester(focusRequester),
+                )
+            }
+
+            LaunchedEffect(Unit) { focusRequester.requestFocus() }
+        }
+
+        rule.block()
+    }
+}

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/interactions/PerformKeyPress.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/interactions/PerformKeyPress.kt
@@ -1,0 +1,30 @@
+package org.jetbrains.jewel.ui.component.interactions
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.performKeyInput
+
+@OptIn(ExperimentalTestApi::class)
+internal fun SemanticsNodeInteraction.performKeyPress(
+    key: Key,
+    ctrl: Boolean = false,
+    shift: Boolean = false,
+    alt: Boolean = false,
+    meta: Boolean = false,
+    duration: Long = 50L,
+): SemanticsNodeInteraction = performKeyInput {
+    if (ctrl) keyDown(Key.CtrlLeft)
+    if (shift) keyDown(Key.ShiftLeft)
+    if (alt) keyDown(Key.AltLeft)
+    if (meta) keyDown(Key.MetaLeft)
+
+    keyDown(key)
+    advanceEventTime(duration)
+    keyUp(key)
+
+    if (meta) keyUp(Key.MetaLeft)
+    if (alt) keyUp(Key.AltLeft)
+    if (shift) keyUp(Key.ShiftLeft)
+    if (ctrl) keyUp(Key.CtrlLeft)
+}

--- a/platform/jewel/ui/api-dump-unreviewed.txt
+++ b/platform/jewel/ui/api-dump-unreviewed.txt
@@ -756,7 +756,6 @@ f:org.jetbrains.jewel.ui.component.TabState$Companion
 - f:of-59c8LF8(Z,Z,Z,Z,Z):J
 - bs:of-59c8LF8$default(org.jetbrains.jewel.ui.component.TabState$Companion,Z,Z,Z,Z,Z,I,java.lang.Object):J
 f:org.jetbrains.jewel.ui.component.TabStripKt
-- sf:TabStrip(java.util.List,org.jetbrains.jewel.ui.component.styling.TabStyle,androidx.compose.ui.Modifier,Z,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.ui.component.TabStripState
 - org.jetbrains.jewel.foundation.state.FocusableComponentState
 - sf:Companion:org.jetbrains.jewel.ui.component.TabStripState$Companion

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -24,6 +24,8 @@ org.jetbrains.jewel.ui.component.MenuScope
 - bs:submenu$default(org.jetbrains.jewel.ui.component.MenuScope,Z,org.jetbrains.jewel.ui.icon.IconKey,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):V
 org.jetbrains.jewel.ui.component.TabContentScope
 - tabContentAlpha-A_ZS63w(androidx.compose.ui.Modifier,J,androidx.compose.runtime.Composer,I):androidx.compose.ui.Modifier
+f:org.jetbrains.jewel.ui.component.TabStripKt
+- sf:TabStrip(java.util.List,org.jetbrains.jewel.ui.component.styling.TabStyle,androidx.compose.ui.Modifier,Z,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.ui.component.TooltipKt
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,org.jetbrains.jewel.ui.component.AutoHideBehavior,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -1003,7 +1003,7 @@ public final class org/jetbrains/jewel/ui/component/TabState$Companion {
 }
 
 public final class org/jetbrains/jewel/ui/component/TabStripKt {
-	public static final fun TabStrip (Ljava/util/List;Lorg/jetbrains/jewel/ui/component/styling/TabStyle;Landroidx/compose/ui/Modifier;ZLandroidx/compose/runtime/Composer;II)V
+	public static final fun TabStrip (Ljava/util/List;Lorg/jetbrains/jewel/ui/component/styling/TabStyle;Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/TabStripState : org/jetbrains/jewel/foundation/state/FocusableComponentState {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
@@ -2,7 +2,6 @@ package org.jetbrains.jewel.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -25,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap
@@ -118,9 +118,10 @@ internal fun TabImpl(
     isActive: Boolean,
     tabData: TabData,
     tabStyle: TabStyle,
+    tabIndex: Int,
+    tabCount: Int,
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    tabIndex: Int,
 ) {
     var tabState by remember { mutableStateOf(TabState.of(selected = tabData.selected, active = isActive)) }
     remember(tabData.selected, isActive) { tabState = tabState.copy(selected = tabData.selected, active = isActive) }
@@ -148,13 +149,13 @@ internal fun TabImpl(
             modifier
                 .height(tabStyle.metrics.tabHeight)
                 .background(backgroundColor)
+                .focusProperties { canFocus = false }
                 .semantics(mergeDescendants = true) {
                     role = Role.Tab
                     selected = tabData.selected
                     collectionItemInfo =
-                        CollectionItemInfo(rowIndex = 0, rowSpan = 1, columnIndex = tabIndex, columnSpan = 1)
+                        CollectionItemInfo(rowIndex = 0, rowSpan = 1, columnIndex = tabIndex, columnSpan = tabCount)
                 }
-                .focusable(enabled = tabData.selected, interactionSource = interactionSource)
                 .selectable(
                     onClick = tabData.onClick,
                     selected = tabData.selected,
@@ -209,7 +210,8 @@ internal fun TabImpl(
                 Icon(
                     key = tabStyle.icons.close,
                     modifier =
-                        Modifier.clickable(
+                        Modifier.focusProperties { canFocus = false }
+                            .clickable(
                                 interactionSource = closeActionInteractionSource,
                                 indication = null,
                                 onClick = tabData.onClose,


### PR DESCRIPTION
> Note: This PR is an improvement to #3016, therefore, we need to merge that one first

# Changes

- Added Interaction Source as argument to TabStrip to keep consistency with other components
- Updated close button to not be accessible by keyboard navigation
- Fixed scroll behavior on TabStrip
- Added Home, End and Delete key handling
- Added scroll to element
- Added UI tests

# Evidences

https://github.com/user-attachments/assets/9d8d54f1-a4b4-4469-8b1b-fd0bfb5c902a

> Video Notes
> 0:00 - Navigating to the tab strip using keyboard tab button
> 0:05 - Navigating tabs using arrow buttons
> 0:08 - Navigating with Home/End keys
> 0:12 - Navigating to a tab that is not fully focus and showing that it starts displaying
> 0:16 - Using trackpad/touchpad horizontal scroll
> 0:21 - Navigating focus out of the tab strip
> 0:26 - Closing tabs 2 and 3 with delete button press


## Release notes

### New features
 * **JEWEL-827** Enabling keyboard navigation in the tab-strip component

### Bug fixes
 * **JEWEL-827** Fixed horizontal scroll issues in the tab-strip component