### PR TITLE
[JEWEL-915] Clean up unnecessary entry point APIs

### DIFF
--- a/platform/jewel/ide-laf-bridge/api-dump-experimental.txt
+++ b/platform/jewel/ide-laf-bridge/api-dump-experimental.txt
@@ -6,10 +6,6 @@ f:org.jetbrains.jewel.bridge.BridgeUtilsKt
 f:org.jetbrains.jewel.bridge.JewelComposePanelWrapperKt
 - *sf:JewelComposeNoThemePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - *bs:JewelComposeNoThemePanel$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
-- *sf:JewelToolWindowNoThemeComposePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
-- *bs:JewelToolWindowNoThemeComposePanel$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
-- *sf:composeForToolWindowWithoutTheme(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
-- *bs:composeForToolWindowWithoutTheme$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - *sf:composeWithoutTheme(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - *bs:composeWithoutTheme$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - *sf:getLocalComponent():androidx.compose.runtime.ProvidableCompositionLocal

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
@@ -18,14 +18,31 @@ import org.jetbrains.jewel.bridge.actionSystem.ComponentDataProviderBridge
 import org.jetbrains.jewel.bridge.component.JBPopupRenderer
 import org.jetbrains.jewel.bridge.theme.SwingBridgeTheme
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
-import org.jetbrains.jewel.foundation.InternalJewelApi
 import org.jetbrains.jewel.foundation.util.JewelLogger
 import org.jetbrains.jewel.ui.component.LocalPopupRenderer
 import org.jetbrains.jewel.ui.util.LocalMessageResourceResolverProvider
 
+/**
+ * Creates a Swing component that can host Compose content.
+ *
+ * The [content] is wrapped in a [SwingBridgeTheme], which will be derived from the current Swing LaF.
+ *
+ * @param config A lambda to configure the underlying [ComposePanel].
+ * @param content The Composable content to display.
+ */
 public fun compose(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposePanel(config, content)
 
+/**
+ * Creates a Swing component that can host Compose content.
+ *
+ * The [content] is wrapped in a [SwingBridgeTheme], which will be derived from the current Swing LaF.
+ *
+ * This is the same as [compose].
+ *
+ * @param config A lambda to configure the underlying [ComposePanel].
+ * @param content The Composable content to display.
+ */
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JewelComposePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     createJewelComposePanel { jewelPanel ->
@@ -42,32 +59,34 @@ public fun JewelComposePanel(config: ComposePanel.() -> Unit = {}, content: @Com
         }
     }
 
-@ApiStatus.Internal
-@InternalJewelApi
-@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-public fun JewelToolWindowComposePanel(
-    config: ComposePanel.() -> Unit = {},
-    content: @Composable () -> Unit,
-): JComponent = createJewelComposePanel { jewelPanel ->
-    config()
-    setContent {
-        SwingBridgeTheme {
-            CompositionLocalProvider(
-                LocalComponent provides this@createJewelComposePanel,
-                LocalPopupRenderer provides JBPopupRenderer,
-            ) {
-                ComponentDataProviderBridge(jewelPanel, content = content)
-            }
-        }
-    }
-}
-
+/**
+ * Creates a Swing component that can host Compose content.
+ *
+ * The [content] is **not** wrapped in a theme, meaning that you **MUST** wrap the content in a theme by yourself.
+ *
+ * This is not normally what you want; use this only if you want to provide a completely custom theme.
+ *
+ * @param config A lambda to configure the underlying [ComposePanel].
+ * @param content The Composable content to display.
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @Suppress("ktlint:standard:function-naming") // Swing to Compose bridge API
 public fun composeWithoutTheme(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposeNoThemePanel(config, content)
 
+/**
+ * Creates a Swing component that can host Compose content.
+ *
+ * The [content] is **not** wrapped in a theme, meaning that you **MUST** wrap the content in a theme by yourself.
+ *
+ * This is not normally what you want; use this only if you want to provide a completely custom theme.
+ *
+ * This is the same as [composeWithoutTheme].
+ *
+ * @param config A lambda to configure the underlying [ComposePanel].
+ * @param content The Composable content to display.
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
@@ -84,33 +103,6 @@ public fun JewelComposeNoThemePanel(config: ComposePanel.() -> Unit = {}, conten
             }
         }
     }
-
-@ApiStatus.Experimental
-@ExperimentalJewelApi
-@Suppress("ktlint:standard:function-naming") // Swing to Compose bridge API
-public fun composeForToolWindowWithoutTheme(
-    config: ComposePanel.() -> Unit = {},
-    content: @Composable () -> Unit,
-): JComponent = JewelToolWindowNoThemeComposePanel(config, content)
-
-@ApiStatus.Experimental
-@ExperimentalJewelApi
-@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-public fun JewelToolWindowNoThemeComposePanel(
-    config: ComposePanel.() -> Unit = {},
-    content: @Composable () -> Unit,
-): JComponent = createJewelComposePanel { jewelPanel ->
-    config()
-    setContent {
-        CompositionLocalProvider(
-            LocalComponent provides this@createJewelComposePanel,
-            LocalPopupRenderer provides JBPopupRenderer,
-            LocalMessageResourceResolverProvider provides BridgeMessageResourceResolver(),
-        ) {
-            ComponentDataProviderBridge(jewelPanel, content = content)
-        }
-    }
-}
 
 private fun createJewelComposePanel(config: ComposePanel.(JewelComposePanelWrapper) -> Unit): JewelComposePanelWrapper {
     if (System.getProperty("skiko.library.path") == null) {
@@ -155,6 +147,8 @@ internal class JewelComposePanelWrapper : JPanel(), UiDataProvider {
     }
 }
 
+/** Provides the root component used to host the current Compose hierarchy. */
+@Suppress("CompositionLocalAllowlist")
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public val LocalComponent: ProvidableCompositionLocal<JComponent> = staticCompositionLocalOf {

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
@@ -5,6 +5,14 @@ import com.intellij.openapi.util.NlsContexts.TabTitle
 import com.intellij.openapi.wm.ToolWindow
 import org.jetbrains.jewel.foundation.enableNewSwingCompositing
 
+/**
+ * Adds a new tab to the tool window with Compose content.
+ *
+ * @param tabDisplayName The title of the tab.
+ * @param isLockable Whether the tab can be locked.
+ * @param isCloseable Whether the tab can be closed.
+ * @param content The Composable content of the tab.
+ */
 public fun ToolWindow.addComposeTab(
     @TabTitle tabDisplayName: String? = null,
     isLockable: Boolean = true,
@@ -17,7 +25,7 @@ public fun ToolWindow.addComposeTab(
 
     val tabContent =
         contentManager.factory.createContent(
-            JewelToolWindowComposePanel {
+            JewelComposePanel {
                 val scope =
                     object : ToolWindowScope {
                         override val toolWindow: ToolWindow
@@ -32,6 +40,8 @@ public fun ToolWindow.addComposeTab(
     contentManager.addContent(tabContent)
 }
 
+/** A scope for the content of a tool window tab. */
 public interface ToolWindowScope {
+    /** The tool window in which the tab is displayed. */
     public val toolWindow: ToolWindow
 }

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/JewelDemoToolWindowFactory.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/JewelDemoToolWindowFactory.kt
@@ -1,18 +1,12 @@
 package org.jetbrains.jewel.samples.ideplugin
 
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.NlsContexts.TabTitle
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import javax.swing.JComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import org.jetbrains.jewel.bridge.addComposeTab
 import org.jetbrains.jewel.foundation.JewelFlags
 import org.jetbrains.jewel.samples.ideplugin.releasessample.ReleasesSampleCompose
@@ -39,12 +33,4 @@ internal class JewelDemoToolWindowFactory : ToolWindowFactory, DumbAware {
         tabContent.isCloseable = false
         manager.addContent(tabContent)
     }
-}
-
-@Suppress("InjectDispatcher") // This is likely wrong anyway, it's only for the demo
-private fun Disposable.createCoroutineScope(): CoroutineScope {
-    val job = SupervisorJob()
-    val scopeDisposable = Disposable { job.cancel("Disposing") }
-    Disposer.register(this, scopeDisposable)
-    return CoroutineScope(job + Dispatchers.Default)
 }

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/dialog/ComponentShowcaseDialog.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/dialog/ComponentShowcaseDialog.kt
@@ -1,12 +1,9 @@
 package org.jetbrains.jewel.samples.ideplugin.dialog
 
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.intellij.ide.ui.UISettings
 import com.intellij.openapi.project.Project
@@ -16,19 +13,17 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.JBUI.CurrentTheme.Toolbar
 import java.awt.Dimension
 import javax.swing.JComponent
-import org.jetbrains.jewel.bridge.JewelComposePanel
+import org.jetbrains.jewel.bridge.compose
 import org.jetbrains.jewel.bridge.retrieveArcAsCornerSizeOrDefault
 import org.jetbrains.jewel.bridge.theme.default
 import org.jetbrains.jewel.bridge.theme.macOs
 import org.jetbrains.jewel.bridge.toDpSize
 import org.jetbrains.jewel.bridge.toPaddingValues
-import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.markdown.bridge.ProvideMarkdownStyling
 import org.jetbrains.jewel.samples.showcase.views.ComponentsView
 import org.jetbrains.jewel.samples.showcase.views.ComponentsViewModel
 import org.jetbrains.jewel.ui.component.styling.IconButtonMetrics
 import org.jetbrains.jewel.ui.component.styling.ScrollbarVisibility
-import org.jetbrains.jewel.ui.theme.iconButtonStyle
 
 internal class ComponentShowcaseDialog(project: Project) : DialogWrapper(project) {
     init {
@@ -47,27 +42,23 @@ internal class ComponentShowcaseDialog(project: Project) : DialogWrapper(project
                 whenScrollingScrollbarVisibility = ScrollbarVisibility.WhenScrolling.macOs(),
             )
 
-        val dialogPanel = JewelComposePanel {
-            val iconButtonMetrics = JewelTheme.iconButtonStyle.metrics
-            val uiSettings = UISettings.Companion.getInstance()
-            ProvideMarkdownStyling { RootLayout(viewModel, uiSettings, iconButtonMetrics) }
+        val dialogPanel = compose {
+            val uiSettings = UISettings.getInstance()
+            ProvideMarkdownStyling { RootLayout(viewModel, uiSettings) }
         }
         dialogPanel.preferredSize = Dimension(800, 600)
         return dialogPanel
     }
 
+    @Suppress("ViewModelForwarding")
     @OptIn(ExperimentalLayoutApi::class)
     @Composable
-    private fun RootLayout(
-        viewModel: ComponentsViewModel,
-        uiSettings: UISettings,
-        iconButtonMetrics: IconButtonMetrics,
-    ) {
+    private fun RootLayout(viewModel: ComponentsViewModel, uiSettings: UISettings) {
         ComponentsView(
             viewModel = viewModel,
             toolbarButtonMetrics =
                 remember(uiSettings.compactMode, ResizeStripeManager.isShowNames()) {
-                    iconButtonMetrics.tweak(
+                    IconButtonMetrics(
                         minSize = Toolbar.stripeToolbarButtonSize().toDpSize(),
                         // See com.intellij.openapi.wm.impl.SquareStripeButtonLook.getButtonArc
                         cornerSize =
@@ -86,11 +77,4 @@ internal class ComponentShowcaseDialog(project: Project) : DialogWrapper(project
                 },
         )
     }
-
-    private fun IconButtonMetrics.tweak(
-        cornerSize: CornerSize = this.cornerSize,
-        borderWidth: Dp = this.borderWidth,
-        padding: PaddingValues = this.padding,
-        minSize: DpSize = this.minSize,
-    ) = IconButtonMetrics(cornerSize, borderWidth, padding, minSize)
 }

--- a/platform/jewel/samples/showcase/api-dump.txt
+++ b/platform/jewel/samples/showcase/api-dump.txt
@@ -175,8 +175,8 @@ f:org.jetbrains.jewel.samples.showcase.components.TooltipsKt
 f:org.jetbrains.jewel.samples.showcase.components.TypographyKt
 - sf:TypographyShowcase(androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.samples.showcase.views.ComponentsViewKt
-- sf:ComponentsToolBar(org.jetbrains.jewel.samples.showcase.views.ComponentsViewModel,org.jetbrains.jewel.ui.component.styling.IconButtonMetrics,androidx.compose.runtime.Composer,I):V
-- sf:ComponentsView(org.jetbrains.jewel.samples.showcase.views.ComponentsViewModel,org.jetbrains.jewel.ui.component.styling.IconButtonMetrics,androidx.compose.runtime.Composer,I):V
+- sf:ComponentsToolBar(org.jetbrains.jewel.ui.component.styling.IconButtonMetrics,java.util.List,org.jetbrains.jewel.samples.showcase.views.ViewInfo,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I,I):V
+- sf:ComponentsView(org.jetbrains.jewel.samples.showcase.views.ComponentsViewModel,org.jetbrains.jewel.ui.component.styling.IconButtonMetrics,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.samples.showcase.views.ComponentsViewModel
 - sf:$stable:I
 - <init>(org.jetbrains.jewel.ui.component.styling.ScrollbarVisibility$AlwaysVisible,org.jetbrains.jewel.ui.component.styling.ScrollbarVisibility$WhenScrolling):V

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/views/ComponentsView.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/views/ComponentsView.kt
@@ -38,9 +38,18 @@ import org.jetbrains.jewel.ui.typography
 
 @ExperimentalLayoutApi
 @Composable
-public fun ComponentsView(viewModel: ComponentsViewModel, toolbarButtonMetrics: IconButtonMetrics) {
-    Row(Modifier.trackActivation().fillMaxSize().background(JewelTheme.globalColors.panelBackground)) {
-        ComponentsToolBar(viewModel, toolbarButtonMetrics)
+public fun ComponentsView(
+    viewModel: ComponentsViewModel,
+    toolbarButtonMetrics: IconButtonMetrics,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier.trackActivation().fillMaxSize().background(JewelTheme.globalColors.panelBackground)) {
+        ComponentsToolBar(
+            buttonMetrics = toolbarButtonMetrics,
+            views = viewModel.getViews(),
+            currentView = viewModel.getCurrentView(),
+            setCurrentView = { viewModel.setCurrentView(it) },
+        )
         Divider(Orientation.Vertical, Modifier.fillMaxHeight())
         ComponentView(viewModel.getCurrentView())
     }
@@ -48,19 +57,25 @@ public fun ComponentsView(viewModel: ComponentsViewModel, toolbarButtonMetrics: 
 
 @ExperimentalLayoutApi
 @Composable
-public fun ComponentsToolBar(viewModel: ComponentsViewModel, buttonMetrics: IconButtonMetrics) {
+public fun ComponentsToolBar(
+    buttonMetrics: IconButtonMetrics,
+    views: List<ViewInfo>,
+    currentView: ViewInfo,
+    setCurrentView: (ViewInfo) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     ZeroDelayNeverHideTooltips {
-        Column(Modifier.fillMaxHeight().verticalScroll(rememberScrollState())) {
+        Column(modifier.fillMaxHeight().verticalScroll(rememberScrollState())) {
             val iconButtonStyle = JewelTheme.iconButtonStyle
             val style = remember(iconButtonStyle) { IconButtonStyle(iconButtonStyle.colors, buttonMetrics) }
-            viewModel.getViews().forEach {
+            views.forEach { viewInfo ->
                 SelectableIconActionButton(
-                    key = it.iconKey,
-                    contentDescription = "Show ${it.title}",
-                    selected = viewModel.getCurrentView() == it,
-                    onClick = { viewModel.setCurrentView(it) },
+                    key = viewInfo.iconKey,
+                    contentDescription = "Show ${viewInfo.title}",
+                    selected = currentView == viewInfo,
+                    onClick = { setCurrentView(viewInfo) },
                     style = style,
-                    tooltip = { Text(it.title) },
+                    tooltip = { Text(viewInfo.title) },
                     tooltipPlacement = TooltipPlacement.ComponentRect(Alignment.CenterEnd, Alignment.CenterEnd),
                     extraHints = arrayOf(Size(20)),
                 )


### PR DESCRIPTION
This removes the following experimental APIs:
 * `JewelToolWindowNoThemeComposePanel`
 * `composeForToolWindowWithoutTheme`

And the internal `JewelToolWindowComposePanel`, since they are doing the exact same thing as their non-ToolWindow counterparts. It also adds KDoc to the remaining JewelComposePanelWrapper APIs, and to the ToolWindowExtensions API.

It also cleans up a tad the IDE plugin and showcase modules code.

## Release notes

### ⚠️ Important Changes
 * Removed the experimental `JewelToolWindowNoThemeComposePanel` and `composeForToolWindowWithoutTheme` APIs — they were identical to the non-ToolWindow variants.