### PR TITLE
[JEWEL-866] Bump CfD Patch Version

### DIFF
--- a/platform/jewel/gradle/libs.versions.toml
+++ b/platform/jewel/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 commonmark = "0.24.0"
-composeDesktop = "1.8.1"
+composeDesktop = "1.8.2"
 detekt = "1.23.6"
 dokka = "2.0.0"
 filepicker = "3.1.0"


### PR DESCRIPTION
Updating Compose for Desktop (CfD) to [1.8.2](https://github.com/JetBrains/compose-multiplatform/releases)

Checked both standalone and IDE versions of jewel, everything looks and behaves the same :)

## Release notes

### ⚠️ Important Changes
 * Updated the Compose for Desktop version to 1.8.2