### PR TITLE
[JEWEL-836] Fix SegmentedControlButton Styling in IDE

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeSegmentedControlButton.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeSegmentedControlButton.kt
@@ -47,7 +47,7 @@ internal fun readSegmentedControlButtonStyle(): SegmentedControlButtonStyle {
                 SolidColor(JBUI.CurrentTheme.SegmentedButton.FOCUSED_SELECTED_BUTTON_COLOR.toComposeColor()),
             content = retrieveColorOrUnspecified("Button.foreground"),
             contentDisabled = retrieveColorOrUnspecified("Label.disabledForeground"),
-            border = normalBorder,
+            border = SolidColor(Color.Transparent),
             borderSelected = normalBorder,
             borderSelectedDisabled = selectedDisabledBorder,
             borderSelectedFocused = SolidColor(JBUI.CurrentTheme.Button.focusBorderColor(false).toComposeColor()),


### PR DESCRIPTION
# Bug

Currently our SegmentedControlButton on the IDE version shows a border for each button, not just for the selected one. This PR fixes this.

## Changes

- Changed the `border` parameter from the `readSegmentedControlButtonStyle()` function to a `SolidColor(Color.Transparent)`. This is the same color used by both light and dark variations in the `IntUiSegmentedControlButtonStyling` file in the stand-alone version.



# Evidences
| Theme | Stand-alone | IDE Before | IDE After |
|---|---|---|---|
| Light | <img src="https://github.com/user-attachments/assets/433644ce-e3ab-4102-a197-4de48803cd8f" width="400" /> | <img src="https://github.com/user-attachments/assets/d72942c0-96dd-4a96-9096-12affc50af54" width="400" /> | <img src="https://github.com/user-attachments/assets/34f89ea6-0f2e-42d5-a147-e28d5813523c" width="400" /> |
| Dark | <img src="https://github.com/user-attachments/assets/aa071e4e-1e5e-4e43-96dd-f06a842d490f" width="400" /> | <img src="https://github.com/user-attachments/assets/d738153e-fab2-4a6b-9936-afa7b6c5a4f2" width="400" /> | <img src="https://github.com/user-attachments/assets/13c1938c-c1e2-414e-9638-cc4d60f46210" width="400" /> |