### PR TITLE
[JEWEL-898] TooltipArea should not be public

### DIFF
--- a/platform/compose/src/com/intellij/platform/compose/showcase/ComposeShowcase.kt
+++ b/platform/compose/src/com/intellij/platform/compose/showcase/ComposeShowcase.kt
@@ -8,12 +8,29 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.*
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -27,7 +44,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.icons.AllIcons
@@ -39,14 +55,26 @@ import com.intellij.util.ui.JBUI
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import org.jetbrains.jewel.ui.component.TooltipArea
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.modifier.onHover
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.OverrideDarkMode
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.Outline
-import org.jetbrains.jewel.ui.component.*
+import org.jetbrains.jewel.ui.component.CheckboxRow
+import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.Divider
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.Link
+import org.jetbrains.jewel.ui.component.OutlinedButton
+import org.jetbrains.jewel.ui.component.RadioButtonRow
+import org.jetbrains.jewel.ui.component.TabData
+import org.jetbrains.jewel.ui.component.TabStrip
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.TextField
+import org.jetbrains.jewel.ui.component.Tooltip
+import org.jetbrains.jewel.ui.component.VerticallyScrollableContainer
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.theme.defaultTabStyle
 import org.jetbrains.jewel.ui.theme.tooltipStyle
@@ -104,8 +132,10 @@ private fun InfiniteAnimation() {
 
 @Composable
 private fun Title() {
-  Text("Showcase of Jewel components", fontSize = 15.sp)
-  Divider(orientation = Orientation.Horizontal, modifier = Modifier.fillMaxWidth())
+  Column {
+    Text("Showcase of Jewel components", fontSize = 15.sp)
+    Divider(orientation = Orientation.Horizontal, modifier = Modifier.fillMaxWidth())
+  }
 }
 
 @Composable
@@ -129,7 +159,7 @@ private fun CheckBox() {
 
 @Composable
 private fun RadioButton() {
-  var selectedRadioButton by remember { mutableStateOf(1) }
+  var selectedRadioButton by remember { mutableIntStateOf(1) }
   Row(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(5.dp),
@@ -181,14 +211,14 @@ private fun Buttons() {
     horizontalArrangement = Arrangement.spacedBy(20.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    var state1 by remember { mutableStateOf(0) }
+    var state1 by remember { mutableIntStateOf(0) }
     OutlinedButton(onClick = {
       state1++
     }) {
       Text("Click me #$state1")
     }
 
-    var state2 by remember { mutableStateOf(0) }
+    var state2 by remember { mutableIntStateOf(0) }
     DefaultButton(onClick = {
       state2++
     }) {
@@ -196,7 +226,7 @@ private fun Buttons() {
     }
 
     Row(verticalAlignment = Alignment.CenterVertically) {
-      var state3 by remember { mutableStateOf(0) }
+      var state3 by remember { mutableIntStateOf(0) }
       var focused by remember { mutableStateOf(false) }
       IconButton(
         onClick = { state3++ },
@@ -214,19 +244,21 @@ private fun Buttons() {
 
 @Composable
 private fun Tabs() {
-  var selectedTabIndex by remember { mutableStateOf(0) }
+  var selectedTabIndex by remember { mutableIntStateOf(0) }
   val tabIds by remember { mutableStateOf((1..12).toList()) }
 
-  val tabs by derivedStateOf {
-    tabIds.mapIndexed { index, id ->
-      TabData.Default(
-        selected = index == selectedTabIndex,
-        content = {
-          Text("Tab $id")
-        },
-        closable = false,
-        onClick = { selectedTabIndex = index },
-      )
+  val tabs by remember {
+    derivedStateOf {
+      tabIds.mapIndexed { index, id ->
+        TabData.Default(
+          selected = index == selectedTabIndex,
+          content = {
+            Text("Tab $id")
+          },
+          closable = false,
+          onClick = { selectedTabIndex = index },
+        )
+      }
     }
   }
 
@@ -308,7 +340,7 @@ private fun TextFieldWithButton() {
         )
       },
       trailingIcon = {
-        TooltipArea(
+        Tooltip(
           tooltip = { TooltipSimple { Text(openFileChooserHint, color = JewelTheme.tooltipStyle.colors.content) } }
         ) {
           IconButton({ chooseFile() }, Modifier.size(18.dp).pointerHoverIcon(PointerIcon.Hand).focusProperties { canFocus = false }) {

--- a/platform/jewel/.idea/vcs.xml
+++ b/platform/jewel/.idea/vcs.xml
@@ -10,6 +10,16 @@
   <component name="GitSharedSettings">
     <option name="synchronizeBranchProtectionRules" value="false" />
   </component>
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="(?x)\b(PRJ_ROAD|CPRTINF|EXPOSED|IDEABKL|MERMAID|SUPPORT|GROOVY|JEWEL|AMPER|BAZEL|IJSDK|IJUCF|JUNIE|RSCPP|RIDER|SKIKO|SPNSR|PSAP|DEXP|AQUA|DCVR|DMRY|DOTP|DTRC|EIJP|GTLB|IDES|IDEA|IJPL|JBAP|JBAI|JPAB|KTIJ|KTLC|KTNB|KTOR|PKGS|PROF|RDCT|RSRP|RSPL|RDOC|RUBY|RUST|TABF|VSAI|VSRS|YTDB|LLM|AIT|AIR|CDC|CPP|CLJ|CWM|RDO|CMP|DBE|DOC|DMU|DPA|EDC|GTW|GRZ|HUB|IFT|VIM|IMP|EDU|JBR|KTI|KMT|MPS|MJP|NIM|PRJ|RCB|BND|SCL|TCC|TBX|WEB|WRS|YTM|OC|AT|CN|DS|FL|GC|GO|IA|OT|KI|KG|KT|KE|LV|MP|MR|WI|PY|QD|RF|RG|RS|TW|XD|JT|R)-\d+\b#YouTrack" />
+          <option name="linkRegexp" value="https://youtrack.jetbrains.com/issue/$0" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -142,8 +142,6 @@ f:org.jetbrains.jewel.ui.component.TextContextMenu
 - sf:$stable:I
 - sf:INSTANCE:org.jetbrains.jewel.ui.component.TextContextMenu
 - Area(androidx.compose.foundation.text.TextContextMenu$TextManager,androidx.compose.foundation.ContextMenuState,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I):V
-f:org.jetbrains.jewel.ui.component.TooltipAreaKt
-- sf:TooltipArea(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,I,androidx.compose.foundation.TooltipPlacement,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.ui.component.TooltipKt
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
 - sf:Tooltip(kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.foundation.TooltipPlacement,org.jetbrains.jewel.ui.component.AutoHideBehavior,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V

--- a/platform/jewel/ui/api/ui.api
+++ b/platform/jewel/ui/api/ui.api
@@ -1261,10 +1261,6 @@ public final class org/jetbrains/jewel/ui/component/ToggleableIconButtonState$Co
 	public static synthetic fun of-CAf7mdk$default (Lorg/jetbrains/jewel/ui/component/ToggleableIconButtonState$Companion;ZLandroidx/compose/ui/state/ToggleableState;ZZZZILjava/lang/Object;)J
 }
 
-public final class org/jetbrains/jewel/ui/component/TooltipAreaKt {
-	public static final fun TooltipArea (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ILandroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-}
-
 public final class org/jetbrains/jewel/ui/component/TooltipKt {
 	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lorg/jetbrains/jewel/ui/component/AutoHideBehavior;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
@@ -74,7 +74,7 @@ public fun Tooltip(
     autoHideBehavior: AutoHideBehavior = AutoHideBehavior.Normal,
     content: @Composable () -> Unit,
 ) {
-    TooltipArea(
+    FlagAwareTooltipArea(
         tooltip = {
             TooltipImpl(
                 enabled = enabled,
@@ -127,7 +127,7 @@ public fun Tooltip(
     tooltipPlacement: TooltipPlacement = style.metrics.placement,
     content: @Composable () -> Unit,
 ) {
-    TooltipArea(
+    FlagAwareTooltipArea(
         tooltip = { TooltipImpl(enabled, style, tooltip = tooltip) },
         modifier = modifier,
         delayMillis = style.metrics.showDelay.inWholeMilliseconds.toInt(),

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TooltipArea.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TooltipArea.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.JewelFlags
 
 /**
@@ -40,14 +39,13 @@ import org.jetbrains.jewel.foundation.JewelFlags
  * @param tooltip Composable content of the tooltip.
  * @param modifier The modifier to be applied to the layout.
  * @param delayMillis Delay in milliseconds.
- * @param tooltipPlacement Defines position of the tooltip.
+ * @param tooltipPlacement Defines the position of the tooltip.
  * @param content Composable content that the current tooltip is set to.
  * @see org.jetbrains.jewel.ui.component.Popup
  * @see androidx.compose.ui.window.Popup
  */
-@ExperimentalJewelApi
 @Composable
-public fun TooltipArea(
+internal fun FlagAwareTooltipArea(
     tooltip: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     delayMillis: Int = 500,


### PR DESCRIPTION
Our public tooltip API should remain `Tooltip`, which delegates to `TooltipArea` that is a private impl detail. It should not be in the public API.

To avoid further confusion, the `TooltipArea` composable has also been renamed to `FlagAwareTooltipArea`. This better describes its function and is clearly a private API name.

This also fixes `ComposeShowcase` to use `Tooltip` instead of `TooltipArea`, and sets up the Jewel VCS settings to recognise YouTrack issues. A few issues in the `ComposeShowcase` have also been fixed.