### PR TITLE
[JEWEL-354] Use instanceUuid instead of isDark as remember key

### DIFF
--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
@@ -146,7 +146,7 @@ public fun JewelTheme.Companion.darkThemeDefinition(
 @Composable
 public fun ComponentStyling.default(): ComponentStyling = with {
     val isDark = JewelTheme.isDark
-    remember(isDark) { if (isDark) dark() else light() }
+    remember(JewelTheme.instanceUuid) { if (isDark) dark() else light() }
 }
 
 public fun ComponentStyling.dark(
@@ -298,7 +298,7 @@ public fun ComponentStyling.light(
 @Composable
 public fun IntUiTheme(isDark: Boolean = false, swingCompatMode: Boolean = false, content: @Composable () -> Unit) {
     val themeDefinition =
-        remember(isDark) {
+        remember(JewelTheme.instanceUuid) {
             if (isDark) {
                 JewelTheme.darkThemeDefinition()
             } else {

--- a/platform/jewel/markdown/extensions/gfm-strikethrough/README.md
+++ b/platform/jewel/markdown/extensions/gfm-strikethrough/README.md
@@ -16,7 +16,9 @@ To use the strikethrough extension, you need to add the `GitHubStrikethroughProc
 ```kotlin
 val isDark = JewelTheme.isDark
 
-val markdownStyling = remember(isDark) { if (isDark) MarkdownStyling.dark() else MarkdownStyling.light() }
+val markdownStyling = remember(JewelTheme.instanceUuid) {
+  if (isDark) MarkdownStyling.dark() else MarkdownStyling.light()
+}
 
 val processor = remember { MarkdownProcessor(listOf(GitHubStrikethroughProcessorExtension)) }
 

--- a/platform/jewel/markdown/extensions/gfm-tables/README.md
+++ b/platform/jewel/markdown/extensions/gfm-tables/README.md
@@ -18,7 +18,9 @@ To use the tables extension, you need to add the `GitHubTableProcessorExtension`
 ```kotlin
 val isDark = JewelTheme.isDark
 
-val markdownStyling = remember(isDark) { if (isDark) MarkdownStyling.dark() else MarkdownStyling.light() }
+val markdownStyling = remember(JewelTheme.instanceUuid) {
+  if (isDark) MarkdownStyling.dark() else MarkdownStyling.light()
+}
 
 val processor = remember { MarkdownProcessor(listOf(GitHubTableProcessorExtension)) }
 

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
@@ -44,7 +44,7 @@ public class GitHubTableBlockRenderer(
 
         // Headers usually have a tweaked font weight
         val headerRootStyling =
-            remember(JewelTheme.name, blockRenderer, tableStyling.headerBaseFontWeight) {
+            remember(JewelTheme.instanceUuid, blockRenderer, tableStyling.headerBaseFontWeight) {
                 val rootStyling = blockRenderer.rootStyling
                 val semiboldInlinesStyling =
                     rootStyling.paragraph.inlinesStyling.withFontWeight(tableStyling.headerBaseFontWeight)

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiProvideMarkdownStyling.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiProvideMarkdownStyling.kt
@@ -33,7 +33,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 public fun ProvideMarkdownStyling(
     isDark: Boolean = JewelTheme.isDark,
     markdownStyling: MarkdownStyling =
-        remember(isDark, JewelTheme.instanceUuid) {
+        remember(JewelTheme.instanceUuid) {
             if (isDark) {
                 MarkdownStyling.dark()
             } else {

--- a/platform/jewel/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/markdown/MarkdownPreview.kt
+++ b/platform/jewel/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/markdown/MarkdownPreview.kt
@@ -49,8 +49,9 @@ import org.jetbrains.jewel.ui.component.scrollbarContentSafePadding
 @Composable
 internal fun MarkdownPreview(rawMarkdown: CharSequence, modifier: Modifier = Modifier) {
     val isDark = JewelTheme.isDark
+    val instanceUuid = JewelTheme.instanceUuid
 
-    val markdownStyling = remember(isDark) { if (isDark) MarkdownStyling.dark() else MarkdownStyling.light() }
+    val markdownStyling = remember(instanceUuid) { if (isDark) MarkdownStyling.dark() else MarkdownStyling.light() }
 
     var markdownBlocks by remember { mutableStateOf(emptyList<MarkdownBlock>()) }
 
@@ -108,7 +109,7 @@ internal fun MarkdownPreview(rawMarkdown: CharSequence, modifier: Modifier = Mod
         }
 
     // Using the values from the GitHub rendering to ensure contrast
-    val background = remember(isDark) { if (isDark) Color(0xff0d1117) else Color.White }
+    val background = remember(instanceUuid) { if (isDark) Color(0xff0d1117) else Color.White }
 
     ProvideMarkdownStyling(markdownStyling, blockRenderer, NoOpCodeHighlighter) {
         val lazyListState = rememberLazyListState()

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/IntUiTestTheme.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/IntUiTestTheme.kt
@@ -1,0 +1,19 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import java.util.UUID
+import org.jetbrains.jewel.foundation.theme.LocalThemeInstanceUuid
+import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+
+@Composable
+internal fun IntUiTestTheme(
+    isDark: Boolean = false,
+    swingCompatMode: Boolean = false,
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(LocalThemeInstanceUuid provides UUID.randomUUID()) {
+        IntUiTheme(isDark, swingCompatMode, content)
+    }
+}

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/LinkUiTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/LinkUiTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.IntUiTestTheme
 import org.junit.Rule
 import org.junit.Test
 
@@ -14,7 +14,7 @@ class LinkUiTest {
 
     @Test
     fun `should apply provided modifier correctly`() {
-        rule.setContent { IntUiTheme { Link("Whatever", {}, modifier = Modifier.testTag("123banana")) } }
+        rule.setContent { IntUiTestTheme { Link("Whatever", {}, modifier = Modifier.testTag("123banana")) } }
         rule.onNodeWithText("Whatever").assertExists()
         rule.onNodeWithTag("123banana").assertExists()
     }

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/ListComboBoxUiTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/ListComboBoxUiTest.kt
@@ -35,8 +35,8 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.unit.dp
 import junit.framework.TestCase.assertEquals
+import org.jetbrains.jewel.IntUiTestTheme
 import org.jetbrains.jewel.foundation.lazy.rememberSelectableLazyListState
-import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -87,7 +87,7 @@ class ListComboBoxUiTest {
     fun `TAB navigation focuses only the editable combo box's text field`() {
         val focusRequester = FocusRequester()
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 Box(modifier = Modifier.size(20.dp).focusRequester(focusRequester).testTag("Pre-Box").focusable(true))
                 EditableListComboBox(
                     items = comboBoxItems,
@@ -393,7 +393,7 @@ class ListComboBoxUiTest {
         var selectedIndex = 0
 
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 EditableListComboBox(
                     items = comboBoxItems,
                     selectedIndex = selectedIndex,
@@ -431,7 +431,7 @@ class ListComboBoxUiTest {
         var selectedIndex = 0
 
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 EditableListComboBox(
                     items = comboBoxItems,
                     selectedIndex = selectedIndex,
@@ -504,7 +504,7 @@ class ListComboBoxUiTest {
         var selectedText = "Item 3"
 
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 ListComboBox(
                     items = comboBoxItems,
                     selectedIndex = selectedIndex,
@@ -540,7 +540,7 @@ class ListComboBoxUiTest {
         var selectedIndex by mutableStateOf(0)
 
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 ListComboBox(
                     items = comboBoxItems,
                     selectedIndex = selectedIndex,
@@ -582,7 +582,7 @@ class ListComboBoxUiTest {
         val focusRequester = FocusRequester()
 
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 EditableListComboBox(
                     items = comboBoxItems,
                     selectedIndex = selectedIndex,
@@ -612,7 +612,7 @@ class ListComboBoxUiTest {
         val focusRequester = FocusRequester()
 
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 EditableListComboBox(
                     items = comboBoxItems,
                     selectedIndex = selectedIndex,
@@ -659,7 +659,7 @@ class ListComboBoxUiTest {
     private fun editableListComboBox(): SemanticsNodeInteraction {
         val focusRequester = FocusRequester()
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 EditableListComboBox(
                     items = comboBoxItems,
                     selectedIndex = 0,
@@ -701,7 +701,7 @@ class ListComboBoxUiTest {
 
     private fun injectListComboBox(focusRequester: FocusRequester, isEnabled: Boolean) {
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 ListComboBox(
                     items = comboBoxItems,
                     selectedIndex = 0,
@@ -716,7 +716,7 @@ class ListComboBoxUiTest {
 
     private fun injectEditableListComboBox(focusRequester: FocusRequester, isEnabled: Boolean) {
         composeRule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 EditableListComboBox(
                     items = comboBoxItems,
                     selectedIndex = 0,

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/MenuContentTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/MenuContentTest.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.test.junit4.createComposeRule
 import javax.swing.KeyStroke
+import org.jetbrains.jewel.IntUiTestTheme
 import org.jetbrains.jewel.intui.standalone.menuShortcut.StandaloneShortcutProvider
-import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.LocalMenuItemShortcutProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -110,7 +110,7 @@ class MenuContentShortcutRegistrationTest {
             )
 
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 CompositionLocalProvider(
                     LocalMenuController provides fakeMenuController,
                     LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
@@ -156,7 +156,7 @@ class MenuContentShortcutRegistrationTest {
             )
 
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 CompositionLocalProvider(
                     LocalMenuController provides fakeMenuController,
                     LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
@@ -197,7 +197,7 @@ class MenuContentShortcutRegistrationTest {
             )
 
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 CompositionLocalProvider(
                     LocalMenuController provides fakeMenuController,
                     LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
@@ -239,7 +239,7 @@ class MenuContentShortcutRegistrationTest {
             )
 
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 CompositionLocalProvider(
                     LocalMenuController provides fakeMenuController,
                     LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
@@ -270,7 +270,7 @@ class MenuContentShortcutRegistrationTest {
                 )
             )
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 CompositionLocalProvider(
                     LocalMenuController provides fakeMenuController,
                     LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
@@ -307,7 +307,7 @@ class MenuContentShortcutRegistrationTest {
                 )
             )
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 CompositionLocalProvider(
                     LocalMenuController provides fakeMenuController,
                     LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
@@ -368,7 +368,7 @@ class MenuContentShortcutRegistrationTest {
         val currentMenuController = mutableStateOf<MenuController>(fakeMenuController)
 
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 CompositionLocalProvider(
                     LocalMenuController provides currentMenuController.value,
                     LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/TabStripTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/TabStripTest.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import kotlin.math.max
+import org.jetbrains.jewel.IntUiTestTheme
 import org.jetbrains.jewel.foundation.theme.JewelTheme
-import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.interactions.performKeyPress
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.hints.Stateful
@@ -156,7 +156,7 @@ class TabStripTest {
                     }
                 }
 
-            IntUiTheme {
+            IntUiTestTheme {
                 TabStrip(
                     tabs = tabs,
                     style = JewelTheme.defaultTabStyle,

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/banners/DefaultBannerTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/banners/DefaultBannerTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
-import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.IntUiTestTheme
 import org.jetbrains.jewel.ui.component.DefaultInformationBanner
 import org.jetbrains.jewel.ui.component.banner.BannerIconActionScope
 import org.jetbrains.jewel.ui.component.banner.BannerLinkActionScope
@@ -21,7 +21,7 @@ class DefaultBannerTest : SharedBannerTest() {
         block: ComposeContentTestRule.() -> Unit,
     ) {
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 DefaultInformationBanner(
                     text = text,
                     linkActions = linkActions,

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/banners/InlineBannerTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/banners/InlineBannerTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
-import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.IntUiTestTheme
 import org.jetbrains.jewel.ui.component.InlineInformationBanner
 import org.jetbrains.jewel.ui.component.banner.BannerIconActionScope
 import org.jetbrains.jewel.ui.component.banner.BannerLinkActionScope
@@ -21,7 +21,7 @@ class InlineBannerTest : SharedBannerTest() {
         block: ComposeContentTestRule.() -> Unit,
     ) {
         rule.setContent {
-            IntUiTheme {
+            IntUiTestTheme {
                 InlineInformationBanner(
                     text = text,
                     linkActions = linkActions,


### PR DESCRIPTION
# Context

It's not technically correct to use the `isDark` variable from `JewelTheme` to recalculate something once the user changes any LaF value. For instance, changing from Darcula to Dark, they are both dark themes but are different themes.

This PR fixes the few cases where we used `isDark` as a remember key.

### Implementation
- Changed variations of `remember(isDark)` to `remember(JewelTheme.instanceUuid)`
   - Markdown was the module with the most changes
- Also updated some README files to show how to properly check for theme changes.