### PR TITLE
K2 UAST: do not use fake PSI as use-site location for local type approximation

### DIFF
--- a/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/FirUastResolveApiFixtureTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/FirUastResolveApiFixtureTest.kt
@@ -338,6 +338,10 @@ class FirUastResolveApiFixtureTest : KotlinLightCodeInsightFixtureTestCase(), Ua
         checkResolveTopLevelInlineReifiedFromLibrary(myFixture, withJvmName = true)
     }
 
+    fun testResolveTopLevelInlineReifiedFromLibraryRecursiveTypeParameter() {
+        checkResolveTopLevelInlineReifiedFromLibrary_recursiveTypeParameter(myFixture, isK2 = true)
+    }
+
     fun testResolveTopLevelInlineInFacadeFromLibrary() {
         checkResolveTopLevelInlineInFacadeFromLibrary(myFixture, isK2 = true)
     }

--- a/plugins/kotlin/uast/uast-kotlin/tests/test/org/jetbrains/uast/test/kotlin/comparison/FE1UastResolveApiFixtureTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin/tests/test/org/jetbrains/uast/test/kotlin/comparison/FE1UastResolveApiFixtureTest.kt
@@ -298,6 +298,10 @@ class FE1UastResolveApiFixtureTest : KotlinLightCodeInsightFixtureTestCase(), Ua
         checkResolveTopLevelInlineReifiedFromLibrary(myFixture, withJvmName = true)
     }
 
+    fun testResolveTopLevelInlineReifiedFromLibraryRecursiveTypeParameter() {
+        checkResolveTopLevelInlineReifiedFromLibrary_recursiveTypeParameter(myFixture, isK2 = false)
+    }
+
     fun testResolveTopLevelInlineInFacadeFromLibrary() {
         checkResolveTopLevelInlineInFacadeFromLibrary(myFixture, isK2 = false)
     }


### PR DESCRIPTION
Exact same test inputs are causing Lint hanging in the middle of type approximation,
which is currently using Kotlinc 2.2.0-Beta2 and IJ 2025.1.

This regression test at least shows that it's fixed upstream recently, and my rough guess is
that lots of changes about approximation of captured types [link]( https://github.com/JetBrains/kotlin/commits?author=dzharkov&since=2025-06-30&until=2025-07-25) may resolve this too: original issue is https://youtrack.jetbrains.com/issue/KT-76453.