### PR TITLE
[JEWEL] Fix standalone sample classpath

### DIFF
--- a/platform/jewel/samples/standalone/intellij.platform.jewel.samples.standalone.iml
+++ b/platform/jewel/samples/standalone/intellij.platform.jewel.samples.standalone.iml
@@ -137,5 +137,6 @@
         </SOURCES>
       </library>
     </orderEntry>
+    <orderEntry type="module" module-name="intellij.platform.icons" />
   </component>
 </module>


### PR DESCRIPTION
This patch fixes missing icons from the Jewel standalone sample when run in the JPS build.

How to run the standalone sample in the JPS build?
 1. Open `org.jetbrains.jewel.samples.standalone.Main.kt`
 2. Press the Run icon in the gutter next to the `main()` function

### Before
![image](https://github.com/user-attachments/assets/45c613cb-c268-4aed-a17d-86fbbb4f602b)

### After
![image](https://github.com/user-attachments/assets/6c2da34e-c293-484a-9de9-a48b5204c542)
