### PR TITLE
Update "Hello and welcome!" templates to use println

### DIFF
--- a/java/java-impl/resources/fileTemplates/internal/SampleCodeWithOnboardingTips.java.ft
+++ b/java/java-impl/resources/fileTemplates/internal/SampleCodeWithOnboardingTips.java.ft
@@ -9,7 +9,7 @@ public class Main {
     public static void main(String[] args) {
         // ${ShowIntentionComment1}
         // ${ShowIntentionComment2}
-        System.out.printf("Hello and welcome!");
+        System.out.println("Hello and welcome!");
 
         // ${RunComment}
         for (int i = 1; i <= 5; i++) {

--- a/java/java-impl/resources/fileTemplates/internal/SampleCodeWithRenderedOnboardingTips.java.ft
+++ b/java/java-impl/resources/fileTemplates/internal/SampleCodeWithRenderedOnboardingTips.java.ft
@@ -9,7 +9,7 @@ public class Main {
     public static void main(String[] args) {
         //TIP ${ShowIntentionComment1}
         // ${ShowIntentionComment2}
-        System.out.printf("Hello and welcome!");
+        System.out.println("Hello and welcome!");
 
         for (int i = 1; i <= 5; i++) {
             //TIP ${DebugComment1}


### PR DESCRIPTION
The default `Main.java` file that is generated for a new project uses `System.out.printf()`. The IDE immediately underlines this and suggests that it is a "Redundant call to 'printf()'". 
![warning](https://github.com/user-attachments/assets/cec467bb-e8ca-4a24-87b3-580d39f56909)

In addition, the output for this example is not ideal. Using `println()` will make the output more readable.

Before:
```
Hello and welcome!i = 1
i = 2
i = 3
i = 4
i = 5
```

After:
```
Hello and welcome!
i = 1
i = 2
i = 3
i = 4
i = 5
```