### PR TITLE
[JEWEL-852] Fixing ComboBoxes crash with Keyboard navigation

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
@@ -133,8 +133,9 @@ public fun PopupMenu(
         properties = popupProperties,
         onPreviewKeyEvent = { false },
         onKeyEvent = {
-            val currentFocusManager = checkNotNull(focusManager) { "FocusManager must not be null" }
-            val currentInputModeManager = checkNotNull(inputModeManager) { "InputModeManager must not be null" }
+            val currentFocusManager = focusManager ?: return@Popup false
+            val currentInputModeManager = inputModeManager ?: return@Popup false
+
             handlePopupMenuOnKeyEvent(it, currentFocusManager, currentInputModeManager, menuManager)
         },
     ) {


### PR DESCRIPTION
- When the combo box does not have an initially selected item, the child focus manager may be null
- This only happens the second time you open a combo box using the keyboard, and the event received is the key up from the trigger to open the menu

# Evidences

| Before | After |
| --- | --- |
| ![Gravação de Tela 2025-06-25 às 14 53 02](https://github.com/user-attachments/assets/698d2777-20cd-46cc-a28e-f6465ae7b6dd) | ![Gravação de Tela 2025-06-25 às 14 52 02](https://github.com/user-attachments/assets/aad78e47-6745-4262-bb79-8ac817b5def2) | 
