### PR TITLE
Updated KeyMap for Visual Studio - Added shorts for cloning caret

### DIFF
--- a/plugins/keymaps/visual-studio-keymap/resources/keymaps/Visual Studio.xml
+++ b/plugins/keymaps/visual-studio-keymap/resources/keymaps/Visual Studio.xml
@@ -1,4 +1,10 @@
 <keymap name="Visual Studio" parent="$default" version="1" disable-mnemonics="false">
+  <action id="EditorCloneCaretAbove">
+    <keyboard-shortcut first-keystroke="shift alt up" />
+  </action>
+  <action id="EditorCloneCaretBelow">
+    <keyboard-shortcut first-keystroke="shift alt down" />
+  </action>
   <action id="StepOut">
     <keyboard-shortcut first-keystroke="shift F11"/>
   </action>


### PR DESCRIPTION
Added shortcuts that are already present in Visual Studio today.
I believe these shortcuts were added in the 2022 release of Visual Studio. Meaning previous didn't have them and that includes macOS

Cloning carets up or down in Visual Studio is possible via:

`ALT+Shift+ARROWUP` and `ALT+Shift+ARROWDOWN`