### PR TITLE
PY-82262: remove usage of noexcept due to no jetbrains ide support

### DIFF
--- a/python/helpers/pydev/_pydevd_frame_eval/pydevd_frame_evaluator_36_38.pyx
+++ b/python/helpers/pydev/_pydevd_frame_eval/pydevd_frame_evaluator_36_38.pyx
@@ -238,7 +238,7 @@ def get_func_code_info_py(code_obj) -> FuncCodeInfo:
 
 
 # noinspection DuplicatedCode
-cdef PyObject * get_bytecode_while_frame_eval(PyFrameObject * frame_obj, int exc) noexcept:
+cdef PyObject * get_bytecode_while_frame_eval(PyFrameObject * frame_obj, int exc):
     '''
     This function makes the actual evaluation and changes the bytecode to a version
     where programmatic breakpoints are added.

--- a/python/helpers/pydev/_pydevd_frame_eval/pydevd_frame_evaluator_39_310.pyx
+++ b/python/helpers/pydev/_pydevd_frame_eval/pydevd_frame_evaluator_39_310.pyx
@@ -238,7 +238,7 @@ def get_func_code_info_py(code_obj) -> FuncCodeInfo:
 
 
 # noinspection DuplicatedCode
-cdef PyObject * get_bytecode_while_frame_eval(PyThreadState *tstate, PyFrameObject * frame_obj, int exc) noexcept:
+cdef PyObject * get_bytecode_while_frame_eval(PyThreadState *tstate, PyFrameObject * frame_obj, int exc):
     '''
     This function makes the actual evaluation and changes the bytecode to a version
     where programmatic breakpoints are added.


### PR DESCRIPTION
This PR closes PY-82262 by removing the usage of the `noexcept` Cython keyword which is presently unsupported by JetBrains products. (See: https://youtrack.jetbrains.com/issue/PY-59249/Latest-Cython-3.0.0b1-except-noexcept-legal-syntax-red-lined for an explanation why)

This probably creates a performance regression, but the code can now be edited by a JetBrains product.