### PR TITLE
KT UAST: detach fake PSI for annotation from FE1.0

### DIFF
--- a/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/declarations/KotlinUMethod.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/declarations/KotlinUMethod.kt
@@ -9,10 +9,10 @@ import org.jetbrains.kotlin.asJava.elements.KtLightElement
 import org.jetbrains.kotlin.asJava.elements.KtLightMethod
 import org.jetbrains.kotlin.asJava.elements.isGetter
 import org.jetbrains.kotlin.asJava.elements.isSetter
+import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_STATIC_FQ_NAME
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
-import org.jetbrains.kotlin.resolve.annotations.JVM_STATIC_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.utils.SmartList
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.uast.*
@@ -179,6 +179,6 @@ open class KotlinUMethod(
             }
         }
 
-        private fun isJvmStatic(it: PsiAnnotation): Boolean = it.hasQualifiedName(JVM_STATIC_ANNOTATION_FQ_NAME.asString())
+        private fun isJvmStatic(it: PsiAnnotation): Boolean = it.hasQualifiedName(JVM_STATIC_FQ_NAME.asString())
     }
 }

--- a/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/psi/UastFakeSourceLightAccessorBase.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/psi/UastFakeSourceLightAccessorBase.kt
@@ -37,6 +37,8 @@ internal open class UastFakeSourceLightAccessorBase<T: KtDeclaration>(
         val useSiteTarget = if (isSetter) AnnotationUseSiteTarget.PROPERTY_SETTER else AnnotationUseSiteTarget.PROPERTY_GETTER
         property.annotationEntries
             .filter { it.useSiteTarget?.getAnnotationUseSiteTarget() == useSiteTarget }
-            .mapTo(annotations) { it.toPsiAnnotation() }
+            .mapNotNullTo(annotations) { entry ->
+                baseResolveProviderService.convertToPsiAnnotation(entry)
+            }
     }
 }

--- a/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/psi/UastFakeSourceLightMethodBase.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/psi/UastFakeSourceLightMethodBase.kt
@@ -6,10 +6,8 @@ import com.intellij.psi.impl.light.LightModifierList
 import com.intellij.psi.impl.light.LightParameterListBuilder
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.kotlin.analysis.api.types.KaTypeNullability
-import org.jetbrains.kotlin.asJava.elements.KtLightAnnotationForSourceEntry
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
@@ -100,22 +98,12 @@ abstract class UastFakeSourceLightMethodBase<T : KtDeclaration>(
     }
 
     override fun computeAnnotations(annotations: SmartSet<PsiAnnotation>) {
-        original.annotationEntries.mapTo(annotations) { entry ->
+        original.annotationEntries.mapNotNullTo(annotations) { entry ->
             // Creation of PsiAnnotation may vary between frontends. For example,
             // SLC doesn't model a declaration with value class in its signature
             // and K2 UAST will fake it, while K1 doesn't need to.
             baseResolveProviderService.convertToPsiAnnotation(entry)
-                ?: entry.toPsiAnnotation()
         }
-    }
-
-    protected fun KtAnnotationEntry.toPsiAnnotation(): PsiAnnotation {
-        return KtLightAnnotationForSourceEntry(
-            name = shortName?.identifier,
-            lazyQualifiedName = { baseResolveProviderService.qualifiedAnnotationName(this) },
-            kotlinOrigin = this,
-            parent = original,
-        )
     }
 
     override fun isConstructor(): Boolean {

--- a/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/FirUastApiFixtureTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/FirUastApiFixtureTest.kt
@@ -238,6 +238,10 @@ class FirUastApiFixtureTest : KotlinLightCodeInsightFixtureTestCase(), UastApiFi
         checkAnnotationOnPropertyWithValueClassInSignature(myFixture)
     }
 
+    fun testAnnotationOnJvmSynthetic() {
+        checkAnnotationOnJvmSynthetic(myFixture)
+    }
+
     fun testTypealiasAnnotation() {
         checkTypealiasAnnotation(myFixture)
     }

--- a/plugins/kotlin/uast/uast-kotlin-idea/src/org/jetbrains/uast/kotlin/internal/IdeaKotlinUastResolveProviderService.kt
+++ b/plugins/kotlin/uast/uast-kotlin-idea/src/org/jetbrains/uast/kotlin/internal/IdeaKotlinUastResolveProviderService.kt
@@ -5,7 +5,6 @@ package org.jetbrains.uast.kotlin.internal
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiModifierListOwner
-import org.jetbrains.kotlin.asJava.toLightAnnotation
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.idea.base.projectStructure.languageVersionSettings
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
@@ -57,7 +56,7 @@ private class IdeaKotlinUastResolveProviderService : KotlinUastResolveProviderSe
     }
 
     override fun convertToPsiAnnotation(ktElement: KtElement): PsiAnnotation? {
-        return ktElement.actionUnderSafeAnalyzeBlock({ ktElement.toLightAnnotation() }, { null })
+        return ktElement.actionUnderSafeAnalyzeBlock({ super.convertToPsiAnnotation(ktElement) }, { null })
     }
 
     override fun getPsiAnnotations(psiElement: PsiModifierListOwner): Array<PsiAnnotation> {

--- a/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastResolveProviderService.kt
+++ b/plugins/kotlin/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/KotlinUastResolveProviderService.kt
@@ -4,6 +4,7 @@ package org.jetbrains.uast.kotlin
 
 import com.intellij.psi.*
 import org.jetbrains.kotlin.analysis.api.types.KaTypeNullability
+import org.jetbrains.kotlin.asJava.elements.KtLightAnnotationForSourceEntry
 import org.jetbrains.kotlin.asJava.toLightAnnotation
 import org.jetbrains.kotlin.asJava.toLightElements
 import org.jetbrains.kotlin.builtins.createFunctionType
@@ -64,7 +65,15 @@ interface KotlinUastResolveProviderService : BaseKotlinUastResolveProviderServic
         get() = KotlinConverter
 
     override fun convertToPsiAnnotation(ktElement: KtElement): PsiAnnotation? {
-        return ktElement.toLightAnnotation()
+        ktElement.toLightAnnotation()?.let { return it }
+        return if (ktElement is KtAnnotationEntry) {
+            KtLightAnnotationForSourceEntry(
+                name = ktElement.shortName?.identifier,
+                lazyQualifiedName = { qualifiedAnnotationName(ktElement) },
+                kotlinOrigin = ktElement,
+                parent = ktElement.parent,
+            )
+        } else null
     }
 
     private fun getResolvedCall(sourcePsi: KtCallElement): ResolvedCall<*>? {

--- a/plugins/kotlin/uast/uast-kotlin/tests/test/org/jetbrains/uast/test/kotlin/comparison/FE1UastApiFixtureTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin/tests/test/org/jetbrains/uast/test/kotlin/comparison/FE1UastApiFixtureTest.kt
@@ -234,6 +234,10 @@ class FE1UastApiFixtureTest : KotlinLightCodeInsightFixtureTestCase(), UastApiFi
         checkAnnotationOnPropertyWithValueClassInSignature(myFixture)
     }
 
+    fun testAnnotationOnJvmSynthetic() {
+        checkAnnotationOnJvmSynthetic(myFixture)
+    }
+
     fun testTypealiasAnnotation() {
         checkTypealiasAnnotation(myFixture)
     }


### PR DESCRIPTION
Now the conversions from source annotation entry to PSI annotation
are implemented on each frontend's resolve provider service.

^KTIJ-34874 fixed