### PR TITLE
[JEWEL-894] Fix EqualityMembersRule, add tests

### DIFF
--- a/.github/workflows/jewel_checks.yml
+++ b/.github/workflows/jewel_checks.yml
@@ -27,4 +27,13 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run :check task
-        run: ./gradlew :decorated-window:check :detekt-plugin:check :foundation:check :ide-laf-bridge:check :int-ui:int-ui-decorated-window:check :int-ui:int-ui-standalone:check :markdown:core:check :markdown:extensions:autolink:check :markdown:extensions:gfm-alerts:check :markdown:extensions:gfm-strikethrough:check :markdown:extensions:gfm-tables:check :markdown:ide-laf-bridge-styling:check :markdown:int-ui-standalone-styling:check :samples:ide-plugin:ktfmtCheck :samples:showcase:check :samples:standalone:check :ui:check :ui-tests:check --continue --no-daemon
+        # Run checks for all modules except the IDE plugin sample, as that is bound to have missing APIs issues
+        run: ./gradlew check -x :samples:ide-plugin:check --continue --no-daemon
+
+      - name: Run detektMain and detektTest tasks
+        # Run detekt checks for all modules except the IDE plugin sample, as that is bound to have missing APIs issues
+        run: ./gradlew detektMain detektTest -x :samples:ide-plugin:detektMain -x :samples:ide-plugin:detektTest --continue --no-daemon
+
+      - name: Run ktfmt and ktlint checks on IDE plugin
+        # We can only use static analysis that doesn't depend on compilation in the IDE plugin
+        run: ./gradlew :samples:ide-plugin:ktfmtCheck :samples:ide-plugin:lintKotlinMain --continue --no-daemon

--- a/platform/jewel/.editorconfig
+++ b/platform/jewel/.editorconfig
@@ -7,7 +7,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 150
+max_line_length = 120
 tab_width = 4
 
 [*.iml]

--- a/platform/jewel/detekt-plugin/build.gradle.kts
+++ b/platform/jewel/detekt-plugin/build.gradle.kts
@@ -3,10 +3,13 @@
 plugins { jewel }
 
 dependencies {
-    compileOnly("io.gitlab.arturbosch.detekt:detekt-api:1.23.7")
+    compileOnly("io.gitlab.arturbosch.detekt:detekt-api:1.23.8")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
-    testImplementation("io.gitlab.arturbosch.detekt:detekt-test:1.23.7")
+    testImplementation("io.gitlab.arturbosch.detekt:detekt-core:1.23.8")
+    testImplementation("io.gitlab.arturbosch.detekt:detekt-test:1.23.8")
     testImplementation("org.assertj:assertj-core:3.26.3")
 }
+
+kotlin.compilerOptions.freeCompilerArgs.add("-Xmulti-dollar-interpolation")
 
 tasks.test { useJUnitPlatform() }

--- a/platform/jewel/detekt-plugin/intellij.platform.jewel.detektPlugin.iml
+++ b/platform/jewel/detekt-plugin/intellij.platform.jewel.detektPlugin.iml
@@ -6,6 +6,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/kotlin" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/kotlin" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="library" name="kotlin-stdlib" level="project" />
@@ -14,33 +15,36 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library">
       <library name="io.gitlab.arturbosch.detekt.api" type="repository">
-        <properties maven-id="io.gitlab.arturbosch.detekt:detekt-api:1.23.7">
+        <properties maven-id="io.gitlab.arturbosch.detekt:detekt-api:1.23.8">
           <verification>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7.jar">
-              <sha256sum>93fd0c9cdb22dd97ecfc843d55abfc52c9d9c6a0db32abdf9c85735e1bc8047d</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar">
+              <sha256sum>dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10.jar">
-              <sha256sum>ea76850ffe3b84c92654a73f8e366964857f7e95687ca158882241cebef591e8</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar">
+              <sha256sum>9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10.jar">
-              <sha256sum>58f4f7ad99a4a045964b44fe55f0b2604d2c5f51ff4d97c7e6817983fdf92ea7</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar">
+              <sha256sum>9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3</sha256sum>
             </artifact>
             <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar">
               <sha256sum>3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10.jar">
-              <sha256sum>a500d6f7bb2152a8387a9e24b886d0654fdbdb6662ec264c544ce9346f186141</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar">
+              <sha256sum>b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03</sha256sum>
             </artifact>
             <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar">
               <sha256sum>c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7.jar">
-              <sha256sum>6a054c91da27aac77db3ed509ff9f408c45410e1a5e989dc380aae3c09d7fb6e</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar">
+              <sha256sum>c24c8bb27bb320c4a93871501a7e5e0c61607638907b197aef675513d4c820be</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7.jar">
-              <sha256sum>0b5c211c72f63985a3e2e0f12f9a7733c7b3411b983a1c7f3175f3bd68d72194</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar">
+              <sha256sum>9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0.jar">
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar">
+              <sha256sum>f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar">
               <sha256sum>940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31</sha256sum>
             </artifact>
           </verification>
@@ -49,37 +53,40 @@
           </exclude>
         </properties>
         <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar!/" />
         </CLASSES>
         <JAVADOC>
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1-javadoc.jar!/" />
         </JAVADOC>
         <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -87,34 +94,34 @@
     <orderEntry type="library" scope="TEST" name="assertJ" level="project" />
     <orderEntry type="module-library" scope="TEST">
       <library name="io.gitlab.arturbosch.detekt.test" type="repository">
-        <properties maven-id="io.gitlab.arturbosch.detekt:detekt-test:1.23.7">
+        <properties maven-id="io.gitlab.arturbosch.detekt:detekt-test:1.23.8">
           <verification>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.7/detekt-test-1.23.7.jar">
-              <sha256sum>fdceebdaead6217fbe6292c15ac93c7712f460458977201a0bb695ae847e3749</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8.jar">
+              <sha256sum>5383c41e5f22c8def6f890bd66820fe9ff438835600525fdf6eba96742499351</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7.jar">
-              <sha256sum>93fd0c9cdb22dd97ecfc843d55abfc52c9d9c6a0db32abdf9c85735e1bc8047d</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar">
+              <sha256sum>dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10.jar">
-              <sha256sum>ea76850ffe3b84c92654a73f8e366964857f7e95687ca158882241cebef591e8</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar">
+              <sha256sum>9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10.jar">
-              <sha256sum>58f4f7ad99a4a045964b44fe55f0b2604d2c5f51ff4d97c7e6817983fdf92ea7</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar">
+              <sha256sum>9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10.jar">
-              <sha256sum>a500d6f7bb2152a8387a9e24b886d0654fdbdb6662ec264c544ce9346f186141</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar">
+              <sha256sum>b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03</sha256sum>
             </artifact>
             <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar">
               <sha256sum>c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7.jar">
-              <sha256sum>6a054c91da27aac77db3ed509ff9f408c45410e1a5e989dc380aae3c09d7fb6e</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar">
+              <sha256sum>9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0.jar">
+            <artifact url="file://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar">
               <sha256sum>940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.7/detekt-test-utils-1.23.7.jar">
-              <sha256sum>33d970cc98c59e5d9d0b01ba7b525a76d363443a6a463f8cb869e08677e37ca3</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8.jar">
+              <sha256sum>c27c0673cad7cc1f2e932c89a060b7ae85749a03d69f221b4c1281f64136c702</sha256sum>
             </artifact>
             <artifact url="file://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar">
               <sha256sum>afff77c186cd317275803872fa5133aa801fd6ac40bd91c78a6cf8009b4b17cc</sha256sum>
@@ -128,29 +135,29 @@
             <artifact url="file://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar">
               <sha256sum>b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.7/detekt-parser-1.23.7.jar">
-              <sha256sum>e217ab883e2e0f0e8a69b1fce7a131ff93a8bf2e06bd5fd395b38cde6b9c9504</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar">
+              <sha256sum>5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5</sha256sum>
             </artifact>
             <artifact url="file://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar">
               <sha256sum>672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.10/kotlin-main-kts-2.0.10.jar">
-              <sha256sum>1ae40572a7b9cc19dde70e88dae3dd7fa9db642578b5fbfaabca4dfc22e76b60</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21.jar">
+              <sha256sum>36fef581638be9c674295c176f10bc9f13025e5e1160030200991ded62ed6c29</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.10/kotlin-scripting-compiler-embeddable-2.0.10.jar">
-              <sha256sum>6c83faccacfc9ed71ade5e5ad1f22202a6b5be37deea10d2bc7df4dc3abdab3a</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21.jar">
+              <sha256sum>2413c230fdd8cd47ebbeba273e4df94cf3b44cb3ec95d2cb35472c93768c9f1c</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.10/kotlin-scripting-compiler-impl-embeddable-2.0.10.jar">
-              <sha256sum>97749ff32fce25ac35b2fd333080d34b6fc4d7a6b6ffb0499ece09ffebd123c8</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21.jar">
+              <sha256sum>6ed0fa5beb25466883989b5641f36809479260b7014535502fd387ce6c7ba833</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.10/kotlin-scripting-common-2.0.10.jar">
-              <sha256sum>37d4671e73ca6599f597aba464577ebb3b8771a31ee9d7dcb52d916762d16871</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21.jar">
+              <sha256sum>f87deb2b14d068f99cba18217d80af85481c029c731ad8704458e9add9ca20f8</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.10/kotlin-scripting-jvm-2.0.10.jar">
-              <sha256sum>5259a5173e2ea1b0256fb5ab994be50c18fdc15ed4f5b62edcf7e2579ecc9a7a</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21.jar">
+              <sha256sum>88427f0f7a4c47845fa2221d29f6e0e0d7cbe73c3edf8bca30b4d8b3a336a77c</sha256sum>
             </artifact>
-            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7.jar">
-              <sha256sum>0b5c211c72f63985a3e2e0f12f9a7733c7b3411b983a1c7f3175f3bd68d72194</sha256sum>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar">
+              <sha256sum>f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056</sha256sum>
             </artifact>
           </verification>
           <exclude>
@@ -162,73 +169,267 @@
           </exclude>
         </properties>
         <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.7/detekt-test-1.23.7.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.7/detekt-test-utils-1.23.7.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.7/detekt-parser-1.23.7.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.10/kotlin-main-kts-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.10/kotlin-scripting-compiler-embeddable-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.10/kotlin-scripting-compiler-impl-embeddable-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.10/kotlin-scripting-common-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.10/kotlin-scripting-jvm-2.0.10.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar!/" />
         </CLASSES>
         <JAVADOC>
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.7/detekt-test-1.23.7-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.7/detekt-test-utils-1.23.7-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.7/detekt-parser-1.23.7-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8-javadoc.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.10/kotlin-main-kts-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.10/kotlin-scripting-compiler-embeddable-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.10/kotlin-scripting-compiler-impl-embeddable-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.10/kotlin-scripting-common-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.10/kotlin-scripting-jvm-2.0.10-javadoc.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8-javadoc.jar!/" />
         </JAVADOC>
         <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.7/detekt-test-1.23.7-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.7/detekt-api-1.23.7-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.10/kotlin-compiler-embeddable-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.10/kotlin-script-runtime-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.10/kotlin-daemon-embeddable-2.0.10-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.7/detekt-psi-utils-1.23.7-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.16.0/poko-annotations-jvm-0.16.0-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.7/detekt-test-utils-1.23.7-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.7/detekt-parser-1.23.7-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.10/kotlin-main-kts-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.10/kotlin-scripting-compiler-embeddable-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.10/kotlin-scripting-compiler-impl-embeddable-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.10/kotlin-scripting-common-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.10/kotlin-scripting-jvm-2.0.10-sources.jar!/" />
-          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.7/detekt-utils-1.23.7-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8-sources.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="io.gitlab.arturbosch.detekt.core" type="repository">
+        <properties maven-id="io.gitlab.arturbosch.detekt:detekt-core:1.23.8">
+          <verification>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar">
+              <sha256sum>1981dea8e4e2e8541af2d83e4f8d3581ce647cfe63175b9eb9ac2a07849d74c9</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar">
+              <sha256sum>dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar">
+              <sha256sum>9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar">
+              <sha256sum>9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar">
+              <sha256sum>b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar">
+              <sha256sum>c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar">
+              <sha256sum>c24c8bb27bb320c4a93871501a7e5e0c61607638907b197aef675513d4c820be</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar">
+              <sha256sum>940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar">
+              <sha256sum>5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar">
+              <sha256sum>672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar">
+              <sha256sum>7e93e9a23b478f70128893b06748673f912100b7ef03040d7d0331e26d30d092</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar">
+              <sha256sum>f31cc53f105a7e48c093683bbd5437561d1233920513774b470805641bedbc09</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0.jar">
+              <sha256sum>ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar">
+              <sha256sum>4053f878c171692aab8782f53a3974f43e55e2b6ed12c3682b36a46968c5ded1</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.jar">
+              <sha256sum>3ad2fcad0c09ddc0922debab4444d612144b7b465b75a8bb7587e20ddfafd799</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar">
+              <sha256sum>718e8f71f5872986e4f5cd4887a41e26aa0aeff42e99cf4a42582291b8738cc4</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar">
+              <sha256sum>9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8.jar">
+              <sha256sum>8068a15e07718e3bdbf501ede5f666812fb5f9fb1450db060449534c05e6722a</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1.jar">
+              <sha256sum>98bda1c78a5028a134ceb25b63f5c130c89349730d35fd47ef7490b6bf0b63b3</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8.jar">
+              <sha256sum>cc5b90b1476cef99e112162dbcd1db32b040284a768f3c975a49ec0b63980ca3</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8.jar">
+              <sha256sum>41e85ca3587abce9a03f8dcb2a67e05fcf59b7518fa016c9350ea73c79f9c54a</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8.jar">
+              <sha256sum>d71abaa98890cae8a618839b1309c013dff39c6bd7d0de0b704e6193e027ef09</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8.jar">
+              <sha256sum>c9f9221fc57ed1fbd1374de5c4da6c069160f892a71f83b551d3a32c8cbad13d</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar">
+              <sha256sum>b3ac96dd97acba8318dbe26f6a432d6c6db91c46c780805e8928b8103e5763dc</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar">
+              <sha256sum>af604c46737121d4225fdb60ef0e17766a3c94b7c1c9ef76b4e3a5c7733d557e</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20.jar">
+              <sha256sum>e0e91962bc0007338bf5b1739f62927ac32d14ba3d827fa608ab4e5351729d5d</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar">
+              <sha256sum>eba7f1c854296e4ce1418fb01360f8f10c5683e7c45aa3472018417a067636f3</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20.jar">
+              <sha256sum>1da0d306c995945e1f807240ef64b5cd2dd5ac58612afb1a8596143d10b7ded5</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20.jar">
+              <sha256sum>524da3c1a2ad56fd52c4ae2272ef3de421de8d2047ab1c51fc306d351243f2f5</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar">
+              <sha256sum>f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056</sha256sum>
+            </artifact>
+          </verification>
+        </properties>
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar!/" />
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8-javadoc.jar!/" />
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/platform/jewel/detekt-plugin/src/test/kotlin/org/jetbrains/jewel/detekt/EqualityMembersRuleSpec.kt
+++ b/platform/jewel/detekt-plugin/src/test/kotlin/org/jetbrains/jewel/detekt/EqualityMembersRuleSpec.kt
@@ -1,42 +1,436 @@
-// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the
-// Apache 2.0 license.
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package org.jetbrains.jewel.detekt
 
+import io.github.detekt.test.utils.compileContentForTest
+import io.github.detekt.test.utils.readResourceContent
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import org.jetbrains.jewel.detekt.rules.EqualityMembersRule
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@Suppress("ClassName")
 class EqualityMembersRuleSpec {
-    private val subject = EqualityMembersRule(Config.empty)
+    private val subject = EqualityMembersRule(TestConfig(Config.AUTO_CORRECT_KEY to true))
 
-    @Test
-    fun `should find missing functions`() {
-        val findings = subject.lint(code)
-        assertEquals(findings.isNotEmpty(), true)
-    }
-}
-
-private val code: String =
-    """
-    annotation class GenerateDataFunctions
-
-    @GenerateDataFunctions
-    class DataFuncTest(
-        val a: String,
-        val b: String
-    ) {
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as DataFuncTest
-
-            if (a != other.a) return false
-
-            return true
+    @Nested
+    inner class `classes without the annotation are ignored` {
+        @Test
+        fun `should not report when no annotation is present`() {
+            val code =
+                """
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |)
+                """
+                    .trimMargin()
+            val findings = subject.lint(code)
+            assertThat(findings).isEmpty()
         }
     }
-"""
-        .trimIndent()
+
+    @Nested
+    inner class `missing members` {
+        @Test
+        fun `should report missing equals, hashCode, and toString`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |)
+                """
+                    .trimMargin()
+            val findings = subject.lint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings[0])
+                .hasMessage("DataFuncTest is missing required functions: equals, hashCode, toString.")
+        }
+
+        @Test
+        fun `should report missing hashCode and toString`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |) {
+                |    override fun equals(other: Any?): Boolean {
+                |        if (this === other) return true
+                |        if (javaClass != other?.javaClass) return false
+                |        
+                |        other as DataFuncTest
+                |        
+                |        if (a != other.a) return false
+                |        if (b != other.b) return false
+                |        return true
+                |    }
+                |}
+                """
+                    .trimMargin()
+            val findings = subject.lint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings[0]).hasMessage("DataFuncTest is missing required functions: hashCode, toString.")
+        }
+    }
+
+    @Nested
+    inner class `incomplete members` {
+        @Test
+        fun `should report incomplete equals method`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |) {
+                |    override fun equals(other: Any?): Boolean {
+                |        if (this === other) return true
+                |        if (javaClass != other?.javaClass) return false
+                |
+                |        other as DataFuncTest
+                |
+                |        if (a != other.a) return false
+                |
+                |        return true
+                |    }
+                |}
+                """
+                    .trimMargin()
+            val findings = subject.lint(code)
+            assertThat(findings).hasSize(2) // Missing hashCode/toString + incomplete equals
+            assertThat(findings[0]).hasMessage("DataFuncTest is missing required functions: hashCode, toString.")
+            assertThat(findings[1]).hasMessage("Function equals is missing property b.")
+        }
+
+        @Test
+        fun `should report incomplete hashCode method`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |) {
+                |    override fun hashCode(): Int {
+                |        return a.hashCode()
+                |    }
+                |}
+                """
+                    .trimMargin()
+            val findings = subject.lint(code)
+            assertThat(findings).hasSize(2) // Missing equals/toString + incomplete hashCode
+            assertThat(findings[0]).hasMessage("DataFuncTest is missing required functions: equals, toString.")
+            assertThat(findings[1]).hasMessage("Function hashCode is missing property b.")
+        }
+
+        @Test
+        fun `should report incomplete toString method`() {
+            val code =
+                $$"""
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |) {
+                |    override fun toString(): String {
+                |        return "DataFuncTest(a=$a)"
+                |    }
+                |}
+                """
+                    .trimMargin()
+            val findings = subject.lint(code)
+            assertThat(findings).hasSize(2) // Missing equals/hashCode + incomplete toString
+            assertThat(findings[0]).hasMessage("DataFuncTest is missing required functions: equals, hashCode.")
+            assertThat(findings[1]).hasMessage("Function toString is missing property b.")
+        }
+    }
+
+    @Nested
+    inner class `auto-correction` {
+        @Test
+        fun `should generate missing equals, hashCode, and toString`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |)
+                """
+                    .trimMargin()
+
+            val (findings, result) = subject.lintAndFix(code)
+
+            assertThat(findings).hasSize(1)
+            assertThat(result)
+                .isEqualTo(
+                    $$"""
+                    |annotation class GenerateDataFunctions
+                    |
+                    |@GenerateDataFunctions
+                    |class DataFuncTest(
+                    |    val a: String,
+                    |    val b: String
+                    |){
+                    |
+                    |override fun equals(other: Any?): Boolean {
+                    |    if (this === other) return true
+                    |    if (javaClass != other?.javaClass) return false
+                    |
+                    |    other as DataFuncTest
+                    |
+                    |    if (a != other.a) return false
+                    |    if (b != other.b) return false
+                    |
+                    |    return true
+                    |}
+                    |
+                    |override fun hashCode(): Int {
+                    |    var result = a.hashCode()
+                    |    result = 31 * result + b.hashCode()
+                    |    return result
+                    |}
+                    |
+                    |override fun toString(): String {
+                    |    return "DataFuncTest(a=$a, b=$b)"
+                    |}
+                    |}
+                    """
+                        .trimMargin()
+                )
+        }
+
+        @Test
+        fun `should fix incomplete equals method`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(val a: String, val b: String) {
+                |    override fun equals(other: Any?): Boolean {
+                |        if (this === other) return true
+                |        if (javaClass != other?.javaClass) return false
+                |
+                |        other as DataFuncTest
+                |
+                |        if (a != other.a) return false
+                |
+                |        return true
+                |    }
+                |}
+                """
+                    .trimMargin()
+
+            val (findings, result) = subject.lintAndFix(code)
+
+            assertThat(findings).hasSize(2)
+
+            assertThat(result)
+                .isEqualTo(
+                    $$"""
+                    |annotation class GenerateDataFunctions
+                    |
+                    |@GenerateDataFunctions
+                    |class DataFuncTest(val a: String, val b: String) {
+                    |
+                    |override fun equals(other: Any?): Boolean {
+                    |    if (this === other) return true
+                    |    if (javaClass != other?.javaClass) return false
+                    |
+                    |    other as DataFuncTest
+                    |
+                    |    if (a != other.a) return false
+                    |    if (b != other.b) return false
+                    |
+                    |    return true
+                    |}
+                    |
+                    |override fun hashCode(): Int {
+                    |    var result = a.hashCode()
+                    |    result = 31 * result + b.hashCode()
+                    |    return result
+                    |}
+                    |
+                    |override fun toString(): String {
+                    |    return "DataFuncTest(a=$a, b=$b)"
+                    |}
+                    |}
+                    """
+                        .trimMargin()
+                )
+        }
+
+        @Test
+        fun `should not touch unrelated functions`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |) {
+                |    fun unrelated() {
+                |        println("hello")
+                |    }
+                |}
+                """
+                    .trimMargin()
+
+            val (findings, result) = subject.lintAndFix(code)
+
+            assertThat(findings).hasSize(1)
+            assertThat(result)
+                .isEqualTo(
+                    $$"""
+                    |annotation class GenerateDataFunctions
+                    |
+                    |@GenerateDataFunctions
+                    |class DataFuncTest(
+                    |    val a: String,
+                    |    val b: String
+                    |) {
+                    |    fun unrelated() {
+                    |        println("hello")
+                    |    }
+                    |
+                    |override fun equals(other: Any?): Boolean {
+                    |    if (this === other) return true
+                    |    if (javaClass != other?.javaClass) return false
+                    |
+                    |    other as DataFuncTest
+                    |
+                    |    if (a != other.a) return false
+                    |    if (b != other.b) return false
+                    |
+                    |    return true
+                    |}
+                    |
+                    |override fun hashCode(): Int {
+                    |    var result = a.hashCode()
+                    |    result = 31 * result + b.hashCode()
+                    |    return result
+                    |}
+                    |
+                    |override fun toString(): String {
+                    |    return "DataFuncTest(a=$a, b=$b)"
+                    |}
+                    |}
+                    """
+                        .trimMargin()
+                )
+        }
+
+        @Test
+        fun `should not reorder unrelated functions`() {
+            val code =
+                """
+                |annotation class GenerateDataFunctions
+                |
+                |@GenerateDataFunctions
+                |class DataFuncTest(
+                |    val a: String,
+                |    val b: String
+                |) {
+                |    fun unrelated() {
+                |        println("hello")
+                |    }
+                |
+                |    fun unrelated2() {
+                |        println("hello2")
+                |    }
+                |}
+                """
+                    .trimMargin()
+
+            val (findings, result) = subject.lintAndFix(code)
+
+            assertThat(findings).hasSize(1)
+            assertThat(result)
+                .isEqualTo(
+                    $$"""
+                    |annotation class GenerateDataFunctions
+                    |
+                    |@GenerateDataFunctions
+                    |class DataFuncTest(
+                    |    val a: String,
+                    |    val b: String
+                    |) {
+                    |    fun unrelated() {
+                    |        println("hello")
+                    |    }
+                    |
+                    |    fun unrelated2() {
+                    |        println("hello2")
+                    |    }
+                    |
+                    |override fun equals(other: Any?): Boolean {
+                    |    if (this === other) return true
+                    |    if (javaClass != other?.javaClass) return false
+                    |
+                    |    other as DataFuncTest
+                    |
+                    |    if (a != other.a) return false
+                    |    if (b != other.b) return false
+                    |
+                    |    return true
+                    |}
+                    |
+                    |override fun hashCode(): Int {
+                    |    var result = a.hashCode()
+                    |    result = 31 * result + b.hashCode()
+                    |    return result
+                    |}
+                    |
+                    |override fun toString(): String {
+                    |    return "DataFuncTest(a=$a, b=$b)"
+                    |}
+                    |}
+                    """
+                        .trimMargin()
+                )
+        }
+    }
+
+    @Nested
+    inner class `real-life scenarios` {
+        @Test
+        fun `should not crash on TitleBarStyling`() {
+            val code = readResourceContent("TitleBarStyling-forTest.kt")
+            val (findings, result) = subject.lintAndFix(code)
+
+            assertThat(findings).isEmpty()
+            assertThat(result).isEqualTo(code)
+        }
+    }
+
+    private fun EqualityMembersRule.lintAndFix(@Language("kotlin") code: String): Pair<List<Finding>, String> {
+        val ktFile = compileContentForTest(code)
+        visit(ktFile)
+        return findings to ktFile.text
+    }
+}

--- a/platform/jewel/detekt-plugin/src/test/resources/TitleBarStyling-forTest.kt
+++ b/platform/jewel/detekt-plugin/src/test/resources/TitleBarStyling-forTest.kt
@@ -1,0 +1,253 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.window.styling
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import org.jetbrains.jewel.foundation.GenerateDataFunctions
+import org.jetbrains.jewel.ui.component.styling.DropdownStyle
+import org.jetbrains.jewel.ui.component.styling.IconButtonStyle
+import org.jetbrains.jewel.ui.icon.IconKey
+import org.jetbrains.jewel.window.DecoratedWindowState
+
+@Stable
+@GenerateDataFunctions
+public class TitleBarStyle(
+    public val colors: TitleBarColors,
+    public val metrics: TitleBarMetrics,
+    public val icons: TitleBarIcons,
+    public val dropdownStyle: DropdownStyle,
+    public val iconButtonStyle: IconButtonStyle,
+    public val paneButtonStyle: IconButtonStyle,
+    public val paneCloseButtonStyle: IconButtonStyle,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TitleBarStyle
+
+        if (colors != other.colors) return false
+        if (metrics != other.metrics) return false
+        if (icons != other.icons) return false
+        if (dropdownStyle != other.dropdownStyle) return false
+        if (iconButtonStyle != other.iconButtonStyle) return false
+        if (paneButtonStyle != other.paneButtonStyle) return false
+        if (paneCloseButtonStyle != other.paneCloseButtonStyle) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = colors.hashCode()
+        result = 31 * result + metrics.hashCode()
+        result = 31 * result + icons.hashCode()
+        result = 31 * result + dropdownStyle.hashCode()
+        result = 31 * result + iconButtonStyle.hashCode()
+        result = 31 * result + paneButtonStyle.hashCode()
+        result = 31 * result + paneCloseButtonStyle.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "TitleBarStyle(" +
+               "colors=$colors, " +
+               "metrics=$metrics, " +
+               "icons=$icons, " +
+               "dropdownStyle=$dropdownStyle, " +
+               "iconButtonStyle=$iconButtonStyle, " +
+               "paneButtonStyle=$paneButtonStyle, " +
+               "paneCloseButtonStyle=$paneCloseButtonStyle" +
+               ")"
+    }
+
+    public companion object
+}
+
+@Immutable
+@GenerateDataFunctions
+public class TitleBarColors(
+    public val background: Color,
+    public val inactiveBackground: Color,
+    public val content: Color,
+    public val border: Color,
+    // The background color for newControlButtons(three circles in left top corner) in MacOS
+    // fullscreen mode
+    public val fullscreenControlButtonsBackground: Color,
+    // The hover and press background color for window control buttons(minimize, maximize) in Linux
+    public val titlePaneButtonHoveredBackground: Color,
+    public val titlePaneButtonPressedBackground: Color,
+    // The hover and press background color for window close button in Linux
+    public val titlePaneCloseButtonHoveredBackground: Color,
+    public val titlePaneCloseButtonPressedBackground: Color,
+    // The hover and press background color for IconButtons in title bar content
+    public val iconButtonHoveredBackground: Color,
+    public val iconButtonPressedBackground: Color,
+    // The hover and press background color for Dropdown in title bar content
+    public val dropdownPressedBackground: Color,
+    public val dropdownHoveredBackground: Color,
+) {
+    @Composable
+    public fun backgroundFor(state: DecoratedWindowState): State<Color> =
+        rememberUpdatedState(
+            when {
+                !state.isActive -> inactiveBackground
+                else -> background
+            }
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TitleBarColors
+
+        if (background != other.background) return false
+        if (inactiveBackground != other.inactiveBackground) return false
+        if (content != other.content) return false
+        if (border != other.border) return false
+        if (fullscreenControlButtonsBackground != other.fullscreenControlButtonsBackground) return false
+        if (titlePaneButtonHoveredBackground != other.titlePaneButtonHoveredBackground) return false
+        if (titlePaneButtonPressedBackground != other.titlePaneButtonPressedBackground) return false
+        if (titlePaneCloseButtonHoveredBackground != other.titlePaneCloseButtonHoveredBackground) return false
+        if (titlePaneCloseButtonPressedBackground != other.titlePaneCloseButtonPressedBackground) return false
+        if (iconButtonHoveredBackground != other.iconButtonHoveredBackground) return false
+        if (iconButtonPressedBackground != other.iconButtonPressedBackground) return false
+        if (dropdownPressedBackground != other.dropdownPressedBackground) return false
+        if (dropdownHoveredBackground != other.dropdownHoveredBackground) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = background.hashCode()
+        result = 31 * result + inactiveBackground.hashCode()
+        result = 31 * result + content.hashCode()
+        result = 31 * result + border.hashCode()
+        result = 31 * result + fullscreenControlButtonsBackground.hashCode()
+        result = 31 * result + titlePaneButtonHoveredBackground.hashCode()
+        result = 31 * result + titlePaneButtonPressedBackground.hashCode()
+        result = 31 * result + titlePaneCloseButtonHoveredBackground.hashCode()
+        result = 31 * result + titlePaneCloseButtonPressedBackground.hashCode()
+        result = 31 * result + iconButtonHoveredBackground.hashCode()
+        result = 31 * result + iconButtonPressedBackground.hashCode()
+        result = 31 * result + dropdownPressedBackground.hashCode()
+        result = 31 * result + dropdownHoveredBackground.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "TitleBarColors(" +
+               "background=$background, " +
+               "inactiveBackground=$inactiveBackground, " +
+               "content=$content, " +
+               "border=$border, " +
+               "fullscreenControlButtonsBackground=$fullscreenControlButtonsBackground, " +
+               "titlePaneButtonHoveredBackground=$titlePaneButtonHoveredBackground, " +
+               "titlePaneButtonPressedBackground=$titlePaneButtonPressedBackground, " +
+               "titlePaneCloseButtonHoveredBackground=$titlePaneCloseButtonHoveredBackground, " +
+               "titlePaneCloseButtonPressedBackground=$titlePaneCloseButtonPressedBackground, " +
+               "iconButtonHoveredBackground=$iconButtonHoveredBackground, " +
+               "iconButtonPressedBackground=$iconButtonPressedBackground, " +
+               "dropdownPressedBackground=$dropdownPressedBackground, " +
+               "dropdownHoveredBackground=$dropdownHoveredBackground" +
+               ")"
+    }
+
+    public companion object
+}
+
+@Immutable
+@GenerateDataFunctions
+public class TitleBarMetrics(
+    public val height: Dp,
+    public val gradientStartX: Dp,
+    public val gradientEndX: Dp,
+    public val titlePaneButtonSize: DpSize,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TitleBarMetrics
+
+        if (height != other.height) return false
+        if (gradientStartX != other.gradientStartX) return false
+        if (gradientEndX != other.gradientEndX) return false
+        if (titlePaneButtonSize != other.titlePaneButtonSize) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = height.hashCode()
+        result = 31 * result + gradientStartX.hashCode()
+        result = 31 * result + gradientEndX.hashCode()
+        result = 31 * result + titlePaneButtonSize.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "TitleBarMetrics(" +
+               "height=$height, " +
+               "gradientStartX=$gradientStartX, " +
+               "gradientEndX=$gradientEndX, " +
+               "titlePaneButtonSize=$titlePaneButtonSize" +
+               ")"
+    }
+
+    public companion object
+}
+
+@Immutable
+@GenerateDataFunctions
+public class TitleBarIcons(
+    public val minimizeButton: IconKey,
+    public val maximizeButton: IconKey,
+    public val restoreButton: IconKey,
+    public val closeButton: IconKey,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TitleBarIcons
+
+        if (minimizeButton != other.minimizeButton) return false
+        if (maximizeButton != other.maximizeButton) return false
+        if (restoreButton != other.restoreButton) return false
+        if (closeButton != other.closeButton) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = minimizeButton.hashCode()
+        result = 31 * result + maximizeButton.hashCode()
+        result = 31 * result + restoreButton.hashCode()
+        result = 31 * result + closeButton.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "TitleBarIcons(" +
+               "minimizeButton=$minimizeButton, " +
+               "maximizeButton=$maximizeButton, " +
+               "restoreButton=$restoreButton, " +
+               "closeButton=$closeButton" +
+               ")"
+    }
+
+    public companion object
+}
+
+public val LocalTitleBarStyle: ProvidableCompositionLocal<TitleBarStyle> = staticCompositionLocalOf {
+    error("No TitleBarStyle provided. Have you forgotten the theme?")
+}

--- a/platform/jewel/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumnTest.kt
+++ b/platform/jewel/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumnTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
+@Suppress("ImplicitUnitReturnType")
 internal class SelectableLazyColumnTest {
     @get:Rule val composeRule = createComposeRule()
 

--- a/platform/jewel/gradle/libs.versions.toml
+++ b/platform/jewel/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 coil = "3.1.0"
 commonmark = "0.24.0"
 composeDesktop = "1.8.2"
-detekt = "1.23.6"
+detekt = "1.23.8"
 dokka = "2.0.0"
 filepicker = "3.1.0"
 idea = "252.16512.17"
@@ -15,7 +15,7 @@ kotlinpoet = "2.1.0"
 kotlinterGradlePlugin = "5.0.1"
 kotlinxSerialization = "1.8.0"
 kotlinxBinaryCompat = "0.17.0"
-ktfmtGradlePlugin = "0.22.0"
+ktfmtGradlePlugin = "0.23.0"
 
 [libraries]
 coil-compose-core = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }

--- a/platform/jewel/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/jewel/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
@@ -115,7 +115,7 @@ private fun JBPopup(
                 content = {
                     ProvideValuesFromOtherContext(compositionLocalContext) {
                         val focusRequester = remember { FocusRequester() }
-                        val popupPositionProvider = currentPopupPositionProvider.value
+                        val positionProvider = currentPopupPositionProvider.value
                         val parentBounds = parentBoundsInRoot.value ?: return@ProvideValuesFromOtherContext
 
                         Layout(
@@ -130,9 +130,9 @@ private fun JBPopup(
                                 }
                             },
                             measurePolicy =
-                                remember(popupPositionProvider, parentBounds) {
+                                remember(positionProvider, parentBounds) {
                                     JBPopupMeasurePolicy(
-                                        popupPositionProvider = popupPositionProvider,
+                                        popupPositionProvider = positionProvider,
                                         screenSize = IntSize.fromScreenSize(owner),
                                         parentBoundsInWindow = parentBounds,
                                         onMeasure = { position, size ->

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeGrayFilterValues.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeGrayFilterValues.kt
@@ -24,13 +24,14 @@ import org.jetbrains.jewel.foundation.DisabledAppearanceValues
  *   to be provided to a CompositionLocal like `LocalGrayFilterValues`.
  * @see DisabledAppearanceValues
  */
+@Suppress("UnstableApiUsage")
 public fun DisabledAppearanceValues.Companion.readFromLaF(): DisabledAppearanceValues {
     val grayFilter = UIUtil.getGrayFilter()
     val (brightness, contrast, alpha) =
         if (grayFilter is GrayFilter) {
-            arrayOf(grayFilter.brightness, grayFilter.contrast, grayFilter.alpha)
+            listOf(grayFilter.brightness, grayFilter.contrast, grayFilter.alpha)
         } else {
-            if (isDark) arrayOf(-70, -70, 100) else arrayOf(33, -35, 100)
+            if (isDark) listOf(-70, -70, 100) else listOf(33, -35, 100)
         }
 
     return DisabledAppearanceValues(brightness, contrast, alpha)

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTooltip.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTooltip.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.jewel.bridge.theme
 
 import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.ui.unit.dp
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.util.ui.JBUI
 import kotlin.time.Duration.Companion.milliseconds

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
@@ -223,8 +223,11 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
      *   effectively hiding it.
      * @return A new [TextStyle] with the properties merged according to the logic.
      */
-    private fun TextStyle.smartMerge(other: SpanStyle, enabled: Boolean) =
-        merge(
+    private fun TextStyle.smartMerge(other: SpanStyle, enabled: Boolean): TextStyle {
+        val otherFontWeight = other.fontWeight
+        val thisFontWeight = fontWeight
+
+        return merge(
             // We use the other's FontStyle (if any) when it's not just Normal, otherwise we keep
             // our own FontStyle. This preserves incoming Italic, since Markdown has no way to
             // reset it to Normal anyway.
@@ -239,10 +242,11 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
             // decrease the weight of text.
             fontWeight =
                 when {
-                    other.fontWeight != null && fontWeight == null -> other.fontWeight
-                    other.fontWeight == null && fontWeight != null -> fontWeight
-                    other.fontWeight != null && fontWeight != null ->
-                        FontWeight(max(fontWeight!!.weight, other.fontWeight!!.weight))
+                    otherFontWeight != null && thisFontWeight == null -> otherFontWeight
+                    otherFontWeight == null && thisFontWeight != null -> thisFontWeight
+                    otherFontWeight != null && thisFontWeight != null ->
+                        FontWeight(max(thisFontWeight.weight, otherFontWeight.weight))
+
                     else -> null
                 },
             // The color is taken from the other, unless it's unspecified, or enabled is false
@@ -263,4 +267,5 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
             platformStyle =
                 PlatformTextStyle(platformStyle?.spanStyle?.merge(other.platformStyle), platformStyle?.paragraphStyle),
         )
+    }
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -541,7 +541,8 @@ public open class DefaultMarkdownBlockRenderer(
                 getImages(blockInlineContent).associate { image ->
                     image.source to imagesRenderer.renderImagesContent(image)
                 }
-            } ?: emptyMap()
+            }
+            .orEmpty()
     }
 
     @Composable

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollingSynchronizer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollingSynchronizer.kt
@@ -166,7 +166,7 @@ public abstract class ScrollingSynchronizer {
         private val blocks2Top = mutableMapOf<MarkdownBlock, Int>()
         private val previousPositions = mutableMapOf<MarkdownBlock, Int>()
 
-        private var lastBlocks = listOf<LocatableMarkdownBlock>()
+        private var lastBlocks = emptyList<LocatableMarkdownBlock>()
         private val currentBlocks = mutableListOf<LocatableMarkdownBlock>()
 
         // It'd be a bit more performant if there were a map mapping lines to offsets,
@@ -191,7 +191,7 @@ public abstract class ScrollingSynchronizer {
             val textOffsets = blocks2TextOffsets[block]
             // The line may be empty and represent no block,
             // in this case scroll to the first line of the first block positioned after the line
-            val lineIndexInBlock = maxOf(0, sourceLine - lineRange.start)
+            val lineIndexInBlock = maxOf(0, sourceLine - lineRange.first)
             val lineOffset = textOffsets?.get(lineIndexInBlock) ?: 0
             scrollState.animateScrollTo(y + lineOffset, animationSpec)
         }
@@ -270,7 +270,7 @@ public abstract class ScrollingSynchronizer {
             if (
                 this is LocatableMarkdownBlock &&
                     other is LocatableMarkdownBlock &&
-                    lines.endInclusive - lines.start != other.lines.endInclusive - other.lines.start
+                    lines.last - lines.first != other.lines.last - other.lines.first
             ) {
                 return false
             }
@@ -295,13 +295,13 @@ public abstract class ScrollingSynchronizer {
         }
 
         override fun acceptBlockSpans(block: MarkdownBlock, sourceRange: IntRange): MarkdownBlock {
-            val block = LocatableMarkdownBlock(block, sourceRange)
+            val locatableMarkdownBlock = LocatableMarkdownBlock(block, sourceRange)
             for (line in sourceRange) {
                 // DFS -- keep the innermost block for the given line
-                lines2Blocks.putIfAbsent(line, block)
+                lines2Blocks.putIfAbsent(line, locatableMarkdownBlock)
             }
-            currentBlocks += block
-            return block
+            currentBlocks += locatableMarkdownBlock
+            return locatableMarkdownBlock
         }
 
         override fun acceptGlobalPosition(block: MarkdownBlock, coordinates: LayoutCoordinates) {

--- a/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollingSynchronizerTest.kt
+++ b/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollingSynchronizerTest.kt
@@ -696,6 +696,7 @@ public class ScrollingSynchronizerTest {
         doTest(yieldBlocks = { processMarkdownDocument(markdown) }, action = action)
     }
 
+    @Suppress("ImplicitUnitReturnType")
     @OptIn(ExperimentalTestApi::class)
     private fun doTest(
         yieldBlocks: MarkdownProcessor.() -> List<MarkdownBlock>,

--- a/platform/jewel/markdown/extensions/images/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImagesRendererExtensionImpl.kt
+++ b/platform/jewel/markdown/extensions/images/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImagesRendererExtensionImpl.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.jewel.markdown.extensions.images
 
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -66,7 +65,12 @@ public class Coil3ImagesRendererExtensionImpl(private val imageLoader: ImageLoad
                 onError = { error ->
                     JewelLogger.getInstance("Jewel").warn("AsyncImage loading: ${error.result.throwable}")
                 },
-                modifier = knownSize.value?.let { Modifier.height(it.height.dp).width(it.width.dp) } ?: Modifier,
+                modifier =
+                    knownSize.value
+                        // If we have a knownSize, let's use it
+                        ?.let { size -> Modifier.size(size.height.dp, size.width.dp) }
+                        // Otherwise, we'll do it when we have it
+                        ?: Modifier,
             )
         }
     }

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -252,8 +252,8 @@ private fun RowScope.ColumnOne() {
                                 "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, " +
                                 "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
                                 "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu " +
-                                "fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa " +
-                                "qui officia deserunt mollit anim id est laborum.",
+                                "fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in " +
+                                "culpa qui officia deserunt mollit anim id est laborum.",
                         actions = {
                             Link("Action A", onClick = { clickLabel = "Success Inline Action A clicked" })
                             Link("Action B", onClick = { clickLabel = "Success Inline Action B clicked" })

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ScrollbarsShowcaseTab.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ScrollbarsShowcaseTab.kt
@@ -83,7 +83,7 @@ private const val ANDROID_IPSUM =
         " aliqua. Ut enim ad activity_main.xml veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip" +
         " ex ea compileOptions consequat. Duis aute irure dolor in reprehenderit in logcat velit esse cillum dolore" +
         "eu fugiat nulla pariatur. Excepteur sint occaecat proident, sunt in culpa qui officia debugImplementation" +
-        " deserunt mollit anim id est laborum. Manifest merger dolor sit amet, androidx.appcompat.app.AppCompatActivity" +
+        " deserunt mollit anim id est laborum. Manifest merger dolor sit amet, androidx.appcompat.app.AppCompatAct" +
         " adipiscing elit, sed do eiusmod tempor incididunt ut buildToolsVersion et dolore magna aliqua. Proguard" +
         " rules enim ad minim veniam, quis nostrud fragmentContainerView ullamco laboris nisi ut aliquip ex ea" +
         " dataBinding compilerOptions consequat. Kotlin coroutine aute irure dolor in reprehenderit in ViewModel" +

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/PopupManagerTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/PopupManagerTest.kt
@@ -86,10 +86,11 @@ class PopupManagerTest {
         assertTrue(first == second)
     }
 
+    @Suppress("UnusedExpression") // Used to make sure the lambdas are different
     @Test
     fun `should ignore onPopupVisibilityChange when checking equality`() {
-        var first = PopupManager({ "first" })
-        var second = PopupManager({ "second" })
+        val first = PopupManager({ "first" })
+        val second = PopupManager({ "second" })
         assertTrue(first == second)
     }
 
@@ -110,10 +111,11 @@ class PopupManagerTest {
         assertTrue(first.hashCode() == second.hashCode())
     }
 
+    @Suppress("UnusedExpression") // Used to make sure the lambdas are different
     @Test
     fun `should ignore onPopupVisibilityChange when computing hashcode`() {
-        var first = PopupManager({ "first" })
-        var second = PopupManager({ "second" })
+        val first = PopupManager({ "first" })
+        val second = PopupManager({ "second" })
         assertTrue(first.hashCode() == second.hashCode())
     }
 }

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/TabStripTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/TabStripTest.kt
@@ -31,6 +31,7 @@ import org.jetbrains.jewel.ui.theme.defaultTabStyle
 import org.junit.Rule
 import org.junit.Test
 
+@Suppress("ImplicitUnitReturnType")
 @OptIn(ExperimentalTestApi::class)
 class TabStripTest {
     @get:Rule val rule = createComposeRule()
@@ -50,7 +51,7 @@ class TabStripTest {
     fun `on press arrow right, moves focus to next tab`() = runComposeTest {
         onNodeWithText("Test Tab 1").assertIsSelected()
 
-        onRoot().performKeyPress(Key.Companion.DirectionRight)
+        onRoot().performKeyPress(Key.DirectionRight)
 
         onNodeWithText("Test Tab 2").assertIsSelected()
     }
@@ -60,7 +61,7 @@ class TabStripTest {
         runComposeTest(initiallySelectedTabIndex = 11) {
             onNodeWithText("Test Tab 12").assertIsSelected()
 
-            onRoot().performKeyPress(Key.Companion.DirectionRight)
+            onRoot().performKeyPress(Key.DirectionRight)
 
             onNodeWithText("Test Tab 1").assertIsSelected()
         }
@@ -69,7 +70,7 @@ class TabStripTest {
     fun `when keeping arrow right pressed, keeps moving the selected tab`() = runComposeTest {
         onNodeWithText("Test Tab 1").assertIsSelected()
 
-        onRoot().performKeyPress(Key.Companion.DirectionRight, duration = 3_000)
+        onRoot().performKeyPress(Key.DirectionRight, duration = 3_000)
 
         onNodeWithText("Test Tab 5").assertIsSelected()
     }
@@ -79,7 +80,7 @@ class TabStripTest {
         runComposeTest(initiallySelectedTabIndex = 1) {
             onNodeWithText("Test Tab 2").assertIsSelected()
 
-            onRoot().performKeyPress(Key.Companion.DirectionLeft)
+            onRoot().performKeyPress(Key.DirectionLeft)
 
             onNodeWithText("Test Tab 1").assertIsSelected()
         }
@@ -88,7 +89,7 @@ class TabStripTest {
     fun `on press arrow left, in the first tab, moves focus to the last tab`() = runComposeTest {
         onNodeWithText("Test Tab 1").assertIsSelected()
 
-        onRoot().performKeyPress(Key.Companion.DirectionLeft)
+        onRoot().performKeyPress(Key.DirectionLeft)
 
         onNodeWithText("Test Tab 12").assertIsSelected()
     }
@@ -97,7 +98,7 @@ class TabStripTest {
     fun `on press end, moves focus to last tab`() = runComposeTest {
         onNodeWithText("Test Tab 1").assertIsSelected()
 
-        onRoot().performKeyPress(Key.Companion.MoveEnd)
+        onRoot().performKeyPress(Key.MoveEnd)
 
         onNodeWithText("Test Tab 12").assertIsSelected()
     }
@@ -107,7 +108,7 @@ class TabStripTest {
         runComposeTest(initiallySelectedTabIndex = 11) {
             onNodeWithText("Test Tab 12").assertIsSelected()
 
-            onRoot().performKeyPress(Key.Companion.MoveHome)
+            onRoot().performKeyPress(Key.MoveHome)
 
             onNodeWithText("Test Tab 1").assertIsSelected()
         }
@@ -116,7 +117,7 @@ class TabStripTest {
     fun `on scroll to tab, set it in focus`() = runComposeTest {
         onNodeWithText("Test Tab 12").assertIsNotDisplayed()
 
-        onRoot().performKeyPress(Key.Companion.MoveEnd)
+        onRoot().performKeyPress(Key.MoveEnd)
 
         onNodeWithText("Test Tab 12").assertIsDisplayed()
     }
@@ -158,8 +159,8 @@ class TabStripTest {
             IntUiTheme {
                 TabStrip(
                     tabs = tabs,
-                    style = JewelTheme.Companion.defaultTabStyle,
-                    modifier = Modifier.Companion.focusRequester(focusRequester),
+                    style = JewelTheme.defaultTabStyle,
+                    modifier = Modifier.focusRequester(focusRequester),
                 )
             }
 

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
@@ -263,7 +263,7 @@ private fun ExternalLinkImpl(
     )
 }
 
-private fun openUri(uriHandler: UriHandler, link: String) =
+private fun openUri(uriHandler: UriHandler, link: String) {
     try {
         uriHandler.openUri(link)
     } catch (e: IllegalArgumentException) {
@@ -271,6 +271,7 @@ private fun openUri(uriHandler: UriHandler, link: String) =
     } catch (e: IOException) {
         JewelLogger.getInstance("ExternalLink").error("Unable to open link ($link). Error: $e")
     }
+}
 
 /**
  * A dropdown link that follows the standard visual styling with customizable appearance and menu content.

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Typography.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Typography.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantSuppression")
+
 package org.jetbrains.jewel.ui.component
 
 import androidx.annotation.Px
@@ -127,6 +129,7 @@ public object Typography {
  *
  * @see Typography.DefaultLineHeightMultiplier
  */
+@Suppress("DEPRECATION")
 @Deprecated("Use computeLineHeightPx() to set the line height appropriately instead.")
 public fun TextStyle.copyWithSize(
     fontSize: TextUnit,
@@ -185,6 +188,7 @@ public fun TextStyle.copyWithSize(
  *
  * @see Typography.DefaultLineHeightMultiplier
  */
+@Suppress("DEPRECATION")
 @Deprecated("Use computeLineHeightPx() to set the line height appropriately instead.")
 public fun TextStyle.copyWithSize(
     fontSize: TextUnit,
@@ -302,5 +306,5 @@ private fun getDefaultFrc(): FontRenderContext {
             }
         defaultFrc = FontRenderContext(tx, false, false)
     }
-    return defaultFrc!!
+    return checkNotNull(defaultFrc) { "The defaultFrc should never be null" }
 }

--- a/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/PainterHintTest.kt
+++ b/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/PainterHintTest.kt
@@ -52,7 +52,7 @@ public class PainterHintTest : BasicJewelUiTest() {
         density: Density,
         override val rawPath: String,
         override val path: String = rawPath,
-        override val acceptedHints: List<PainterHint> = listOf(),
+        override val acceptedHints: List<PainterHint> = emptyList(),
     ) : PainterProviderScope, Density by density {
         private val documentBuilderFactory =
             DocumentBuilderFactory.newDefaultInstance().apply {


### PR DESCRIPTION
The rule is a bit buggy, and difficult to read. It also has essentially no tests. This addresses both concerns. I also noticed for whatever reason we were not properly running detektMain and detektTest on the GitHub CI, which means we had a bunch of warnings. I have now added both checks to the GitHub CI. Hopefully, we'll be able to run the same checks on TeamCity at some point, too.

Note: this bumps Detekt to 1.23.8 (latest version) and adds a test-only dependency to detekt-core — I'm not sure if this will require manual merging due to Bazel.

It also tweaks the Jewel .editorconfig to 120 as that's the value used by the CI, and fixes all outstanding static analysis warnings.