### PR TITLE
[JEWEL-843] Make disabled variant of icons look darker in dark mode

### DIFF
--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
@@ -1,42 +1,27 @@
 package org.jetbrains.jewel.samples.ideplugin
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import com.intellij.icons.AllIcons
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
 import com.intellij.openapi.editor.colors.EditorFontType
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.util.IconLoader
 import com.intellij.ui.JBColor
+import com.intellij.ui.components.BrowserLink
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.dsl.builder.AlignY
-import com.intellij.ui.dsl.builder.COLUMNS_SHORT
-import com.intellij.ui.dsl.builder.Panel
-import com.intellij.ui.dsl.builder.Row
-import com.intellij.ui.dsl.builder.RowLayout
-import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.*
 import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
@@ -50,15 +35,9 @@ import org.jetbrains.jewel.bridge.JewelComposePanel
 import org.jetbrains.jewel.bridge.medium
 import org.jetbrains.jewel.bridge.retrieveEditorColorScheme
 import org.jetbrains.jewel.foundation.theme.JewelTheme
-import org.jetbrains.jewel.ui.component.DefaultButton
-import org.jetbrains.jewel.ui.component.EditableListComboBox
-import org.jetbrains.jewel.ui.component.Icon
-import org.jetbrains.jewel.ui.component.ListComboBox
-import org.jetbrains.jewel.ui.component.OutlinedButton
-import org.jetbrains.jewel.ui.component.Text
-import org.jetbrains.jewel.ui.component.TextArea
-import org.jetbrains.jewel.ui.component.TextField
-import org.jetbrains.jewel.ui.component.Typography
+import org.jetbrains.jewel.ui.component.*
+import org.jetbrains.jewel.ui.disabledThemeAware
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.theme.textAreaStyle
 
 internal class SwingComparisonTabPanel : BorderLayoutPanel() {
@@ -71,6 +50,8 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                 separator()
                 iconsRow()
                 separator()
+                linksRow()
+                separator()
                 textFieldsRow()
                 separator()
                 textAreasRow()
@@ -82,6 +63,28 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                 border = JBUI.Borders.empty(0, 10)
                 isOpaque = false
             }
+
+    private fun Panel.linksRow() {
+        row("Links:") {
+                browserLink("Enabled link", "")
+
+                compose { ExternalLink(text = "Enabled link", enabled = true, onClick = {}) }
+
+                cell(
+                        component =
+                            BrowserLink(
+                                icon = IconLoader.getDisabledIcon(AllIcons.Ide.External_link_arrow),
+                                text = "Disabled link",
+                                tooltip = null,
+                                url = "",
+                            )
+                    )
+                    .applyToComponent { foreground = JBUI.CurrentTheme.Link.Foreground.DISABLED }
+
+                compose { ExternalLink(text = "Disabled Link", enabled = false, onClick = {}) }
+            }
+            .layout(RowLayout.PARENT_GRID)
+    }
 
     private val scrollingContainer =
         JBScrollPane(
@@ -204,6 +207,59 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                         contentDescription = "Jewel Tool Window Icon",
                         modifier = Modifier.border(1.dp, Color.Red),
                     )
+                }
+
+                panel {
+                    row {
+                        label("Swing").widthGroup("swing disabled")
+                        label("Compose").widthGroup("compose disabled")
+                        label("Swing").widthGroup("swing enabled")
+                        label("Compose").widthGroup("compose enabled")
+
+                        label("Swing").widthGroup("swing disabled")
+                        label("Compose").widthGroup("compose disabled")
+                        label("Swing").widthGroup("swing enabled")
+                        label("Compose").widthGroup("compose enabled")
+                    }
+                    row {
+                        icon(icon = IconLoader.getDisabledIcon(AllIcons.Actions.CheckOut)).widthGroup("swing disabled")
+                        compose {
+                                Icon(
+                                    key = AllIconsKeys.Actions.CheckOut,
+                                    contentDescription = null,
+                                    colorFilter = ColorFilter.disabledThemeAware(),
+                                )
+                            }
+                            .widthGroup("compose disabled")
+                        icon(icon = AllIcons.Actions.CheckOut).widthGroup("swing enabled")
+                        compose {
+                                Icon(
+                                    key = AllIconsKeys.Actions.CheckOut,
+                                    contentDescription = null,
+                                    colorFilter = null, // Not disabled
+                                )
+                            }
+                            .widthGroup("compose enabled")
+
+                        icon(icon = IconLoader.getDisabledIcon(AllIcons.Actions.Close)).widthGroup("swing disabled")
+                        compose {
+                                Icon(
+                                    key = AllIconsKeys.Actions.Close,
+                                    contentDescription = null,
+                                    colorFilter = ColorFilter.disabledThemeAware(),
+                                )
+                            }
+                            .widthGroup("compose disabled")
+                        icon(icon = AllIcons.Actions.Close).widthGroup("swing enabled")
+                        compose {
+                                Icon(
+                                    key = AllIconsKeys.Actions.Close,
+                                    contentDescription = null,
+                                    colorFilter = null, // Not disabled
+                                )
+                            }
+                            .widthGroup("compose enabled")
+                    }
                 }
             }
             .layout(RowLayout.PARENT_GRID)

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
@@ -29,7 +29,7 @@ import org.jetbrains.jewel.ui.component.PopupContainer
 import org.jetbrains.jewel.ui.component.PopupManager
 import org.jetbrains.jewel.ui.component.SimpleListItem
 import org.jetbrains.jewel.ui.component.Text
-import org.jetbrains.jewel.ui.disabled
+import org.jetbrains.jewel.ui.disabledThemeAware
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 
@@ -149,7 +149,7 @@ private fun ListComboBoxes() {
                         active = isActive,
                         iconContentDescription = item.name,
                         icon = item.icon,
-                        colorFilter = ColorFilter.disabled(),
+                        colorFilter = ColorFilter.disabledThemeAware(),
                     )
                 },
             )

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -5,6 +5,8 @@ org.jetbrains.jewel.ui.ComponentStyling
 - a:styles(androidx.compose.runtime.Composer,I):androidx.compose.runtime.ProvidedValue[]
 - with(kotlin.jvm.functions.Function2):org.jetbrains.jewel.ui.ComponentStyling
 - with(org.jetbrains.jewel.ui.ComponentStyling):org.jetbrains.jewel.ui.ComponentStyling
+f:org.jetbrains.jewel.ui.DisabledColorFilterKt
+- sf:disabledThemeAware(androidx.compose.ui.graphics.ColorFilter$Companion,androidx.compose.runtime.Composer,I):androidx.compose.ui.graphics.ColorFilter
 e:org.jetbrains.jewel.ui.component.AutoHideBehavior
 - java.lang.Enum
 - sf:Long:org.jetbrains.jewel.ui.component.AutoHideBehavior

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -70,6 +70,7 @@ public final class org/jetbrains/jewel/ui/DefaultComponentStyling : org/jetbrain
 
 public final class org/jetbrains/jewel/ui/DisabledColorFilterKt {
 	public static final fun disabled (Landroidx/compose/ui/graphics/ColorFilter$Companion;)Landroidx/compose/ui/graphics/ColorFilter;
+	public static final fun disabledThemeAware (Landroidx/compose/ui/graphics/ColorFilter$Companion;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/ColorFilter;
 }
 
 public final class org/jetbrains/jewel/ui/Orientation : java/lang/Enum {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/DisabledColorFilter.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/DisabledColorFilter.kt
@@ -1,20 +1,23 @@
 package org.jetbrains.jewel.ui
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
+import org.jetbrains.jewel.foundation.theme.JewelTheme
 
 // Implements javax.swing.GrayFilter's behaviour with percent = 50, brighter = true
 // to match the GrayFilter#createDisabledImage behavior, used by Swing.
-private val disabledColorMatrixGammaEncoded =
+private fun disabledColorMatrixGammaEncoded(isSystemInDarkMode: Boolean = false) =
     ColorMatrix().apply {
         val saturation = .5f
+        val brightness = if (isSystemInDarkMode) .125f else .25f
 
         // We use NTSC luminance weights like Swing does as it's gamma-encoded RGB,
         // and add some brightness to emulate Swing's "brighter" approach, which is
         // not representable with a ColorMatrix alone as it's a non-linear op.
-        val redFactor = .299f * saturation + .25f
-        val greenFactor = .587f * saturation + .25f
-        val blueFactor = .114f * saturation + .25f
+        val redFactor = .299f * saturation + brightness
+        val greenFactor = .587f * saturation + brightness
+        val blueFactor = .114f * saturation + brightness
         this[0, 0] = redFactor
         this[0, 1] = greenFactor
         this[0, 2] = blueFactor
@@ -26,4 +29,9 @@ private val disabledColorMatrixGammaEncoded =
         this[2, 2] = blueFactor
     }
 
-public fun ColorFilter.Companion.disabled(): ColorFilter = colorMatrix(disabledColorMatrixGammaEncoded)
+@Deprecated("Use disabledThemeAware instead. This way you get nice colors on dark theme too!")
+public fun ColorFilter.Companion.disabled(): ColorFilter = colorMatrix(disabledColorMatrixGammaEncoded())
+
+@Composable
+public fun ColorFilter.Companion.disabledThemeAware(): ColorFilter =
+    colorMatrix(disabledColorMatrixGammaEncoded(JewelTheme.isDark))

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/DisabledColorFilter.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/DisabledColorFilter.kt
@@ -10,7 +10,7 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 private fun disabledColorMatrixGammaEncoded(isSystemInDarkMode: Boolean = false) =
     ColorMatrix().apply {
         val saturation = .5f
-        val brightness = if (isSystemInDarkMode) .125f else .25f
+        val brightness = if (isSystemInDarkMode) 0f else .25f
 
         // We use NTSC luminance weights like Swing does as it's gamma-encoded RGB,
         // and add some brightness to emulate Swing's "brighter" approach, which is

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Dropdown.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Dropdown.kt
@@ -48,7 +48,7 @@ import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.foundation.theme.LocalTextStyle
 import org.jetbrains.jewel.ui.Outline
 import org.jetbrains.jewel.ui.component.styling.DropdownStyle
-import org.jetbrains.jewel.ui.disabled
+import org.jetbrains.jewel.ui.disabledThemeAware
 import org.jetbrains.jewel.ui.focusOutline
 import org.jetbrains.jewel.ui.outline
 import org.jetbrains.jewel.ui.painter.hints.Stateful
@@ -138,7 +138,7 @@ public fun Dropdown(
                 contentAlignment = Alignment.Center,
             ) {
                 val alpha = if (dropdownState.isEnabled) 1f else 0.5f
-                val colorFilter = if (dropdownState.isEnabled) null else ColorFilter.disabled()
+                val colorFilter = if (dropdownState.isEnabled) null else ColorFilter.disabledThemeAware()
                 Icon(
                     modifier = Modifier.alpha(alpha),
                     key = style.icons.chevronDown,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
@@ -47,7 +47,7 @@ import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior.ShowOnHove
 import org.jetbrains.jewel.ui.component.styling.LocalLinkStyle
 import org.jetbrains.jewel.ui.component.styling.LocalMenuStyle
 import org.jetbrains.jewel.ui.component.styling.MenuStyle
-import org.jetbrains.jewel.ui.disabled
+import org.jetbrains.jewel.ui.disabledThemeAware
 import org.jetbrains.jewel.ui.focusOutline
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.painter.hints.Stateful
@@ -304,7 +304,7 @@ private fun LinkImpl(
                 key = icon,
                 contentDescription = null,
                 modifier = Modifier.size(style.metrics.iconSize),
-                colorFilter = if (!linkState.isEnabled) ColorFilter.disabled() else null,
+                colorFilter = if (!linkState.isEnabled) ColorFilter.disabledThemeAware() else null,
                 hint = Stateful(linkState),
             )
         }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
@@ -40,7 +40,7 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.util.JewelLogger
 import org.jetbrains.jewel.ui.Outline
 import org.jetbrains.jewel.ui.component.styling.ComboBoxStyle
-import org.jetbrains.jewel.ui.disabled
+import org.jetbrains.jewel.ui.disabledThemeAware
 import org.jetbrains.jewel.ui.theme.comboBoxStyle
 
 /**
@@ -335,7 +335,7 @@ public fun ListComboBox(
                     selected = isSelected,
                     active = isActive,
                     iconContentDescription = item,
-                    colorFilter = if (enabled) null else ColorFilter.disabled(),
+                    colorFilter = if (enabled) null else ColorFilter.disabledThemeAware(),
                 )
             },
         )


### PR DESCRIPTION
# Context

Currently, our disabled icons are really bright compared to Swing's counterpart. That's because we are always adding an arbitrary value to emulate the brightness that Swing applies to icons through its non-linear calculations. So each and every icon will have the same brightness. This PR fixes this so that we don't apply any brightness to an icon if the current theme is set to dark.

## Code changed
- Changed `disabledColorMatrixGammaEncoded` to a `fun` so we can set a specific brightness value given the current theme.
- Created a new `.disabledThemeAware()` Composable function that checks if the current theme
- Added `@Deprecated` annotation to current `disabled()` function since that one doesn't take into account the user's theme.
- Added new neat swing comparisons examples!

### Investigation
<details><summary>If you'd like to learn more about how IJP (IntelliJ Platform) actually greys out their icons to look disabled, check this collapsed section!</summary>
<p>
Whenever a plugin needs to fetch a disabled version of an icon, they typically call the `getDisabledIcon(icon: Icon)` function from `IconLoader`. This code down the line fetch the greyed out icon from this variable:

```kotlin
private val iconToDisabledIcon: LoadingCache<Icon, Icon> = Caffeine.newBuilder()
  .maximumSize(1024)
  .executor(Dispatchers.Default.asExecutor())
  .expireAfterAccess(10.minutes.toJavaDuration())
  .build<Icon, Icon>(CacheLoader { icon ->
    if (icon is CachedImageIcon) {
      icon.createWithFilter(standardDisablingFilter)
    }
    else {
      FilteredIcon(baseIcon = icon, filterSupplier = standardDisablingFilter)
    }
  })
  .also {
    registerIconCacheCleaner(it::invalidateAll)
  }
```

That, as you can see, uses the `standardDisablingFilter` and applies the filter to the specific icon. This variable calls the filter from `UIUtil.getGrayFilter()`:

```java
public static @NotNull RGBImageFilter getGrayFilter() {
  return GrayFilter.namedFilter("grayFilter", new GrayFilter(33, -35, 100));
}
```

Passing the values 33 as `brightness`, -35 as `contrast` and 100 as `opacity`.

The `GrayFilter` class has a function `filterRGB` that, given the `brightness`, `contrast` and `opacity` passed to it, does some non-linear calculations:

```java
public int filterRGB(int x, int y, int rgb) {
  // Use NTSC conversion formula.
  int gray = (int)(0.30 * (rgb >> 16 & 0xff) +
                   0.59 * (rgb >> 8 & 0xff) +
                   0.11 * (rgb & 0xff));

  if (brightness >= 0) {
    gray = (int)((gray + brightness * 255) / (1 + brightness));
  }
  else {
    gray = (int)(gray / (1 - brightness));
  }

  if (contrast >= 0) {
    if (gray >= 127) {
      gray = (int)(gray + (255 - gray) * contrast);
    }
    else {
      gray = (int)(gray - gray * contrast);
    }
  }
  else {
    gray = (int)(127 + (gray - 127) * (contrast + 1));
  }

  int a = ((rgb >> 24) & 0xff) * alpha / 100;

  return (a << 24) | (gray << 16) | (gray << 8) | gray;
}
```

Unfortunately, `ColorMatrix` from Compose doesn't support non-linear calculations yet. In other words, we can't faithfully recreate this code right now. The best we can do is get an approximation, but as you can see from the evidences below, some icons (even though they can have the exact same hex color) may appear a little brighter or darker.

So, for now, this will have to suffice.

</p>
</details> 

# Evidences

## Dark Mode
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4f3b04f1-8cf2-4167-b78e-9023a3a29fca) | ![image](https://github.com/user-attachments/assets/31492585-75c9-4124-8f52-e2260273a9c7) |

## Light Mode
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5654f4de-230c-417c-a2d7-c270cc181425) | ![image](https://github.com/user-attachments/assets/3a07a4e6-d67d-4d04-ba36-c9a032b54af6) |

## Swing Comparison Tab
| Light Mode | Dark Mode |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/8db091e7-18ee-4679-ac07-034b05b1ff7e) | ![image](https://github.com/user-attachments/assets/9703eb44-bdeb-4440-9355-44fd448abe44) |
> Honestly, it's really hard to horizontally align content from two different rows in Swing

## Dynamically switching between themes
| IDE | Standalone| 
|---|---|
| <video src="https://github.com/user-attachments/assets/dcbeb4f0-b290-49c5-8693-a6ba8bcb2333" width="400" /> | <video src="https://github.com/user-attachments/assets/9058a941-31ad-47a3-a65f-532fc8ae52d7" width="400" /> |