### PR TITLE
[JEWEL-946] Fix SimpleListItem styling

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeSimpleListItem.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeSimpleListItem.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.jewel.bridge.theme
 
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.intellij.util.ui.JBUI
 import org.jetbrains.jewel.bridge.dp
@@ -11,18 +12,20 @@ import org.jetbrains.jewel.ui.component.styling.SimpleListItemColors
 import org.jetbrains.jewel.ui.component.styling.SimpleListItemMetrics
 import org.jetbrains.jewel.ui.component.styling.SimpleListItemStyle
 
-internal fun readSimpleListItemStyle() =
-    SimpleListItemStyle(
+internal fun readSimpleListItemStyle(): SimpleListItemStyle {
+    val content = retrieveColorOrUnspecified("List.foreground")
+
+    return SimpleListItemStyle(
         colors =
             SimpleListItemColors(
-                background = retrieveColorOrUnspecified("ComboBox.background"),
-                backgroundActive = retrieveColorOrUnspecified("ComboBox.background"),
-                backgroundSelected = retrieveColorOrUnspecified("ComboBox.selectionBackground"),
-                backgroundSelectedActive = retrieveColorOrUnspecified("ComboBox.selectionBackground"),
-                content = retrieveColorOrUnspecified("ComboBox.foreground"),
-                contentActive = retrieveColorOrUnspecified("ComboBox.foreground"),
-                contentSelected = retrieveColorOrUnspecified("ComboBox.foreground"),
-                contentSelectedActive = retrieveColorOrUnspecified("ComboBox.foreground"),
+                background = Color.Unspecified,
+                backgroundActive = Color.Unspecified,
+                backgroundSelected = retrieveColorOrUnspecified("List.selectionInactiveBackground"),
+                backgroundSelectedActive = retrieveColorOrUnspecified("List.selectionBackground"),
+                content = content,
+                contentActive = content,
+                contentSelected = content,
+                contentSelectedActive = content,
             ),
         metrics =
             SimpleListItemMetrics(
@@ -33,3 +36,4 @@ internal fun readSimpleListItemStyle() =
                 iconTextGap = 2.dp,
             ),
     )
+}

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiSimpleListItemStyling.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiSimpleListItemStyling.kt
@@ -41,8 +41,8 @@ public fun SimpleListItemStyle.Companion.darkFullWidth(
 
 public fun SimpleListItemColors.Companion.light(
     background: Color = Color.Unspecified,
-    backgroundActive: Color = Color.Unspecified,
-    backgroundSelected: Color = IntUiLightTheme.colors.blue(11),
+    backgroundActive: Color = background,
+    backgroundSelected: Color = IntUiLightTheme.colors.gray(11),
     backgroundSelectedActive: Color = IntUiLightTheme.colors.blue(11),
     content: Color = Color.Unspecified,
     contentActive: Color = Color.Unspecified,
@@ -62,8 +62,8 @@ public fun SimpleListItemColors.Companion.light(
 
 public fun SimpleListItemColors.Companion.dark(
     background: Color = Color.Unspecified,
-    backgroundActive: Color = IntUiLightTheme.colors.blue(2),
-    backgroundSelected: Color = IntUiLightTheme.colors.blue(2),
+    backgroundActive: Color = background,
+    backgroundSelected: Color = IntUiLightTheme.colors.gray(2),
     backgroundSelectedActive: Color = IntUiLightTheme.colors.blue(2),
     content: Color = Color.Unspecified,
     contentActive: Color = Color.Unspecified,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
@@ -169,7 +169,10 @@ public fun <T : Any> ListComboBox(
         interactionSource = interactionSource,
         outline = outline,
         popupManager = popupManager,
-        labelContent = { itemContent(items[selectedIndex], false, false) },
+        labelContent = {
+            // We draw label items as not selected and not active
+            itemContent(items[selectedIndex], false, false)
+        },
     ) {
         PopupContent(
             items = items,
@@ -585,7 +588,8 @@ private fun <T : Any> PopupContent(
                         val showAsSelected =
                             (isItemSelected && previewSelectedItemIndex < 0) || previewSelectedItemIndex == index
 
-                        itemContent(item, showAsSelected, isActive)
+                        // We assume items are active when visible (the popup isn't really, but should show as such)
+                        itemContent(item, showAsSelected, true)
                     }
                 },
             )


### PR DESCRIPTION
In the bridge, we were reading the `SimpleListItem` colours from the wrong keys. This was not obvious in the light theme, but in the dark theme this resulted in weird background colours. Additionally, we were not correctly applying the "active" status to items in the popup, and the inactive selection background colour was incorrect in standalone, too.

This fixes both issues :) Note that in the light theme you didn't really see any issue, so don't be surprised if you can't tell below!

| |Standalone|
|---|---|
|After (light)|<img width="1470" height="820" alt="image" src="https://github.com/user-attachments/assets/277e6f05-ac99-4ff8-b2ea-0b3b4e422cd5" />|
|After (dark)|<img width="1458" height="834" alt="image" src="https://github.com/user-attachments/assets/fe2a7d25-228f-4c9d-910a-67154990a3ec" />|

| |Bridge|
|---|---|
|Before (light)|<img width="731" height="408" alt="image" src="https://github.com/user-attachments/assets/724a931e-273a-4374-94f5-11831c49d5c9" />|
|After (light)|<img width="1458" height="828" alt="image" src="https://github.com/user-attachments/assets/68aa9ffc-ab1f-4bc8-a130-509e7d2c43d2" />|
|Before (light)|<img width="731" height="407" alt="image" src="https://github.com/user-attachments/assets/4c042838-a01d-4c11-a546-7e5f703dd542" />|
|After (dark)|<img width="1464" height="820" alt="image" src="https://github.com/user-attachments/assets/cc63d504-aa7e-4c57-9ac2-79535aaffb8a" />|

## Release notes

### Bug fixes
 * Fixed `SimpleListItem` colours in standalone and bridge
 * Fixed incorrect application of the "active" state in list combobox items