### PR TITLE
Update `MayBeConstant` inspection

### DIFF
--- a/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/MayBeConstant.html
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/MayBeConstant.html
@@ -14,6 +14,6 @@ for better performance and Java interoperability.
       const val foo = 1
   }
 </code></pre>
-<b>For library authors:</b> using const for public API symbols is dangerous as two different values may be used if the compile-time version of the library is not the same as the run-time version of the library.
+<b>For library authors:</b> using const for public API symbols is dangerous as two different values may be used if the compile-time version of the library is not the same as the run-time version of the library. Use with caution.
 </body>
 </html>

--- a/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/MayBeConstant.html
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/MayBeConstant.html
@@ -14,5 +14,6 @@ for better performance and Java interoperability.
       const val foo = 1
   }
 </code></pre>
+<b>For library authors:</b> using const for public API symbols is dangerous as two different values may be used if the compile-time version of the library is not the same as the run-time version of the library.
 </body>
 </html>


### PR DESCRIPTION
I have once again been bitten by this. While I agree `const` is a reasonnable default for most app authors out there, the situation is a lot different for library authors.

I don't think it's worth disabling the inspection all together (but maybe it is? curious what you think?). This PR is adding some explicit wording for library authors to at least raise the potential tradeoffs. 