### PR TITLE
[JEWEL-776] Improvements to Context Menu

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
@@ -22,6 +22,7 @@ public fun compose(config: ComposePanel.() -> Unit = {}, content: @Composable ()
     JewelComposePanel(config, content)
 
 @ExperimentalJewelApi
+@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JBPanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposePanel(config, content)
 

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/menuShortcut/BridgeMenuItemShortcutHintProvider.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/menuShortcut/BridgeMenuItemShortcutHintProvider.kt
@@ -1,0 +1,24 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.bridge.menuShortcut
+
+import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.openapi.keymap.KeymapUtil
+import org.jetbrains.jewel.ui.MenuItemShortcutHintProvider
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.CopyMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.CutMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.PasteMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.SelectAllMenuItemOptionAction
+
+internal object BridgeMenuItemShortcutHintProvider : MenuItemShortcutHintProvider {
+    override fun getShortcutHint(actionType: ContextMenuItemOptionAction): String =
+        KeymapUtil.getShortcutText(actionTypeToIdeAction(actionType))
+}
+
+internal fun actionTypeToIdeAction(actionType: ContextMenuItemOptionAction) =
+    when (actionType) {
+        is CopyMenuItemOptionAction -> IdeActions.ACTION_COPY
+        is PasteMenuItemOptionAction -> IdeActions.ACTION_PASTE
+        is CutMenuItemOptionAction -> IdeActions.ACTION_CUT
+        is SelectAllMenuItemOptionAction -> IdeActions.ACTION_SELECT_ALL
+    }

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/menuShortcut/BridgeMenuItemShortcutProvider.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/menuShortcut/BridgeMenuItemShortcutProvider.kt
@@ -1,0 +1,17 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.bridge.menuShortcut
+
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.keymap.KeymapUtil
+import javax.swing.KeyStroke
+import org.jetbrains.jewel.ui.MenuItemShortcutProvider
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+
+internal object BridgeMenuItemShortcutProvider : MenuItemShortcutProvider {
+    override fun getShortcutKeyStroke(actionType: ContextMenuItemOptionAction): KeyStroke? =
+        KeymapUtil.getActiveKeymapShortcuts(actionTypeToIdeAction(actionType))
+            .shortcuts
+            .filterIsInstance<KeyboardShortcut>()
+            .firstOrNull()
+            ?.firstKeyStroke
+}

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
@@ -11,9 +11,13 @@ import org.jetbrains.jewel.bridge.BridgePainterHintsProvider
 import org.jetbrains.jewel.bridge.SwingBridgeReader
 import org.jetbrains.jewel.bridge.clipboard.JewelBridgeClipboard
 import org.jetbrains.jewel.bridge.icon.BridgeNewUiChecker
+import org.jetbrains.jewel.bridge.menuShortcut.BridgeMenuItemShortcutHintProvider
+import org.jetbrains.jewel.bridge.menuShortcut.BridgeMenuItemShortcutProvider
 import org.jetbrains.jewel.bridge.scaleDensityWithIdeScale
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.ui.ComponentStyling
+import org.jetbrains.jewel.ui.LocalMenuItemShortcutHintProvider
+import org.jetbrains.jewel.ui.LocalMenuItemShortcutProvider
 import org.jetbrains.jewel.ui.icon.LocalNewUiChecker
 import org.jetbrains.jewel.ui.painter.LocalPainterHintsProvider
 import org.jetbrains.jewel.ui.theme.BaseJewelTheme
@@ -35,6 +39,8 @@ public fun SwingBridgeTheme(content: @Composable () -> Unit) {
             LocalNewUiChecker provides BridgeNewUiChecker,
             LocalDensity provides scaleDensityWithIdeScale(LocalDensity.current),
             LocalClipboard provides remember { JewelBridgeClipboard() },
+            LocalMenuItemShortcutProvider provides BridgeMenuItemShortcutProvider,
+            LocalMenuItemShortcutHintProvider provides BridgeMenuItemShortcutHintProvider,
         ) {
             content()
         }

--- a/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
@@ -1,3 +1,8 @@
+f:org.jetbrains.jewel.intui.standalone.menuShortcut.StandaloneShortcutProvider
+- org.jetbrains.jewel.ui.MenuItemShortcutProvider
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.intui.standalone.menuShortcut.StandaloneShortcutProvider
+- getShortcutKeyStroke(org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction):javax.swing.KeyStroke
 f:org.jetbrains.jewel.intui.standalone.styling.IntUiTooltipStylingKt
 - sf:dark(org.jetbrains.jewel.ui.component.styling.TooltipStyle$Companion,org.jetbrains.jewel.ui.component.styling.TooltipColors,org.jetbrains.jewel.ui.component.styling.TooltipMetrics):org.jetbrains.jewel.ui.component.styling.TooltipStyle
 - sf:dark(org.jetbrains.jewel.ui.component.styling.TooltipStyle$Companion,org.jetbrains.jewel.ui.component.styling.TooltipColors,org.jetbrains.jewel.ui.component.styling.TooltipMetrics,org.jetbrains.jewel.ui.component.styling.TooltipAutoHideBehavior):org.jetbrains.jewel.ui.component.styling.TooltipStyle

--- a/platform/jewel/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/platform/jewel/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -38,6 +38,12 @@ public final class org/jetbrains/jewel/intui/standalone/StandalonePainterHintsPr
 public final class org/jetbrains/jewel/intui/standalone/StandalonePainterHintsProvider$Companion {
 }
 
+public final class org/jetbrains/jewel/intui/standalone/menuShortcut/StandaloneShortcutProvider : org/jetbrains/jewel/ui/MenuItemShortcutProvider {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/menuShortcut/StandaloneShortcutProvider;
+	public fun getShortcutKeyStroke (Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;)Ljavax/swing/KeyStroke;
+}
+
 public final class org/jetbrains/jewel/intui/standalone/styling/IntUIBannerStylingKt {
 	public static final fun default-3ABfNKs (Lorg/jetbrains/jewel/ui/component/styling/BannerMetrics$Companion;F)Lorg/jetbrains/jewel/ui/component/styling/BannerMetrics;
 	public static synthetic fun default-3ABfNKs$default (Lorg/jetbrains/jewel/ui/component/styling/BannerMetrics$Companion;FILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/BannerMetrics;

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/menuShortcut/StandaloneMenuItemShortcutHintProvider.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/menuShortcut/StandaloneMenuItemShortcutHintProvider.kt
@@ -1,0 +1,40 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.intui.standalone.menuShortcut
+
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+import org.jetbrains.jewel.ui.MenuItemShortcutHintProvider
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+import org.jetbrains.skiko.hostOs
+
+internal object StandaloneMenuItemShortcutHintProvider : MenuItemShortcutHintProvider {
+    override fun getShortcutHint(actionType: ContextMenuItemOptionAction): String =
+        getKeyStrokeText(actionTypeToKeyStroke(actionType))
+
+    private fun getKeyStrokeText(keyStroke: KeyStroke?): String {
+        if (keyStroke == null) return ""
+
+        val modifiers = keyStroke.modifiers
+        var text = ""
+
+        if (modifiers != 0) {
+            text = KeyEvent.getModifiersExText(modifiers)
+            if (text.isNotEmpty()) {
+                text += if (!hostOs.isMacOS) "+" else ""
+            }
+        }
+
+        val keyCode = keyStroke.keyCode
+        if (keyCode != 0) {
+            // KeyEvent.getKeyText() gives the textual representation of the key, e.g., "C", "F1", "Space"
+            text += KeyEvent.getKeyText(keyCode)
+        } else {
+            // For keyChar-based KeyStrokes (less common for menu shortcuts)
+            val keyChar = keyStroke.keyChar
+            if (keyChar != KeyEvent.CHAR_UNDEFINED) {
+                text += keyChar.uppercaseChar()
+            }
+        }
+        return text
+    }
+}

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/menuShortcut/StandaloneShortcutProvider.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/menuShortcut/StandaloneShortcutProvider.kt
@@ -1,0 +1,36 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.intui.standalone.menuShortcut
+
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+import org.jetbrains.jewel.foundation.InternalJewelApi
+import org.jetbrains.jewel.ui.MenuItemShortcutProvider
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.CopyMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.PasteMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.SelectAllMenuItemOptionAction
+import org.jetbrains.skiko.hostOs
+
+@InternalJewelApi
+public object StandaloneShortcutProvider : MenuItemShortcutProvider {
+    override fun getShortcutKeyStroke(actionType: ContextMenuItemOptionAction): KeyStroke? =
+        actionTypeToKeyStroke(actionType)
+}
+
+internal fun actionTypeToKeyStroke(actionType: ContextMenuItemOptionAction) =
+    when (actionType) {
+        is CopyMenuItemOptionAction -> KeyStroke.getKeyStroke(KeyEvent.VK_C, getPrimaryMenuModifierMask())
+        is PasteMenuItemOptionAction -> KeyStroke.getKeyStroke(KeyEvent.VK_V, getPrimaryMenuModifierMask())
+        ContextMenuItemOptionAction.CutMenuItemOptionAction ->
+            KeyStroke.getKeyStroke(KeyEvent.VK_X, getPrimaryMenuModifierMask())
+        is SelectAllMenuItemOptionAction -> KeyStroke.getKeyStroke(KeyEvent.VK_A, getPrimaryMenuModifierMask())
+    }
+
+private fun getPrimaryMenuModifierMask(): Int {
+    return if (hostOs.isMacOS) {
+        InputEvent.META_DOWN_MASK
+    } else {
+        InputEvent.CTRL_DOWN_MASK
+    }
+}

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
@@ -16,6 +16,8 @@ import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.StandalonePainterHintsProvider
 import org.jetbrains.jewel.intui.standalone.icon.StandaloneNewUiChecker
+import org.jetbrains.jewel.intui.standalone.menuShortcut.StandaloneMenuItemShortcutHintProvider
+import org.jetbrains.jewel.intui.standalone.menuShortcut.StandaloneShortcutProvider
 import org.jetbrains.jewel.intui.standalone.styling.Default
 import org.jetbrains.jewel.intui.standalone.styling.Editor
 import org.jetbrains.jewel.intui.standalone.styling.Outlined
@@ -24,6 +26,8 @@ import org.jetbrains.jewel.intui.standalone.styling.dark
 import org.jetbrains.jewel.intui.standalone.styling.light
 import org.jetbrains.jewel.ui.ComponentStyling
 import org.jetbrains.jewel.ui.DefaultComponentStyling
+import org.jetbrains.jewel.ui.LocalMenuItemShortcutHintProvider
+import org.jetbrains.jewel.ui.LocalMenuItemShortcutProvider
 import org.jetbrains.jewel.ui.component.styling.ButtonStyle
 import org.jetbrains.jewel.ui.component.styling.CheckboxStyle
 import org.jetbrains.jewel.ui.component.styling.ChipStyle
@@ -310,6 +314,8 @@ public fun IntUiTheme(
         CompositionLocalProvider(
             LocalPainterHintsProvider provides StandalonePainterHintsProvider(theme),
             LocalNewUiChecker provides StandaloneNewUiChecker,
+            LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+            LocalMenuItemShortcutHintProvider provides StandaloneMenuItemShortcutHintProvider,
         ) {
             content()
         }

--- a/platform/jewel/samples/standalone/api-dump-unreviewed.txt
+++ b/platform/jewel/samples/standalone/api-dump-unreviewed.txt
@@ -6,6 +6,5 @@ f:org.jetbrains.jewel.samples.standalone.markdown.ComposableSingletons$MarkdownE
 f:org.jetbrains.jewel.samples.standalone.markdown.JewelReadmeKt
 - sf:getJewelReadme():java.lang.String
 f:org.jetbrains.jewel.samples.standalone.markdown.MarkdownEditorKt
-- sf:MarkdownEditor(androidx.compose.foundation.text.input.TextFieldState,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.samples.standalone.markdown.MarkdownPreviewKt
 - sf:MarkdownPreview(androidx.compose.ui.Modifier,java.lang.CharSequence,androidx.compose.runtime.Composer,I,I):V

--- a/platform/jewel/samples/standalone/api-dump.txt
+++ b/platform/jewel/samples/standalone/api-dump.txt
@@ -1,0 +1,2 @@
+f:org.jetbrains.jewel.samples.standalone.markdown.MarkdownEditorKt
+- sf:MarkdownEditor(androidx.compose.foundation.text.input.TextFieldState,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I,I):V

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/MenuContentTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/MenuContentTest.kt
@@ -1,0 +1,393 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui.component
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.test.junit4.createComposeRule
+import javax.swing.KeyStroke
+import org.jetbrains.jewel.intui.standalone.menuShortcut.StandaloneShortcutProvider
+import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.ui.LocalMenuItemShortcutProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+// A fake MenuController that records interactions for assertions.
+class FakeMenuController : MenuController {
+    val registeredActions = mutableMapOf<KeyStroke, () -> Unit>()
+    var clearCount = 0
+        private set
+
+    override val onDismissRequest: (InputMode) -> Boolean = { true }
+
+    override fun onHoveredChange(hovered: Boolean) {
+        // DO NOTHING
+    }
+
+    override fun closeAll(mode: InputMode, force: Boolean) {
+        // DO NOTHING
+    }
+
+    override fun close(mode: InputMode): Boolean = true
+
+    override fun isRootMenu(): Boolean = true
+
+    override fun isSubmenu(): Boolean = false
+
+    override fun submenuController(onDismissRequest: (InputMode) -> Boolean): MenuController = this
+
+    override fun registerShortcutAction(keyStroke: KeyStroke, action: () -> Unit) {
+        registeredActions[keyStroke] = action
+    }
+
+    override fun clearShortcutActions() {
+        clearCount++
+        registeredActions.clear()
+    }
+
+    override fun findAndExecuteShortcut(keyStroke: KeyStroke?): Boolean? = null
+}
+
+class MenuContentShortcutRegistrationTest {
+    @get:Rule val rule = createComposeRule()
+
+    private lateinit var fakeMenuController: FakeMenuController
+
+    private val copyAction = ContextMenuItemOptionAction.CopyMenuItemOptionAction
+    private val pasteAction = ContextMenuItemOptionAction.PasteMenuItemOptionAction
+
+    private val copyKeyStroke = StandaloneShortcutProvider.getShortcutKeyStroke(copyAction)!!
+    private val pasteKeyStroke = StandaloneShortcutProvider.getShortcutKeyStroke(pasteAction)!!
+
+    private var triggeredActionType: String? = null
+
+    @Before
+    fun setUp() {
+        fakeMenuController = FakeMenuController()
+        triggeredActionType = null
+    }
+
+    // Helper to create the content lambda for MenuContent
+    private fun createMenuContentLambda(items: List<MenuSelectableItem>): MenuScope.() -> Unit = {
+        items.forEach { item ->
+            selectableItemWithActionType(
+                selected = false,
+                onClick = item.onClick,
+                enabled = item.isEnabled,
+                actionType = item.itemOptionAction,
+                content = item.content,
+            )
+        }
+    }
+
+    @Test
+    fun `reordering items should not mix up shortcut actions`() {
+        val itemsState =
+            mutableStateOf(
+                listOf(
+                    MenuSelectableItem(
+                        itemOptionAction = copyAction,
+                        onClick = { triggeredActionType = "COPY" },
+                        isSelected = true,
+                        isEnabled = true,
+                        iconKey = null,
+                        content = {},
+                    ),
+                    MenuSelectableItem(
+                        itemOptionAction = pasteAction,
+                        onClick = { triggeredActionType = "PASTE" },
+                        isSelected = true,
+                        isEnabled = true,
+                        iconKey = null,
+                        content = {},
+                    ),
+                )
+            )
+
+        rule.setContent {
+            IntUiTheme {
+                CompositionLocalProvider(
+                    LocalMenuController provides fakeMenuController,
+                    LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+                ) {
+                    MenuContent(content = createMenuContentLambda(itemsState.value))
+                }
+            }
+        }
+
+        itemsState.value = itemsState.value.reversed()
+        rule.waitForIdle()
+
+        assertTrue("Clear should have been called when items reordered", fakeMenuController.clearCount >= 1)
+        assertEquals(2, fakeMenuController.registeredActions.size)
+
+        fakeMenuController.registeredActions[copyKeyStroke]?.invoke()
+        assertEquals("Copy KeyStroke must still trigger the copy action", "COPY", triggeredActionType)
+
+        fakeMenuController.registeredActions[pasteKeyStroke]?.invoke()
+        assertEquals("Paste KeyStroke must still trigger the paste action", "PASTE", triggeredActionType)
+    }
+
+    @Test
+    fun `initial items should register their shortcuts`() {
+        val initialItems =
+            listOf(
+                MenuSelectableItem(
+                    itemOptionAction = copyAction,
+                    onClick = { triggeredActionType = "COPY" },
+                    isSelected = true,
+                    isEnabled = true,
+                    iconKey = null,
+                    content = {},
+                ),
+                MenuSelectableItem(
+                    itemOptionAction = pasteAction,
+                    onClick = { triggeredActionType = "PASTE" },
+                    isSelected = true,
+                    isEnabled = true,
+                    iconKey = null,
+                    content = {},
+                ),
+            )
+
+        rule.setContent {
+            IntUiTheme {
+                CompositionLocalProvider(
+                    LocalMenuController provides fakeMenuController,
+                    LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+                ) {
+                    MenuContent(content = createMenuContentLambda(initialItems))
+                }
+            }
+        }
+
+        assertEquals("Clear should NOT be called on first composition", 0, fakeMenuController.clearCount)
+        assertEquals(2, fakeMenuController.registeredActions.size)
+        assertNotNull(fakeMenuController.registeredActions[copyKeyStroke])
+
+        fakeMenuController.registeredActions[copyKeyStroke]?.invoke()
+        assertEquals("COPY", triggeredActionType)
+    }
+
+    @Test
+    fun `disabled items should not have their shortcuts registered`() {
+        val items =
+            listOf(
+                MenuSelectableItem(
+                    itemOptionAction = copyAction,
+                    onClick = {},
+                    isSelected = true,
+                    isEnabled = true,
+                    iconKey = null,
+                    content = {},
+                ),
+                MenuSelectableItem(
+                    itemOptionAction = pasteAction,
+                    onClick = {},
+                    isEnabled = false, // This one is disabled
+                    isSelected = true,
+                    iconKey = null,
+                    content = {},
+                ),
+            )
+
+        rule.setContent {
+            IntUiTheme {
+                CompositionLocalProvider(
+                    LocalMenuController provides fakeMenuController,
+                    LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+                ) {
+                    MenuContent(content = createMenuContentLambda(items))
+                }
+            }
+        }
+
+        assertEquals(
+            "Only enabled items should have shortcuts registered",
+            1,
+            fakeMenuController.registeredActions.size,
+        )
+        assertNotNull("Enabled item's shortcut should be present", fakeMenuController.registeredActions[copyKeyStroke])
+        assertNull("Disabled item's shortcut should be absent", fakeMenuController.registeredActions[pasteKeyStroke])
+    }
+
+    @Test
+    fun `items without an actionType should not have shortcuts registered`() {
+        val items =
+            listOf(
+                MenuSelectableItem(
+                    itemOptionAction = copyAction,
+                    onClick = {},
+                    isSelected = true,
+                    isEnabled = true,
+                    iconKey = null,
+                    content = {},
+                ),
+                MenuSelectableItem(
+                    itemOptionAction = null, // No action type
+                    onClick = {},
+                    isSelected = true,
+                    isEnabled = true,
+                    iconKey = null,
+                    content = {},
+                ),
+            )
+
+        rule.setContent {
+            IntUiTheme {
+                CompositionLocalProvider(
+                    LocalMenuController provides fakeMenuController,
+                    LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+                ) {
+                    MenuContent(content = createMenuContentLambda(items))
+                }
+            }
+        }
+
+        assertEquals("Only items with actionType should have shortcuts", 1, fakeMenuController.registeredActions.size)
+        assertNotNull(fakeMenuController.registeredActions[copyKeyStroke])
+        assertEquals(false, fakeMenuController.registeredActions.containsKey(pasteKeyStroke)) // Just to be explicit
+    }
+
+    @Test
+    fun `empty list of items should result in no registered shortcuts`() {
+        val itemsState =
+            mutableStateOf(
+                listOf(
+                    MenuSelectableItem(
+                        itemOptionAction = copyAction,
+                        onClick = {},
+                        isSelected = true,
+                        isEnabled = true,
+                        iconKey = null,
+                        content = {},
+                    )
+                )
+            )
+        rule.setContent {
+            IntUiTheme {
+                CompositionLocalProvider(
+                    LocalMenuController provides fakeMenuController,
+                    LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+                ) {
+                    MenuContent(content = createMenuContentLambda(itemsState.value))
+                }
+            }
+        }
+        assertEquals("Should start with one registered shortcut", 1, fakeMenuController.registeredActions.size)
+
+        itemsState.value = emptyList()
+        rule.waitForIdle()
+
+        assertTrue("Clear should have been called when list became empty", fakeMenuController.clearCount == 1)
+        assertTrue(
+            "No shortcuts should be registered for an empty list",
+            fakeMenuController.registeredActions.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `toggling an item's enabled state should re-register shortcuts`() {
+        val itemsState =
+            mutableStateOf(
+                listOf(
+                    MenuSelectableItem(
+                        itemOptionAction = copyAction,
+                        onClick = {},
+                        isSelected = true,
+                        isEnabled = true,
+                        iconKey = null,
+                        content = {},
+                    )
+                )
+            )
+        rule.setContent {
+            IntUiTheme {
+                CompositionLocalProvider(
+                    LocalMenuController provides fakeMenuController,
+                    LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+                ) {
+                    MenuContent(content = createMenuContentLambda(itemsState.value))
+                }
+            }
+        }
+        assertEquals("Enabled item should be registered initially", 1, fakeMenuController.registeredActions.size)
+
+        itemsState.value =
+            listOf(
+                MenuSelectableItem(
+                    itemOptionAction = copyAction,
+                    onClick = {},
+                    isSelected = true,
+                    isEnabled = false, // Toggled state
+                    iconKey = null,
+                    content = {},
+                )
+            )
+        rule.waitForIdle()
+
+        assertTrue("Clear should be called again when item is disabled", fakeMenuController.clearCount == 1)
+        assertTrue("Disabled item should not be registered", fakeMenuController.registeredActions.isEmpty())
+
+        itemsState.value =
+            listOf(
+                MenuSelectableItem(
+                    itemOptionAction = copyAction,
+                    onClick = {},
+                    isSelected = true,
+                    isEnabled = true, // Re-enabled state
+                    iconKey = null,
+                    content = {},
+                )
+            )
+        rule.waitForIdle()
+
+        assertTrue("Clear should be called when item is re-enabled", fakeMenuController.clearCount == 2)
+        assertEquals("Re-enabled item should be registered again", 1, fakeMenuController.registeredActions.size)
+        assertNotNull(fakeMenuController.registeredActions[copyKeyStroke])
+    }
+
+    @Test
+    fun `changing the menu manager should re-register shortcuts`() {
+        val items =
+            listOf(
+                MenuSelectableItem(
+                    itemOptionAction = copyAction,
+                    onClick = {},
+                    isSelected = true,
+                    isEnabled = true,
+                    iconKey = null,
+                    content = {},
+                )
+            )
+        val currentMenuController = mutableStateOf<MenuController>(fakeMenuController)
+
+        rule.setContent {
+            IntUiTheme {
+                CompositionLocalProvider(
+                    LocalMenuController provides currentMenuController.value,
+                    LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
+                ) {
+                    MenuContent(content = createMenuContentLambda(items))
+                }
+            }
+        }
+        assertEquals("Initial manager should have shortcuts", 1, fakeMenuController.registeredActions.size)
+
+        val newFakeMenuController = FakeMenuController()
+        currentMenuController.value = newFakeMenuController
+        rule.waitForIdle()
+
+        assertEquals("Old manager should be cleared on dispose", 1, fakeMenuController.clearCount)
+        assertTrue("Old manager should have no actions", fakeMenuController.registeredActions.isEmpty())
+
+        assertEquals("New manager should not clear on its first composition", 0, newFakeMenuController.clearCount)
+        assertEquals("New manager should have the shortcut registered", 1, newFakeMenuController.registeredActions.size)
+        assertNotNull(newFakeMenuController.registeredActions[copyKeyStroke])
+    }
+}

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -8,6 +8,14 @@ org.jetbrains.jewel.ui.ComponentStyling
 f:org.jetbrains.jewel.ui.DisabledAppearanceKt
 - sf:disabledAppearance(androidx.compose.ui.Modifier,I,I,I,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.Modifier
 f:org.jetbrains.jewel.ui.DisabledColorFilterKt
+org.jetbrains.jewel.ui.MenuItemShortcutHintProvider
+- a:getShortcutHint(org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction):java.lang.String
+f:org.jetbrains.jewel.ui.MenuItemShortcutHintProviderKt
+- sf:getLocalMenuItemShortcutHintProvider():androidx.compose.runtime.ProvidableCompositionLocal
+org.jetbrains.jewel.ui.MenuItemShortcutProvider
+- a:getShortcutKeyStroke(org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction):javax.swing.KeyStroke
+f:org.jetbrains.jewel.ui.MenuItemShortcutProviderKt
+- sf:getLocalMenuItemShortcutProvider():androidx.compose.runtime.ProvidableCompositionLocal
 e:org.jetbrains.jewel.ui.component.AutoHideBehavior
 - java.lang.Enum
 - sf:Long:org.jetbrains.jewel.ui.component.AutoHideBehavior
@@ -16,16 +24,99 @@ e:org.jetbrains.jewel.ui.component.AutoHideBehavior
 - s:getEntries():kotlin.enums.EnumEntries
 - s:valueOf(java.lang.String):org.jetbrains.jewel.ui.component.AutoHideBehavior
 - s:values():org.jetbrains.jewel.ui.component.AutoHideBehavior[]
+f:org.jetbrains.jewel.ui.component.ContextMenuItemOption
+- androidx.compose.foundation.ContextMenuItem
+- sf:$stable:I
+- <init>(org.jetbrains.jewel.ui.icon.IconKey,org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction,java.lang.String,kotlin.jvm.functions.Function0):V
+- b:<init>(org.jetbrains.jewel.ui.icon.IconKey,org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction,java.lang.String,kotlin.jvm.functions.Function0,I,kotlin.jvm.internal.DefaultConstructorMarker):V
+- f:getActionType():org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+- f:getIcon():org.jetbrains.jewel.ui.icon.IconKey
+a:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+- sf:$stable:I
+f:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$CopyMenuItemOptionAction
+- org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$CopyMenuItemOptionAction
+- equals(java.lang.Object):Z
+- hashCode():I
+f:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$CutMenuItemOptionAction
+- org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$CutMenuItemOptionAction
+- equals(java.lang.Object):Z
+- hashCode():I
+f:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$PasteMenuItemOptionAction
+- org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$PasteMenuItemOptionAction
+- equals(java.lang.Object):Z
+- hashCode():I
+f:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$SelectAllMenuItemOptionAction
+- org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction$SelectAllMenuItemOptionAction
+- equals(java.lang.Object):Z
+- hashCode():I
+f:org.jetbrains.jewel.ui.component.DefaultMenuController
+- org.jetbrains.jewel.ui.component.MenuController
+- sf:$stable:I
+- <init>(kotlin.jvm.functions.Function1,org.jetbrains.jewel.ui.component.DefaultMenuController):V
+- b:<init>(kotlin.jvm.functions.Function1,org.jetbrains.jewel.ui.component.DefaultMenuController,I,kotlin.jvm.internal.DefaultConstructorMarker):V
+- clearShortcutActions():V
+- close-iuPiT84(I):Z
+- closeAll-HMVJIwE(I,Z):V
+- findAndExecuteShortcut(javax.swing.KeyStroke):java.lang.Boolean
+- getOnDismissRequest():kotlin.jvm.functions.Function1
+- isRootMenu():Z
+- isSubmenu():Z
+- onHoveredChange(Z):V
+- registerShortcutAction(javax.swing.KeyStroke,kotlin.jvm.functions.Function0):V
+- submenuController(kotlin.jvm.functions.Function1):org.jetbrains.jewel.ui.component.DefaultMenuController
+org.jetbrains.jewel.ui.component.MenuController
+- a:clearShortcutActions():V
+- a:close-iuPiT84(I):Z
+- a:closeAll-HMVJIwE(I,Z):V
+- a:findAndExecuteShortcut(javax.swing.KeyStroke):java.lang.Boolean
+- a:getOnDismissRequest():kotlin.jvm.functions.Function1
+- a:isRootMenu():Z
+- a:isSubmenu():Z
+- a:onHoveredChange(Z):V
+- a:registerShortcutAction(javax.swing.KeyStroke,kotlin.jvm.functions.Function0):V
+- a:submenuController(kotlin.jvm.functions.Function1):org.jetbrains.jewel.ui.component.MenuController
+f:org.jetbrains.jewel.ui.component.MenuControllerKt
+- sf:getLocalMenuController():androidx.compose.runtime.ProvidableCompositionLocal
+f:org.jetbrains.jewel.ui.component.MenuKt
+- sf:MenuContent(androidx.compose.ui.Modifier,org.jetbrains.jewel.ui.component.styling.MenuStyle,kotlin.jvm.functions.Function1,androidx.compose.runtime.Composer,I,I):V
 org.jetbrains.jewel.ui.component.MenuScope
 - a:passiveItem(kotlin.jvm.functions.Function2):V
 - a:selectableItem(Z,org.jetbrains.jewel.ui.icon.IconKey,java.util.Set,kotlin.jvm.functions.Function0,Z,kotlin.jvm.functions.Function2):V
 - bs:selectableItem$default(org.jetbrains.jewel.ui.component.MenuScope,Z,org.jetbrains.jewel.ui.icon.IconKey,java.util.Set,kotlin.jvm.functions.Function0,Z,kotlin.jvm.functions.Function2,I,java.lang.Object):V
+- a:selectableItemWithActionType(Z,org.jetbrains.jewel.ui.icon.IconKey,org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction,kotlin.jvm.functions.Function0,Z,kotlin.jvm.functions.Function2):V
+- bs:selectableItemWithActionType$default(org.jetbrains.jewel.ui.component.MenuScope,Z,org.jetbrains.jewel.ui.icon.IconKey,org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction,kotlin.jvm.functions.Function0,Z,kotlin.jvm.functions.Function2,I,java.lang.Object):V
 - a:submenu(Z,org.jetbrains.jewel.ui.icon.IconKey,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):V
 - bs:submenu$default(org.jetbrains.jewel.ui.component.MenuScope,Z,org.jetbrains.jewel.ui.icon.IconKey,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):V
+f:org.jetbrains.jewel.ui.component.MenuSelectableItem
+- sf:$stable:I
+- <init>(Z,Z,org.jetbrains.jewel.ui.icon.IconKey,org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction,java.util.Set,kotlin.jvm.functions.Function0,kotlin.jvm.functions.Function2):V
+- b:<init>(Z,Z,org.jetbrains.jewel.ui.icon.IconKey,org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction,java.util.Set,kotlin.jvm.functions.Function0,kotlin.jvm.functions.Function2,I,kotlin.jvm.internal.DefaultConstructorMarker):V
+- equals(java.lang.Object):Z
+- getContent():kotlin.jvm.functions.Function2
+- f:getIconKey():org.jetbrains.jewel.ui.icon.IconKey
+- f:getItemOptionAction():org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+- f:getKeybinding():java.util.Set
+- f:getOnClick():kotlin.jvm.functions.Function0
+- hashCode():I
+- f:isEnabled():Z
+- f:isSelected():Z
 org.jetbrains.jewel.ui.component.TabContentScope
 - tabContentAlpha-A_ZS63w(androidx.compose.ui.Modifier,J,androidx.compose.runtime.Composer,I):androidx.compose.ui.Modifier
 f:org.jetbrains.jewel.ui.component.TabStripKt
 - sf:TabStrip(java.util.List,org.jetbrains.jewel.ui.component.styling.TabStyle,androidx.compose.ui.Modifier,Z,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.runtime.Composer,I,I):V
+f:org.jetbrains.jewel.ui.component.TextContextMenu
+- androidx.compose.foundation.text.TextContextMenu
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.ui.component.TextContextMenu
+- Area(androidx.compose.foundation.text.TextContextMenu$TextManager,androidx.compose.foundation.ContextMenuState,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I):V
 f:org.jetbrains.jewel.ui.component.TooltipKt
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,org.jetbrains.jewel.ui.component.AutoHideBehavior,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -76,6 +76,22 @@ public final class org/jetbrains/jewel/ui/DisabledColorFilterKt {
 	public static final fun disabled (Landroidx/compose/ui/graphics/ColorFilter$Companion;)Landroidx/compose/ui/graphics/ColorFilter;
 }
 
+public abstract interface class org/jetbrains/jewel/ui/MenuItemShortcutHintProvider {
+	public abstract fun getShortcutHint (Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;)Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/ui/MenuItemShortcutHintProviderKt {
+	public static final fun getLocalMenuItemShortcutHintProvider ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/ui/MenuItemShortcutProvider {
+	public abstract fun getShortcutKeyStroke (Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;)Ljavax/swing/KeyStroke;
+}
+
+public final class org/jetbrains/jewel/ui/MenuItemShortcutProviderKt {
+	public static final fun getLocalMenuItemShortcutProvider ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public final class org/jetbrains/jewel/ui/Orientation : java/lang/Enum {
 	public static final field Horizontal Lorg/jetbrains/jewel/ui/Orientation;
 	public static final field Vertical Lorg/jetbrains/jewel/ui/Orientation;
@@ -341,6 +357,50 @@ public final class org/jetbrains/jewel/ui/component/ContextMenuDivider : android
 	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/ContextMenuDivider;
 }
 
+public final class org/jetbrains/jewel/ui/component/ContextMenuItemOption : androidx/compose/foundation/ContextMenuItem {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getActionType ()Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;
+	public final fun getIcon ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+}
+
+public abstract class org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction {
+	public static final field $stable I
+}
+
+public final class org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$CopyMenuItemOptionAction : org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$CopyMenuItemOptionAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$CutMenuItemOptionAction : org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$CutMenuItemOptionAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$PasteMenuItemOptionAction : org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$PasteMenuItemOptionAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$SelectAllMenuItemOptionAction : org/jetbrains/jewel/ui/component/ContextMenuItemOptionAction {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction$SelectAllMenuItemOptionAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/jetbrains/jewel/ui/component/ContextMenuRepresentation : androidx/compose/foundation/ContextMenuRepresentation {
 	public static final field $stable I
 	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/ContextMenuRepresentation;
@@ -351,6 +411,23 @@ public final class org/jetbrains/jewel/ui/component/ContextSubmenu : androidx/co
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public final fun getSubmenu ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class org/jetbrains/jewel/ui/component/DefaultMenuController : org/jetbrains/jewel/ui/component/MenuController {
+	public static final field $stable I
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/ui/component/DefaultMenuController;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/ui/component/DefaultMenuController;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clearShortcutActions ()V
+	public fun close-iuPiT84 (I)Z
+	public fun closeAll-HMVJIwE (IZ)V
+	public fun findAndExecuteShortcut (Ljavax/swing/KeyStroke;)Ljava/lang/Boolean;
+	public fun getOnDismissRequest ()Lkotlin/jvm/functions/Function1;
+	public fun isRootMenu ()Z
+	public fun isSubmenu ()Z
+	public fun onHoveredChange (Z)V
+	public fun registerShortcutAction (Ljavax/swing/KeyStroke;Lkotlin/jvm/functions/Function0;)V
+	public fun submenuController (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/ui/component/DefaultMenuController;
+	public synthetic fun submenuController (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/ui/component/MenuController;
 }
 
 public final class org/jetbrains/jewel/ui/component/DividerKt {
@@ -586,6 +663,23 @@ public final class org/jetbrains/jewel/ui/component/ListItemState {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class org/jetbrains/jewel/ui/component/MenuController {
+	public abstract fun clearShortcutActions ()V
+	public abstract fun close-iuPiT84 (I)Z
+	public abstract fun closeAll-HMVJIwE (IZ)V
+	public abstract fun findAndExecuteShortcut (Ljavax/swing/KeyStroke;)Ljava/lang/Boolean;
+	public abstract fun getOnDismissRequest ()Lkotlin/jvm/functions/Function1;
+	public abstract fun isRootMenu ()Z
+	public abstract fun isSubmenu ()Z
+	public abstract fun onHoveredChange (Z)V
+	public abstract fun registerShortcutAction (Ljavax/swing/KeyStroke;Lkotlin/jvm/functions/Function0;)V
+	public abstract fun submenuController (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/ui/component/MenuController;
+}
+
+public final class org/jetbrains/jewel/ui/component/MenuControllerKt {
+	public static final fun getLocalMenuController ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public final class org/jetbrains/jewel/ui/component/MenuItemState : org/jetbrains/jewel/foundation/state/FocusableComponentState, org/jetbrains/jewel/foundation/state/SelectableComponentState {
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/MenuItemState$Companion;
 	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/ui/component/MenuItemState;
@@ -623,6 +717,7 @@ public final class org/jetbrains/jewel/ui/component/MenuItemState$Companion {
 }
 
 public final class org/jetbrains/jewel/ui/component/MenuKt {
+	public static final fun MenuContent (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MenuSeparator (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/MenuItemMetrics;Lorg/jetbrains/jewel/ui/component/styling/MenuItemColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MenuSubmenuItem (Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/ui/icon/IconKey;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun PopupMenu (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Landroidx/compose/ui/window/PopupProperties;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
@@ -650,12 +745,30 @@ public final class org/jetbrains/jewel/ui/component/MenuManagerKt {
 public abstract interface class org/jetbrains/jewel/ui/component/MenuScope {
 	public abstract fun passiveItem (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun selectableItem (ZLorg/jetbrains/jewel/ui/icon/IconKey;Ljava/util/Set;Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function2;)V
+	public abstract fun selectableItemWithActionType (ZLorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function2;)V
 	public abstract fun submenu (ZLorg/jetbrains/jewel/ui/icon/IconKey;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class org/jetbrains/jewel/ui/component/MenuScope$DefaultImpls {
 	public static synthetic fun selectableItem$default (Lorg/jetbrains/jewel/ui/component/MenuScope;ZLorg/jetbrains/jewel/ui/icon/IconKey;Ljava/util/Set;Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun selectableItemWithActionType$default (Lorg/jetbrains/jewel/ui/component/MenuScope;ZLorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static synthetic fun submenu$default (Lorg/jetbrains/jewel/ui/component/MenuScope;ZLorg/jetbrains/jewel/ui/icon/IconKey;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public final class org/jetbrains/jewel/ui/component/MenuSelectableItem : org/jetbrains/jewel/ui/component/MenuItem {
+	public static final field $stable I
+	public fun <init> (ZZLorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (ZZLorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContent ()Lkotlin/jvm/functions/Function2;
+	public final fun getIconKey ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+	public final fun getItemOptionAction ()Lorg/jetbrains/jewel/ui/component/ContextMenuItemOptionAction;
+	public final fun getKeybinding ()Ljava/util/Set;
+	public final fun getOnClick ()Lkotlin/jvm/functions/Function0;
+	public fun hashCode ()I
+	public final fun isEnabled ()Z
+	public final fun isSelected ()Z
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/jewel/ui/component/PopupContainerKt {
@@ -1049,6 +1162,12 @@ public final class org/jetbrains/jewel/ui/component/TabsKt {
 public final class org/jetbrains/jewel/ui/component/TextAreaKt {
 	public static final fun TextArea (Landroidx/compose/foundation/text/input/TextFieldState;Landroidx/compose/ui/Modifier;ZZLandroidx/compose/foundation/text/input/InputTransformation;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/input/KeyboardActionHandler;Landroidx/compose/foundation/text/input/TextFieldLineLimits;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/TextAreaStyle;Lorg/jetbrains/jewel/ui/Outline;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/text/input/OutputTransformation;ZLandroidx/compose/foundation/ScrollState;Lorg/jetbrains/jewel/ui/component/styling/ScrollbarStyle;Landroidx/compose/runtime/Composer;III)V
 	public static final fun TextArea (Landroidx/compose/ui/text/input/TextFieldValue;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function2;ZLorg/jetbrains/jewel/ui/Outline;Landroidx/compose/ui/text/input/VisualTransformation;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;ILkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/ui/component/styling/TextAreaStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class org/jetbrains/jewel/ui/component/TextContextMenu : androidx/compose/foundation/text/TextContextMenu {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/TextContextMenu;
+	public fun Area (Landroidx/compose/foundation/text/TextContextMenu$TextManager;Landroidx/compose/foundation/ContextMenuState;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class org/jetbrains/jewel/ui/component/TextFieldKt {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/DefaultComponentStyling.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/DefaultComponentStyling.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.jewel.ui
 
 import androidx.compose.foundation.LocalContextMenuRepresentation
+import androidx.compose.foundation.text.LocalTextContextMenu
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.Stable
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 import org.jetbrains.jewel.ui.component.ContextMenuRepresentation
+import org.jetbrains.jewel.ui.component.TextContextMenu
 import org.jetbrains.jewel.ui.component.styling.ButtonStyle
 import org.jetbrains.jewel.ui.component.styling.CheckboxStyle
 import org.jetbrains.jewel.ui.component.styling.ChipStyle
@@ -110,6 +112,7 @@ public class DefaultComponentStyling(
             LocalChipStyle provides chipStyle,
             LocalCircularProgressStyle provides circularProgressStyle,
             LocalContextMenuRepresentation provides ContextMenuRepresentation,
+            LocalTextContextMenu provides TextContextMenu,
             LocalDefaultBannerStyle provides defaultBannerStyle,
             LocalDefaultComboBoxStyle provides comboBoxStyle,
             LocalDefaultButtonStyle provides defaultButtonStyle,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/MenuItemShortcutHintProvider.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/MenuItemShortcutHintProvider.kt
@@ -1,0 +1,22 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+
+public interface MenuItemShortcutHintProvider {
+    /**
+     * Gets the formatted shortcut string for the given action identifier.
+     *
+     * @param actionType The action type. See [ContextMenuItemOptionAction].
+     * @return The human-readable shortcut string (e.g., "⌘C", "Ctrl+S"), or empty if no shortcut is defined or it
+     *   shouldn't be displayed.
+     */
+    public fun getShortcutHint(actionType: ContextMenuItemOptionAction): String
+}
+
+public val LocalMenuItemShortcutHintProvider: ProvidableCompositionLocal<MenuItemShortcutHintProvider> =
+    staticCompositionLocalOf {
+        error("No LocalMenuItemShortcutHintProvider provided. Have you forgotten the theme?")
+    }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/MenuItemShortcutProvider.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/MenuItemShortcutProvider.kt
@@ -1,0 +1,24 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import javax.swing.KeyStroke
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+
+/** Provides a way to also get the actual KeyStroke of a shortcut besides its hint */
+public interface MenuItemShortcutProvider {
+
+    /**
+     * Gets the KeyStroke for a given action identifier.
+     *
+     * @param actionType The action type. See [ContextMenuItemOptionAction].
+     * @return The Swing representation of the shortcut, or empty if a given action can't be mapped to a KeyStroke.
+     */
+    public fun getShortcutKeyStroke(actionType: ContextMenuItemOptionAction): KeyStroke?
+}
+
+public val LocalMenuItemShortcutProvider: ProvidableCompositionLocal<MenuItemShortcutProvider> =
+    staticCompositionLocalOf {
+        error("No LocalMenuItemShortcutProvider provided. Have you forgotten the theme?")
+    }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/MenuController.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/MenuController.kt
@@ -1,0 +1,96 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui.component
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.input.InputMode
+import javax.swing.KeyStroke
+import org.jetbrains.jewel.foundation.InternalJewelApi
+
+public interface MenuController {
+    public val onDismissRequest: (InputMode) -> Boolean
+
+    public fun onHoveredChange(hovered: Boolean)
+
+    public fun closeAll(mode: InputMode, force: Boolean)
+
+    public fun close(mode: InputMode): Boolean
+
+    public fun isRootMenu(): Boolean
+
+    public fun isSubmenu(): Boolean
+
+    public fun submenuController(onDismissRequest: (InputMode) -> Boolean): MenuController
+
+    public fun registerShortcutAction(keyStroke: KeyStroke, action: () -> Unit)
+
+    public fun clearShortcutActions()
+
+    public fun findAndExecuteShortcut(keyStroke: KeyStroke?): Boolean?
+}
+
+@InternalJewelApi
+public class DefaultMenuController(
+    override val onDismissRequest: (InputMode) -> Boolean,
+    private val parentMenuController: DefaultMenuController? = null,
+) : MenuController {
+    private var isHovered: Boolean = false
+    private val currentMenuShortcutActions = mutableListOf<MenuShortcutAction>()
+
+    /**
+     * Called when the hovered state of the menu changes. This is used to abort parent menu closing in unforced mode
+     * when submenu closed by click parent menu's item.
+     *
+     * @param hovered true if the menu is hovered, false otherwise.
+     */
+    override fun onHoveredChange(hovered: Boolean) {
+        isHovered = hovered
+    }
+
+    /**
+     * Close all menus in the hierarchy.
+     *
+     * @param mode the input mode, menus close by pointer or keyboard event.
+     * @param force true to force close all menus ignore parent hover state, false otherwise.
+     */
+    override fun closeAll(mode: InputMode, force: Boolean) {
+        // We ignore the pointer event if the menu is hovered in unforced mode.
+        if (!force && mode == InputMode.Touch && isHovered) return
+
+        if (onDismissRequest(mode)) {
+            parentMenuController?.closeAll(mode, force)
+        }
+    }
+
+    override fun close(mode: InputMode): Boolean = onDismissRequest(mode)
+
+    override fun isRootMenu(): Boolean = parentMenuController == null
+
+    override fun isSubmenu(): Boolean = parentMenuController != null
+
+    override fun submenuController(onDismissRequest: (InputMode) -> Boolean): DefaultMenuController =
+        DefaultMenuController(onDismissRequest = onDismissRequest, parentMenuController = this)
+
+    override fun registerShortcutAction(keyStroke: KeyStroke, action: () -> Unit) {
+        currentMenuShortcutActions.add(MenuShortcutAction(keyStroke, action))
+    }
+
+    override fun clearShortcutActions() {
+        currentMenuShortcutActions.clear()
+    }
+
+    override fun findAndExecuteShortcut(keyStroke: KeyStroke?): Boolean? {
+        val actionToExecute = currentMenuShortcutActions.firstOrNull { it.keyStroke == keyStroke }
+        if (actionToExecute != null) {
+            actionToExecute.action.invoke()
+            return true
+        }
+        return null
+    }
+}
+
+public val LocalMenuController: ProvidableCompositionLocal<MenuController> = staticCompositionLocalOf {
+    error("No MenuController provided. Have you forgotten the theme?")
+}
+
+internal data class MenuShortcutAction(val keyStroke: KeyStroke, val action: () -> Unit)

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/MenuManager.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/MenuManager.kt
@@ -4,6 +4,13 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.input.InputMode
 
+@Deprecated(
+    message =
+        "The MenuManager class has been superseded by the MenuController interface, " +
+            "which offers improved abstraction and new functionalities like shortcut management. " +
+            "Depend on the DefaultMenuController class for all menu operations.",
+    replaceWith = ReplaceWith("org.jetbrains.jewel.ui.component.DefaultMenuController"),
+)
 public class MenuManager(
     public val onDismissRequest: (InputMode) -> Boolean,
     private val parentMenuManager: MenuManager? = null,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Popup.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Popup.kt
@@ -24,7 +24,7 @@ internal fun handlePopupMenuOnKeyEvent(
     keyEvent: KeyEvent,
     focusManager: FocusManager,
     inputModeManager: InputModeManager,
-    menuManager: MenuManager,
+    menuController: MenuController,
 ): Boolean {
     if (keyEvent.type != KeyEventType.KeyDown) return false
 
@@ -43,14 +43,14 @@ internal fun handlePopupMenuOnKeyEvent(
 
         Key.Escape -> {
             inputModeManager.requestInputMode(InputMode.Keyboard)
-            menuManager.closeAll(InputMode.Keyboard, true)
+            menuController.closeAll(InputMode.Keyboard, true)
             true
         }
 
         Key.DirectionLeft -> {
-            if (menuManager.isSubmenu()) {
+            if (menuController.isSubmenu()) {
                 inputModeManager.requestInputMode(InputMode.Keyboard)
-                menuManager.close(InputMode.Keyboard)
+                menuController.close(InputMode.Keyboard)
                 true
             } else {
                 false

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextContextMenu.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextContextMenu.kt
@@ -1,0 +1,66 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui.component
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.foundation.text.TextContextMenu
+import androidx.compose.foundation.text.TextContextMenuArea
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLocalization
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.CopyMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.CutMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.PasteMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction.SelectAllMenuItemOptionAction
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+
+public object TextContextMenu : TextContextMenu {
+    @Composable
+    override fun Area(
+        textManager: TextContextMenu.TextManager,
+        state: ContextMenuState,
+        content: @Composable (() -> Unit),
+    ) {
+        val localization = LocalLocalization.current
+        val items: () -> List<ContextMenuItem> =
+            remember(textManager, state) {
+                {
+                    listOfNotNull(
+                        textManager.cut?.let {
+                            ContextMenuItemOption(
+                                icon = AllIconsKeys.Actions.MenuCut,
+                                actionType = CutMenuItemOptionAction,
+                                label = localization.cut,
+                                action = it,
+                            )
+                        },
+                        textManager.copy?.let {
+                            ContextMenuItemOption(
+                                icon = AllIconsKeys.Actions.Copy,
+                                actionType = CopyMenuItemOptionAction,
+                                label = localization.copy,
+                                action = it,
+                            )
+                        },
+                        textManager.paste?.let {
+                            ContextMenuItemOption(
+                                icon = AllIconsKeys.Actions.MenuPaste,
+                                actionType = PasteMenuItemOptionAction,
+                                label = localization.paste,
+                                action = it,
+                            )
+                        },
+                        textManager.selectAll?.let {
+                            ContextMenuItemOption(
+                                actionType = SelectAllMenuItemOptionAction,
+                                label = localization.selectAll,
+                                action = it,
+                            )
+                        },
+                    )
+                }
+            }
+
+        TextContextMenuArea(textManager, items, state, content)
+    }
+}


### PR DESCRIPTION
# Context

Currently our [Context Menu](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-desktop-context-menus.html) has the correct styles, but it's missing the ability to display an icon and shortcut hints as well as handling said shortcuts.

Main changes:

- Overriding `TextContextMenu` so that we can display shortcut hints and handle shortcuts and also shows an icon.
- Created a `ContextMenuItemOption` data class that holds both the context menu item icon and shortcut type.
- Created a `MenuController` interface which will substitute our current `MenuManager` class, which got deprecated. With this interface, we can test the shortcut handling logic.
- Created a sealed class `ContextMenuItemOptionAction` that's used to map to a shortcut hint or the keystroke for the shortcut.
- Created a `selectableItemWithActionType` variant for `MenuScope`. This variation doesn't rely on a `keybinding: Set<String>` but instead a `ContextMenuItemOptionAction`.
- Turned `MenuSelectableItem` into a class. It's public now but only visible for testing.
- Put all related composable logic from MenuItem into a `MenuItemBase`. Added a new variation of `MenuItem` that accepts a `ContextMenuItemOptionAction` instead of a `keybinding: Set<String>`.
- Updated `ContextMenu` code to use our new `MenuController` and delegate key presses to it. If the menu controller can't find a menu shortcut associated with the keys being pressed, then we fallback to the more general purpose `handlePopupMenuOnKeyEvent`.

# Evidences

## Standalone
| Context | Evidence |
|--------|--------|
| `SelectionContainer` light theme | <img src="https://github.com/user-attachments/assets/cc515a7f-5f7d-4e50-88de-58291b252006" width="400" /> |
| `SelectionContainer` dark theme | <img src="https://github.com/user-attachments/assets/f3da29f5-6edf-4bc4-a82c-7a57c8ba3e55" width="400" /> |
| `SelectionContainer` copy shortcut (clicking on the option/using shortcut/selecting by enter key) | <video src="https://github.com/user-attachments/assets/837fab09-0dfc-437b-89ae-f8f860b511dc" width="400" /> |
| `BasicTextField` light theme | <img src="https://github.com/user-attachments/assets/bb910697-cc80-48ed-9e74-5f8d57d184e2" width="400" /> |
| `BasicTextField` dark theme | <img src="https://github.com/user-attachments/assets/1a1709bf-6c08-4490-a2de-b6274486de82" width="400" /> |
| Copy shortcut (directly clicking on the context menu option) | <video src="https://github.com/user-attachments/assets/1423226e-03bb-4a75-9c69-2339ee7f8b0d" width="400" /> |
| Copy shortcut (typing the shortcut without selecting option in context menu) | <video src="https://github.com/user-attachments/assets/14e8b481-9a6c-4671-b571-58e9d3269532" width="400" /> |
| Copy shortcut (selecting option with arrow + enter keys) | <video src="https://github.com/user-attachments/assets/b67c45d2-8fac-4aa4-9902-1c4a5d0fdeba" width="400" /> |
| Paste shortcut | <video src="https://github.com/user-attachments/assets/84e809ed-9d1f-437d-8899-903794b1485a" width="400" /> |
| Cut shortcut | <video src="https://github.com/user-attachments/assets/0332a5cf-fa95-46d2-8e74-0b25d632cc1a" width="400" /> |
| Select All shortcut | <video src="https://github.com/user-attachments/assets/b9004271-1d42-4bfd-b463-a5ad92423f1d" width="400" /> |


## IJP
| Context | Evidence |
|--------|--------|
| `SelectionContainer` light theme | <img src="https://github.com/user-attachments/assets/00883488-0537-48b1-a648-9539605ef95e" width="400" /> |
| `SelectionContainer` dark theme | <img src="https://github.com/user-attachments/assets/1e99bf96-f1e2-422b-9780-efa5a2e0d732" width="400" /> |
| `SelectionContainer` copy shortcut (clicking on the option/using shortcut/selecting by enter key) | <video src="https://github.com/user-attachments/assets/437fa4ca-8a0b-4185-b1a8-f62da4183faf" width="400" /> |
| `BasicTextField` light theme | <img src="https://github.com/user-attachments/assets/9086c848-30f1-4eab-9905-ac59cc1cc725" width="400" /> |
| `BasicTextField` dark theme | <img src="https://github.com/user-attachments/assets/95f1138b-4047-4e03-8a98-2f26886748c5" width="400" /> |
| Copy shortcut (directly clicking on the context menu option) | <video src="https://github.com/user-attachments/assets/08094b9d-5a99-4ec5-8611-4a1d180c601b" width="400" /> |
| Copy shortcut (typing the shortcut without selecting option in context menu) | <video src="https://github.com/user-attachments/assets/2ed2e4a1-2695-4f1e-8880-453e57059865" width="400" /> |
| Copy shortcut (selecting option with enter key) | <video src="https://github.com/user-attachments/assets/26104f69-d635-4eba-a468-f0ed134827fc" width="400" /> |
| Paste shortcut | <video src="https://github.com/user-attachments/assets/282699c5-1fab-4562-b916-16e77f8bdee7" width="400" /> |
| Cut shortcut | <video src="https://github.com/user-attachments/assets/0083d081-e56b-442f-a812-4fc157407fb5" width="400" /> |
| Select All shortcut | <video src="https://github.com/user-attachments/assets/1f6c1b68-c040-4106-b897-601729668068" width="400" /> |

## Release notes

### New features
 * Created a `ContextMenuItemOption`. You should use this class to provide icons and shortcut data (hint and what keystroke corresponds to said shortcut).

### Deprecated API
 * `MenuManager` is now deprecated. You should use `MenuController` or `BaseMenuController`. This new interface now handles shortcut key presses.