### PR TITLE
[JEWEL-910] Fix GitHub CI to use the JBR

### DIFF
--- a/.github/workflows/jewel_checks.yml
+++ b/.github/workflows/jewel_checks.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: zulu
+          distribution: jetbrains
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/platform/jewel/settings.gradle.kts
+++ b/platform/jewel/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-    plugins { kotlin("jvm") version "2.1.0" }
+    plugins { kotlin("jvm") version "2.2.20" }
 }
 
 dependencyResolutionManagement {
@@ -27,8 +27,8 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise") version "3.15.1"
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("com.gradle.develocity") version "4.1"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 include(
@@ -53,11 +53,10 @@ include(
     ":ui-tests",
 )
 
-gradleEnterprise {
+develocity {
     buildScan {
-        publishAlwaysIf(System.getenv("CI") == "true")
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        publishing.onlyIf { System.getenv("CI") == "true" }
+        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+        termsOfUseAgree.set("yes")
     }
 }
-


### PR DESCRIPTION
The CI stopped working seemingly overnight due to Gradle needing the JetBrains Runtime, and the agents not having it. This makes the agents use the JBR runtime instead of `zulu`, and updates the foojay plugin to the latest version (as the plugin should be able to download the JBR if missing anyway, so maybe that stopped working?).

This also bumps the Kotlin version in the Gradle build to match IJP 252, and replaces the deprecated Gradle Enterprise plugin with the new Develocity one.