### PR TITLE
[JEWEL] IJPL-190270 Rename Jewel -> Compose

### DIFF
--- a/platform/compose/src/com/intellij/platform/compose/showcase/ComposeShowcaseAction.kt
+++ b/platform/compose/src/com/intellij/platform/compose/showcase/ComposeShowcaseAction.kt
@@ -7,12 +7,15 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.util.NlsSafe
 import com.intellij.ui.PaintingParent.Wrapper
+import com.intellij.ui.components.JBPanel
+import org.jetbrains.jewel.bridge.JBPanel
 import org.jetbrains.jewel.bridge.JewelComposePanel
+import org.jetbrains.jewel.bridge.compose
 import java.awt.Dimension
 import javax.swing.JComponent
 
 private fun createComposeShowcaseComponent(): JComponent {
-  return JewelComposePanel {
+  return compose {
     ComposeShowcase()
   }
 }

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/JewelTheme.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/JewelTheme.kt
@@ -16,6 +16,8 @@ import org.jetbrains.jewel.foundation.LocalDisabledAppearanceValues
 import org.jetbrains.jewel.foundation.LocalGlobalColors
 import org.jetbrains.jewel.foundation.LocalGlobalMetrics
 
+public typealias ComposeTheme = JewelTheme
+
 public interface JewelTheme {
     public companion object {
         public val name: String
@@ -53,8 +55,18 @@ public interface JewelTheme {
 }
 
 @Composable
+public fun ComposeTheme(theme: ThemeDefinition, swingCompatMode: Boolean, content: @Composable () -> Unit) {
+    JewelTheme(theme, swingCompatMode, content)
+}
+
+@Composable
 public fun JewelTheme(theme: ThemeDefinition, swingCompatMode: Boolean, content: @Composable () -> Unit) {
     CompositionLocalProvider(LocalSwingCompatMode provides swingCompatMode) { JewelTheme(theme, content) }
+}
+
+@Composable
+public fun ComposeTheme(theme: ThemeDefinition, content: @Composable () -> Unit) {
+    JewelTheme(theme, content)
 }
 
 @Composable

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
@@ -94,7 +94,7 @@ public fun retrieveIntAsDp(key: String, default: Dp? = null): Dp {
 public fun retrieveIntAsDpOrUnspecified(key: String): Dp =
     try {
         retrieveIntAsDp(key)
-    } catch (_: JewelBridgeException) {
+    } catch (_: ComposeBridgeException) {
         Dp.Unspecified
     }
 

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ComposeBridgeException.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ComposeBridgeException.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.jewel.bridge
 
-public sealed class JewelBridgeException(override val message: String?) : RuntimeException(message) {
+public typealias JewelBridgeException = ComposeBridgeException
+
+public sealed class ComposeBridgeException(override val message: String?) : RuntimeException(message) {
     public class KeyNotFoundException(key: String, type: String) :
-        JewelBridgeException("Key '$key' not found in Swing LaF, was expecting a value of type $type")
+        ComposeBridgeException("Key '$key' not found in Swing LaF, was expecting a value of type $type")
 
     public class KeysNotFoundException(keys: List<String>, type: String) :
-        JewelBridgeException(
+        ComposeBridgeException(
             "Keys ${keys.joinToString(", ") { "'$it'" }} not found in Swing LaF, " +
                 "was expecting a value of type $type"
         )
@@ -13,8 +15,8 @@ public sealed class JewelBridgeException(override val message: String?) : Runtim
 
 @Suppress("NOTHING_TO_INLINE") // Same implementation as error()
 internal inline fun keyNotFound(key: String, type: String): Nothing =
-    throw JewelBridgeException.KeyNotFoundException(key, type)
+    throw ComposeBridgeException.KeyNotFoundException(key, type)
 
 @Suppress("NOTHING_TO_INLINE") // Same implementation as error()
 internal inline fun keysNotFound(keys: List<String>, type: String): Nothing =
-    throw JewelBridgeException.KeysNotFoundException(keys, type)
+    throw ComposeBridgeException.KeysNotFoundException(keys, type)

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
@@ -18,6 +18,11 @@ import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.InternalJewelApi
 import org.jetbrains.jewel.foundation.util.JewelLogger
 
+public fun compose(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent = JewelComposePanel(config, content)
+
+@ExperimentalJewelApi
+public fun JBPanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent = JewelComposePanel(config, content)
+
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JewelComposePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     createJewelComposePanel { jewelPanel ->
@@ -49,6 +54,11 @@ public fun JewelToolWindowComposePanel(
 
 @ExperimentalJewelApi
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
+public fun composeWithoutTheme(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
+    JewelComposeNoThemePanel(config, content)
+
+@ExperimentalJewelApi
+@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JewelComposeNoThemePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     createJewelComposePanel { jewelPanel ->
         config()
@@ -58,6 +68,11 @@ public fun JewelComposeNoThemePanel(config: ComposePanel.() -> Unit = {}, conten
             }
         }
     }
+
+@ExperimentalJewelApi
+@Suppress("ktlint:standard:function-naming") // Swing to Compose bridge API
+public fun composeForToolWindowWithoutTheme(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
+    JewelToolWindowNoThemeComposePanel(config, content)
 
 @ExperimentalJewelApi
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
@@ -173,9 +173,26 @@ public val JewelTheme.Companion.iconButtonStyle: IconButtonStyle
 public val JewelTheme.Companion.sliderStyle: SliderStyle
     @Composable @ReadOnlyComposable get() = LocalSliderStyle.current
 
+// Alias for BaseJewelTheme
+@Composable
+public fun BaseComposeTheme(theme: ThemeDefinition, styling: ComponentStyling, content: @Composable () -> Unit) {
+    BaseJewelTheme(theme, styling, content)
+}
+
 @Composable
 public fun BaseJewelTheme(theme: ThemeDefinition, styling: ComponentStyling, content: @Composable () -> Unit) {
     BaseJewelTheme(theme, styling, swingCompatMode = false, content)
+}
+
+// Alias for BaseJewelTheme
+@Composable
+public fun BaseComposeTheme(
+    theme: ThemeDefinition,
+    styling: ComponentStyling,
+    swingCompatMode: Boolean = false,
+    content: @Composable () -> Unit,
+) {
+    BaseJewelTheme(theme, styling, swingCompatMode, content)
 }
 
 @Composable

--- a/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/BasicJewelUiTest.kt
+++ b/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/BasicJewelUiTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 
+public typealias BasicComposeUiTest = BasicJewelUiTest
+
 public open class BasicJewelUiTest {
     @get:Rule public val composeRule: ComposeContentTestRule = createComposeRule()
 


### PR DESCRIPTION
Jewel word was removed from public api, I kept backward compatibility by either a typealias, or wrapper function.

Not sure if renaming `BasicJewelUiTest` was needed.

Have I missed something?