### PR TITLE
[JEWEL-937] Update Jewel changelog

### DIFF
--- a/platform/jewel/RELEASE NOTES.md
+++ b/platform/jewel/RELEASE NOTES.md
@@ -4,7 +4,7 @@
 
 | Supported IJP versions | Compose Multiplatform version |
 |------------------------|-------------------------------|
-| 2025.2.1+, 2025.1.5+   | 1.8.2                         |
+| 2025.2.1+, 2025.1.4.1+ | 1.8.2                         |
 
 ### ⚠️ Important Changes
 


### PR DESCRIPTION
Jewel 0.29 was included in IJP 251.4.1 instead of the intended 251.5, so this updates the release notes accordingly.