### PR TITLE
[JEWEL-901] Fixing popup destruction on clicking outside

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
@@ -49,7 +49,6 @@ import java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
 import java.awt.event.KeyEvent.KEY_LOCATION_UNKNOWN
 import java.awt.event.KeyEvent.KEY_PRESSED
 import java.awt.event.KeyEvent.KEY_RELEASED
-import java.awt.event.MouseEvent
 import org.jetbrains.jewel.bridge.JewelComposePanelWrapper
 import org.jetbrains.jewel.bridge.LocalComponent
 import org.jetbrains.jewel.bridge.compose
@@ -158,9 +157,9 @@ private fun JBPopup(
                 val composeEvent = event.toComposeKeyEvent()
                 onPreviewKeyEvent?.invoke(composeEvent) == true || onKeyEvent?.invoke(composeEvent) == true
             }
-            .setCancelOnMouseOutCallback {
-                if (it.button != MouseEvent.NOBUTTON) onDismissRequest?.invoke()
-                false
+            .setCancelCallback {
+                onDismissRequest?.invoke()
+                true
             }
             .createPopup()
     }
@@ -172,7 +171,7 @@ private fun JBPopup(
     }
 
     DisposableEffect(Unit) {
-        // Showing on the top-left corner of the owner component so we can measure and show it correctly
+        // Showing in the top-left corner of the owner component so we can measure and show it correctly
         popup.showInScreenCoordinates(owner, Point(0, 0))
         onDispose { popup.cancel() }
     }

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
@@ -53,8 +53,10 @@ import org.jetbrains.jewel.bridge.JewelComposePanel
 import org.jetbrains.jewel.bridge.retrieveEditorColorScheme
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.EditableListComboBox
 import org.jetbrains.jewel.ui.component.ExternalLink
 import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.ListComboBox
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextArea
@@ -376,7 +378,7 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                     }
                     .run { cell(this).align(AlignY.TOP) }
 
-                compose(modifier = Modifier.padding(horizontal = 8.dp, vertical = 0.dp)) {
+                compose(modifier = Modifier.padding(horizontal = 8.dp)) {
                     val comboBoxItems = remember {
                         listOf(
                             "Cat",
@@ -400,12 +402,12 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                             Text("Not editable")
                             Text(text = "Selected item: $selectedText")
 
-                            //                            ListComboBox(
-                            //                                items = comboBoxItems,
-                            //                                selectedIndex = selectedIndex,
-                            //                                onSelectedItemChange = { selectedIndex = it },
-                            //                                modifier = Modifier.width(200.dp),
-                            //                            )
+                            ListComboBox(
+                                items = comboBoxItems,
+                                selectedIndex = selectedIndex,
+                                onSelectedItemChange = { selectedIndex = it },
+                                modifier = Modifier.width(200.dp),
+                            )
                         }
 
                         Column {
@@ -415,13 +417,13 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                             Text("Not editable + disabled")
                             Text(text = "Selected item: $selectedText")
 
-                            //                            ListComboBox(
-                            //                                items = comboBoxItems,
-                            //                                selectedIndex = selectedIndex,
-                            //                                onSelectedItemChange = { selectedIndex = it },
-                            //                                modifier = Modifier.width(200.dp),
-                            //                                enabled = false,
-                            //                            )
+                            ListComboBox(
+                                items = comboBoxItems,
+                                selectedIndex = selectedIndex,
+                                onSelectedItemChange = { selectedIndex = it },
+                                modifier = Modifier.width(200.dp),
+                                enabled = false,
+                            )
                         }
 
                         Column {
@@ -431,13 +433,13 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                             Text("Editable")
                             Text(text = "Selected item: $selectedText")
 
-                            //                            EditableListComboBox(
-                            //                                items = comboBoxItems,
-                            //                                selectedIndex = selectedIndex,
-                            //                                onSelectedItemChange = { selectedIndex = it },
-                            //                                modifier = Modifier.width(200.dp),
-                            //                                maxPopupHeight = 150.dp,
-                            //                            )
+                            EditableListComboBox(
+                                items = comboBoxItems,
+                                selectedIndex = selectedIndex,
+                                onSelectedItemChange = { selectedIndex = it },
+                                modifier = Modifier.width(200.dp),
+                                maxPopupHeight = 150.dp,
+                            )
                         }
 
                         Column {
@@ -447,13 +449,13 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                             Text("Editable + disabled")
                             Text(text = "Selected item: $selectedText")
 
-                            //                            EditableListComboBox(
-                            //                                items = comboBoxItems,
-                            //                                selectedIndex = selectedIndex,
-                            //                                onSelectedItemChange = { selectedIndex = it },
-                            //                                modifier = Modifier.width(200.dp),
-                            //                                enabled = false,
-                            //                            )
+                            EditableListComboBox(
+                                items = comboBoxItems,
+                                selectedIndex = selectedIndex,
+                                onSelectedItemChange = { selectedIndex = it },
+                                modifier = Modifier.width(200.dp),
+                                enabled = false,
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
- When clicking outside of the popup, the JBPopup was getting destroyed, but the composable node was still present;
- As the composable node was still there, it was requiring an extra click to properly destroy it and be able to show again;

| When | Recording |
| --- | --- |
| Before | ![Screen Recording 2025-07-16 at 19 15 50](https://github.com/user-attachments/assets/e8c66b5a-242d-474b-9dd7-1701df8210c5)
| After | ![Screen Recording 2025-07-16 at 19 25 15](https://github.com/user-attachments/assets/7e98a96a-9a87-4ada-9f33-f2a598f2d890)


## Release notes

### Bug fixes
 * Fixed an issue in the JBPopup API where the popup was getting destroyed, but the node wasn't. It was resulting in the need for two clicks to open the popups again

