### PR TITLE
K2 UAST: try underlying symbol's PSI first for annotation resolution

### DIFF
--- a/plugins/kotlin/uast/uast-kotlin-fir/src/org/jetbrains/uast/kotlin/internal/firKotlinInternalUastUtils.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/src/org/jetbrains/uast/kotlin/internal/firKotlinInternalUastUtils.kt
@@ -76,7 +76,15 @@ internal fun toPsiClass(
     typeOwnerKind: TypeOwnerKind,
     isBoxed: Boolean = true,
 ): PsiClass? {
+    // Try the underlying symbol's PSI first, if any.
+    // For the declaration from the Library, this will give
+    // [FirKotlinUastLibraryPsiProviderService] a chance to provide a PSI.
+    (ktType as? KaClassType)?.symbol?.let { classSymbol ->
+        psiForUast(classSymbol, context) as? PsiClass
+    }?.let { return it }
+    // Next, try SLC conversion if from Kotlin
     (context as? KtClass)?.toLightClass()?.let { return it }
+    // Then, use JavaPsiFacade if from Java
     return PsiTypesUtil.getPsiClass(
         toPsiType(
             ktType,

--- a/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/FirUastResolveApiFixtureTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/FirUastResolveApiFixtureTest.kt
@@ -326,6 +326,10 @@ class FirUastResolveApiFixtureTest : KotlinLightCodeInsightFixtureTestCase(), Ua
         checkResolveConstructorCallFromLibrary(myFixture)
     }
 
+    fun testResolveAnnotationConstructorCallFromLibrary() {
+        checkResolveAnnotationConstructorCallFromLibrary(myFixture)
+    }
+
     fun testResolveTopLevelInlineReifiedFromLibrary() {
         checkResolveTopLevelInlineReifiedFromLibrary(myFixture, withJvmName = false)
     }

--- a/plugins/kotlin/uast/uast-kotlin/tests/test/org/jetbrains/uast/test/kotlin/comparison/FE1UastResolveApiFixtureTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin/tests/test/org/jetbrains/uast/test/kotlin/comparison/FE1UastResolveApiFixtureTest.kt
@@ -286,6 +286,10 @@ class FE1UastResolveApiFixtureTest : KotlinLightCodeInsightFixtureTestCase(), Ua
         checkResolveConstructorCallFromLibrary(myFixture)
     }
 
+    fun testResolveAnnotationConstructorCallFromLibrary() {
+        checkResolveAnnotationConstructorCallFromLibrary(myFixture)
+    }
+
     fun testResolveTopLevelInlineReifiedFromLibrary() {
         checkResolveTopLevelInlineReifiedFromLibrary(myFixture, withJvmName = false)
     }


### PR DESCRIPTION
That way, we can give FirKotlinUastLibraryPsiProviderService a chance to look through any binary dependencies, including klib.

^KTIJ-34942 fixed