### PR TITLE
Consume version catalog for included gradle build module

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/CommonGradleProjectResolverExtension.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/project/CommonGradleProjectResolverExtension.java
@@ -238,6 +238,11 @@ public final class CommonGradleProjectResolverExtension extends AbstractProjectR
         ideModule.createChild(ProjectKeys.TEST, testData);
       }
     }
+
+    final VersionCatalogsModel versionCatalogsModel = resolverCtx.getRootModel(VersionCatalogsModel.class);
+    if (versionCatalogsModel != null) {
+      ideModule.createChild(BuildScriptClasspathData.VERSION_CATALOGS, versionCatalogsModel);
+    }
   }
 
   @Override


### PR DESCRIPTION
CommonGradleProjectResolverExtension creates and fill IdeaProject/IdeaModule models with Gradle Sync data.
It attaches BuildScriptClasspathData.VERSION_CATALOGS to IdeaProject  for regular projects. However, project with included builds there is module that may have it's own catalog. So it also needs to be consumed

Android Studio heavily rely on catalog data that is available after sync (parsing settings files is slow), so also need to have this additional chunk of data too
