### PR TITLE
[JEWEL-870] Render images in Markdown headers

### DIFF
--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -187,6 +187,7 @@ public open class DefaultMarkdownBlockRenderer(
     ) {
         val renderedContent = rememberRenderedContent(block, styling.inlinesStyling, enabled, onUrlClick)
         Heading(
+            block,
             renderedContent,
             styling.inlinesStyling.textStyle,
             styling.padding,
@@ -199,6 +200,7 @@ public open class DefaultMarkdownBlockRenderer(
 
     @Composable
     private fun Heading(
+        block: Heading,
         renderedContent: AnnotatedString,
         textStyle: TextStyle,
         paddingValues: PaddingValues,
@@ -210,7 +212,12 @@ public open class DefaultMarkdownBlockRenderer(
         Column(modifier = modifier.padding(paddingValues)) {
             val textColor = textStyle.color.takeOrElse { LocalContentColor.current.takeOrElse { textStyle.color } }
             val mergedStyle = textStyle.merge(TextStyle(color = textColor))
-            Text(text = renderedContent, style = mergedStyle, modifier = Modifier.focusProperties { canFocus = false })
+            Text(
+                text = renderedContent,
+                style = mergedStyle,
+                modifier = Modifier.focusProperties { canFocus = false },
+                inlineContent = renderedImages(block),
+            )
 
             if (underlineWidth > 0.dp && underlineColor.isSpecified) {
                 Spacer(Modifier.height(underlineGap))


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/JEWEL-870/Images-in-headers-arent-loading

There's still problem with the text not being rendered though :) The one mentioned [here](https://youtrack.jetbrains.com/issue/JEWEL-762/Coil-image-rendering-issues-with-SVG).