### PR TITLE
[JEWEL-874] Fix `reverseLayout` on non-lazy scrolling containers

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ScrollableContainer.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ScrollableContainer.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.styling.ScrollbarStyle
+import org.jetbrains.jewel.ui.component.styling.ScrollbarVisibility
 import org.jetbrains.jewel.ui.component.styling.ScrollbarVisibility.AlwaysVisible
 import org.jetbrains.jewel.ui.component.styling.ScrollbarVisibility.WhenScrolling
 import org.jetbrains.jewel.ui.theme.scrollbarStyle
@@ -64,12 +65,13 @@ private const val ID_HORIZONTAL_SCROLLBAR = "VerticallyScrollableContainer_horiz
  *
  * @param modifier Modifier to be applied to the container
  * @param scrollbarModifier Modifier to be applied to the scrollbar
- * @param scrollState The state object to control and observe scrolling
- * @param style The visual styling configuration for the scrollbar
- * @param reverseLayout Whether the scrollbar should be displayed on the opposite side
- * @param scrollbarEnabled Controls whether the scrollbar is enabled
- * @param scrollbarInteractionSource Source of interactions for the scrollbar
- * @param content The content to be displayed in the scrollable container
+ * @param scrollState The state of the scroll
+ * @param style The visual styling for the scrollbar
+ * @param reverseLayout Reverse the direction of scrolling, when `true`, 0 [ScrollState.value] will mean bottom, when
+ *   `false`, 0 [ScrollState.value] will mean top
+ * @param scrollbarEnabled Whether scrolling is enabled or not
+ * @param scrollbarInteractionSource The interaction source used for the scrollbar
+ * @param content The main content of the scrollable container
  * @see com.intellij.ui.components.JBScrollBar
  */
 @Composable
@@ -102,7 +104,7 @@ public fun VerticallyScrollableContainer(
         modifier = modifier.withKeepVisible(style.scrollbarVisibility.lingerDuration, scope) { keepVisible = it },
         scrollbarStyle = style,
     ) {
-        Box(Modifier.layoutId(ID_CONTENT).verticalScroll(scrollState)) { content() }
+        Box(Modifier.layoutId(ID_CONTENT).verticalScroll(scrollState, reverseScrolling = reverseLayout)) { content() }
     }
 }
 
@@ -148,14 +150,15 @@ internal fun TextAreaScrollableContainer(
  * **Swing equivalent:**
  * [`JBScrollBar`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/components/JBScrollBar.java)
  *
- * @param scrollState The state object to control and observe scrolling
+ * @param scrollState The state of the scroll
  * @param modifier Modifier to be applied to the container
  * @param scrollbarModifier Modifier to be applied to the scrollbar
- * @param style The visual styling configuration for the scrollbar
- * @param reverseLayout Whether the scrollbar should be displayed on the opposite side
- * @param scrollbarEnabled Controls whether the scrollbar is enabled
- * @param scrollbarInteractionSource Source of interactions for the scrollbar
- * @param content The content to be displayed in the scrollable container
+ * @param style The visual styling for the scrollbar
+ * @param reverseLayout Reverse the direction of scrolling, when `true`, 0 [ScrollState.value] will mean bottom, when
+ *   `false`, 0 [ScrollState.value] will mean top
+ * @param scrollbarEnabled Whether scrolling is enabled or not
+ * @param scrollbarInteractionSource The interaction source used for the scrollbar
+ * @param content The main content of the scrollable container
  * @see com.intellij.ui.components.JBScrollBar
  */
 @Composable
@@ -207,14 +210,15 @@ public fun VerticallyScrollableContainer(
  * **Swing equivalent:**
  * [`JBScrollBar`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/components/JBScrollBar.java)
  *
- * @param scrollState The state object to control and observe scrolling
+ * @param scrollState The state of the scroll
  * @param modifier Modifier to be applied to the container
  * @param scrollbarModifier Modifier to be applied to the scrollbar
- * @param style The visual styling configuration for the scrollbar
- * @param reverseLayout Whether the scrollbar should be displayed on the opposite side
- * @param scrollbarEnabled Controls whether the scrollbar is enabled
- * @param scrollbarInteractionSource Source of interactions for the scrollbar
- * @param content The content to be displayed in the scrollable container
+ * @param style The visual styling for the scrollbar
+ * @param reverseLayout Reverse the direction of scrolling, when `true`, 0 [ScrollState.value] will mean bottom, when
+ *   `false`, 0 [ScrollState.value] will mean top
+ * @param scrollbarEnabled Whether scrolling is enabled or not
+ * @param scrollbarInteractionSource The interaction source used for the scrollbar
+ * @param content The main content of the scrollable container
  * @see com.intellij.ui.components.JBScrollBar
  */
 @Composable
@@ -306,7 +310,7 @@ public fun HorizontallyScrollableContainer(
         modifier = modifier.withKeepVisible(style.scrollbarVisibility.lingerDuration, scope) { keepVisible = it },
         scrollbarStyle = style,
     ) {
-        Box(Modifier.layoutId(ID_CONTENT).horizontalScroll(scrollState)) { content() }
+        Box(Modifier.layoutId(ID_CONTENT).horizontalScroll(scrollState, reverseScrolling = reverseLayout)) { content() }
     }
 }
 
@@ -325,14 +329,15 @@ public fun HorizontallyScrollableContainer(
  * **Swing equivalent:**
  * [`JBScrollBar`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/components/JBScrollBar.java)
  *
+ * @param scrollState The state of the scroll
  * @param modifier Modifier to be applied to the container
  * @param scrollbarModifier Modifier to be applied to the scrollbar
- * @param scrollState The state object to control and observe scrolling
- * @param style The visual styling configuration for the scrollbar
- * @param reverseLayout Whether the scrollbar should be displayed on the opposite side
- * @param scrollbarEnabled Controls whether the scrollbar is enabled
- * @param scrollbarInteractionSource Source of interactions for the scrollbar
- * @param content The content to be displayed in the scrollable container
+ * @param style The visual styling for the scrollbar
+ * @param reverseLayout Reverse the direction of scrolling, when `true`, 0 [ScrollState.value] will mean bottom, when
+ *   `false`, 0 [ScrollState.value] will mean top
+ * @param scrollbarEnabled Whether scrolling is enabled or not
+ * @param scrollbarInteractionSource The interaction source used for the scrollbar
+ * @param content The main content of the scrollable container
  * @see com.intellij.ui.components.JBScrollBar
  */
 @Composable
@@ -384,14 +389,15 @@ public fun HorizontallyScrollableContainer(
  * **Swing equivalent:**
  * [`JBScrollBar`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/components/JBScrollBar.java)
  *
+ * @param scrollState The state of the scroll
  * @param modifier Modifier to be applied to the container
  * @param scrollbarModifier Modifier to be applied to the scrollbar
- * @param scrollState The state object to control and observe scrolling
- * @param style The visual styling configuration for the scrollbar
- * @param reverseLayout Whether the scrollbar should be displayed on the opposite side
- * @param scrollbarEnabled Controls whether the scrollbar is enabled
- * @param scrollbarInteractionSource Source of interactions for the scrollbar
- * @param content The content to be displayed in the scrollable container
+ * @param style The visual styling for the scrollbar
+ * @param reverseLayout Reverse the direction of scrolling, when `true`, 0 [ScrollState.value] will mean bottom, when
+ *   `false`, 0 [ScrollState.value] will mean top
+ * @param scrollbarEnabled Whether scrolling is enabled or not
+ * @param scrollbarInteractionSource The interaction source used for the scrollbar
+ * @param content The main content of the scrollable container
  * @see com.intellij.ui.components.JBScrollBar
  */
 @Composable
@@ -440,6 +446,8 @@ private fun Modifier.withKeepVisible(
             if (event.type == PointerEventType.Move) {
                 delayJob?.cancel()
                 onKeepVisibleChange(true)
+
+                @Suppress("AssignedValueIsNeverRead") // It's read on each gesture, two lines above; false positive
                 delayJob =
                     scope.launch {
                         delay(lingerDuration)
@@ -610,8 +618,15 @@ private fun computeContentConstraints(
 }
 
 /**
- * Calculates the safe padding needed to prevent content from being overlapped by scrollbars. This value can be used for
- * both vertical and horizontal scrollbars.
+ * Calculates the safe padding needed to prevent scrollable containers' content from being overlapped by scrollbars.
+ *
+ * This value can be used for both vertical and horizontal scrollbars. You can use it on the root content of a
+ * scrollable container, but if you have background elements that should extend behind the scrollbars (e.g., a list
+ * item's selected background), you should consider applying it instead to the actual content: text, images, etc.
+ *
+ * If you want to overlay something on top of a scrollable container, and avoid overlapping the scrollbars, you should
+ * use
+ * [`JewelTheme.scrollbarStyle.scrollbarVisibility.trackThicknessExpanded`][ScrollbarVisibility.trackThicknessExpanded].
  *
  * Returns a padding value that ensures content remains fully visible when scrollbars are present. The value depends on
  * the platform (macOS vs Windows/Linux) and the scrollbar visibility style:

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbar.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbar.kt
@@ -79,6 +79,17 @@ import org.jetbrains.jewel.ui.component.styling.TrackClickBehavior.JumpToSpot
 import org.jetbrains.jewel.ui.component.styling.TrackClickBehavior.NextPage
 import org.jetbrains.jewel.ui.theme.scrollbarStyle
 
+/**
+ * A vertical scrollbar that can be tied to a [ScrollableState].
+ *
+ * @param scrollState The [ScrollableState] to control
+ * @param modifier The modifier to apply to this layout node
+ * @param reverseLayout `true` to reverse the direction of the scrollbar, `false` otherwise.
+ * @param enabled `true` to enable the scrollbar, `false` otherwise.
+ * @param interactionSource The [MutableInteractionSource] that will be used to dispatch events.
+ * @param style The [ScrollbarStyle] to use for this scrollbar.
+ * @param keepVisible `true` to keep the scrollbar visible even when not scrolling, `false` otherwise.
+ */
 @Composable
 public fun VerticalScrollbar(
     scrollState: ScrollableState,
@@ -101,6 +112,17 @@ public fun VerticalScrollbar(
     )
 }
 
+/**
+ * A horizontal scrollbar that can be tied to a [ScrollableState].
+ *
+ * @param scrollState The [ScrollableState] to control.
+ * @param modifier The modifier to apply to this layout node.
+ * @param reverseLayout `true` to reverse the direction of the scrollbar, `false` otherwise.
+ * @param enabled `true` to enable the scrollbar, `false` otherwise.
+ * @param interactionSource The [MutableInteractionSource] that will be used to dispatch events.
+ * @param style The [ScrollbarStyle] to use for this scrollbar.
+ * @param keepVisible `true` to keep the scrollbar visible even when not scrolling, `false` otherwise.
+ */
 @Composable
 public fun HorizontalScrollbar(
     scrollState: ScrollableState,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/ScrollbarStyling.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/ScrollbarStyling.kt
@@ -11,7 +11,18 @@ import androidx.compose.ui.unit.Dp
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
+import org.jetbrains.jewel.ui.theme.scrollbarStyle
 
+/**
+ * Defines the visual style for a scrollbar. This includes colors, metrics, and behaviors.
+ *
+ * The style can be accessed through [`JewelTheme.scrollbarStyle`][scrollbarStyle].
+ *
+ * @param colors The set of colors used to paint the scrollbar.
+ * @param metrics The sizing and shape properties of the scrollbar.
+ * @param trackClickBehavior The behavior of the scrollbar track when clicked.
+ * @param scrollbarVisibility The visibility behavior of the scrollbar.
+ */
 @Stable
 @GenerateDataFunctions
 public class ScrollbarStyle(
@@ -54,6 +65,22 @@ public class ScrollbarStyle(
     public companion object
 }
 
+/**
+ * Contains the color properties for a [ScrollbarStyle].
+ *
+ * @param thumbBackground The background color of the scrollbar thumb.
+ * @param thumbBackgroundActive The background color of the scrollbar thumb when active (e.g., being dragged).
+ * @param thumbOpaqueBackground The background color of the scrollbar thumb when the scrollbar is in opaque mode.
+ * @param thumbOpaqueBackgroundHovered The background color of the scrollbar thumb when hovered and in opaque mode.
+ * @param thumbBorder The border color of the scrollbar thumb.
+ * @param thumbBorderActive The border color of the scrollbar thumb when active.
+ * @param thumbOpaqueBorder The border color of the scrollbar thumb when in opaque mode.
+ * @param thumbOpaqueBorderHovered The border color of the scrollbar thumb when hovered and in opaque mode.
+ * @param trackBackground The background color of the scrollbar track.
+ * @param trackBackgroundExpanded The background color of the scrollbar track when expanded.
+ * @param trackOpaqueBackground The background color of the scrollbar track when in opaque mode.
+ * @param trackOpaqueBackgroundHovered The background color of the scrollbar track when hovered and in opaque mode.
+ */
 @Immutable
 @GenerateDataFunctions
 public class ScrollbarColors(
@@ -108,8 +135,8 @@ public class ScrollbarColors(
         return result
     }
 
-    override fun toString(): String {
-        return "ScrollbarColors(" +
+    override fun toString(): String =
+        "ScrollbarColors(" +
             "thumbBackground=$thumbBackground, " +
             "thumbBackgroundActive=$thumbBackgroundActive, " +
             "thumbOpaqueBackground=$thumbOpaqueBackground, " +
@@ -123,11 +150,16 @@ public class ScrollbarColors(
             "trackOpaqueBackground=$trackOpaqueBackground, " +
             "trackOpaqueBackgroundHovered=$trackOpaqueBackgroundHovered" +
             ")"
-    }
 
     public companion object
 }
 
+/**
+ * Defines the metrics for a [ScrollbarStyle].
+ *
+ * @param thumbCornerSize The corner size of the scrollbar thumb.
+ * @param minThumbLength The minimum length of the scrollbar thumb.
+ */
 @Stable
 @GenerateDataFunctions
 public class ScrollbarMetrics(public val thumbCornerSize: CornerSize, public val minThumbLength: Dp) {
@@ -155,16 +187,56 @@ public class ScrollbarMetrics(public val thumbCornerSize: CornerSize, public val
     public companion object
 }
 
+/** Defines the visibility behavior of a scrollbar. */
 public sealed interface ScrollbarVisibility {
+    /** The thickness of the scrollbar track when not expanded. */
     public val trackThickness: Dp
+
+    /** The thickness of the scrollbar track when expanded (e.g., on hover). */
     public val trackThicknessExpanded: Dp
+
+    /** The padding around the scrollbar track. */
     public val trackPadding: PaddingValues
+
+    /** The padding around the scrollbar track when a border is visible. */
     public val trackPaddingWithBorder: PaddingValues
+
+    /** The duration for the track color animation. */
     public val trackColorAnimationDuration: Duration
+
+    /** The duration for the track expansion animation. */
     public val expandAnimationDuration: Duration
+
+    /** The duration for the thumb color animation. */
     public val thumbColorAnimationDuration: Duration
+
+    /**
+     * The duration to wait before hiding the scrollbar after scrolling has stopped. When using a
+     * [org.jetbrains.jewel.ui.component.VerticallyScrollableContainer] or a
+     * [org.jetbrains.jewel.ui.component.HorizontallyScrollableContainer], the linger starts after the scroll ends and
+     * the user stops moving the mouse over the content.
+     */
     public val lingerDuration: Duration
 
+    /**
+     * A [ScrollbarVisibility] that keeps the scrollbar always visible.
+     *
+     * This is equivalent to the _Always_ setting in macOS' _System Settings > Appearance > Show scroll bars_ settings.
+     * It is also used when the _Automatically based on mouse or trackpad_ option is selected, and there is a mouse
+     * connected to the computer.
+     *
+     * Note that this behavior is usually only used on macOS, and it causes the scrollbars to be laid out to the side of
+     * a [org.jetbrains.jewel.ui.component.VerticallyScrollableContainer]'s main content (or below, for a
+     * [org.jetbrains.jewel.ui.component.HorizontallyScrollableContainer]), instead of overlaid.
+     *
+     * @param trackThickness The thickness of the scrollbar track.
+     * @param trackPadding The padding around the scrollbar track.
+     * @param trackPaddingWithBorder The padding when a border is visible.
+     * @param thumbColorAnimationDuration The duration for the thumb color animation.
+     * @param trackColorAnimationDuration The duration for the track color animation.
+     * @param scrollbarBackgroundColorLight The background color in light theme.
+     * @param scrollbarBackgroundColorDark The background color in dark theme.
+     */
     @GenerateDataFunctions
     public class AlwaysVisible(
         public override val trackThickness: Dp,
@@ -231,6 +303,22 @@ public sealed interface ScrollbarVisibility {
         public companion object
     }
 
+    /**
+     * A [ScrollbarVisibility] that shows the scrollbar only when scrolling, overlaid on top of the content.
+     *
+     * This is the only available behavior on Windows and Linux. On macOS, it is equivalent to the _When scrolling_
+     * setting in macOS' _System Settings > Appearance > Show scroll bars_ settings. It is also used when the
+     * _Automatically based on mouse or trackpad_ option is selected, and there is no mouse connected to the computer.
+     *
+     * @param trackThickness The thickness of the scrollbar track.
+     * @param trackThicknessExpanded The thickness when expanded.
+     * @param trackPadding The padding around the scrollbar track.
+     * @param trackPaddingWithBorder The padding when a border is visible.
+     * @param trackColorAnimationDuration The duration for the track color animation.
+     * @param expandAnimationDuration The duration for the track expansion animation.
+     * @param thumbColorAnimationDuration The duration for the thumb color animation.
+     * @param lingerDuration The duration to wait before hiding the scrollbar.
+     */
     @GenerateDataFunctions
     public class WhenScrolling(
         public override val trackThickness: Dp,
@@ -289,11 +377,30 @@ public sealed interface ScrollbarVisibility {
     }
 }
 
+/** Defines the behavior when the scrollbar track is clicked. */
 public enum class TrackClickBehavior {
+    /**
+     * Scrolls to the next page in the direction of the click.
+     *
+     * Equivalent to the _Jump to the next page_ setting in macOS' _System Settings > Appearance > Click in the scroll
+     * bar to_ settings.
+     *
+     * This is normally not used on Windows and Linux.
+     */
     NextPage,
+
+    /**
+     * Jumps directly to the clicked spot on the track.
+     *
+     * Equivalent to the _Jump to the spot that's clicked_ setting in macOS' _System Settings > Appearance > Click in
+     * the scroll bar to_ settings.
+     *
+     * This is the only available behavior on Windows and Linux.
+     */
     JumpToSpot,
 }
 
+/** The CompositionLocal that provides the default [ScrollbarStyle]. */
 public val LocalScrollbarStyle: ProvidableCompositionLocal<ScrollbarStyle> = staticCompositionLocalOf {
     error("No ScrollbarStyle provided. Have you forgotten the theme?")
 }


### PR DESCRIPTION
This fixes the behaviour of `reverseLayout` on non-lazy scrolling containers. We had forgotten to pass the flag value to the `reverseScrolling` parameter of the `vertical`/`horizontalScroll` modifiers. Lazy overloads do not provide their own scrolling modifier, and thus worked fine.

I also took the opportunity to add a bunch of KDoc clarifying how the scrollbars & styling works, and fixed the scrollable containers' KDoc, which were wrong or imprecise in several points.

## Release notes

### Bug fixes
 * Fix `reverseLayout` behaviour for non-lazy `ScrollableContainer`s