### PR TITLE
[JEWEL-918] Fix checkbox and radio button icons in Darcula

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
@@ -311,6 +311,8 @@ internal fun lafName(): String {
     return lafInfo.name
 }
 
+internal fun isDarculaTheme(): Boolean = lafName() == "Darcula"
+
 @Suppress("UnstableApiUsage") // We need to use @Internal APIs
 public fun retrieveEditorColorScheme(): EditorColorsScheme {
     val manager = EditorColorsManager.getInstance() as EditorColorsManagerImpl

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeCheckbox.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeCheckbox.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
+import org.jetbrains.jewel.bridge.isDarculaTheme
 import org.jetbrains.jewel.bridge.isNewUiTheme
 import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
 import org.jetbrains.jewel.bridge.retrieveIntAsNonNegativeDpOrUnspecified
@@ -24,7 +25,7 @@ internal fun readCheckboxStyle(): CheckboxStyle {
         )
 
     val newUiTheme = isNewUiTheme()
-    val metrics = if (newUiTheme) NewUiCheckboxMetrics else ClassicUiCheckboxMetrics
+    val metrics = if (newUiTheme && !isDarculaTheme()) NewUiCheckboxMetrics else ClassicUiCheckboxMetrics
 
     // This value is not normally defined in the themes, but Swing checks it anyway.
     // The default hardcoded in

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeRadioButton.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeRadioButton.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
+import org.jetbrains.jewel.bridge.isDarculaTheme
 import org.jetbrains.jewel.bridge.isNewUiTheme
 import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
 import org.jetbrains.jewel.bridge.retrieveIntAsNonNegativeDpOrUnspecified
@@ -27,7 +28,7 @@ internal fun readRadioButtonStyle(): RadioButtonStyle {
         )
 
     val newUiTheme = isNewUiTheme()
-    val metrics = if (newUiTheme) NewUiRadioButtonMetrics else ClassicUiRadioButtonMetrics
+    val metrics = if (newUiTheme && !isDarculaTheme()) NewUiRadioButtonMetrics else ClassicUiRadioButtonMetrics
 
     // This value is not normally defined in the themes, but Swing checks it anyway
     // The default hardcoded in


### PR DESCRIPTION
The Darcula theme is now considered "new UI". Our check to adopt the "old themes" metrics (that consider that the Darcula SVGs are borked) thus doesn't work any more. The fix is to explicitly adopt the "old theme" metrics when the current theme is Darcula.

 Before | After
 --- | ---
 ![before](https://github.com/user-attachments/assets/afc1b10b-0f95-40f5-a0c8-4aaba81e8cf7) | ![after](https://github.com/user-attachments/assets/98768a6e-6009-4e30-be71-a3f129c08862)

The fix is not 100% perfect, but our old metrics are "good enough" for now. Swing is faring [a lot worse than this](https://youtrack.jetbrains.com/issue/JEWEL-918/Checkboxes-and-radio-buttons-in-the-Darcula-theme-look-wrong) anyway, and we should go back to polish only after the Swing implementation is fixed.

This only impacts the bridge, since we do not support Darcula in the standalone mode.

## Release notes

### Bug fixes
 * Fixed the checkbox and radio button appearance in the IDE when using the Darcula theme