### PR TITLE
Map GitHub issue labels to Task types for Task Tracking.

### DIFF
--- a/plugins/github/github-tracker/BUILD.bazel
+++ b/plugins/github/github-tracker/BUILD.bazel
@@ -28,3 +28,36 @@ jvm_library(
   runtime_deps = [":vcs-github-tracker_resources"]
 )
 ### auto-generated section `build intellij.vcs.github.tracker` end
+
+### auto-generated section `test intellij.vcs.github.tracker` start
+load("@community//build:tests-options.bzl", "jps_test")
+
+jvm_library(
+  name = "vcs-github-tracker_test_lib",
+  srcs = glob(
+    [
+      "src/**/*.kt",
+      "src/**/*.java",
+      "test/**/*.kt",
+      "test/**/*.java",
+    ],
+    allow_empty = True,
+  ),
+  associates = [":vcs-github-tracker"],
+  visibility = ["//visibility:private"],
+  deps = [
+    "//platform/testFramework",
+    "//platform/testFramework:testFramework_test_lib",
+    "@lib//:assert_j",
+    "@lib//:junit5",
+  ],
+)
+
+jps_test(
+  name = "vcs-github-tracker_test",
+  runtime_deps = [
+    ":vcs-github-tracker",
+    ":vcs-github-tracker_test_lib",
+  ],
+)
+### auto-generated section `test intellij.vcs.github.tracker` end

--- a/plugins/github/github-tracker/intellij.vcs.github.tracker.iml
+++ b/plugins/github/github-tracker/intellij.vcs.github.tracker.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -19,5 +20,6 @@
     <orderEntry type="module" module-name="intellij.platform.core.ui" />
     <orderEntry type="library" name="kotlin-stdlib" level="project" />
     <orderEntry type="module" module-name="intellij.platform.ide.impl" />
+    <orderEntry type="library" scope="TEST" name="JUnit5" level="project" />
   </component>
 </module>

--- a/plugins/github/github-tracker/src/org/jetbrains/plugins/github/tasks/GithubRepository.java
+++ b/plugins/github/github-tracker/src/org/jetbrains/plugins/github/tasks/GithubRepository.java
@@ -23,6 +23,7 @@ import org.jetbrains.plugins.github.api.GithubServerPath;
 import org.jetbrains.plugins.github.api.data.GithubIssue;
 import org.jetbrains.plugins.github.api.data.GithubIssueBase;
 import org.jetbrains.plugins.github.api.data.GithubIssueCommentWithHtml;
+import org.jetbrains.plugins.github.api.data.GithubIssueLabel;
 import org.jetbrains.plugins.github.api.data.GithubIssueState;
 import org.jetbrains.plugins.github.api.util.GithubApiPagesLoader;
 import org.jetbrains.plugins.github.exceptions.GithubAuthenticationException;
@@ -203,7 +204,21 @@ final class GithubRepository extends BaseRepository {
 
       @Override
       public @NotNull TaskType getType() {
-        return TaskType.BUG;
+        List<GithubIssueLabel> labels = issue.getLabels();
+        if (labels == null || labels.isEmpty()) return TaskType.OTHER;
+
+        // Map GitHub's default labels to TaskType
+        for (GithubIssueLabel label : labels) {
+          String name = label.getName();
+          switch (name) {
+            case "bug":
+              return TaskType.BUG;
+            case "enhancement":
+              return TaskType.FEATURE;
+          }
+        }
+
+        return TaskType.OTHER;
       }
 
       @Override

--- a/plugins/github/github-tracker/test/org/jetbrains/plugins/github/tasks/GithubRepositoryTest.java
+++ b/plugins/github/github-tracker/test/org/jetbrains/plugins/github/tasks/GithubRepositoryTest.java
@@ -1,0 +1,129 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.github.tasks;
+
+import com.intellij.tasks.Task;
+import com.intellij.tasks.TaskType;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.github.api.data.GithubIssueBase;
+import org.jetbrains.plugins.github.api.data.GithubIssueCommentWithHtml;
+import org.jetbrains.plugins.github.api.data.GithubIssueLabel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GithubRepositoryTest {
+
+  private GithubRepository repository;
+
+  @BeforeEach
+  public void setUp() {
+    repository = new GithubRepository();
+  }
+
+  @Test
+  public void testCreateTaskBug() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    GithubIssueBase issue = makeIssueWithLabels(Collections.singletonList("bug"));
+    Task task = createTask(repository, issue, Collections.emptyList());
+    assertEquals(TaskType.BUG, task.getType());
+  }
+
+  @Test
+  public void testCreateTaskFeature() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    GithubIssueBase issue = makeIssueWithLabels(Collections.singletonList("enhancement"));
+    Task task = createTask(repository, issue, Collections.emptyList());
+    assertEquals(TaskType.FEATURE, task.getType());
+  }
+
+  @Test
+  public void testCreateTaskUnmapped() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    // Test with a label that is not recognized as a specific type
+    GithubIssueBase issue = makeIssueWithLabels(Collections.singletonList("question"));
+    Task task = createTask(repository, issue, Collections.emptyList());
+    assertEquals(TaskType.OTHER, task.getType());
+  }
+
+  @Test
+  public void testCreateTaskMultipleLabelsMatchFirstWins() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    GithubIssueBase issue = makeIssueWithLabels(
+      List.of("bug", "enhancement", "feature", "task", "question") // Multiple labels including bug and enhancement
+    );
+    Task task = createTask(repository, issue, Collections.emptyList());
+    assertEquals(TaskType.BUG, task.getType());
+  }
+
+  @Test
+  public void testCreateTaskMultipleLabelsSingleMatch() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    GithubIssueBase issue = makeIssueWithLabels(
+      List.of("custom1", "enhancement", "custom2") // Multiple labels including enhancement in the middle
+    );
+    Task task = createTask(repository, issue, Collections.emptyList());
+    assertEquals(TaskType.FEATURE, task.getType());
+  }
+
+  @Test
+  public void testCreateTaskNoLabel() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    GithubIssueBase issue = makeIssueWithLabels(
+      Collections.emptyList()
+    );
+    Task task = createTask(repository, issue, Collections.emptyList());
+    assertEquals(TaskType.OTHER, task.getType());
+  }
+
+  /**
+   * Helper method to create a GithubIssueLabel instance for testing.
+   *
+   * @param name the name of the label
+   * @return a new instance of GithubIssueLabel with the specified name
+   */
+  public GithubIssueLabel makeLabel(String name) {
+    return new GithubIssueLabel() {
+      @Override
+      public @NotNull String getName() {
+        return name;
+      }
+    };
+  }
+
+  /**
+   * Helper method to create a GithubIssueBase instance with specified labels.
+   *
+   * @param labelNames the names of the labels to be associated with the issue
+   * @return a new instance of GithubIssueBase with the specified labels
+   */
+  public GithubIssueBase makeIssueWithLabels(@NotNull List<String> labelNames) {
+    List<GithubIssueLabel> labels = ContainerUtil.map(labelNames, name -> makeLabel(name));
+    return new GithubIssueBase() {
+      @Override
+      public List<GithubIssueLabel> getLabels() {
+        return labels;
+      }
+    };
+  }
+
+  /**
+   * Helper method to invoke the private createTask method using reflection.
+   *
+   * @param repo     the GithubRepository instance
+   * @param issue    the GithubIssueBase instance
+   * @param comments the list of comments associated with the issue
+   * @return a Task object created by the private createTask method
+   * @throws NoSuchMethodException     if the method is not found
+   * @throws InvocationTargetException if the method invocation fails
+   * @throws IllegalAccessException    if access to the method is denied
+   */
+  private static Task createTask(GithubRepository repo, GithubIssueBase issue, List<GithubIssueCommentWithHtml> comments)
+    throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method createTask = GithubRepository.class.getDeclaredMethod("createTask", GithubIssueBase.class, List.class);
+    createTask.setAccessible(true);
+    Task task = (Task) createTask.invoke(repo, issue, comments);
+    return task;
+  }
+
+}


### PR DESCRIPTION
### Summary

This change extends GitHub issue tracking integration to better infer `TaskType` based on default GitHub labels. Previously, **all GitHub issues were treated as `TaskType.BUG`**, represented with a 🐞 icon in the IDE's Task Tracking UI.

### What's Changed

Tasks are now categorized based on their GitHub labels:

```text
Github Label  → IntelliJ TaskType
----------------------------------
"bug"         → TaskType.BUG
"enhancement" → TaskType.FEATURE
(any other)   → TaskType.OTHER
```

* The label-matching logic is case-sensitive.
* Only default GitHub labels are supported.
* Custom mappings (e.g., for `TaskType.EXCEPTION`) are not currently implemented.

#### Additional Changes
Unit tests were added to the github-tracker module for the first time, so I've included the project and Bazel build configurations associated with adding the unit tests.

### Rationale

Improves issue-type accuracy in the task UI without requiring any custom configuration from the user.

### Testing

New unit tests are included to validate behavior across:

* No label
* Single mapped label
* Single unmapped label
* Multiple labels with mixed mapping
* Multiple mapped labels (first match wins)

All tests pass successfully on macOS ARM64.

Example test run:

```bash
❯ ./bazel.cmd test //plugins/github/github-tracker:vcs-github-tracker_test \
  --test_output=all --nocache_test_results
...
Test plan finished with 6 tests.
...
PASSED in 1.8s
Executed 1 out of 1 test: 1 test passes.
```
