### PR TITLE
[JEWEL-879] Fix Link State Not Being Updated After Being Re-enabled

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
@@ -365,10 +365,9 @@ private fun LinkImpl(
     icon: IconKey?,
 ) {
     var linkState by remember(interactionSource, enabled) { mutableStateOf(LinkState.of(enabled = enabled)) }
-    remember(enabled) { linkState = linkState.copy(enabled = enabled) }
 
     val inputModeManager = LocalInputModeManager.current
-    LaunchedEffect(interactionSource) {
+    LaunchedEffect(interactionSource, enabled) {
         interactionSource.interactions.collect { interaction ->
             when (interaction) {
                 is PressInteraction.Press -> linkState = linkState.copy(pressed = true)


### PR DESCRIPTION
# Context
The link state isn't being updated with the user's interaction after being re-enabled. This PR fixes this.

## Bug Cause

We are updating the `linkState` variable if either the interaction source or the `enabled` flag changes:

`var linkState by remember(interactionSource, enabled) { mutableStateOf(LinkState.of(enabled = enabled)) }`

However, the coroutine that actually collects interaction events from the interaction source is only re-launched when the interaction source changes:

```kotlin
LaunchedEffect(interactionSource) {
    interactionSource.interactions.collect { interaction ->
        // update linkState based on interaction
    }
}
```

The problem is that once we disable a link, the `remember()` block runs again and creates a new object. However, the `linkState` being used by the `LaunchedEffect` is still referencing the old stale state. You can check that this is the case by adding some good old print statements, in the video below I added prints in: `is HoverInteraction.Enter -> linkState = linkState.copy(hovered = true)` and inside the `val mergedTextStyle = remember(style.underlineBehavior, textStyle, linkState, textColor)` block.

https://github.com/user-attachments/assets/1abc1d48-85ee-46c7-a34b-e9a0b25d9a45

You can see that, even though the `linkState` variable is being updated in the `isHoverInteraction.Enter` check, the `mergedTextStyle` itself is never recalculated. That's because they are observing different states.

The fix is to simply add `enabled` as one of the keys to `LaunchedEffect`, just like we do for `linkState` itself!

# Evidence
| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/fe7a5006-2a7f-4686-a844-06142f0114df" width="400" /> | <video src="https://github.com/user-attachments/assets/3479c730-e9b6-4281-b20c-8534f07386b9" width="400" /> |

## Release notes

### Bug fixes
 * `Link` now continues to update state related to interactions (such as hovering, clicking, focusing, etc.) after the link is re-enabled.