### PR TITLE
Jewel - Fix RTL Title-Bar Button Order on Windows

### DIFF
--- a/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
+++ b/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
@@ -1,10 +1,7 @@
 package org.jetbrains.jewel.window
 
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerButton
@@ -14,18 +11,11 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.window.styling.TitleBarStyle
+import org.jetbrains.jewel.window.utils.WindowControlArea
 import java.awt.Frame
 import java.awt.event.MouseEvent
-import java.awt.event.WindowEvent
-import org.jetbrains.jewel.foundation.theme.JewelTheme
-import org.jetbrains.jewel.ui.component.Icon
-import org.jetbrains.jewel.ui.component.IconButton
-import org.jetbrains.jewel.ui.component.styling.IconButtonStyle
-import org.jetbrains.jewel.ui.icon.IconKey
-import org.jetbrains.jewel.ui.painter.PainterHint
-import org.jetbrains.jewel.ui.painter.PainterProviderScope
-import org.jetbrains.jewel.ui.painter.PainterSuffixHint
-import org.jetbrains.jewel.window.styling.TitleBarStyle
 
 @Composable
 internal fun DecoratedWindowScope.TitleBarOnLinux(
@@ -60,50 +50,7 @@ internal fun DecoratedWindowScope.TitleBarOnLinux(
         style,
         { _, _ -> PaddingValues(0.dp) },
     ) { state ->
-        CloseButton({ window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) }, state, style)
-
-        if (state.isMaximized) {
-            ControlButton({ window.extendedState = Frame.NORMAL }, state, style.icons.restoreButton, "Restore")
-        } else {
-            ControlButton(
-                { window.extendedState = Frame.MAXIMIZED_BOTH },
-                state,
-                style.icons.maximizeButton,
-                "Maximize",
-            )
-        }
-        ControlButton({ window.extendedState = Frame.ICONIFIED }, state, style.icons.minimizeButton, "Minimize")
+        WindowControlArea(window, state, style)
         content(state)
     }
-}
-
-@Composable
-private fun TitleBarScope.CloseButton(
-    onClick: () -> Unit,
-    state: DecoratedWindowState,
-    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
-) {
-    ControlButton(onClick, state, style.icons.closeButton, "Close", style, style.paneCloseButtonStyle)
-}
-
-@Composable
-private fun TitleBarScope.ControlButton(
-    onClick: () -> Unit,
-    state: DecoratedWindowState,
-    iconKey: IconKey,
-    description: String,
-    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
-    iconButtonStyle: IconButtonStyle = style.paneButtonStyle,
-) {
-    IconButton(
-        onClick,
-        Modifier.align(Alignment.End).focusable(false).size(style.metrics.titlePaneButtonSize),
-        style = iconButtonStyle,
-    ) {
-        Icon(iconKey, description, hint = if (state.isActive) PainterHint else Inactive)
-    }
-}
-
-private data object Inactive : PainterSuffixHint() {
-    override fun PainterProviderScope.suffix(): String = "Inactive"
 }

--- a/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
+++ b/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
 import com.jetbrains.WindowDecorations.CustomTitleBar
@@ -18,6 +20,7 @@ import kotlinx.coroutines.isActive
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.util.isDark
 import org.jetbrains.jewel.window.styling.TitleBarStyle
+import org.jetbrains.jewel.window.utils.WindowControlArea
 
 @Composable
 internal fun DecoratedWindowScope.TitleBarOnWindows(
@@ -27,7 +30,8 @@ internal fun DecoratedWindowScope.TitleBarOnWindows(
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
-
+    val layoutDirection = LocalLayoutDirection.current
+    val isRtl = layoutDirection == LayoutDirection.Rtl
     TitleBarImpl(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
@@ -35,12 +39,15 @@ internal fun DecoratedWindowScope.TitleBarOnWindows(
         applyTitleBar = { height, _ ->
             titleBar.height = height.value
             titleBar.putProperty("controls.dark", style.colors.background.isDark())
+            if (isRtl) titleBar.putProperty("controls.visible", false)
             JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
             PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
         },
         backgroundContent = { Spacer(modifier = modifier.fillMaxSize().customTitleBarMouseEventHandler(titleBar)) },
-        content = content,
-    )
+    ) { state ->
+        if (isRtl) WindowControlArea(window, state, style)
+        content(state)
+    }
 }
 
 internal fun Modifier.customTitleBarMouseEventHandler(titleBar: CustomTitleBar): Modifier =

--- a/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/utils/macos/WindowControlArea.kt
+++ b/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/utils/macos/WindowControlArea.kt
@@ -1,0 +1,74 @@
+package org.jetbrains.jewel.window.utils
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.styling.IconButtonStyle
+import org.jetbrains.jewel.ui.icon.IconKey
+import org.jetbrains.jewel.ui.painter.PainterHint
+import org.jetbrains.jewel.ui.painter.PainterProviderScope
+import org.jetbrains.jewel.ui.painter.PainterSuffixHint
+import org.jetbrains.jewel.window.DecoratedWindowState
+import org.jetbrains.jewel.window.TitleBarScope
+import org.jetbrains.jewel.window.defaultTitleBarStyle
+import org.jetbrains.jewel.window.styling.TitleBarStyle
+import java.awt.Frame
+import java.awt.event.WindowEvent
+
+@Composable
+private fun TitleBarScope.CloseButton(
+    onClick: () -> Unit,
+    state: DecoratedWindowState,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+) {
+    ControlButton(onClick, state, style.icons.closeButton, "Close", style, style.paneCloseButtonStyle)
+}
+
+@Composable
+private fun TitleBarScope.ControlButton(
+    onClick: () -> Unit,
+    state: DecoratedWindowState,
+    iconKey: IconKey,
+    description: String,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    iconButtonStyle: IconButtonStyle = style.paneButtonStyle,
+) {
+    IconButton(
+        onClick,
+        Modifier.align(Alignment.End).focusable(false).size(style.metrics.titlePaneButtonSize),
+        style = iconButtonStyle,
+    ) {
+        Icon(iconKey, description, hint = if (state.isActive) PainterHint else Inactive)
+    }
+}
+
+private data object Inactive : PainterSuffixHint() {
+    override fun PainterProviderScope.suffix(): String = "Inactive"
+}
+
+@Composable
+internal fun TitleBarScope.WindowControlArea(
+    window: ComposeWindow,
+    state: DecoratedWindowState,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+) {
+    CloseButton({ window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) }, state, style)
+
+    if (state.isMaximized) {
+        ControlButton({ window.extendedState = Frame.NORMAL }, state, style.icons.restoreButton, "Restore")
+    } else {
+        ControlButton(
+            { window.extendedState = Frame.MAXIMIZED_BOTH },
+            state,
+            style.icons.maximizeButton,
+            "Maximize",
+        )
+    }
+    ControlButton({ window.extendedState = Frame.ICONIFIED }, state, style.icons.minimizeButton, "Minimize")
+}


### PR DESCRIPTION
When Compose Desktop runs in RTL (LayoutDirection.Rtl) on Windows, the caption text automatically moves to the right, but the native caption buttons (Minimize / Maximize / Close) remain on the far right. The result is a visually incorrect ordering (Title → Buttons).

This PR ports JetBrains’ upstream patch  into jewel‑decorated‑window and fully restores correct RTL behaviour.

Before : 
![צילום מסך 2025-06-06 131359](https://github.com/user-attachments/assets/938fa27f-5376-4730-93f2-3c27206286e2)

After : 
![Capture d'écran 2025-06-06 184600 s](https://github.com/user-attachments/assets/fb1d116e-4a5b-46b4-9ada-e09d0b617547)

As a workaround, I simply hide the native controls when RTL is active and reuse the Linux-style window control components, which naturally support RTL layout and behave correctly.



