### PR TITLE
[JEWEL-906] Mandate valid JEWEL issue ID in single commit messages

### DIFF
--- a/.github/workflows/jewel_checks.yml
+++ b/.github/workflows/jewel_checks.yml
@@ -11,16 +11,18 @@ defaults:
 
 jobs:
   checks:
+    name: CI code checks
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+        name: Check out repository
 
-      - name: Set up JDK 21
+      - name: Set up JBR 21
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: zulu
+          distribution: jetbrains
           cache: gradle
 
       - name: Grant execute permission for gradlew
@@ -37,3 +39,54 @@ jobs:
       - name: Run ktfmt and ktlint checks on IDE plugin
         # We can only use static analysis that doesn't depend on compilation in the IDE plugin
         run: ./gradlew :samples:ide-plugin:ktfmtCheck :samples:ide-plugin:lintKotlinMain --continue --no-daemon
+
+  check_paths:
+    name: Check changed files
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      run_formalities: ${{ steps.filter.outputs.run_formalities }}
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Check out repository
+
+      - uses: dorny/paths-filter@v3
+        name: Check which files are changed
+        id: filter
+        with:
+          filters: |
+            run_formalities:
+              - '!all(platform/jewel/ui/generated/org/jetbrains/jewel/ui/icons/AllIconsKeys.java)'
+
+  formalities:
+    name: PR formalities
+    runs-on: ubuntu-latest
+    needs: check_paths
+    if: needs.check_paths.outputs.run_formalities == 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Check out repository
+        with:
+          # Assume we don't have more than 10 commits in the branch —
+          # if we do, it'll fail on the single-commit check anyway.
+          fetch-depth: 10
+
+      - name: Validate PR has single commit
+        run: |
+          commit_count=$(git rev-list --count ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          if [ "$commit_count" -ne 1 ]; then
+            echo "ERROR: This pull request must contain exactly one commit."
+            echo "Please squash your commits into a single commit."
+            exit 1
+          fi
+
+      - name: Grant execute permission for validation script
+        run: chmod +x validate-commit-message.sh
+
+      - name: Validate commit message
+        env:
+          JEWEL_YT_TOKEN: ${{ secrets.JEWEL_YT_TOKEN }}
+        run: ./validate-commit-message.sh "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"

--- a/platform/jewel/validate-commit-message.sh
+++ b/platform/jewel/validate-commit-message.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+echoerr() {
+  echo -e "\033[0;31m$@\033[0m" 1>&2
+}
+
+commit_range="$1"
+if [ -z "$commit_range" ]; then
+  echoerr "ERROR: Commit range not provided."
+  exit 1
+fi
+
+echo "Checking commits in range: $commit_range"
+
+git log --format=%s "$commit_range" | while IFS= read -r message; do
+  # 1. Validate commit message format.
+  # The regex checks for a ticket ID like [JEWEL-123] followed by a space.
+  # Using [[:space:]] is slightly more robust than a literal space ' '.
+  if [[ ! "$message" =~ ^\[(JEWEL-[0-9]+)\][[:space:]] ]]; then
+    echoerr "ERROR: Invalid commit message format: '$message'"
+    echoerr "Each commit message must start with '[JEWEL-xxx] ', where xxx is a YouTrack issue number."
+    exit 1
+  fi
+
+  # 2. If a secret is available, validate the issue against the YouTrack API.
+  if [ -n "$JEWEL_YT_TOKEN" ]; then
+    issue_id=${BASH_REMATCH[1]}
+    echo "YouTrack token is present, validating issue $issue_id..."
+
+    # Obtain the draft and resolved status of the issue, and append the HTTP status code.
+    # The -s flag silences progress, and -w "%{http_code}" appends the status code to the output.
+    response=$(curl -s -w "%{http_code}" \
+      -H "Authorization: Bearer $JEWEL_YT_TOKEN" \
+      -H "Accept: application/json" \
+      "https://youtrack.jetbrains.com/api/issues/$issue_id?fields=resolved,isDraft")
+
+    # Extract the HTTP status code and the JSON body from the response string.
+    http_code=${response: -3}
+    body_len=$((${#response} - 3))
+    body=${response:0:$body_len}
+
+    if [ "$http_code" -ne 200 ]; then
+      echoerr "ERROR: YouTrack issue $issue_id not found or there was an API error."
+      echoerr "HTTP status: $http_code"
+      echoerr "Please check the issue ID and your YouTrack permissions."
+      exit 1
+    fi
+
+    # Use jq to parse the JSON response.
+    is_resolved=$(echo "$body" | jq -r '.resolved')
+    if [ "$is_resolved" != "null" ]; then
+      echoerr "ERROR: YouTrack issue $issue_id is already resolved."
+      exit 1
+    fi
+
+    is_draft=$(echo "$body" | jq -r '.isDraft')
+    if [ "$is_draft" == "true" ]; then
+      echoerr "ERROR: YouTrack issue $issue_id is a draft."
+      exit 1
+    fi
+
+    echo "Issue $issue_id is valid and not resolved or a draft."
+  else
+    echo -e "\033[1;33mYouTrack token is not present, skipping YouTrack validation.\033[0m"
+  fi
+done


### PR DESCRIPTION
This adds a check to GitHub Actions that validates:
 1. The PR has only one commit
 2. The commit message starts with "[JEWEL-xxx] ", where xxx is a positive number

These checks only run if the PR contains changes in the Jewel folder other than `AllIconsKeys`. That gets autogenerated by a script when any changes are made to IJP icons, and is high-traffic. Any IJP dev can run the script, and it should not block PRs added elsewhere in the IJP that update the icons.

Additionally, if there is a `JEWEL_YT_TOKEN` secret defined, the check also validates that the referenced issue is valid — meaning, it exists, is not resolved, and not a draft.