### PR TITLE
[Debugger] Add a test for inline scope numbers integration with try finally blocks

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class InlineScopesAndK2IdeK2CodeEvaluateExpressionTestGenerated 
                 runTest("../testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("../testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("../testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/k2/test/org/jetbrains/kotlin/idea/k2/debugger/test/cases/K2IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class K2IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
                 runTest("../testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("../testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("../testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaIrKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IndyLambdaIrKotlinEvaluateExpressionTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class IndyLambdaIrKotlinEvaluateExpressionTestGenerated extends 
                 runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class InlineScopesAndK1IdeK2CodeEvaluateExpressionTestGenerated 
                 runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionInMppTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class IrKotlinEvaluateExpressionInMppTestGenerated extends Abstr
                 runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class IrKotlinEvaluateExpressionWithIRFragmentCompilerTestGenera
                 runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionInMppTestGenerated exte
                 runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
+++ b/plugins/kotlin/jvm-debugger/test/test/org/jetbrains/kotlin/idea/debugger/test/K1IdeK2CodeKotlinEvaluateExpressionTestGenerated.java
@@ -2669,6 +2669,11 @@ public abstract class K1IdeK2CodeKotlinEvaluateExpressionTestGenerated extends A
                 runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithNestedLambdas.kt");
             }
 
+            @TestMetadata("inlineStackTraceWithTryFinally.kt")
+            public void testInlineStackTraceWithTryFinally() throws Exception {
+                runTest("testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt");
+            }
+
             @TestMetadata("invisibleDeclarations.kt")
             public void testInvisibleDeclarations() throws Exception {
                 runTest("testData/evaluation/multipleBreakpoints/invisibleDeclarations.kt");

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.kt
@@ -1,0 +1,34 @@
+package inlineStackTraceWithTryFinally
+
+inline fun <R> analyze(
+    action: () -> R,
+): R {
+    println("Start")
+    return try {
+        action()
+    } finally {
+        println("End")
+    }
+}
+
+
+private fun foo(a: Int, b: Int) {
+    analyze {
+        foo() ?: return
+        println("$a $b")
+        //Breakpoint!
+        42
+    }
+}
+
+fun foo(): Int? = 42
+
+fun main() {
+    foo(1, 2)
+}
+
+// PRINT_FRAME
+// SHOW_KOTLIN_VARIABLES
+
+// EXPRESSION: a
+// RESULT: 1: I

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.out
@@ -1,0 +1,15 @@
+LineBreakpoint created at inlineStackTraceWithTryFinally.kt:20
+Run Java
+Connected to the target VM
+inlineStackTraceWithTryFinally.kt:20
+Compile bytecode for a
+InlineStackFrame analyze (inlineStackTraceWithTryFinally.kt:20)
+InlineStackFrame lambda 'analyze' in 'foo' (inlineStackTraceWithTryFinally.kt:10)
+    JavaValue[local] a: int = 1 (inlineStackTraceWithTryFinally.kt:15)
+    JavaValue[local] b: int = 2 (inlineStackTraceWithTryFinally.kt:15)
+KotlinStackFrame (inlineStackTraceWithTryFinally.kt:10)
+    JavaValue[local] a: int = 1 (inlineStackTraceWithTryFinally.kt:15)
+    JavaValue[local] b: int = 2 (inlineStackTraceWithTryFinally.kt:15)
+Disconnected from the target VM
+
+Process finished with exit code 0

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.scopes.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/multipleBreakpoints/inlineStackTraceWithTryFinally.scopes.out
@@ -1,0 +1,15 @@
+LineBreakpoint created at inlineStackTraceWithTryFinally.kt:20
+Run Java
+Connected to the target VM
+inlineStackTraceWithTryFinally.kt:20
+Compile bytecode for a
+InlineStackFrame analyze (inlineStackTraceWithTryFinally.kt:20)
+InlineStackFrame lambda 'analyze' in 'foo' (inlineStackTraceWithTryFinally.kt:16)
+    JavaValue[local] a: int = 1 (inlineStackTraceWithTryFinally.kt:15)
+    JavaValue[local] b: int = 2 (inlineStackTraceWithTryFinally.kt:15)
+KotlinStackFrame (inlineStackTraceWithTryFinally.kt:8)
+    JavaValue[local] a: int = 1 (inlineStackTraceWithTryFinally.kt:15)
+    JavaValue[local] b: int = 2 (inlineStackTraceWithTryFinally.kt:15)
+Disconnected from the target VM
+
+Process finished with exit code 0


### PR DESCRIPTION
Hi @zuevmaxim! 
This commit simply adds a test checking that inline scope numbers are processed correctly in a case with try finally. 
See https://youtrack.jetbrains.com/issue/KT-62934/Incorrect-line-mapping-inside-inline-lambda-after-non-local-return.