### PR TITLE
[JEWEL-97] Render popups using the JBPopup component on IDE

### DIFF
--- a/platform/compose/src/com/intellij/platform/compose/showcase/ComposeShowcase.kt
+++ b/platform/compose/src/com/intellij/platform/compose/showcase/ComposeShowcase.kt
@@ -39,6 +39,7 @@ import com.intellij.util.ui.JBUI
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import org.jetbrains.jewel.ui.component.TooltipArea
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.modifier.onHover
 import org.jetbrains.jewel.foundation.theme.JewelTheme

--- a/platform/jewel/foundation/api-dump.txt
+++ b/platform/jewel/foundation/api-dump.txt
@@ -10,6 +10,11 @@ f:org.jetbrains.jewel.foundation.DisabledAppearanceValues
 f:org.jetbrains.jewel.foundation.DisabledAppearanceValues$Companion
 f:org.jetbrains.jewel.foundation.DisabledAppearanceValuesKt
 - sf:getLocalDisabledAppearanceValues():androidx.compose.runtime.ProvidableCompositionLocal
+f:org.jetbrains.jewel.foundation.JewelFlags
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.foundation.JewelFlags
+- f:getUseCustomPopupRenderer():Z
+- f:setUseCustomPopupRenderer(Z):V
 org.jetbrains.jewel.foundation.actionSystem.DataProviderContext
 - a:lazy(java.lang.String,kotlin.jvm.functions.Function0):V
 - a:set(java.lang.String,java.lang.Object):V

--- a/platform/jewel/foundation/api/foundation.api
+++ b/platform/jewel/foundation/api/foundation.api
@@ -83,6 +83,13 @@ public final class org/jetbrains/jewel/foundation/GlobalMetricsKt {
 public abstract interface annotation class org/jetbrains/jewel/foundation/InternalJewelApi : java/lang/annotation/Annotation {
 }
 
+public final class org/jetbrains/jewel/foundation/JewelFlags {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/foundation/JewelFlags;
+	public final fun getUseCustomPopupRenderer ()Z
+	public final fun setUseCustomPopupRenderer (Z)V
+}
+
 public final class org/jetbrains/jewel/foundation/OutlineColors {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/OutlineColors$Companion;

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/JewelFlags.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/JewelFlags.kt
@@ -1,0 +1,27 @@
+package org.jetbrains.jewel.foundation
+
+/**
+ * JewelFlags is an object that holds configuration flags used in the Jewel library.
+ *
+ * These flags can control specific behaviors or enable experimental features within Jewel.
+ */
+public object JewelFlags {
+    /**
+     * Enable custom popups handling in Jewel. The default value is `false`.
+     *
+     * If enabled, the Jewel library will use a custom popup renderer, using separate windows instead of being drawn
+     * onto the same layer.
+     *
+     * This is an experimental feature and may not be fully stable. When enabled, Compose's popup settings are ignored
+     * when using Jewel popups and tooltips. This means that setting `compose.layers.type` will have no effect on Jewel
+     * popups and tooltips.
+     *
+     * To set this flag, you can also set the system property `jewel.customPopupRender` to `true`/`false`, or pass the
+     * `-Djewel.customPopupRender=[true|false]` argument when running your application.
+     *
+     * Note that this flag affects popups, menus and tooltips rendering from Jewel Components. It does not affect
+     * `Dialog`s.
+     */
+    @ExperimentalJewelApi
+    public var useCustomPopupRenderer: Boolean = System.getProperty("jewel.customPopupRender", "false").toBoolean()
+}

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
@@ -1,0 +1,318 @@
+package org.jetbrains.jewel.bridge.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.currentCompositionLocalContext
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.semantics.popup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.roundToIntRect
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxBy
+import androidx.compose.ui.util.fastRoundToInt
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.ScreenUtil
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.scale.JBUIScale
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.Point
+import java.awt.Rectangle
+import java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
+import java.awt.event.KeyEvent.KEY_LOCATION_UNKNOWN
+import java.awt.event.KeyEvent.KEY_PRESSED
+import java.awt.event.KeyEvent.KEY_RELEASED
+import java.awt.event.MouseEvent
+import org.jetbrains.jewel.bridge.JewelComposePanelWrapper
+import org.jetbrains.jewel.bridge.LocalComponent
+import org.jetbrains.jewel.bridge.compose
+import org.jetbrains.jewel.ui.component.PopupRenderer
+
+internal object JBPopupRenderer : PopupRenderer {
+    @Composable
+    override fun Popup(
+        popupPositionProvider: PopupPositionProvider,
+        properties: PopupProperties,
+        onDismissRequest: (() -> Unit)?,
+        onPreviewKeyEvent: ((KeyEvent) -> Boolean)?,
+        onKeyEvent: ((KeyEvent) -> Boolean)?,
+        content: @Composable () -> Unit,
+    ) {
+        JBPopup(
+            popupPositionProvider = popupPositionProvider,
+            onDismissRequest = onDismissRequest,
+            properties = properties,
+            onPreviewKeyEvent = onPreviewKeyEvent,
+            onKeyEvent = onKeyEvent,
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun JBPopup(
+    popupPositionProvider: PopupPositionProvider,
+    onDismissRequest: (() -> Unit)? = null,
+    properties: PopupProperties = PopupProperties(),
+    onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null,
+    onKeyEvent: ((KeyEvent) -> Boolean)? = null,
+    content: @Composable () -> Unit,
+) {
+    val currentContent = rememberUpdatedState(content)
+    val currentPopupPositionProvider = rememberUpdatedState(popupPositionProvider)
+
+    val owner = LocalComponent.current
+    val compositionLocalContext = currentCompositionLocalContext
+
+    val parentBoundsInRoot = remember { mutableStateOf<IntRect?>(null) }
+    val popupRectangle = remember { mutableStateOf<Rectangle?>(null) }
+
+    Layout(
+        content = {},
+        modifier =
+            Modifier.onGloballyPositioned { childCoordinates ->
+                childCoordinates.parentCoordinates?.let {
+                    parentBoundsInRoot.value = it.boundsInRoot().roundToIntRect().fromRelativeToScreen(owner)
+                }
+            },
+        measurePolicy = { _, _ -> layout(0, 0) {} },
+    )
+
+    val popup: JBPopup = remember {
+        val jewelComposePanelWrapper =
+            compose(
+                config = {
+                    // Setting initial dimensions as 1x1 to calculate the size
+                    preferredSize = Dimension(1, 1)
+                },
+                content = {
+                    ProvideValuesFromOtherContext(compositionLocalContext) {
+                        val focusRequester = remember { FocusRequester() }
+                        val popupPositionProvider = currentPopupPositionProvider.value
+                        val parentBounds = parentBoundsInRoot.value ?: return@ProvideValuesFromOtherContext
+
+                        Layout(
+                            modifier = Modifier.focusRequester(focusRequester).semantics { popup() },
+                            content = {
+                                currentContent.value()
+
+                                LaunchedEffect(Unit) {
+                                    if (properties.focusable) {
+                                        focusRequester.requestFocus()
+                                    }
+                                }
+                            },
+                            measurePolicy =
+                                remember(popupPositionProvider, parentBounds) {
+                                    JBPopupMeasurePolicy(
+                                        popupPositionProvider = popupPositionProvider,
+                                        screenSize = IntSize.fromScreenSize(owner),
+                                        parentBoundsInWindow = parentBounds,
+                                        onMeasure = { position, size ->
+                                            popupRectangle.value =
+                                                Rectangle(position.x, position.y, size.width, size.height)
+                                        },
+                                    )
+                                },
+                        )
+                    }
+                },
+            )
+                as JewelComposePanelWrapper
+
+        JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(jewelComposePanelWrapper, jewelComposePanelWrapper.composePanel)
+            .setFocusable(properties.focusable)
+            .setRequestFocus(properties.focusable)
+            .setCancelOnClickOutside(properties.dismissOnClickOutside)
+            .setCancelOnWindowDeactivation(true)
+            .setLocateWithinScreenBounds(false)
+            .setKeyEventHandler { event ->
+                val composeEvent = event.toComposeKeyEvent()
+                onPreviewKeyEvent?.invoke(composeEvent) == true || onKeyEvent?.invoke(composeEvent) == true
+            }
+            .setCancelOnMouseOutCallback {
+                if (it.button != MouseEvent.NOBUTTON) onDismissRequest?.invoke()
+                false
+            }
+            .createPopup()
+    }
+
+    val rectValue = popupRectangle.value
+    LaunchedEffect(rectValue) {
+        val rectangle = rectValue ?: return@LaunchedEffect
+        popup.setSize(rectangle.location.fromCurrentScreenToGlobal(owner), rectangle.size.withSystemDensity(owner))
+    }
+
+    DisposableEffect(Unit) {
+        // Showing on the top-left corner of the owner component so we can measure and show it correctly
+        popup.showInScreenCoordinates(owner, Point(0, 0))
+        onDispose { popup.cancel() }
+    }
+}
+
+private class JBPopupMeasurePolicy(
+    private val popupPositionProvider: PopupPositionProvider,
+    private val screenSize: IntSize,
+    private val parentBoundsInWindow: IntRect,
+    private val onMeasure: (IntOffset, IntSize) -> Unit,
+) : MeasurePolicy {
+    override fun MeasureScope.measure(measurables: List<Measurable>, constraints: Constraints): MeasureResult {
+        val relaxedConstraints =
+            constraints.copy(minWidth = 0, minHeight = 0, maxWidth = screenSize.width, maxHeight = screenSize.height)
+
+        val placeables = measurables.fastMap { it.measure(relaxedConstraints) }
+        val contentSize =
+            IntSize(
+                width = placeables.fastMaxBy { it.width }?.width ?: constraints.minWidth,
+                height = placeables.fastMaxBy { it.height }?.height ?: constraints.minHeight,
+            )
+
+        val position =
+            popupPositionProvider.calculatePosition(
+                anchorBounds = parentBoundsInWindow,
+                windowSize = screenSize,
+                layoutDirection = layoutDirection,
+                popupContentSize = contentSize,
+            )
+
+        onMeasure(position, contentSize)
+
+        return layout(constraints.maxWidth, constraints.maxHeight) { placeables.fastForEach { it.place(0, 0) } }
+    }
+}
+
+/** Update the sizes of the popup to match the system scale factor. */
+private fun Dimension.withSystemDensity(owner: Component): Dimension {
+    val density = JBUIScale.sysScale(owner)
+
+    return Dimension((width / density).fastRoundToInt(), (height / density).fastRoundToInt())
+}
+
+/**
+ * As mentioned in the `locationOnDisplay` function, getLocationOnScreen() can return negative values. But for the popup
+ * position calculation, we need to convert the point to the relative position in the component's current monitor.
+ *
+ * This function converts the point relative to the component's current monitor screen coordinates.
+ *
+ * @return An `IntRect` representing the rectangle in the component's current monitor screen coordinates to be used in
+ *   the `popupPositionProvider.calculatePosition` call.
+ */
+private fun IntRect.fromRelativeToScreen(owner: Component): IntRect {
+    val density = JBUIScale.sysScale(owner)
+    val ownerLocation = owner.locationOnDisplay()
+
+    return IntRect(
+        left = (ownerLocation.x * density).fastRoundToInt() + left,
+        top = (ownerLocation.y * density).fastRoundToInt() + top,
+        right = (ownerLocation.x * density).fastRoundToInt() + right,
+        bottom = (ownerLocation.y * density).fastRoundToInt() + bottom,
+    )
+}
+
+/**
+ * Same as `fromRelativeToScreen`, but performs the inverse operation. Converts the point relative to the component's
+ * current monitor screen coordinates to the global screen coordinates.
+ *
+ * @return A `Point` representing the point in the component's current monitor screen coordinates, to be used in the
+ *   JBPopup position update.
+ */
+private fun Point.fromCurrentScreenToGlobal(owner: Component): Point {
+    val density = JBUIScale.sysScale(owner)
+    val ownerLocation = owner.locationOnDisplay()
+
+    val point =
+        Point(x - (ownerLocation.x * density).fastRoundToInt(), y - (ownerLocation.y * density).fastRoundToInt())
+
+    return RelativePoint(owner, Point((point.x / density).fastRoundToInt(), (point.y / density).fastRoundToInt()))
+        .screenPoint
+}
+
+/**
+ * Gets the screen size of the monitor that the component is currently on. It already takes into account the system
+ * scale factor and returns the value in pixels.
+ *
+ * For the popup to be displayed correctly, it is important to use the screen size, and not only the size of the
+ * component itself, as the popup may be larger than the component.
+ */
+private fun IntSize.Companion.fromScreenSize(owner: Component): IntSize =
+    ScreenUtil.getScreenRectangle(owner).let {
+        val density = JBUIScale.sysScale(owner)
+        IntSize((it.width * density).fastRoundToInt(), (it.height * density).fastRoundToInt())
+    }
+
+/**
+ * Calculates a component's location relative to the top-left corner of the screen it is currently on. This is useful in
+ * multi-monitor setups where getLocationOnScreen() can return negative values for screens positioned to the left of or
+ * above the primary display.
+ *
+ * @return A Point object containing the x and y coordinates relative to the component's current monitor.
+ */
+private fun Component.locationOnDisplay(): Point {
+    val globalLocation = locationOnScreen
+    val gc = graphicsConfiguration
+    val screenBounds = gc.bounds
+
+    val relativeX = globalLocation.x - screenBounds.x
+    val relativeY = globalLocation.y - screenBounds.y
+
+    return Point(relativeX, relativeY)
+}
+
+private val java.awt.event.KeyEvent.keyLocationForCompose
+    get() = if (keyLocation == KEY_LOCATION_UNKNOWN) KEY_LOCATION_STANDARD else keyLocation
+
+@OptIn(InternalComposeUiApi::class)
+private fun java.awt.event.KeyEvent.toComposeKeyEvent(): KeyEvent =
+    KeyEvent(
+        key = Key(nativeKeyCode = keyCode, nativeKeyLocation = keyLocationForCompose),
+        type =
+            when (id) {
+                KEY_PRESSED -> KeyEventType.KeyDown
+                KEY_RELEASED -> KeyEventType.KeyUp
+                else -> KeyEventType.Unknown
+            },
+        codePoint = keyChar.code,
+        isCtrlPressed = isControlDown,
+        isMetaPressed = isMetaDown,
+        isAltPressed = isAltDown,
+        isShiftPressed = isShiftDown,
+        nativeEvent = this,
+    )
+
+/**
+ * When inheriting from another context, we need to ensure that values already provided in the current context are not
+ * overridden.
+ */
+@Composable
+private fun ProvideValuesFromOtherContext(context: CompositionLocalContext, content: @Composable () -> Unit) {
+    val existingContext = currentCompositionLocalContext
+    CompositionLocalProvider(context) { CompositionLocalProvider(existingContext, content) }
+}

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/JewelDemoToolWindowFactory.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/JewelDemoToolWindowFactory.kt
@@ -14,12 +14,16 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import org.jetbrains.jewel.bridge.addComposeTab
+import org.jetbrains.jewel.foundation.JewelFlags
 import org.jetbrains.jewel.samples.ideplugin.releasessample.ReleasesSampleCompose
 
 @Suppress("unused")
 @ExperimentalCoroutinesApi
 internal class JewelDemoToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        // Enable custom popup rendering to use JBPopup instead of default Compose implementation
+        JewelFlags.useCustomPopupRenderer = true
+
         toolWindow.addComposeTab("Components") { ComponentShowcaseTab(project) }
 
         toolWindow.addComposeTab("Releases Demo") { ReleasesSampleCompose(project) }

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
@@ -367,7 +367,7 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                     }
                     .run { cell(this).align(AlignY.TOP) }
 
-                compose(modifier = Modifier.height(200.dp).padding(horizontal = 8.dp, vertical = 0.dp)) {
+                compose(modifier = Modifier.padding(horizontal = 8.dp, vertical = 0.dp)) {
                     val comboBoxItems = remember {
                         listOf(
                             "Cat",

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -124,6 +124,13 @@ f:org.jetbrains.jewel.ui.component.MenuSelectableItem
 - hashCode():I
 - f:isEnabled():Z
 - f:isSelected():Z
+f:org.jetbrains.jewel.ui.component.PopupKt
+- sf:Popup(androidx.compose.ui.window.PopupPositionProvider,kotlin.jvm.functions.Function0,androidx.compose.ui.window.PopupProperties,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
+- sf:getLocalPopupRenderer():androidx.compose.runtime.ProvidableCompositionLocal
+org.jetbrains.jewel.ui.component.PopupRenderer
+- sf:Companion:org.jetbrains.jewel.ui.component.PopupRenderer$Companion
+- a:Popup(androidx.compose.ui.window.PopupPositionProvider,androidx.compose.ui.window.PopupProperties,kotlin.jvm.functions.Function0,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I):V
+f:org.jetbrains.jewel.ui.component.PopupRenderer$Companion
 org.jetbrains.jewel.ui.component.TabContentScope
 - tabContentAlpha-A_ZS63w(androidx.compose.ui.Modifier,J,androidx.compose.runtime.Composer,I):androidx.compose.ui.Modifier
 f:org.jetbrains.jewel.ui.component.TabStripKt
@@ -133,6 +140,8 @@ f:org.jetbrains.jewel.ui.component.TextContextMenu
 - sf:$stable:I
 - sf:INSTANCE:org.jetbrains.jewel.ui.component.TextContextMenu
 - Area(androidx.compose.foundation.text.TextContextMenu$TextManager,androidx.compose.foundation.ContextMenuState,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I):V
+f:org.jetbrains.jewel.ui.component.TooltipAreaKt
+- sf:TooltipArea(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,I,androidx.compose.foundation.TooltipPlacement,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.ui.component.TooltipKt
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,org.jetbrains.jewel.ui.component.AutoHideBehavior,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -795,6 +795,11 @@ public final class org/jetbrains/jewel/ui/component/PopupContainerKt {
 	public static final fun PopupContainer (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/PopupContainerStyle;Landroidx/compose/ui/window/PopupProperties;Landroidx/compose/ui/window/PopupPositionProvider;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class org/jetbrains/jewel/ui/component/PopupKt {
+	public static final fun Popup (Landroidx/compose/ui/window/PopupPositionProvider;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/PopupProperties;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun getLocalPopupRenderer ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public final class org/jetbrains/jewel/ui/component/PopupManager {
 	public static final field $stable I
 	public fun <init> ()V
@@ -808,6 +813,14 @@ public final class org/jetbrains/jewel/ui/component/PopupManager {
 	public final fun setPopupVisible (Z)V
 	public fun toString ()Ljava/lang/String;
 	public final fun togglePopupVisibility ()V
+}
+
+public abstract interface class org/jetbrains/jewel/ui/component/PopupRenderer {
+	public static final field Companion Lorg/jetbrains/jewel/ui/component/PopupRenderer$Companion;
+	public abstract fun Popup (Landroidx/compose/ui/window/PopupPositionProvider;Landroidx/compose/ui/window/PopupProperties;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class org/jetbrains/jewel/ui/component/PopupRenderer$Companion {
 }
 
 public final class org/jetbrains/jewel/ui/component/RadioButtonKt {
@@ -1245,6 +1258,10 @@ public final class org/jetbrains/jewel/ui/component/ToggleableIconButtonState : 
 public final class org/jetbrains/jewel/ui/component/ToggleableIconButtonState$Companion {
 	public final fun of-CAf7mdk (ZLandroidx/compose/ui/state/ToggleableState;ZZZZ)J
 	public static synthetic fun of-CAf7mdk$default (Lorg/jetbrains/jewel/ui/component/ToggleableIconButtonState$Companion;ZLandroidx/compose/ui/state/ToggleableState;ZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/ui/component/TooltipAreaKt {
+	public static final fun TooltipArea (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ILandroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/TooltipKt {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ComboBox.kt
@@ -92,7 +92,7 @@ public fun ComboBox(
     textStyle: TextStyle = JewelTheme.defaultTextStyle,
     onArrowDownPress: () -> Unit = {},
     onArrowUpPress: () -> Unit = {},
-    popupManager: PopupManager = PopupManager(),
+    popupManager: PopupManager = remember { PopupManager() },
     popupContent: @Composable () -> Unit,
 ) {
     var chevronHovered by remember { mutableStateOf(false) }
@@ -274,7 +274,7 @@ public fun ComboBox(
     style: ComboBoxStyle = JewelTheme.comboBoxStyle,
     onArrowDownPress: () -> Unit = {},
     onArrowUpPress: () -> Unit = {},
-    popupManager: PopupManager = PopupManager(),
+    popupManager: PopupManager = remember { PopupManager() },
     labelContent: @Composable (() -> Unit),
     popupContent: @Composable (() -> Unit),
 ) {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ContextMenu.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ContextMenu.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.nativeKeyCode
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
-import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.rememberCursorPositionProvider
 import java.awt.event.InputEvent

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
@@ -88,7 +88,7 @@ public fun EditableComboBox(
     onArrowDownPress: () -> Unit = {},
     onArrowUpPress: () -> Unit = {},
     onEnterPress: () -> Unit = {},
-    popupManager: PopupManager = PopupManager(),
+    popupManager: PopupManager = remember { PopupManager() },
     popupContent: @Composable () -> Unit,
 ) {
     var chevronHovered by remember { mutableStateOf(false) }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 import org.jetbrains.jewel.foundation.InternalJewelApi

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PopupContainer.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PopupContainer.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.jewel.foundation.Stroke

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.jewel.ui.component
 
-import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TooltipArea.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TooltipArea.kt
@@ -1,0 +1,154 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea as ComposeTooltipArea
+import androidx.compose.foundation.TooltipPlacement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.areAnyPressed
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.JewelFlags
+
+/**
+ * A composable function that provides a tooltip area to display additional information associated with a UI element.
+ * The tooltip appears when the user hovers over the content with their cursor, after an optional delay.
+ *
+ * This function behavior is influenced by the [JewelFlags.useCustomPopupRenderer]. If set to true, it will use the
+ * custom popup implementation. Otherwise, it will use the default Compose tooltip implementation.
+ *
+ * @param tooltip Composable content of the tooltip.
+ * @param modifier The modifier to be applied to the layout.
+ * @param delayMillis Delay in milliseconds.
+ * @param tooltipPlacement Defines position of the tooltip.
+ * @param content Composable content that the current tooltip is set to.
+ * @see org.jetbrains.jewel.ui.component.Popup
+ * @see androidx.compose.ui.window.Popup
+ */
+@ExperimentalJewelApi
+@Composable
+public fun TooltipArea(
+    tooltip: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    delayMillis: Int = 500,
+    tooltipPlacement: TooltipPlacement = TooltipPlacement.CursorPoint(offset = DpOffset(0.dp, 16.dp)),
+    content: @Composable () -> Unit,
+) {
+    if (JewelFlags.useCustomPopupRenderer) {
+        JewelTooltipArea(
+            tooltip = tooltip,
+            modifier = modifier,
+            delayMillis = delayMillis,
+            tooltipPlacement = tooltipPlacement,
+            content = content,
+        )
+    } else {
+        ComposeTooltipArea(
+            tooltip = tooltip,
+            modifier = modifier,
+            delayMillis = delayMillis,
+            tooltipPlacement = tooltipPlacement,
+            content = content,
+        )
+    }
+}
+
+/** Copy of the [androidx.compose.foundation.TooltipArea], but using our implementation of [Popup]. */
+@Composable
+private fun JewelTooltipArea(
+    tooltip: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    delayMillis: Int = 500,
+    tooltipPlacement: TooltipPlacement = TooltipPlacement.CursorPoint(offset = DpOffset(0.dp, 16.dp)),
+    content: @Composable () -> Unit,
+) {
+    var parentBounds by remember { mutableStateOf(Rect.Zero) }
+    var cursorPosition by remember { mutableStateOf(Offset.Zero) }
+    var isVisible by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    var job: Job? by remember { mutableStateOf(null) }
+
+    fun startShowing() {
+        if (job?.isActive == true) { // Don't restart the job if it's already active
+            return
+        }
+        job =
+            scope.launch {
+                delay(delayMillis.toLong())
+                isVisible = true
+            }
+    }
+
+    fun hide() {
+        job?.cancel()
+        job = null
+        isVisible = false
+    }
+
+    fun hideIfNotHovered(globalPosition: Offset) {
+        if (!parentBounds.contains(globalPosition)) {
+            hide()
+        }
+    }
+
+    Box(
+        modifier =
+            modifier
+                .onGloballyPositioned { parentBounds = it.boundsInWindow() }
+                .onPointerEvent(PointerEventType.Enter) {
+                    cursorPosition = it.position
+                    if (!isVisible && !it.buttons.areAnyPressed) {
+                        startShowing()
+                    }
+                }
+                .onPointerEvent(PointerEventType.Move) {
+                    cursorPosition = it.position
+                    if (!isVisible && !it.buttons.areAnyPressed) {
+                        startShowing()
+                    }
+                }
+                .onPointerEvent(PointerEventType.Exit) { hideIfNotHovered(parentBounds.topLeft + it.position) }
+                .onPointerEvent(PointerEventType.Press, pass = PointerEventPass.Initial) { hide() }
+    ) {
+        content()
+        if (isVisible) {
+            @OptIn(ExperimentalFoundationApi::class)
+            Popup(
+                popupPositionProvider = tooltipPlacement.positionProvider(cursorPosition),
+                onDismissRequest = { isVisible = false },
+            ) {
+                var popupPosition by remember { mutableStateOf(Offset.Zero) }
+                Box(
+                    Modifier.onGloballyPositioned { popupPosition = it.positionInWindow() }
+                        .onPointerEvent(PointerEventType.Move) { hideIfNotHovered(popupPosition + it.position) }
+                        .onPointerEvent(PointerEventType.Exit) { hideIfNotHovered(popupPosition + it.position) }
+                ) {
+                    tooltip()
+                }
+            }
+        }
+    }
+}
+
+private val PointerEvent.position
+    get() = changes.first().position


### PR DESCRIPTION
- Created `JewelConfigs` to enable/disable this new feature
- Created `PopupRender` interface to support different ways to handle popups
- Created `Popup` component to use the render based on the flag
- Updated our sample code to use the new popup component instead of the compose version -

# Evidences

### Compose Popup

https://github.com/user-attachments/assets/81f2eaa9-6c3a-4c9e-9543-2ff64a43acff

### JBPopup

https://github.com/user-attachments/assets/7ee63d6d-9089-4852-90f1-3c583e019404

### IDE Zoom

https://github.com/user-attachments/assets/5fbdfe1f-8ee8-497e-bd38-090c9da5ca21

### Zero-delay

https://github.com/user-attachments/assets/1950e747-3e21-4fa7-a205-1c26b4feeeae

### Secondary screen

https://github.com/user-attachments/assets/2ab36345-5d37-45a8-84ec-d2a6bc03da1f

### Secondary screen + IDE Zoom

https://github.com/user-attachments/assets/825068dd-4b75-46bb-a953-10238efbef0b


## Release notes

### ⚠️ Important Changes
 * **JEWEL-97** - Created JewelFlags object that controls how a few components should behave
 * **JEWEL-97** - Created 'useCustomPopupRenderer' flag to allow using external popup implementations

### New features
 * **JEWEL-97** - Added support to use JBPopup API for Popups, Tooltips and Menus. This allows popups to grow over the composable area if needed
