### PR TITLE
[JEWEL-891] Annotate detectPressAndCancel as internal API

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.coroutineScope
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.jewel.foundation.InternalJewelApi
 import org.jetbrains.jewel.foundation.Stroke
 import org.jetbrains.jewel.foundation.modifier.border
 import org.jetbrains.jewel.foundation.modifier.onHover
@@ -366,6 +367,7 @@ public value class ComboBoxState(public val state: ULong) : FocusableComponentSt
     }
 }
 
+@InternalJewelApi
 @ApiStatus.Internal
 public suspend fun PointerInputScope.detectPressAndCancel(onPress: () -> Unit, onCancel: () -> Unit) {
     coroutineScope {


### PR DESCRIPTION
It was opened up by someone without our knowledge, and it risks leaking into the public API otherwise.

APIs annotated as `@ApiStatus.Internal` do not show up in the API dumps, because as far as IJP is concerned, they should not be used. However, we also have standalone users, and for them that annotation has no meaning.

This will need to be cherry-picked onto 252 asap, too. It is being done manually in the 251 cherry pick.