### PR TITLE
[JEWEL-913] Implement Factory Function for InlineMarkdownRenderer

### DIFF
--- a/platform/jewel/markdown/core/api-dump-experimental.txt
+++ b/platform/jewel/markdown/core/api-dump-experimental.txt
@@ -293,8 +293,12 @@ f:org.jetbrains.jewel.markdown.processing.ProcessingUtilKt
 - render(org.jetbrains.jewel.markdown.MarkdownBlock,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
 - renderThematicBreak(org.jetbrains.jewel.markdown.rendering.MarkdownStyling$ThematicBreak,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
 *:org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
+- *sf:Companion:org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer$Companion
 - a:renderAsAnnotatedString(java.lang.Iterable,org.jetbrains.jewel.markdown.rendering.InlinesStyling,Z,kotlin.jvm.functions.Function1):androidx.compose.ui.text.AnnotatedString
 - bs:renderAsAnnotatedString$default(org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,java.lang.Iterable,org.jetbrains.jewel.markdown.rendering.InlinesStyling,Z,kotlin.jvm.functions.Function1,I,java.lang.Object):androidx.compose.ui.text.AnnotatedString
+*f:org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer$Companion
+f:org.jetbrains.jewel.markdown.rendering.InlineMarkdownRendererKt
+- *sf:create(org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer$Companion,java.util.List):org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 *f:org.jetbrains.jewel.markdown.rendering.InlinesStyling
 - sf:$stable:I
 - *sf:Companion:org.jetbrains.jewel.markdown.rendering.InlinesStyling$Companion

--- a/platform/jewel/markdown/core/api-dump.txt
+++ b/platform/jewel/markdown/core/api-dump.txt
@@ -9,6 +9,7 @@ f:org.jetbrains.jewel.markdown.processing.MarkdownParserFactory
 - bs:create$default(org.jetbrains.jewel.markdown.processing.MarkdownParserFactory,Z,java.util.List,kotlin.jvm.functions.Function1,I,java.lang.Object):org.commonmark.parser.Parser
 f:org.jetbrains.jewel.markdown.processing.ProcessingUtilKt
 - sf:toInlineMarkdownOrNull(org.commonmark.node.Node,org.jetbrains.jewel.markdown.processing.MarkdownProcessor):org.jetbrains.jewel.markdown.InlineMarkdown
+f:org.jetbrains.jewel.markdown.rendering.InlineMarkdownRendererKt
 org.jetbrains.jewel.markdown.rendering.WithInlinesStyling
 - a:getInlinesStyling():org.jetbrains.jewel.markdown.rendering.InlinesStyling
 org.jetbrains.jewel.markdown.rendering.WithUnderline

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -77,7 +77,7 @@ import org.jetbrains.jewel.ui.component.Text
 public open class DefaultMarkdownBlockRenderer(
     override val rootStyling: MarkdownStyling,
     override val rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    override val inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
+    override val inlineRenderer: InlineMarkdownRenderer = InlineMarkdownRenderer.create(rendererExtensions),
 ) : MarkdownBlockRenderer {
     @Composable
     override fun render(

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
@@ -4,15 +4,49 @@ import androidx.compose.ui.text.AnnotatedString
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
+import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 
+/**
+ * Renders a sequence of [InlineMarkdown] elements into an [AnnotatedString].
+ *
+ * This renderer is responsible for handling inline-level Markdown elements like text, emphasis, links, and code spans.
+ * It translates these elements into a single, styled `AnnotatedString` that can be displayed in a Compose UI.
+ *
+ * @see renderAsAnnotatedString
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public interface InlineMarkdownRenderer {
-    /** Render the [inlineMarkdown] as an [AnnotatedString], using the [styling] provided. */
+    /**
+     * Renders a sequence of [InlineMarkdown] elements into a single [AnnotatedString], applying the provided [styling].
+     *
+     * @param inlineMarkdown The sequence of [InlineMarkdown] elements to be rendered.
+     * @param styling The [InlinesStyling] that defines the visual appearance of the different inline elements.
+     * @param enabled Controls the enabled state of the rendered content. When `false`, interactive elements like links
+     *   will be visually disabled.
+     * @param onUrlClicked A callback that will be invoked when a user clicks on a link. The clicked URL is passed as an
+     *   argument.
+     * @return An [AnnotatedString] containing the fully rendered and styled inline content.
+     */
     public fun renderAsAnnotatedString(
         inlineMarkdown: Iterable<InlineMarkdown>,
         styling: InlinesStyling,
         enabled: Boolean,
         onUrlClicked: ((String) -> Unit)? = null,
     ): AnnotatedString
+
+    /** Companion object for [InlineMarkdownRenderer]. */
+    public companion object
 }
+
+/**
+ * Creates a new instance of the default [InlineMarkdownRenderer].
+ *
+ * @param rendererExtensions A list of [MarkdownRendererExtension]s to support rendering custom inline Markdown nodes.
+ * @return A new [DefaultInlineMarkdownRenderer] instance.
+ */
+@ApiStatus.Experimental
+@ExperimentalJewelApi
+public fun InlineMarkdownRenderer.Companion.create(
+    rendererExtensions: List<MarkdownRendererExtension>
+): InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions)

--- a/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlockRendererExtensions.kt
+++ b/platform/jewel/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlockRendererExtensions.kt
@@ -4,16 +4,16 @@ import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.intui.markdown.bridge.styling.create
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
-import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
+import org.jetbrains.jewel.markdown.rendering.create
 
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public fun MarkdownBlockRenderer.Companion.create(
     styling: MarkdownStyling = MarkdownStyling.create(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
+    inlineRenderer: InlineMarkdownRenderer = InlineMarkdownRenderer.create(rendererExtensions),
 ): MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(styling, rendererExtensions, inlineRenderer)

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiMarkdownBlockRendererExtensions.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiMarkdownBlockRendererExtensions.kt
@@ -5,18 +5,18 @@ import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.intui.markdown.standalone.styling.dark
 import org.jetbrains.jewel.intui.markdown.standalone.styling.light
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
-import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
+import org.jetbrains.jewel.markdown.rendering.create
 
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public fun MarkdownBlockRenderer.Companion.light(
     styling: MarkdownStyling = MarkdownStyling.light(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
+    inlineRenderer: InlineMarkdownRenderer = InlineMarkdownRenderer.create(rendererExtensions),
 ): MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(styling, rendererExtensions, inlineRenderer)
 
 @ApiStatus.Experimental
@@ -24,5 +24,5 @@ public fun MarkdownBlockRenderer.Companion.light(
 public fun MarkdownBlockRenderer.Companion.dark(
     styling: MarkdownStyling = MarkdownStyling.dark(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
+    inlineRenderer: InlineMarkdownRenderer = InlineMarkdownRenderer.create(rendererExtensions),
 ): MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(styling, rendererExtensions, inlineRenderer)

--- a/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/MarkdownComposePanel.kt
+++ b/plugins/markdown/compose/src/main/kotlin/com/intellij/markdown/compose/preview/MarkdownComposePanel.kt
@@ -4,11 +4,21 @@ package com.intellij.markdown.compose.preview
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.TweenSpec
-import androidx.compose.foundation.*
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -49,7 +59,8 @@ import org.jetbrains.jewel.markdown.extensions.github.tables.GitHubTableProcesso
 import org.jetbrains.jewel.markdown.extensions.github.tables.GitHubTableRendererExtension
 import org.jetbrains.jewel.markdown.extensions.images.Coil3ImageRendererExtension
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
-import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
+import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
+import org.jetbrains.jewel.markdown.rendering.create
 import org.jetbrains.jewel.markdown.scrolling.ScrollSyncMarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.scrolling.ScrollingSynchronizer
 import javax.swing.JComponent
@@ -104,7 +115,7 @@ internal class MarkdownComposePanel(
       ScrollSyncMarkdownBlockRenderer(
         markdownStyling,
         allRenderingExtensions,
-        DefaultInlineMarkdownRenderer(allRenderingExtensions),
+        InlineMarkdownRenderer.create(allRenderingExtensions),
       )
     }
     ProvideMarkdownStyling(


### PR DESCRIPTION
# Context

Currently our `InlineMarkdownRenderer` doesn't have a factory function that calls its default implementation like `MarkdownBlockRenderer` has.

This PR adds such factory function to inline markdown renderer.

## Implementation
- Add a `public companion object` to `InlineMarkdownRenderer`
- Created a common `create()` factory function that's used in both bridge and standalone
- Added KDoc to both the interface and the default implementation
- Removed some star imports

## Release notes

### New features
 * Now `InlineMarkdownRenderer` has a factory function to help you provide an inline markdown renderer: `InlineMarkdownRenderer.create(/*your markdown extensions*/)`