### PR TITLE
[JEWEL-832] Annotate all Markdown API as experimental

### DIFF
--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/InlineMarkdown.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/InlineMarkdown.kt
@@ -1,12 +1,15 @@
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 
 /**
  * An inline Markdown node, usually found as content for [block-level elements][MarkdownBlock] or other inline nodes
  * annotated with the [WithInlineMarkdown] interface.
  */
+@ExperimentalJewelApi
 public sealed interface InlineMarkdown {
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Code(override val content: String) : InlineMarkdown, WithTextContent {
         override fun equals(other: Any?): Boolean {
@@ -31,6 +34,7 @@ public sealed interface InlineMarkdown {
      * [org.jetbrains.jewel.markdown.extensions.MarkdownDelimitedInlineProcessorExtension] and rendered by a
      * [org.jetbrains.jewel.markdown.extensions.MarkdownDelimitedInlineRendererExtension].
      */
+    @ExperimentalJewelApi
     public interface CustomDelimitedNode : InlineMarkdown, WithInlineMarkdown {
         /**
          * The string used to indicate the beginning of this type of inline node. Can be identical to the
@@ -45,6 +49,7 @@ public sealed interface InlineMarkdown {
             get() = openingDelimiter
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Emphasis(public val delimiter: String, override val inlineContent: List<InlineMarkdown>) :
         InlineMarkdown, WithInlineMarkdown {
@@ -76,6 +81,7 @@ public sealed interface InlineMarkdown {
 
     public data object HardLineBreak : InlineMarkdown
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class HtmlInline(override val content: String) : InlineMarkdown, WithTextContent {
         override fun equals(other: Any?): Boolean {
@@ -92,6 +98,7 @@ public sealed interface InlineMarkdown {
         override fun toString(): String = "HtmlInline(content='$content')"
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Image(
         public val source: String,
@@ -138,6 +145,7 @@ public sealed interface InlineMarkdown {
         }
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Link(
         public val destination: String,
@@ -175,6 +183,7 @@ public sealed interface InlineMarkdown {
 
     public data object SoftLineBreak : InlineMarkdown
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class StrongEmphasis(public val delimiter: String, override val inlineContent: List<InlineMarkdown>) :
         InlineMarkdown, WithInlineMarkdown {
@@ -204,6 +213,7 @@ public sealed interface InlineMarkdown {
         override fun toString(): String = "StrongEmphasis(delimiter='$delimiter', inlineContent=$inlineContent)"
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Text(override val content: String) : InlineMarkdown, WithTextContent {
         override fun equals(other: Any?): Boolean {

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
@@ -1,9 +1,12 @@
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 import org.jetbrains.jewel.foundation.code.MimeType
 
+@ExperimentalJewelApi
 public sealed interface MarkdownBlock {
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class BlockQuote(override val children: List<MarkdownBlock>) : MarkdownBlock, WithChildBlocks {
         public constructor(vararg children: MarkdownBlock) : this(children.toList())
@@ -22,9 +25,11 @@ public sealed interface MarkdownBlock {
         override fun toString(): String = "BlockQuote(children=$children)"
     }
 
+    @ExperimentalJewelApi
     public sealed interface CodeBlock : MarkdownBlock {
         public val content: String
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class IndentedCodeBlock(override val content: String) : CodeBlock {
             override fun equals(other: Any?): Boolean {
@@ -41,6 +46,7 @@ public sealed interface MarkdownBlock {
             override fun toString(): String = "IndentedCodeBlock(content='$content')"
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class FencedCodeBlock(override val content: String, public val mimeType: MimeType?) : CodeBlock {
             override fun equals(other: Any?): Boolean {
@@ -65,8 +71,9 @@ public sealed interface MarkdownBlock {
         }
     }
 
-    public interface CustomBlock : MarkdownBlock
+    @ExperimentalJewelApi public interface CustomBlock : MarkdownBlock
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Heading(override val inlineContent: List<InlineMarkdown>, public val level: Int) :
         MarkdownBlock, WithInlineMarkdown {
@@ -93,6 +100,7 @@ public sealed interface MarkdownBlock {
         override fun toString(): String = "Heading(inlineContent=$inlineContent, level=$level)"
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class HtmlBlock(public val content: String) : MarkdownBlock {
         override fun equals(other: Any?): Boolean {
@@ -109,10 +117,12 @@ public sealed interface MarkdownBlock {
         override fun toString(): String = "HtmlBlock(content='$content')"
     }
 
+    @ExperimentalJewelApi
     public sealed interface ListBlock : MarkdownBlock, WithChildBlocks {
         override val children: List<ListItem>
         public val isTight: Boolean
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class OrderedList(
             override val children: List<ListItem>,
@@ -159,6 +169,7 @@ public sealed interface MarkdownBlock {
             }
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class UnorderedList(
             override val children: List<ListItem>,
@@ -195,6 +206,7 @@ public sealed interface MarkdownBlock {
         }
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class ListItem(override val children: List<MarkdownBlock>) : MarkdownBlock, WithChildBlocks {
         public constructor(vararg children: MarkdownBlock) : this(children.toList())
@@ -213,8 +225,9 @@ public sealed interface MarkdownBlock {
         override fun toString(): String = "ListItem(children=$children)"
     }
 
-    public data object ThematicBreak : MarkdownBlock
+    @ExperimentalJewelApi public data object ThematicBreak : MarkdownBlock
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Paragraph(override val inlineContent: List<InlineMarkdown>) : MarkdownBlock, WithInlineMarkdown {
         public constructor(vararg inlineContent: InlineMarkdown) : this(inlineContent.toList())

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownMode.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownMode.kt
@@ -17,7 +17,7 @@ import org.jetbrains.jewel.markdown.scrolling.ScrollingSynchronizer
 @ExperimentalJewelApi
 public sealed interface MarkdownMode {
     /** Default mode when only rendered contents of a file is shown to a user. */
-    public object Standalone : MarkdownMode
+    @ExperimentalJewelApi public object Standalone : MarkdownMode
 
     /**
      * Mode that is intended for cases when the raw file can be edited, and changes are expected to affect rendered
@@ -26,6 +26,7 @@ public sealed interface MarkdownMode {
      * @param scrollingSynchronizer [ScrollingSynchronizer] that enables auto-scrolling in the preview to match the
      *   scrolling position in the editor and therefore show the same blocks that are currently visible in the editor.
      */
+    @ExperimentalJewelApi
     public class EditorPreview(public val scrollingSynchronizer: ScrollingSynchronizer?) : MarkdownMode
 }
 

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/Semantics.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/Semantics.kt
@@ -1,7 +1,22 @@
 package org.jetbrains.jewel.markdown
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 
-public val RawMarkdown: SemanticsPropertyKey<String> = SemanticsPropertyKey("RawMarkdown")
-public var SemanticsPropertyReceiver.rawMarkdown: String by RawMarkdown
+/**
+ * A semantics property key used to store the raw Markdown content for a [Markdown] composable.
+ *
+ * Can be used in UI tests to assert a node contains a certain raw Markdown, since [SemanticsProperties.Text] is not a
+ * viable way to assess a node's content.
+ */
+@ExperimentalJewelApi public val RawMarkdown: SemanticsPropertyKey<String> = SemanticsPropertyKey("RawMarkdown")
+
+/**
+ * A semantics property used to store the raw Markdown content for a [Markdown] composable.
+ *
+ * Can be used in UI tests to assert a node contains a certain raw Markdown, since [androidx.compose.ui.semantics.text]
+ * is not a viable way to assess a node's content.
+ */
+@ExperimentalJewelApi public var SemanticsPropertyReceiver.rawMarkdown: String by RawMarkdown

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithChildBlocks.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithChildBlocks.kt
@@ -2,6 +2,10 @@
 // Apache 2.0 license.
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+
+/** A [MarkdownBlock] that contains child blocks. */
+@ExperimentalJewelApi
 public interface WithChildBlocks {
     public val children: List<MarkdownBlock>
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithInlineMarkdown.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithInlineMarkdown.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+
 /** An inline Markdown node that contains other [InlineMarkdown] nodes. */
+@ExperimentalJewelApi
 public interface WithInlineMarkdown {
     /** Child inline Markdown nodes. */
     public val inlineContent: List<InlineMarkdown>

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithTextContent.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithTextContent.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+
 /** An inline Markdown node that has a plain text content, or can be rendered as plain text. */
+@ExperimentalJewelApi
 public interface WithTextContent {
     /** The plain text content or representation of this node. */
     public val content: String

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/Markdown.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/Markdown.kt
@@ -3,36 +3,45 @@ package org.jetbrains.jewel.markdown.extensions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.markdown.MarkdownMode
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
+@ExperimentalJewelApi
 public val LocalMarkdownStyling: ProvidableCompositionLocal<MarkdownStyling> = staticCompositionLocalOf {
     error("No MarkdownStyling defined, have you forgotten to provide it?")
 }
 
+@ExperimentalJewelApi
 public val JewelTheme.Companion.markdownStyling: MarkdownStyling
     @Composable get() = LocalMarkdownStyling.current
 
+@ExperimentalJewelApi
 public val LocalMarkdownProcessor: ProvidableCompositionLocal<MarkdownProcessor> = staticCompositionLocalOf {
     error("No MarkdownProcessor defined, have you forgotten to provide it?")
 }
 
+@ExperimentalJewelApi
 public val JewelTheme.Companion.markdownProcessor: MarkdownProcessor
     @Composable get() = LocalMarkdownProcessor.current
 
+@ExperimentalJewelApi
 public val LocalMarkdownBlockRenderer: ProvidableCompositionLocal<MarkdownBlockRenderer> = staticCompositionLocalOf {
     error("No MarkdownBlockRenderer defined, have you forgotten to provide it?")
 }
 
+@ExperimentalJewelApi
 public val JewelTheme.Companion.markdownBlockRenderer: MarkdownBlockRenderer
     @Composable get() = LocalMarkdownBlockRenderer.current
 
+@ExperimentalJewelApi
 public val LocalMarkdownMode: ProvidableCompositionLocal<MarkdownMode> = staticCompositionLocalOf {
     MarkdownMode.Standalone
 }
 
+@ExperimentalJewelApi
 public val JewelTheme.Companion.markdownMode: MarkdownMode
     @Composable get() = LocalMarkdownMode.current

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension.kt
@@ -1,9 +1,11 @@
 package org.jetbrains.jewel.markdown.extensions
 
 import org.commonmark.node.CustomBlock
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
 
+@ExperimentalJewelApi
 /** Extension that can process a custom block-level [CustomBlock]. */
 public interface MarkdownBlockProcessorExtension {
     /**

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
@@ -2,11 +2,13 @@ package org.jetbrains.jewel.markdown.extensions
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CustomBlock
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 
+@ExperimentalJewelApi
 /** An extension for [MarkdownBlockRenderer] that can render one or more [MarkdownBlock.CustomBlock]s. */
 public interface MarkdownBlockRendererExtension {
     /**

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownDelimitedInlineProcessorExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownDelimitedInlineProcessorExtension.kt
@@ -1,9 +1,11 @@
 package org.jetbrains.jewel.markdown.extensions
 
 import org.commonmark.node.Delimited
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
 
+@ExperimentalJewelApi
 /** An extension for parsing [org.commonmark.node.Delimited] inline nodes. */
 public interface MarkdownDelimitedInlineProcessorExtension {
     /** Checks whether the [delimited] can be processed by this instance. */

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownDelimitedInlineRendererExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownDelimitedInlineRendererExtension.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.jewel.markdown.extensions
 
 import androidx.compose.ui.text.AnnotatedString
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.InlineMarkdown.CustomDelimitedNode
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
@@ -12,6 +13,7 @@ import org.jetbrains.jewel.markdown.rendering.InlinesStyling
  *
  * Only `Delimited` nodes that can be rendered as an [AnnotatedString] are supported; other kinds of inline node aren't.
  */
+@ExperimentalJewelApi
 public interface MarkdownDelimitedInlineRendererExtension {
     /**
      * Check whether the provided [node] node can be rendered by this extension.

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
@@ -25,6 +25,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.Code.Fenced.InfoPo
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.Code.Fenced.InfoPosition.TopEnd
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.Code.Fenced.InfoPosition.TopStart
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class MarkdownStyling(
     public val blockVerticalSpacing: Dp,
@@ -39,6 +40,7 @@ public class MarkdownStyling(
 ) {
     @ExperimentalJewelApi public val baseInlinesStyling: InlinesStyling = paragraph.inlinesStyling
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Paragraph(override val inlinesStyling: InlinesStyling) : WithInlinesStyling {
         override fun equals(other: Any?): Boolean {
@@ -57,6 +59,7 @@ public class MarkdownStyling(
         public companion object
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Heading(
         public val h1: H1,
@@ -70,6 +73,7 @@ public class MarkdownStyling(
             public val padding: PaddingValues
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class H1(
             override val inlinesStyling: InlinesStyling,
@@ -115,6 +119,7 @@ public class MarkdownStyling(
             public companion object
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class H2(
             override val inlinesStyling: InlinesStyling,
@@ -160,6 +165,7 @@ public class MarkdownStyling(
             public companion object
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class H3(
             override val inlinesStyling: InlinesStyling,
@@ -205,6 +211,7 @@ public class MarkdownStyling(
             public companion object
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class H4(
             override val inlinesStyling: InlinesStyling,
@@ -250,6 +257,7 @@ public class MarkdownStyling(
             public companion object
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class H5(
             override val inlinesStyling: InlinesStyling,
@@ -295,6 +303,7 @@ public class MarkdownStyling(
             public companion object
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class H6(
             override val inlinesStyling: InlinesStyling,
@@ -371,6 +380,7 @@ public class MarkdownStyling(
         public companion object
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class BlockQuote(
         public val padding: PaddingValues,
@@ -420,8 +430,10 @@ public class MarkdownStyling(
         public companion object
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class List(public val ordered: Ordered, public val unordered: Unordered) {
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class Ordered(
             public val numberStyle: TextStyle,
@@ -475,6 +487,7 @@ public class MarkdownStyling(
             public companion object
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class Unordered(
             public val bullet: Char?,
@@ -547,8 +560,10 @@ public class MarkdownStyling(
         public companion object
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Code(public val indented: Indented, public val fenced: Fenced) {
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class Indented(
             public val editorTextStyle: TextStyle,
@@ -606,6 +621,7 @@ public class MarkdownStyling(
             public companion object
         }
 
+        @ExperimentalJewelApi
         @GenerateDataFunctions
         public class Fenced(
             public val editorTextStyle: TextStyle,
@@ -708,6 +724,7 @@ public class MarkdownStyling(
         public companion object
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class Image(
         public val alignment: Alignment,
@@ -761,6 +778,7 @@ public class MarkdownStyling(
         public companion object
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class ThematicBreak(
         public val padding: PaddingValues,
@@ -792,6 +810,7 @@ public class MarkdownStyling(
         public companion object
     }
 
+    @ExperimentalJewelApi
     @GenerateDataFunctions
     public class HtmlBlock(
         public val textStyle: TextStyle,
@@ -904,6 +923,7 @@ public interface WithUnderline {
     public val underlineGap: Dp
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class InlinesStyling(
     public val textStyle: TextStyle,

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/AutoScrollingUtil.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/AutoScrollingUtil.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import kotlin.math.abs
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 
 /**
@@ -21,6 +22,7 @@ import org.jetbrains.jewel.markdown.MarkdownBlock
  *
  * @see [ScrollSyncMarkdownBlockRenderer]
  */
+@ExperimentalJewelApi
 @Composable
 public fun AutoScrollableBlock(
     block: MarkdownBlock,

--- a/platform/jewel/markdown/extensions/autolink/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/autolink/AutolinkProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/autolink/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/autolink/AutolinkProcessorExtension.kt
@@ -2,8 +2,10 @@ package org.jetbrains.jewel.markdown.extensions.autolink
 
 import org.commonmark.ext.autolink.AutolinkExtension
 import org.commonmark.parser.Parser.ParserExtension
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 
+@ExperimentalJewelApi
 public object AutolinkProcessorExtension : MarkdownProcessorExtension {
     override val parserExtension: ParserExtension = AutolinkExtension.create() as ParserExtension
 }

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlert.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlert.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.jewel.markdown.extensions.github.alerts
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 
+@ExperimentalJewelApi
 public sealed interface GitHubAlert : MarkdownBlock.CustomBlock {
     public val content: List<MarkdownBlock>
 

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.LayoutDirection.Ltr
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.markdown.MarkdownBlock.CustomBlock
 import org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
@@ -29,6 +30,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.Text
 
+@ExperimentalJewelApi
 public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private val rootStyling: MarkdownStyling) :
     MarkdownBlockRendererExtension {
     override fun canRender(block: CustomBlock): Boolean = block is GitHubAlert

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertIcons.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertIcons.kt
@@ -1,8 +1,10 @@
 package org.jetbrains.jewel.markdown.extensions.github.alerts
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.icon.PathIconKey
 
+@ExperimentalJewelApi
 public object GitHubAlertIcons {
     public val Note: IconKey =
         PathIconKey(

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension.kt
@@ -15,6 +15,7 @@ import org.commonmark.renderer.text.TextContentNodeRendererContext
 import org.commonmark.renderer.text.TextContentRenderer
 import org.commonmark.renderer.text.TextContentRenderer.TextContentRendererExtension
 import org.commonmark.text.Characters
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.extensions.MarkdownBlockProcessorExtension
 import org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
@@ -28,6 +29,7 @@ import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertBlock.Warning
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
+@ExperimentalJewelApi
 public object GitHubAlertProcessorExtension : MarkdownProcessorExtension {
     override val parserExtension: ParserExtension = GitHubAlertCommonMarkExtension
     override val textRendererExtension: TextContentRendererExtension = GitHubAlertCommonMarkExtension
@@ -57,6 +59,7 @@ public object GitHubAlertProcessorExtension : MarkdownProcessorExtension {
     }
 }
 
+@ExperimentalJewelApi
 public class GitHubAlertRendererExtension(alertStyling: AlertStyling, rootStyling: MarkdownStyling) :
     MarkdownRendererExtension {
     override val blockRenderer: MarkdownBlockRendererExtension = GitHubAlertBlockRenderer(alertStyling, rootStyling)

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertStyling.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertStyling.kt
@@ -6,9 +6,11 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 import org.jetbrains.jewel.ui.icon.IconKey
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class AlertStyling(
     public val note: NoteAlertStyling,
@@ -54,6 +56,7 @@ public class AlertStyling(
     public companion object
 }
 
+@ExperimentalJewelApi
 public sealed interface BaseAlertStyling {
     public val padding: PaddingValues
     public val lineWidth: Dp
@@ -66,6 +69,7 @@ public sealed interface BaseAlertStyling {
     public val textColor: Color
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class NoteAlertStyling(
     override val padding: PaddingValues,
@@ -127,6 +131,7 @@ public class NoteAlertStyling(
     public companion object
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class TipAlertStyling(
     override val padding: PaddingValues,
@@ -188,6 +193,7 @@ public class TipAlertStyling(
     public companion object
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class ImportantAlertStyling(
     override val padding: PaddingValues,
@@ -249,6 +255,7 @@ public class ImportantAlertStyling(
     public companion object
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class WarningAlertStyling(
     override val padding: PaddingValues,
@@ -310,6 +317,7 @@ public class WarningAlertStyling(
     public companion object
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class CautionAlertStyling(
     override val padding: PaddingValues,

--- a/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughInlineProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughInlineProcessorExtension.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.markdown.extensions.github.strikethrough
 import org.commonmark.ext.gfm.strikethrough.Strikethrough
 import org.commonmark.node.Delimited
 import org.commonmark.node.Node
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.extensions.MarkdownDelimitedInlineProcessorExtension
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
@@ -18,6 +19,7 @@ import org.jetbrains.jewel.markdown.processing.readInlineMarkdown
  * @see GitHubStrikethroughNode
  * @see GitHubStrikethroughRendererExtension
  */
+@ExperimentalJewelApi
 public object GitHubStrikethroughInlineProcessorExtension : MarkdownDelimitedInlineProcessorExtension {
     override fun canProcess(delimited: Delimited): Boolean = delimited is Strikethrough
 

--- a/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughInlineRendererExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughInlineRendererExtension.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.extensions.MarkdownDelimitedInlineRendererExtension
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
@@ -14,6 +15,7 @@ import org.jetbrains.jewel.markdown.rendering.InlinesStyling
  * An extension for [`MarkdownInlineRenderer`][org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer] that
  * renders [GitHubStrikethroughNode]s into annotated strings.
  */
+@ExperimentalJewelApi
 public object GitHubStrikethroughInlineRendererExtension : MarkdownDelimitedInlineRendererExtension {
     private val strikethroughSpanStyle = SpanStyle(textDecoration = TextDecoration.Companion.LineThrough)
 

--- a/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughNode.kt
+++ b/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughNode.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.markdown.extensions.github.strikethrough
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.WithInlineMarkdown
 
@@ -13,6 +14,7 @@ import org.jetbrains.jewel.markdown.WithInlineMarkdown
  * @see GitHubStrikethroughProcessorExtension
  * @see GitHubStrikethroughRendererExtension
  */
+@ExperimentalJewelApi
 public data class GitHubStrikethroughNode(val delimiter: String, override val inlineContent: List<InlineMarkdown>) :
     InlineMarkdown.CustomDelimitedNode, WithInlineMarkdown {
     override val openingDelimiter: String = delimiter

--- a/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughProcessorExtension.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.markdown.extensions.github.strikethrough
 import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
 import org.commonmark.parser.Parser.ParserExtension
 import org.commonmark.renderer.text.TextContentRenderer
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.extensions.MarkdownDelimitedInlineProcessorExtension
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 
@@ -16,6 +17,7 @@ import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
  * @see GitHubStrikethroughNode
  * @see GitHubStrikethroughRendererExtension
  */
+@ExperimentalJewelApi
 public class GitHubStrikethroughProcessorExtension(requireTwoTildes: Boolean = false) : MarkdownProcessorExtension {
     private val commonMarkExtension = StrikethroughExtension.builder().requireTwoTildes(requireTwoTildes).build()
 

--- a/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughRendererExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-strikethrough/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/strikethrough/GitHubStrikethroughRendererExtension.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.markdown.extensions.github.strikethrough
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.extensions.MarkdownDelimitedInlineRendererExtension
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 
@@ -7,6 +8,7 @@ import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
  * A [MarkdownRendererExtension] that supports rendering
  * [org.jetbrains.jewel.markdown.InlineMarkdown.CustomDelimitedNode]s into [androidx.compose.ui.text.AnnotatedString]s.
  */
+@ExperimentalJewelApi
 public object GitHubStrikethroughRendererExtension : MarkdownRendererExtension {
     public override val delimitedInlineRenderer: MarkdownDelimitedInlineRendererExtension =
         GitHubStrikethroughInlineRendererExtension

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
@@ -21,7 +21,7 @@ import org.jetbrains.jewel.markdown.rendering.InlinesStyling
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
-@OptIn(ExperimentalJewelApi::class)
+@ExperimentalJewelApi
 public class GitHubTableBlockRenderer(
     private val rootStyling: MarkdownStyling,
     private val tableStyling: GfmTableStyling,

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
@@ -33,7 +33,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
  *
  * @see TablesExtension
  */
-@OptIn(ExperimentalJewelApi::class)
+@ExperimentalJewelApi
 public object GitHubTableProcessorExtension : MarkdownProcessorExtension {
     override val parserExtension: ParserExtension = GitHubTablesCommonMarkExtension
     override val textRendererExtension: TextContentRendererExtension = GitHubTablesCommonMarkExtension
@@ -129,7 +129,7 @@ private object GitHubTablesCommonMarkExtension : ParserExtension, TextContentRen
     }
 }
 
-@OptIn(ExperimentalJewelApi::class)
+@ExperimentalJewelApi
 public class GitHubTableRendererExtension(tableStyling: GfmTableStyling, rootStyling: MarkdownStyling) :
     MarkdownRendererExtension {
     override val blockRenderer: MarkdownBlockRendererExtension = GitHubTableBlockRenderer(rootStyling, tableStyling)

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableStyling.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableStyling.kt
@@ -10,13 +10,13 @@ import androidx.compose.ui.unit.Dp
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class GfmTableStyling(
     public val colors: GfmTableColors,
     public val metrics: GfmTableMetrics,
     public val headerBaseFontWeight: FontWeight,
 ) {
-    @ExperimentalJewelApi
     public constructor(
         borderColor: Color,
         rowBackgroundColor: Color,
@@ -64,6 +64,7 @@ public class GfmTableStyling(
     public companion object
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class GfmTableColors(
     public val borderColor: Color,
@@ -104,6 +105,7 @@ public class GfmTableColors(
     public companion object
 }
 
+@ExperimentalJewelApi
 public enum class RowBackgroundStyle {
     /**
      * All rows have the same background color, [GfmTableColors.rowBackgroundColor]. In this style,
@@ -118,6 +120,7 @@ public enum class RowBackgroundStyle {
     Striped,
 }
 
+@ExperimentalJewelApi
 @GenerateDataFunctions
 public class GfmTableMetrics(
     public val borderWidth: Dp,

--- a/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlockRendererExtensions.kt
+++ b/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlockRendererExtensions.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.intui.markdown.bridge
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.intui.markdown.bridge.styling.create
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
@@ -8,6 +9,7 @@ import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
+@ExperimentalJewelApi
 public fun MarkdownBlockRenderer.Companion.create(
     styling: MarkdownStyling = MarkdownStyling.create(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),

--- a/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
+++ b/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
@@ -25,6 +25,7 @@ import org.jetbrains.jewel.bridge.retrieveEditorColorScheme
 import org.jetbrains.jewel.bridge.theme.retrieveDefaultTextStyle
 import org.jetbrains.jewel.bridge.theme.retrieveEditorTextStyle
 import org.jetbrains.jewel.bridge.toComposeColor
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.rendering.InlinesStyling
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.BlockQuote
@@ -41,6 +42,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.List.Unordered
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.Paragraph
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.ThematicBreak
 
+@ExperimentalJewelApi
 public fun MarkdownStyling.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     editorTextStyle: TextStyle = defaultEditorTextStyle,
@@ -57,9 +59,11 @@ public fun MarkdownStyling.Companion.create(
 ): MarkdownStyling =
     MarkdownStyling(blockVerticalSpacing, paragraph, heading, blockQuote, code, list, image, thematicBreak, htmlBlock)
 
+@ExperimentalJewelApi
 public fun Paragraph.Companion.create(inlinesStyling: InlinesStyling = InlinesStyling.create()): Paragraph =
     Paragraph(inlinesStyling)
 
+@ExperimentalJewelApi
 public fun Heading.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     h1: Heading.H1 =
@@ -113,6 +117,7 @@ public fun Heading.Companion.create(
         ),
 ): Heading = Heading(h1, h2, h3, h4, h5, h6)
 
+@ExperimentalJewelApi
 public fun Heading.H1.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     inlinesStyling: InlinesStyling =
@@ -129,6 +134,7 @@ public fun Heading.H1.Companion.create(
     padding: PaddingValues = PaddingValues(top = 24.dp, bottom = 16.dp),
 ): Heading.H1 = Heading.H1(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
+@ExperimentalJewelApi
 public fun Heading.H2.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     inlinesStyling: InlinesStyling =
@@ -146,6 +152,7 @@ public fun Heading.H2.Companion.create(
 ): Heading.H2 = Heading.H2(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H3.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     inlinesStyling: InlinesStyling =
@@ -163,6 +170,7 @@ public fun Heading.H3.Companion.create(
 ): Heading.H3 = Heading.H3(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H4.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     inlinesStyling: InlinesStyling =
@@ -180,6 +188,7 @@ public fun Heading.H4.Companion.create(
 ): Heading.H4 = Heading.H4(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H5.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     inlinesStyling: InlinesStyling =
@@ -197,6 +206,7 @@ public fun Heading.H5.Companion.create(
 ): Heading.H5 = Heading.H5(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H6.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     inlinesStyling: InlinesStyling =
@@ -214,6 +224,7 @@ public fun Heading.H6.Companion.create(
     padding: PaddingValues = PaddingValues(top = 24.dp, bottom = 16.dp),
 ): Heading.H6 = Heading.H6(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
+@ExperimentalJewelApi
 public fun BlockQuote.Companion.create(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 4.dp,
@@ -223,12 +234,14 @@ public fun BlockQuote.Companion.create(
     textColor: Color = Color(0xFF656d76),
 ): BlockQuote = BlockQuote(padding, lineWidth, lineColor, pathEffect, strokeCap, textColor)
 
+@ExperimentalJewelApi
 public fun List.Companion.create(
     baseTextStyle: TextStyle = defaultTextStyle,
     ordered: Ordered = Ordered.create(numberStyle = baseTextStyle),
     unordered: Unordered = Unordered.create(bulletStyle = baseTextStyle.copy(fontWeight = FontWeight.Black)),
 ): List = List(ordered, unordered)
 
+@ExperimentalJewelApi
 public fun Ordered.Companion.create(
     numberStyle: TextStyle = defaultTextStyle,
     numberContentGap: Dp = 8.dp,
@@ -248,6 +261,7 @@ public fun Ordered.Companion.create(
         padding,
     )
 
+@ExperimentalJewelApi
 public fun Unordered.Companion.create(
     bullet: Char? = '•',
     bulletStyle: TextStyle = defaultTextStyle.copy(fontWeight = FontWeight.Black),
@@ -257,12 +271,14 @@ public fun Unordered.Companion.create(
     padding: PaddingValues = PaddingValues(start = 16.dp),
 ): Unordered = Unordered(bullet, bulletStyle, bulletContentGap, itemVerticalSpacing, itemVerticalSpacingTight, padding)
 
+@ExperimentalJewelApi
 public fun Code.Companion.create(
     editorTextStyle: TextStyle = defaultEditorTextStyle,
     indented: Indented = Indented.create(editorTextStyle),
     fenced: Fenced = Fenced.create(editorTextStyle),
 ): Code = Code(indented, fenced)
 
+@ExperimentalJewelApi
 public fun Indented.Companion.create(
     textStyle: TextStyle = defaultEditorTextStyle,
     padding: PaddingValues = PaddingValues(16.dp),
@@ -274,6 +290,7 @@ public fun Indented.Companion.create(
     scrollsHorizontally: Boolean = true,
 ): Indented = Indented(textStyle, padding, shape, background, borderWidth, borderColor, fillWidth, scrollsHorizontally)
 
+@ExperimentalJewelApi
 public fun Fenced.Companion.create(
     textStyle: TextStyle = defaultEditorTextStyle,
     padding: PaddingValues = PaddingValues(16.dp),
@@ -301,6 +318,7 @@ public fun Fenced.Companion.create(
         infoPosition,
     )
 
+@ExperimentalJewelApi
 public fun Image.Companion.default(
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
@@ -311,12 +329,14 @@ public fun Image.Companion.default(
     borderColor: Color = Color.Unspecified,
 ): Image = Image(alignment, contentScale, padding, shape, background, borderWidth, borderColor)
 
+@ExperimentalJewelApi
 public fun ThematicBreak.Companion.create(
     padding: PaddingValues = PaddingValues(),
     lineWidth: Dp = 2.dp,
     lineColor: Color = dividerColor,
 ): ThematicBreak = ThematicBreak(padding, lineWidth, lineColor)
 
+@ExperimentalJewelApi
 public fun HtmlBlock.Companion.create(
     textStyle: TextStyle = defaultEditorTextStyle,
     padding: PaddingValues = PaddingValues(8.dp),
@@ -327,6 +347,7 @@ public fun HtmlBlock.Companion.create(
     fillWidth: Boolean = true,
 ): HtmlBlock = HtmlBlock(textStyle, padding, shape, background, borderWidth, borderColor, fillWidth)
 
+@ExperimentalJewelApi
 public fun InlinesStyling.Companion.create(
     textStyle: TextStyle = defaultTextStyle,
     editorTextStyle: TextStyle = defaultEditorTextStyle,
@@ -380,6 +401,7 @@ public fun InlinesStyling.Companion.create(
     )
 
 @Deprecated("Use the variant without renderInlineHtml instead", level = DeprecationLevel.HIDDEN)
+@ExperimentalJewelApi
 public fun InlinesStyling.Companion.create(
     textStyle: TextStyle = defaultTextStyle,
     inlineCode: SpanStyle =

--- a/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/extensions/github/alerts/BridgeGitHubAlertStyling.kt
+++ b/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/extensions/github/alerts/BridgeGitHubAlertStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.intui.markdown.bridge.styling.isLightTheme
 import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertStyling
 import org.jetbrains.jewel.markdown.extensions.github.alerts.CautionAlertStyling
@@ -20,6 +21,7 @@ import org.jetbrains.jewel.markdown.extensions.github.alerts.TipAlertStyling
 import org.jetbrains.jewel.markdown.extensions.github.alerts.WarningAlertStyling
 import org.jetbrains.jewel.ui.icon.IconKey
 
+@ExperimentalJewelApi
 public fun AlertStyling.Companion.create(
     note: NoteAlertStyling = NoteAlertStyling.create(),
     tip: TipAlertStyling = TipAlertStyling.create(),
@@ -28,6 +30,7 @@ public fun AlertStyling.Companion.create(
     caution: CautionAlertStyling = CautionAlertStyling.create(),
 ): AlertStyling = AlertStyling(note, tip, important, warning, caution)
 
+@ExperimentalJewelApi
 public fun NoteAlertStyling.Companion.create(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -51,6 +54,7 @@ public fun NoteAlertStyling.Companion.create(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun TipAlertStyling.Companion.create(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -74,6 +78,7 @@ public fun TipAlertStyling.Companion.create(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun ImportantAlertStyling.Companion.create(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -97,6 +102,7 @@ public fun ImportantAlertStyling.Companion.create(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun WarningAlertStyling.Companion.create(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -120,6 +126,7 @@ public fun WarningAlertStyling.Companion.create(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun CautionAlertStyling.Companion.create(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,

--- a/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/extensions/github/tables/BridgeGitHubTableStyling.kt
+++ b/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/extensions/github/tables/BridgeGitHubTableStyling.kt
@@ -8,18 +8,21 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.intui.markdown.bridge.styling.isLightTheme
 import org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableColors
 import org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableMetrics
 import org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableStyling
 import org.jetbrains.jewel.markdown.extensions.github.tables.RowBackgroundStyle
 
+@ExperimentalJewelApi
 public fun GfmTableStyling.Companion.create(
     colors: GfmTableColors = GfmTableColors.create(),
     metrics: GfmTableMetrics = GfmTableMetrics.create(),
     headerBaseFontWeight: FontWeight = FontWeight.SemiBold,
 ): GfmTableStyling = GfmTableStyling(colors, metrics, headerBaseFontWeight)
 
+@ExperimentalJewelApi
 public fun GfmTableColors.Companion.create(
     borderColor: Color = if (isLightTheme) Color(0xffd1d9e0) else Color(0xff3d444d),
     rowBackgroundColor: Color = Color.Unspecified,
@@ -27,6 +30,7 @@ public fun GfmTableColors.Companion.create(
     rowBackgroundStyle: RowBackgroundStyle = RowBackgroundStyle.Striped,
 ): GfmTableColors = GfmTableColors(borderColor, rowBackgroundColor, alternateRowBackgroundColor, rowBackgroundStyle)
 
+@ExperimentalJewelApi
 public fun GfmTableMetrics.Companion.create(
     borderWidth: Dp = 1.dp,
     cellPadding: PaddingValues = PaddingValues(horizontal = 13.dp, vertical = 6.dp),

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiMarkdownBlockRendererExtensions.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiMarkdownBlockRendererExtensions.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.intui.markdown.standalone
 
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.intui.markdown.standalone.styling.dark
 import org.jetbrains.jewel.intui.markdown.standalone.styling.light
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
@@ -9,12 +10,14 @@ import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
+@ExperimentalJewelApi
 public fun MarkdownBlockRenderer.Companion.light(
     styling: MarkdownStyling = MarkdownStyling.light(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
     inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
 ): MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(styling, rendererExtensions, inlineRenderer)
 
+@ExperimentalJewelApi
 public fun MarkdownBlockRenderer.Companion.dark(
     styling: MarkdownStyling = MarkdownStyling.dark(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
@@ -40,6 +41,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.Paragraph
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.ThematicBreak
 import org.jetbrains.jewel.ui.component.Typography
 
+@ExperimentalJewelApi
 public fun MarkdownStyling.Companion.light(
     baseTextStyle: TextStyle = defaultTextStyle,
     editorTextStyle: TextStyle = defaultEditorTextStyle,
@@ -56,6 +58,7 @@ public fun MarkdownStyling.Companion.light(
 ): MarkdownStyling =
     MarkdownStyling(blockVerticalSpacing, paragraph, heading, blockQuote, code, list, image, thematicBreak, htmlBlock)
 
+@ExperimentalJewelApi
 public fun MarkdownStyling.Companion.dark(
     baseTextStyle: TextStyle = defaultTextStyle,
     editorTextStyle: TextStyle = defaultEditorTextStyle,
@@ -72,14 +75,17 @@ public fun MarkdownStyling.Companion.dark(
 ): MarkdownStyling =
     MarkdownStyling(blockVerticalSpacing, paragraph, heading, blockQuote, code, list, image, thematicBreak, htmlBlock)
 
+@ExperimentalJewelApi
 public fun Paragraph.Companion.light(
     inlinesStyling: InlinesStyling = InlinesStyling.light(defaultTextStyle, defaultEditorTextStyle)
 ): Paragraph = Paragraph(inlinesStyling)
 
+@ExperimentalJewelApi
 public fun Paragraph.Companion.dark(
     inlinesStyling: InlinesStyling = InlinesStyling.dark(defaultTextStyle, defaultEditorTextStyle)
 ): Paragraph = Paragraph(inlinesStyling)
 
+@ExperimentalJewelApi
 public fun Heading.Companion.light(
     baseTextStyle: TextStyle = defaultTextStyle,
     h1: Heading.H1 =
@@ -133,6 +139,7 @@ public fun Heading.Companion.light(
         ),
 ): Heading = Heading(h1, h2, h3, h4, h5, h6)
 
+@ExperimentalJewelApi
 public fun Heading.Companion.dark(
     baseTextStyle: TextStyle = defaultTextStyle,
     h1: Heading.H1 =
@@ -186,6 +193,7 @@ public fun Heading.Companion.dark(
         ),
 ): Heading = Heading(h1, h2, h3, h4, h5, h6)
 
+@ExperimentalJewelApi
 public fun Heading.H1.Companion.light(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -200,6 +208,7 @@ public fun Heading.H1.Companion.light(
     padding: PaddingValues = PaddingValues(top = 24.dp, bottom = 16.dp),
 ): Heading.H1 = Heading.H1(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
+@ExperimentalJewelApi
 public fun Heading.H1.Companion.dark(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -214,6 +223,7 @@ public fun Heading.H1.Companion.dark(
     padding: PaddingValues = PaddingValues(top = 24.dp, bottom = 16.dp),
 ): Heading.H1 = Heading.H1(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
+@ExperimentalJewelApi
 public fun Heading.H2.Companion.light(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -228,6 +238,7 @@ public fun Heading.H2.Companion.light(
     padding: PaddingValues = PaddingValues(top = 24.dp, bottom = 16.dp),
 ): Heading.H2 = Heading.H2(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
+@ExperimentalJewelApi
 public fun Heading.H2.Companion.dark(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -243,6 +254,7 @@ public fun Heading.H2.Companion.dark(
 ): Heading.H2 = Heading.H2(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H3.Companion.light(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -258,6 +270,7 @@ public fun Heading.H3.Companion.light(
 ): Heading.H3 = Heading.H3(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H3.Companion.dark(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -273,6 +286,7 @@ public fun Heading.H3.Companion.dark(
 ): Heading.H3 = Heading.H3(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H4.Companion.light(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -288,6 +302,7 @@ public fun Heading.H4.Companion.light(
 ): Heading.H4 = Heading.H4(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // This doesn't match Int UI specs as there is no spec for HTML rendering
+@ExperimentalJewelApi
 public fun Heading.H4.Companion.dark(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -303,6 +318,7 @@ public fun Heading.H4.Companion.dark(
 ): Heading.H4 = Heading.H4(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // H5 is identical to H4 and H6
+@ExperimentalJewelApi
 public fun Heading.H5.Companion.light(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -318,6 +334,7 @@ public fun Heading.H5.Companion.light(
 ): Heading.H5 = Heading.H5(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // H5 is identical to H4 and H6
+@ExperimentalJewelApi
 public fun Heading.H5.Companion.dark(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -333,6 +350,7 @@ public fun Heading.H5.Companion.dark(
 ): Heading.H5 = Heading.H5(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // H6 is identical to H4 and H5
+@ExperimentalJewelApi
 public fun Heading.H6.Companion.light(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -349,6 +367,7 @@ public fun Heading.H6.Companion.light(
 ): Heading.H6 = Heading.H6(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
 // H6 is identical to H4 and H5
+@ExperimentalJewelApi
 public fun Heading.H6.Companion.dark(
     baseTextStyle: TextStyle =
         defaultTextStyle.copy(
@@ -364,6 +383,7 @@ public fun Heading.H6.Companion.dark(
     padding: PaddingValues = PaddingValues(top = 24.dp, bottom = 16.dp),
 ): Heading.H6 = Heading.H6(inlinesStyling, underlineWidth, underlineColor, underlineGap, padding)
 
+@ExperimentalJewelApi
 public fun BlockQuote.Companion.light(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 4.dp,
@@ -373,6 +393,7 @@ public fun BlockQuote.Companion.light(
     textColor: Color = Color(0xFF656d76),
 ): BlockQuote = BlockQuote(padding, lineWidth, lineColor, pathEffect, strokeCap, textColor)
 
+@ExperimentalJewelApi
 public fun BlockQuote.Companion.dark(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 4.dp,
@@ -382,18 +403,21 @@ public fun BlockQuote.Companion.dark(
     textColor: Color = Color(0xFF848d97),
 ): BlockQuote = BlockQuote(padding, lineWidth, lineColor, pathEffect, strokeCap, textColor)
 
+@ExperimentalJewelApi
 public fun List.Companion.light(
     baseTextStyle: TextStyle = defaultTextStyle,
     ordered: Ordered = Ordered.light(numberStyle = baseTextStyle),
     unordered: Unordered = Unordered.light(bulletStyle = baseTextStyle.copy(fontWeight = FontWeight.Black)),
 ): List = List(ordered, unordered)
 
+@ExperimentalJewelApi
 public fun List.Companion.dark(
     baseTextStyle: TextStyle = defaultTextStyle,
     ordered: Ordered = Ordered.dark(numberStyle = baseTextStyle),
     unordered: Unordered = Unordered.dark(bulletStyle = baseTextStyle.copy(fontWeight = FontWeight.Black)),
 ): List = List(ordered, unordered)
 
+@ExperimentalJewelApi
 public fun Ordered.Companion.light(
     numberStyle: TextStyle = defaultTextStyle,
     numberContentGap: Dp = 8.dp,
@@ -413,6 +437,7 @@ public fun Ordered.Companion.light(
         padding,
     )
 
+@ExperimentalJewelApi
 public fun Ordered.Companion.dark(
     numberStyle: TextStyle = defaultTextStyle,
     numberContentGap: Dp = 8.dp,
@@ -432,6 +457,7 @@ public fun Ordered.Companion.dark(
         padding,
     )
 
+@ExperimentalJewelApi
 public fun Unordered.Companion.light(
     bullet: Char? = '•',
     bulletStyle: TextStyle = defaultTextStyle.copy(fontWeight = FontWeight.Black),
@@ -441,6 +467,7 @@ public fun Unordered.Companion.light(
     padding: PaddingValues = PaddingValues(start = 16.dp),
 ): Unordered = Unordered(bullet, bulletStyle, bulletContentGap, itemVerticalSpacing, itemVerticalSpacingTight, padding)
 
+@ExperimentalJewelApi
 public fun Unordered.Companion.dark(
     bullet: Char? = '•',
     bulletStyle: TextStyle = defaultTextStyle.copy(fontWeight = FontWeight.Black),
@@ -450,18 +477,21 @@ public fun Unordered.Companion.dark(
     padding: PaddingValues = PaddingValues(start = 16.dp),
 ): Unordered = Unordered(bullet, bulletStyle, bulletContentGap, itemVerticalSpacing, itemVerticalSpacingTight, padding)
 
+@ExperimentalJewelApi
 public fun Code.Companion.light(
     editorTextStyle: TextStyle = defaultEditorTextStyle.copy(color = blockContentColorLight),
     indented: Indented = Indented.light(editorTextStyle),
     fenced: Fenced = Fenced.light(editorTextStyle),
 ): Code = Code(indented, fenced)
 
+@ExperimentalJewelApi
 public fun Code.Companion.dark(
     editorTextStyle: TextStyle = defaultEditorTextStyle.copy(color = blockContentColorDark),
     indented: Indented = Indented.dark(editorTextStyle),
     fenced: Fenced = Fenced.dark(editorTextStyle),
 ): Code = Code(indented, fenced)
 
+@ExperimentalJewelApi
 public fun Indented.Companion.light(
     editorTextStyle: TextStyle = defaultEditorTextStyle.copy(color = blockContentColorLight),
     padding: PaddingValues = PaddingValues(16.dp),
@@ -474,6 +504,7 @@ public fun Indented.Companion.light(
 ): Indented =
     Indented(editorTextStyle, padding, shape, background, borderWidth, borderColor, fillWidth, scrollsHorizontally)
 
+@ExperimentalJewelApi
 public fun Indented.Companion.dark(
     editorTextStyle: TextStyle = defaultEditorTextStyle.copy(color = blockContentColorDark),
     padding: PaddingValues = PaddingValues(16.dp),
@@ -486,6 +517,7 @@ public fun Indented.Companion.dark(
 ): Indented =
     Indented(editorTextStyle, padding, shape, background, borderWidth, borderColor, fillWidth, scrollsHorizontally)
 
+@ExperimentalJewelApi
 public fun Fenced.Companion.light(
     editorTextStyle: TextStyle = defaultEditorTextStyle.copy(color = blockContentColorLight),
     padding: PaddingValues = PaddingValues(16.dp),
@@ -513,6 +545,7 @@ public fun Fenced.Companion.light(
         infoPosition,
     )
 
+@ExperimentalJewelApi
 public fun Fenced.Companion.dark(
     editorTextStyle: TextStyle = defaultEditorTextStyle.copy(color = blockContentColorDark),
     padding: PaddingValues = PaddingValues(16.dp),
@@ -540,6 +573,7 @@ public fun Fenced.Companion.dark(
         infoPosition,
     )
 
+@ExperimentalJewelApi
 public fun Image.Companion.default(
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
@@ -550,18 +584,21 @@ public fun Image.Companion.default(
     borderColor: Color = Color.Unspecified,
 ): Image = Image(alignment, contentScale, padding, shape, background, borderWidth, borderColor)
 
+@ExperimentalJewelApi
 public fun ThematicBreak.Companion.light(
     padding: PaddingValues = PaddingValues(),
     lineWidth: Dp = 2.dp,
     lineColor: Color = Color.LightGray,
 ): ThematicBreak = ThematicBreak(padding, lineWidth, lineColor)
 
+@ExperimentalJewelApi
 public fun ThematicBreak.Companion.dark(
     padding: PaddingValues = PaddingValues(),
     lineWidth: Dp = 2.dp,
     lineColor: Color = Color.DarkGray,
 ): ThematicBreak = ThematicBreak(padding, lineWidth, lineColor)
 
+@ExperimentalJewelApi
 public fun HtmlBlock.Companion.light(
     textStyle: TextStyle = defaultEditorTextStyle.copy(color = Color.DarkGray),
     padding: PaddingValues = PaddingValues(8.dp),
@@ -572,6 +609,7 @@ public fun HtmlBlock.Companion.light(
     fillWidth: Boolean = true,
 ): HtmlBlock = HtmlBlock(textStyle, padding, shape, background, borderWidth, borderColor, fillWidth)
 
+@ExperimentalJewelApi
 public fun HtmlBlock.Companion.dark(
     textStyle: TextStyle = defaultEditorTextStyle.copy(color = Color.Gray),
     padding: PaddingValues = PaddingValues(8.dp),
@@ -582,6 +620,7 @@ public fun HtmlBlock.Companion.dark(
     fillWidth: Boolean = true,
 ): HtmlBlock = HtmlBlock(textStyle, padding, shape, background, borderWidth, borderColor, fillWidth)
 
+@ExperimentalJewelApi
 public fun InlinesStyling.Companion.light(
     textStyle: TextStyle = defaultTextStyle,
     editorTextStyle: TextStyle = defaultEditorTextStyle,
@@ -629,6 +668,7 @@ public fun InlinesStyling.Companion.light(
     "Use the new variant, without renderInlineHtml and with editorTextStyle, instead",
     level = DeprecationLevel.HIDDEN,
 )
+@ExperimentalJewelApi
 public fun InlinesStyling.Companion.light(
     textStyle: TextStyle = defaultTextStyle,
     inlineCode: SpanStyle =
@@ -660,6 +700,7 @@ public fun InlinesStyling.Companion.light(
         inlineHtml = inlineHtml,
     )
 
+@ExperimentalJewelApi
 public fun InlinesStyling.Companion.dark(
     textStyle: TextStyle = defaultTextStyle,
     editorTextStyle: TextStyle = defaultEditorTextStyle,
@@ -707,6 +748,7 @@ public fun InlinesStyling.Companion.dark(
     "Use the new variant, without renderInlineHtml and with editorTextStyle, instead",
     level = DeprecationLevel.HIDDEN,
 )
+@ExperimentalJewelApi
 public fun InlinesStyling.Companion.dark(
     textStyle: TextStyle = defaultTextStyle,
     inlineCode: SpanStyle =

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/extensions/github/alerts/IntUiGitHubAlertStyling.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/extensions/github/alerts/IntUiGitHubAlertStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertStyling
 import org.jetbrains.jewel.markdown.extensions.github.alerts.CautionAlertStyling
 import org.jetbrains.jewel.markdown.extensions.github.alerts.GitHubAlertIcons
@@ -17,6 +18,7 @@ import org.jetbrains.jewel.markdown.extensions.github.alerts.TipAlertStyling
 import org.jetbrains.jewel.markdown.extensions.github.alerts.WarningAlertStyling
 import org.jetbrains.jewel.ui.icon.IconKey
 
+@ExperimentalJewelApi
 public fun AlertStyling.Companion.light(
     note: NoteAlertStyling = NoteAlertStyling.light(),
     tip: TipAlertStyling = TipAlertStyling.light(),
@@ -25,6 +27,7 @@ public fun AlertStyling.Companion.light(
     caution: CautionAlertStyling = CautionAlertStyling.light(),
 ): AlertStyling = AlertStyling(note, tip, important, warning, caution)
 
+@ExperimentalJewelApi
 public fun AlertStyling.Companion.dark(
     note: NoteAlertStyling = NoteAlertStyling.dark(),
     tip: TipAlertStyling = TipAlertStyling.dark(),
@@ -33,6 +36,7 @@ public fun AlertStyling.Companion.dark(
     caution: CautionAlertStyling = CautionAlertStyling.dark(),
 ): AlertStyling = AlertStyling(note, tip, important, warning, caution)
 
+@ExperimentalJewelApi
 public fun NoteAlertStyling.Companion.light(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -56,6 +60,7 @@ public fun NoteAlertStyling.Companion.light(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun NoteAlertStyling.Companion.dark(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -79,6 +84,7 @@ public fun NoteAlertStyling.Companion.dark(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun TipAlertStyling.Companion.light(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -102,6 +108,7 @@ public fun TipAlertStyling.Companion.light(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun TipAlertStyling.Companion.dark(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -125,6 +132,7 @@ public fun TipAlertStyling.Companion.dark(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun ImportantAlertStyling.Companion.light(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -148,6 +156,7 @@ public fun ImportantAlertStyling.Companion.light(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun ImportantAlertStyling.Companion.dark(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -171,6 +180,7 @@ public fun ImportantAlertStyling.Companion.dark(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun WarningAlertStyling.Companion.light(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -194,6 +204,7 @@ public fun WarningAlertStyling.Companion.light(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun WarningAlertStyling.Companion.dark(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -217,6 +228,7 @@ public fun WarningAlertStyling.Companion.dark(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun CautionAlertStyling.Companion.light(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,
@@ -240,6 +252,7 @@ public fun CautionAlertStyling.Companion.light(
         textColor,
     )
 
+@ExperimentalJewelApi
 public fun CautionAlertStyling.Companion.dark(
     padding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     lineWidth: Dp = 3.dp,

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/extensions/github/tables/IntUiGitHubTableStyling.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/extensions/github/tables/IntUiGitHubTableStyling.kt
@@ -6,23 +6,27 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableColors
 import org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableMetrics
 import org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableStyling
 import org.jetbrains.jewel.markdown.extensions.github.tables.RowBackgroundStyle
 
+@ExperimentalJewelApi
 public fun GfmTableStyling.Companion.light(
     colors: GfmTableColors = GfmTableColors.light(),
     metrics: GfmTableMetrics = GfmTableMetrics.defaults(),
     headerBaseFontWeight: FontWeight = FontWeight.SemiBold,
 ): GfmTableStyling = GfmTableStyling(colors, metrics, headerBaseFontWeight)
 
+@ExperimentalJewelApi
 public fun GfmTableStyling.Companion.dark(
     colors: GfmTableColors = GfmTableColors.dark(),
     metrics: GfmTableMetrics = GfmTableMetrics.defaults(),
     headerBaseFontWeight: FontWeight = FontWeight.SemiBold,
 ): GfmTableStyling = GfmTableStyling(colors, metrics, headerBaseFontWeight)
 
+@ExperimentalJewelApi
 public fun GfmTableColors.Companion.light(
     borderColor: Color = Color(0xffd1d9e0),
     rowBackgroundColor: Color = Color.Unspecified,
@@ -30,6 +34,7 @@ public fun GfmTableColors.Companion.light(
     rowBackgroundStyle: RowBackgroundStyle = RowBackgroundStyle.Striped,
 ): GfmTableColors = GfmTableColors(borderColor, rowBackgroundColor, alternateRowBackgroundColor, rowBackgroundStyle)
 
+@ExperimentalJewelApi
 public fun GfmTableColors.Companion.dark(
     borderColor: Color = Color(0xff3d444d),
     rowBackgroundColor: Color = Color.Unspecified,
@@ -37,6 +42,7 @@ public fun GfmTableColors.Companion.dark(
     rowBackgroundStyle: RowBackgroundStyle = RowBackgroundStyle.Striped,
 ): GfmTableColors = GfmTableColors(borderColor, rowBackgroundColor, alternateRowBackgroundColor, rowBackgroundStyle)
 
+@ExperimentalJewelApi
 public fun GfmTableMetrics.Companion.defaults(
     borderWidth: Dp = 1.dp,
     cellPadding: PaddingValues = PaddingValues(horizontal = 13.dp, vertical = 6.dp),


### PR DESCRIPTION
We forgot to annotate quite a few Markdown APIs as experimental, even though they should all be. This results in Markdown APIs being partly annotated, and partly not. This change improves consistency by marking all public Markdown APIs as experimental.

## Release notes

### ⚠️ Important Changes
 * Several Markdown APIs that had mistakenly not been annotated as experimental have been marked as experimental