### PR TITLE
[JEWEL-868] Fix parameter value leak in Modifiers

### DIFF
--- a/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
+++ b/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
@@ -44,7 +44,7 @@ internal fun DecoratedWindowScope.TitleBarOnWindows(
 }
 
 internal fun Modifier.customTitleBarMouseEventHandler(titleBar: CustomTitleBar): Modifier =
-    pointerInput(Unit) {
+    pointerInput(titleBar) {
         val currentContext = currentCoroutineContext()
         awaitPointerEventScope {
             var inUserControl = false

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/modifier/PointerModifiers.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/modifier/PointerModifiers.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import java.awt.event.MouseEvent
 
 public fun Modifier.onHover(onHover: (Boolean) -> Unit): Modifier =
-    pointerInput(Unit) {
+    pointerInput(onHover) {
         awaitPointerEventScope {
             while (true) {
                 val event = awaitPointerEvent()
@@ -20,7 +20,7 @@ public fun Modifier.onHover(onHover: (Boolean) -> Unit): Modifier =
     }
 
 public fun Modifier.onMove(onMove: (MouseEvent?) -> Unit): Modifier =
-    pointerInput(Unit) {
+    pointerInput(onMove) {
         awaitPointerEventScope {
             while (true) {
                 val event = awaitPointerEvent()


### PR DESCRIPTION
`Modifier.onHover`, `Modifier.onMove`, and `Modifier.customTitleBarMouseEventHandler` are using a captured parameter in `pointerInput`, without using it as a key.

This means that if the parameter value changes, the old value is kept around in the `pointerInput` and can cause leaks and bugs where the old lambda gets invoked instead of the new one.

## Release notes

### Bug fixes
 * Fix parameter value leak in `Modifier.onHover` and `Modifier.onMove`