### PR TITLE
[JEWEL-872] Remove unnecessary JBPanel API

### DIFF
--- a/platform/jewel/ide-laf-bridge/api-dump.txt
+++ b/platform/jewel/ide-laf-bridge/api-dump.txt
@@ -57,8 +57,6 @@ f:org.jetbrains.jewel.bridge.JewelBridgeException$KeysNotFoundException
 - sf:$stable:I
 - <init>(java.util.List,java.lang.String):V
 f:org.jetbrains.jewel.bridge.JewelComposePanelWrapperKt
-- sf:JBPanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
-- bs:JBPanel$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - sf:JewelComposeNoThemePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - bs:JewelComposeNoThemePanel$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - sf:JewelComposePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent

--- a/platform/jewel/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/platform/jewel/ide-laf-bridge/api/ide-laf-bridge.api
@@ -71,8 +71,6 @@ public final class org/jetbrains/jewel/bridge/JewelBridgeException$KeysNotFoundE
 }
 
 public final class org/jetbrains/jewel/bridge/JewelComposePanelWrapperKt {
-	public static final fun JBPanel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
-	public static synthetic fun JBPanel$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljavax/swing/JComponent;
 	public static final fun JewelComposeNoThemePanel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
 	public static synthetic fun JewelComposeNoThemePanel$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljavax/swing/JComponent;
 	public static final fun JewelComposePanel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
@@ -21,11 +21,6 @@ import org.jetbrains.jewel.foundation.util.JewelLogger
 public fun compose(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposePanel(config, content)
 
-@ExperimentalJewelApi
-@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-public fun JBPanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
-    JewelComposePanel(config, content)
-
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JewelComposePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     createJewelComposePanel { jewelPanel ->


### PR DESCRIPTION
This is a new experimental API added by #3099, a PR that was merged without approval. It can be safely removed.

We already have the new `compose { }` and the existing `JewelComposePanel { }` APIs, we do not need a `JBPanel { }` API too — especially since it does NOT create a `JBPanel`.