### PR TITLE
[JEWEL-845] Add Context Menu to External Links

### DIFF
--- a/platform/jewel/ide-laf-bridge/api-dump.txt
+++ b/platform/jewel/ide-laf-bridge/api-dump.txt
@@ -1,3 +1,13 @@
+f:org.jetbrains.jewel.bridge.BridgeLabelProvider
+- org.jetbrains.jewel.ui.util.LabelProvider
+- sf:$stable:I
+- <init>():V
+- fetchLabelFromKey(java.lang.String):java.lang.String
+f:org.jetbrains.jewel.bridge.BridgeUriHandler
+- androidx.compose.ui.platform.UriHandler
+- sf:$stable:I
+- <init>():V
+- openUri(java.lang.String):V
 f:org.jetbrains.jewel.bridge.BridgeUtilsKt
 - sf:createVerticalBrush-8A-3gB4(java.util.List,F,F,I):androidx.compose.ui.graphics.Brush
 - bs:createVerticalBrush-8A-3gB4$default(java.util.List,F,F,I,I,java.lang.Object):androidx.compose.ui.graphics.Brush

--- a/platform/jewel/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/platform/jewel/ide-laf-bridge/api/ide-laf-bridge.api
@@ -2,6 +2,12 @@ public final class org/jetbrains/jewel/bridge/BridgeIconDataKt {
 	public static final fun readFromLaF (Lorg/jetbrains/jewel/foundation/theme/ThemeIconData$Companion;)Lorg/jetbrains/jewel/foundation/theme/ThemeIconData;
 }
 
+public final class org/jetbrains/jewel/bridge/BridgeLabelProvider : org/jetbrains/jewel/ui/util/LabelProvider {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun fetchLabelFromKey (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public final class org/jetbrains/jewel/bridge/BridgePainterHintsProvider : org/jetbrains/jewel/ui/painter/PalettePainterHintsProvider {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/bridge/BridgePainterHintsProvider$Companion;
@@ -16,6 +22,12 @@ public final class org/jetbrains/jewel/bridge/BridgePainterHintsProvider$Compani
 public final class org/jetbrains/jewel/bridge/BridgeResourceResolverKt {
 	public static final fun bridgePainterProvider (Ljava/lang/String;)Lorg/jetbrains/jewel/ui/painter/ResourcePainterProvider;
 	public static final fun bridgePainterProvider (Lorg/jetbrains/jewel/ui/icon/IconKey;)Lorg/jetbrains/jewel/ui/painter/ResourcePainterProvider;
+}
+
+public final class org/jetbrains/jewel/bridge/BridgeUriHandler : androidx/compose/ui/platform/UriHandler {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun openUri (Ljava/lang/String;)V
 }
 
 public final class org/jetbrains/jewel/bridge/BridgeUtilsKt {

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeLabelProvider.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeLabelProvider.kt
@@ -1,0 +1,9 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.bridge
+
+import com.intellij.ide.IdeBundle
+import org.jetbrains.jewel.ui.util.LabelProvider
+
+public class BridgeLabelProvider : LabelProvider {
+    override fun fetchLabelFromKey(key: String): String = IdeBundle.messagePointer(key).get()
+}

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUriHandler.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUriHandler.kt
@@ -1,0 +1,11 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.bridge
+
+import androidx.compose.ui.platform.UriHandler
+import com.intellij.ide.BrowserUtil
+
+public class BridgeUriHandler : UriHandler {
+    override fun openUri(uri: String) {
+        BrowserUtil.browse(uri)
+    }
+}

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
@@ -7,7 +7,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalUriHandler
+import org.jetbrains.jewel.bridge.BridgeLabelProvider
 import org.jetbrains.jewel.bridge.BridgePainterHintsProvider
+import org.jetbrains.jewel.bridge.BridgeUriHandler
 import org.jetbrains.jewel.bridge.SwingBridgeReader
 import org.jetbrains.jewel.bridge.clipboard.JewelBridgeClipboard
 import org.jetbrains.jewel.bridge.icon.BridgeNewUiChecker
@@ -17,6 +20,7 @@ import org.jetbrains.jewel.ui.ComponentStyling
 import org.jetbrains.jewel.ui.icon.LocalNewUiChecker
 import org.jetbrains.jewel.ui.painter.LocalPainterHintsProvider
 import org.jetbrains.jewel.ui.theme.BaseJewelTheme
+import org.jetbrains.jewel.ui.util.LocalLabelProvider
 
 private val bridgeThemeReader by lazy { SwingBridgeReader() }
 
@@ -35,6 +39,8 @@ public fun SwingBridgeTheme(content: @Composable () -> Unit) {
             LocalNewUiChecker provides BridgeNewUiChecker,
             LocalDensity provides scaleDensityWithIdeScale(LocalDensity.current),
             LocalClipboard provides remember { JewelBridgeClipboard() },
+            LocalUriHandler provides BridgeUriHandler(),
+            LocalLabelProvider provides BridgeLabelProvider(),
         ) {
             content()
         }

--- a/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
@@ -1,3 +1,8 @@
+f:org.jetbrains.jewel.intui.standalone.IntUiLabelProvider
+- org.jetbrains.jewel.ui.util.LabelProvider
+- sf:$stable:I
+- <init>():V
+- fetchLabelFromKey(java.lang.String):java.lang.String
 f:org.jetbrains.jewel.intui.standalone.styling.IntUiTooltipStylingKt
 - sf:dark(org.jetbrains.jewel.ui.component.styling.TooltipStyle$Companion,org.jetbrains.jewel.ui.component.styling.TooltipColors,org.jetbrains.jewel.ui.component.styling.TooltipMetrics):org.jetbrains.jewel.ui.component.styling.TooltipStyle
 - sf:dark(org.jetbrains.jewel.ui.component.styling.TooltipStyle$Companion,org.jetbrains.jewel.ui.component.styling.TooltipColors,org.jetbrains.jewel.ui.component.styling.TooltipMetrics,org.jetbrains.jewel.ui.component.styling.TooltipAutoHideBehavior):org.jetbrains.jewel.ui.component.styling.TooltipStyle

--- a/platform/jewel/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/platform/jewel/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -16,6 +16,12 @@ public final class org/jetbrains/jewel/intui/core/theme/IntUiLightTheme : org/je
 	public fun isDark ()Z
 }
 
+public final class org/jetbrains/jewel/intui/standalone/IntUiLabelProvider : org/jetbrains/jewel/ui/util/LabelProvider {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun fetchLabelFromKey (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public final class org/jetbrains/jewel/intui/standalone/InterFontKt {
 	public static final fun getInter (Landroidx/compose/ui/text/font/FontFamily$Companion;)Landroidx/compose/ui/text/font/FontFamily;
 }

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/IntUiLabelProvider.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/IntUiLabelProvider.kt
@@ -1,0 +1,13 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.intui.standalone
+
+import org.jetbrains.jewel.ui.util.LabelProvider
+
+public class IntUiLabelProvider : LabelProvider {
+    override fun fetchLabelFromKey(key: String): String =
+        when (key) {
+            "action.text.open.link.in.browser" -> "Open Link in Browser"
+            "action.text.copy.link.address" -> "Copy Link Address"
+            else -> ""
+        }
+}

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
@@ -14,6 +14,7 @@ import org.jetbrains.jewel.foundation.theme.ThemeDefinition
 import org.jetbrains.jewel.foundation.theme.ThemeIconData
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
+import org.jetbrains.jewel.intui.standalone.IntUiLabelProvider
 import org.jetbrains.jewel.intui.standalone.StandalonePainterHintsProvider
 import org.jetbrains.jewel.intui.standalone.icon.StandaloneNewUiChecker
 import org.jetbrains.jewel.intui.standalone.styling.Default
@@ -55,6 +56,7 @@ import org.jetbrains.jewel.ui.component.styling.TooltipStyle
 import org.jetbrains.jewel.ui.icon.LocalNewUiChecker
 import org.jetbrains.jewel.ui.painter.LocalPainterHintsProvider
 import org.jetbrains.jewel.ui.theme.BaseJewelTheme
+import org.jetbrains.jewel.ui.util.LocalLabelProvider
 
 /**
  * Create a light theme definition.
@@ -310,6 +312,7 @@ public fun IntUiTheme(
         CompositionLocalProvider(
             LocalPainterHintsProvider provides StandalonePainterHintsProvider(theme),
             LocalNewUiChecker provides StandaloneNewUiChecker,
+            LocalLabelProvider provides IntUiLabelProvider(),
         ) {
             content()
         }

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -79,7 +79,7 @@ import org.jetbrains.jewel.ui.component.WarningDefaultBanner
 import org.jetbrains.jewel.ui.component.WarningInlineBanner
 import org.jetbrains.jewel.ui.component.separator
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
-import org.jetbrains.jewel.ui.painter.badge.DotBadgeShape 
+import org.jetbrains.jewel.ui.painter.badge.DotBadgeShape
 import org.jetbrains.jewel.ui.painter.hints.Badge
 import org.jetbrains.jewel.ui.painter.hints.Size
 import org.jetbrains.jewel.ui.painter.hints.Stroke

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -79,7 +79,7 @@ import org.jetbrains.jewel.ui.component.WarningDefaultBanner
 import org.jetbrains.jewel.ui.component.WarningInlineBanner
 import org.jetbrains.jewel.ui.component.separator
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
-import org.jetbrains.jewel.ui.painter.badge.DotBadgeShape
+import org.jetbrains.jewel.ui.painter.badge.DotBadgeShape 
 import org.jetbrains.jewel.ui.painter.hints.Badge
 import org.jetbrains.jewel.ui.painter.hints.Size
 import org.jetbrains.jewel.ui.painter.hints.Stroke

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
@@ -66,6 +66,7 @@ import org.jetbrains.jewel.ui.component.Typography
 import org.jetbrains.jewel.ui.disabledAppearance
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.theme.textAreaStyle
+import org.jetbrains.skia.impl.Stats.enabled
 
 internal class SwingComparisonTabPanel : BorderLayoutPanel() {
     private val mainContent =
@@ -92,24 +93,33 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
             }
 
     private fun Panel.linksRow() {
-        row("Links:") {
-                browserLink("Enabled link", "")
+        val jewelReadmeLink = "https://github.com/JetBrains/intellij-community/tree/master/platform/jewel/#readme"
 
-                compose { ExternalLink(text = "Enabled link", enabled = true, onClick = {}) }
+        row("Links:") {
+                cell(
+                    component =
+                        BrowserLink(
+                                icon = AllIcons.Ide.External_link_arrow,
+                                text = "Enabled link",
+                                tooltip = null,
+                                url = "",
+                            )
+                            .apply { enabled(true) }
+                )
+
+                compose { ExternalLink(text = "Enabled link", link = "", enabled = true, onLinkOpened = {}) }
 
                 cell(
                         component =
                             BrowserLink(
-                                icon = IconLoader.getDisabledIcon(AllIcons.Ide.External_link_arrow),
-                                text = "Disabled link",
-                                tooltip = null,
-                                url = "",
-                            )
+                                    icon = IconLoader.getDisabledIcon(AllIcons.Ide.External_link_arrow),
+                                    text = "Disabled link",
+                                    tooltip = null,
+                                    url = jewelReadmeLink,
+                                )
+                                .apply { isEnabled = false }
                     )
-                    .applyToComponent {
-                        enabled(false)
-                        autoHideOnDisable = false
-                    }
+                    .applyToComponent { autoHideOnDisable = false }
 
                 compose { ExternalLink(text = "Disabled link", enabled = false, onClick = {}) }
             }

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
@@ -63,8 +63,8 @@ public fun Banners() {
                     style = JewelTheme.defaultBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     actions = {
-                        Link("Action A", onClick = { clickLabel = "Info default no icon Action A clicked" })
-                        Link("Action B", onClick = { clickLabel = "Info default no icon Action B clicked" })
+                        Link("Action A", onClick = { clickLabel = "Info default with icon Action A clicked" })
+                        Link("Action B", onClick = { clickLabel = "Info default with icon Action B clicked" })
                     },
                 )
 

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Links.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Links.kt
@@ -27,12 +27,13 @@ import org.jetbrains.jewel.ui.theme.linkStyle
 @Composable
 public fun Links() {
     val alwaysUnderline = JewelTheme.linkStyle.copy(underlineBehavior = LinkUnderlineBehavior.ShowAlways)
+    val jewelReadMeLink = "https://github.com/JetBrains/intellij-community/tree/master/platform/jewel/#readme"
     Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
         Link(text = "Link", onClick = {})
 
         Link(text = "Always underlined", onClick = {}, style = alwaysUnderline)
 
-        ExternalLink("ExternalLink", {})
+        ExternalLink("ExternalLink", link = jewelReadMeLink, { println(it) })
 
         val items = remember { listOf("Light", "Dark", "---", "High Contrast", "Darcula", "IntelliJ Light") }
         var selected by remember { mutableStateOf(items.first()) }
@@ -51,7 +52,7 @@ public fun Links() {
 
         Link(text = "Always underlined", onClick = {}, style = alwaysUnderline, enabled = false)
 
-        ExternalLink(text = "ExternalLink", onClick = {}, enabled = false)
+        ExternalLink(text = "ExternalLink", link = jewelReadMeLink, onLinkOpened = {}, enabled = false)
 
         DropdownLink(text = "DropdownLink", enabled = false) {}
     }

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -16,6 +16,8 @@ e:org.jetbrains.jewel.ui.component.AutoHideBehavior
 - s:getEntries():kotlin.enums.EnumEntries
 - s:valueOf(java.lang.String):org.jetbrains.jewel.ui.component.AutoHideBehavior
 - s:values():org.jetbrains.jewel.ui.component.AutoHideBehavior[]
+f:org.jetbrains.jewel.ui.component.LinkKt
+- sf:ExternalLink-XSU6r7E(java.lang.String,java.lang.String,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,Z,androidx.compose.ui.text.TextStyle,I,androidx.compose.foundation.interaction.MutableInteractionSource,org.jetbrains.jewel.ui.component.styling.LinkStyle,androidx.compose.runtime.Composer,I,I):V
 org.jetbrains.jewel.ui.component.MenuScope
 - a:passiveItem(kotlin.jvm.functions.Function2):V
 - a:selectableItem(Z,org.jetbrains.jewel.ui.icon.IconKey,java.util.Set,kotlin.jvm.functions.Function0,Z,kotlin.jvm.functions.Function2):V
@@ -254,3 +256,7 @@ org.jetbrains.jewel.ui.painter.PainterProviderScope
 org.jetbrains.jewel.ui.painter.ResourcePainterProviderScope
 - org.jetbrains.jewel.ui.painter.PainterProviderScope
 - a:getClassLoaders():java.util.Set
+org.jetbrains.jewel.ui.util.LabelProvider
+- a:fetchLabelFromKey(java.lang.String):java.lang.String
+f:org.jetbrains.jewel.ui.util.LabelProviderKt
+- sf:getLocalLabelProvider():androidx.compose.runtime.ProvidableCompositionLocal

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -528,6 +528,7 @@ public final class org/jetbrains/jewel/ui/component/LinearProgressBarKt {
 
 public final class org/jetbrains/jewel/ui/component/LinkKt {
 	public static final fun DropdownLink-RWo7tUw (Ljava/lang/String;Landroidx/compose/ui/Modifier;ZLandroidx/compose/ui/text/TextStyle;ILandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ExternalLink-XSU6r7E (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZLandroidx/compose/ui/text/TextStyle;ILandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ExternalLink-kye4rC8 (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/ui/text/TextStyle;ILandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Link-kye4rC8 (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/ui/text/TextStyle;ILandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;Landroidx/compose/runtime/Composer;II)V
 }
@@ -4937,6 +4938,14 @@ public final class org/jetbrains/jewel/ui/util/ColorExtensionsKt {
 	public static final fun isDark-8_81llA (J)Z
 	public static final fun toRgbaHexString (Ljava/awt/Color;)Ljava/lang/String;
 	public static final fun toRgbaHexString-8_81llA (J)Ljava/lang/String;
+}
+
+public abstract interface class org/jetbrains/jewel/ui/util/LabelProvider {
+	public abstract fun fetchLabelFromKey (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/ui/util/LabelProviderKt {
+	public static final fun getLocalLabelProvider ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
 public final class org/jetbrains/jewel/ui/util/ModifierExtensionsKt {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import java.awt.Cursor
 import java.awt.datatransfer.StringSelection
+import java.io.IOException
 import kotlinx.coroutines.launch
 import org.jetbrains.jewel.foundation.modifier.onHover
 import org.jetbrains.jewel.foundation.modifier.thenIf
@@ -60,7 +61,6 @@ import org.jetbrains.jewel.ui.focusOutline
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.painter.hints.Stateful
 import org.jetbrains.jewel.ui.util.LocalLabelProvider
-import java.io.IOException
 
 /**
  * A clickable text link that follows the standard visual styling with customizable appearance.
@@ -164,7 +164,7 @@ public fun ExternalLink(
  * An external link that follows the standard visual styling, including an external link icon.
  *
  * Please be aware that this ExternalLink will automatically open a link on click, unlike the other.
- * 
+ *
  * Provides a text link with an external link icon that indicates the link leads to external content. The link supports
  * various states including enabled/disabled, focused, and hovered, with optional underline behavior based on the style
  * configuration.
@@ -212,7 +212,7 @@ public fun ExternalLink(
                     label = labelProvider.fetchLabelFromKey("action.text.open.link.in.browser"),
                     onClick = {
                         val success = openLink(uriHandler, link)
-                        
+
                         onLinkOpened(success)
                     },
                 ),
@@ -228,7 +228,7 @@ public fun ExternalLink(
                 text = text,
                 onClick = {
                     val success = openLink(uriHandler, link)
-                    
+
                     onLinkOpened(success)
                 },
                 modifier = modifier,
@@ -239,7 +239,7 @@ public fun ExternalLink(
                 textStyle = textStyle,
                 icon = style.icons.externalLink,
             )
-        }
+        },
     )
 }
 
@@ -247,11 +247,11 @@ private fun openLink(uriHandler: UriHandler, link: String): Boolean {
     return try {
         uriHandler.openUri(link)
         true
-    } catch(e: IllegalArgumentException) {
-        println("Oh no!!!! $e")
+    } catch (e: IllegalArgumentException) {
+        // Log something?
         false
-    } catch(e: IOException) {
-        println("Oh DAMN! $e")
+    } catch (e: IOException) {
+        // Log something?
         false
     }
 }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/util/LabelProvider.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/util/LabelProvider.kt
@@ -1,0 +1,15 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui.util
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import org.jetbrains.jewel.foundation.InternalJewelApi
+
+@InternalJewelApi
+public interface LabelProvider {
+    public fun fetchLabelFromKey(key: String): String
+}
+
+public val LocalLabelProvider: ProvidableCompositionLocal<LabelProvider> = staticCompositionLocalOf {
+    error("No LocalLabelProvider provided. Have you forgotten the theme?")
+}


### PR DESCRIPTION
# Context

> [!IMPORTANT]
> This PR will stay marked as Draft as long as #3091 is not merged. It'd be great to have #3105 merged before too, but is not a prerequesite.

Currently, our ExternalLink implementation doesn't show a context menu with the default action group from IntelliJ `BrowserLink` component (see screenshot below). This PR makes the necessary changes to show such context menu **for external links only**.

<img width="510" alt="image" src="https://github.com/user-attachments/assets/11a13d7b-3dc5-4ecd-b9d4-27f6521d6fea" />


## Main Changes
- Created a `LabelProvider` interface which both IDE and standalone versions will implement to return the action action label.
- Created a `BridgeUriHandler` class which implements `UriHandler` since in IDE we need to call IntelliJ's `BrowserUtil.browse()` function.
- Created a new `ExternalLink` overload where clicking the element automatically opens the given link and also displays a `ContextMenu`. It also has a new parameter `link` which users can use to specify the actual link from the text.
- This PR also fixes a weird visual bug in the Links row in `SwingComparisonPanel`.


# Evidences

## Right clicking external link
| IDE | Stand-alone |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/45fdbacf-f898-44e6-a0d5-d2996859e500" width="400" /> | <video src="https://github.com/user-attachments/assets/c00ab635-bffc-445d-8d18-1532f8457570" width="400" /> |

## Using a valid browser link
| IDE | Stand-alone |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/9d9afa08-bfb7-4e36-a504-ceb60ac0748d" width="400" /> | <video src="https://github.com/user-attachments/assets/f452c03c-1415-449a-814f-95baadbc1fe8" width="400" /> |

## Using an empty string
| IDE | Stand-alone |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/30f8beb3-de87-4286-81a6-f5ea084a8d5e" width="400" /> | <video src="https://github.com/user-attachments/assets/810edbf6-df4d-4f9f-a59e-bcca4cee8a51" width="400" /> |

