### PR TITLE
[JEWEL-949] Fix interaction of links and selection in Markdown

### DIFF
--- a/platform/jewel/markdown/core/api-dump-experimental.txt
+++ b/platform/jewel/markdown/core/api-dump-experimental.txt
@@ -182,8 +182,11 @@
 - hashCode():I
 f:org.jetbrains.jewel.markdown.MarkdownKt
 - *sf:LazyMarkdown(java.util.List,androidx.compose.ui.Modifier,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.lazy.LazyListState,Z,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,org.jetbrains.jewel.markdown.rendering.MarkdownStyling,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,androidx.compose.runtime.Composer,I,I):V
+- *sf:LazyMarkdown(java.util.List,androidx.compose.ui.Modifier,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.lazy.LazyListState,Z,Z,kotlin.jvm.functions.Function1,org.jetbrains.jewel.markdown.rendering.MarkdownStyling,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,androidx.compose.runtime.Composer,I,I):V
 - *sf:Markdown(java.lang.String,androidx.compose.ui.Modifier,Z,Z,kotlinx.coroutines.CoroutineDispatcher,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,org.jetbrains.jewel.markdown.rendering.MarkdownStyling,org.jetbrains.jewel.markdown.processing.MarkdownProcessor,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,androidx.compose.runtime.Composer,I,I):V
+- *sf:Markdown(java.lang.String,androidx.compose.ui.Modifier,Z,Z,kotlinx.coroutines.CoroutineDispatcher,kotlin.jvm.functions.Function1,org.jetbrains.jewel.markdown.rendering.MarkdownStyling,org.jetbrains.jewel.markdown.processing.MarkdownProcessor,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,androidx.compose.runtime.Composer,I,I):V
 - *sf:Markdown(java.util.List,java.lang.String,androidx.compose.ui.Modifier,Z,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,org.jetbrains.jewel.markdown.rendering.MarkdownStyling,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,androidx.compose.runtime.Composer,I,I):V
+- *sf:Markdown(java.util.List,java.lang.String,androidx.compose.ui.Modifier,Z,Z,kotlin.jvm.functions.Function1,org.jetbrains.jewel.markdown.rendering.MarkdownStyling,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,androidx.compose.runtime.Composer,I,I):V
 *:org.jetbrains.jewel.markdown.MarkdownMode
 *f:org.jetbrains.jewel.markdown.MarkdownMode$EditorPreview
 - org.jetbrains.jewel.markdown.MarkdownMode
@@ -207,13 +210,14 @@ f:org.jetbrains.jewel.markdown.SemanticsKt
 *:org.jetbrains.jewel.markdown.WithTextContent
 - a:getContent():java.lang.String
 *:org.jetbrains.jewel.markdown.extensions.ImageRendererExtension
-- a:renderImagesContent(org.jetbrains.jewel.markdown.InlineMarkdown$Image,androidx.compose.runtime.Composer,I):androidx.compose.foundation.text.InlineTextContent
+- a:renderImageContent(org.jetbrains.jewel.markdown.InlineMarkdown$Image,androidx.compose.runtime.Composer,I):androidx.compose.foundation.text.InlineTextContent
 *:org.jetbrains.jewel.markdown.extensions.MarkdownBlockProcessorExtension
 - a:canProcess(org.commonmark.node.CustomBlock):Z
 - a:processMarkdownBlock(org.commonmark.node.CustomBlock,org.jetbrains.jewel.markdown.processing.MarkdownProcessor):org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock
 *:org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
+- a:RenderCustomBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function1,androidx.compose.runtime.Composer,I):V
 - a:canRender(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock):Z
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.runtime.Composer,I):V
 *:org.jetbrains.jewel.markdown.extensions.MarkdownDelimitedInlineProcessorExtension
 - a:canProcess(org.commonmark.node.Delimited):Z
 - a:processDelimitedInline(org.commonmark.node.Delimited,org.jetbrains.jewel.markdown.processing.MarkdownProcessor):org.jetbrains.jewel.markdown.InlineMarkdown$CustomDelimitedNode
@@ -272,6 +276,21 @@ f:org.jetbrains.jewel.markdown.processing.ProcessingUtilKt
 - <init>(org.jetbrains.jewel.markdown.rendering.MarkdownStyling,java.util.List,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer):V
 - b:<init>(org.jetbrains.jewel.markdown.rendering.MarkdownStyling,java.util.List,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,I,kotlin.jvm.internal.DefaultConstructorMarker):V
 - pf:MaybeScrollingContainer(Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I):V
+- RenderBlock(org.jetbrains.jewel.markdown.MarkdownBlock,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderBlockQuote(org.jetbrains.jewel.markdown.MarkdownBlock$BlockQuote,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$BlockQuote,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderBlocks(java.util.List,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderCodeBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderFencedCodeBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$FencedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Fenced,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderHeading(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading$HN,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderHeading(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderHtmlBlock(org.jetbrains.jewel.markdown.MarkdownBlock$HtmlBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$HtmlBlock,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderIndentedCodeBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$IndentedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Indented,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderList(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderListItem(org.jetbrains.jewel.markdown.MarkdownBlock$ListItem,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderOrderedList(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$OrderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Ordered,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderParagraph(org.jetbrains.jewel.markdown.MarkdownBlock$Paragraph,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Paragraph,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderThematicBreak(org.jetbrains.jewel.markdown.rendering.MarkdownStyling$ThematicBreak,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderUnorderedList(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$UnorderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Unordered,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
 - createCopy(org.jetbrains.jewel.markdown.rendering.MarkdownStyling,java.util.List,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer):org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 - getInlineRenderer():org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 - getRendererExtensions():java.util.List
@@ -321,27 +340,42 @@ f:org.jetbrains.jewel.markdown.rendering.InlineMarkdownRendererKt
 *f:org.jetbrains.jewel.markdown.rendering.InlinesStyling$Companion
 *:org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 - *sf:Companion:org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer$Companion
+- a:RenderBlock(org.jetbrains.jewel.markdown.MarkdownBlock,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderBlockQuote(org.jetbrains.jewel.markdown.MarkdownBlock$BlockQuote,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$BlockQuote,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderBlocks(java.util.List,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderCodeBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderFencedCodeBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$FencedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Fenced,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderHeading(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading$HN,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderHeading(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderHtmlBlock(org.jetbrains.jewel.markdown.MarkdownBlock$HtmlBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$HtmlBlock,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderIndentedCodeBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$IndentedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Indented,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderList(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderListItem(org.jetbrains.jewel.markdown.MarkdownBlock$ListItem,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderOrderedList(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$OrderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Ordered,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderParagraph(org.jetbrains.jewel.markdown.MarkdownBlock$Paragraph,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Paragraph,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderThematicBreak(org.jetbrains.jewel.markdown.rendering.MarkdownStyling$ThematicBreak,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- a:RenderUnorderedList(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$UnorderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Unordered,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
 - a:createCopy(org.jetbrains.jewel.markdown.rendering.MarkdownStyling,java.util.List,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer):org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 - bs:createCopy$default(org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.MarkdownStyling,java.util.List,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,I,java.lang.Object):org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 - a:getInlineRenderer():org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 - a:getRendererExtensions():java.util.List
 - a:getRootStyling():org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 - *a:plus(org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension):org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
-- a:render(java.util.List,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$BlockQuote,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$BlockQuote,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$FencedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Fenced,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$IndentedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Indented,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading$HN,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$HtmlBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$HtmlBlock,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$OrderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Ordered,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$UnorderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Unordered,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$ListItem,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock$Paragraph,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Paragraph,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:render(org.jetbrains.jewel.markdown.MarkdownBlock,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- a:renderThematicBreak(org.jetbrains.jewel.markdown.rendering.MarkdownStyling$ThematicBreak,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(java.util.List,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$BlockQuote,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$BlockQuote,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$FencedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Fenced,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$IndentedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Indented,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading$HN,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$HtmlBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$HtmlBlock,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$OrderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Ordered,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock$UnorderedList,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List$Unordered,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$ListBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$List,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$ListItem,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock$Paragraph,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Paragraph,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- render(org.jetbrains.jewel.markdown.MarkdownBlock,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- renderThematicBreak(org.jetbrains.jewel.markdown.rendering.MarkdownStyling$ThematicBreak,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
 *f:org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer$Companion
 *f:org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 - sf:$stable:I
@@ -635,10 +669,10 @@ f:org.jetbrains.jewel.markdown.scrolling.AutoScrollingUtilKt
 - org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
 - sf:$stable:I
 - <init>(org.jetbrains.jewel.markdown.rendering.MarkdownStyling,java.util.List,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer):V
-- render(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$IndentedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Indented,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- render(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading$HN,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- render(org.jetbrains.jewel.markdown.MarkdownBlock$Paragraph,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Paragraph,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
-- render(org.jetbrains.jewel.markdown.MarkdownBlock,Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderBlock(org.jetbrains.jewel.markdown.MarkdownBlock,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderHeading(org.jetbrains.jewel.markdown.MarkdownBlock$Heading,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Heading,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderIndentedCodeBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CodeBlock$IndentedCodeBlock,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Code$Indented,Z,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
+- RenderParagraph(org.jetbrains.jewel.markdown.MarkdownBlock$Paragraph,org.jetbrains.jewel.markdown.rendering.MarkdownStyling$Paragraph,Z,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.runtime.Composer,I):V
 *a:org.jetbrains.jewel.markdown.scrolling.ScrollingSynchronizer
 - sf:$stable:I
 - *sf:Companion:org.jetbrains.jewel.markdown.scrolling.ScrollingSynchronizer$Companion

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/Markdown.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/Markdown.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -23,6 +24,7 @@ import kotlinx.coroutines.withContext
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.modifier.thenIf
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.markdown.extensions.markdownBlockRenderer
 import org.jetbrains.jewel.markdown.extensions.markdownProcessor
@@ -32,6 +34,30 @@ import org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
+/**
+ * A Composable that renders a Markdown string.
+ *
+ * For large amounts of Markdown, such as documents, you can consider using [LazyMarkdown] instead to get better
+ * performance.
+ *
+ * @param markdown The Markdown string to render.
+ * @param modifier The modifier to apply to this layout node.
+ * @param selectable Whether the text can be selected.
+ * @param enabled Whether the rendered content is enabled.
+ * @param renderingDispatcher The dispatcher to use for processing the Markdown.
+ * @param onUrlClick The callback to be invoked when a URL is clicked.
+ * @param onTextClick This parameter is ignored and is only here for binary/source compat reasons.
+ * @param markdownStyling The styling to use for the rendered Markdown.
+ * @param processor The processor to use for parsing the Markdown.
+ * @param blockRenderer The renderer to use for rendering the Markdown blocks.
+ */
+@Deprecated(
+    "Use the Markdown overload without onTextClick instead.",
+    ReplaceWith(
+        "Markdown(markdown, modifier, selectable, enabled, renderingDispatcher, onUrlClick, " +
+            "markdownStyling, processor, blockRenderer)"
+    ),
+)
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @Composable
@@ -42,14 +68,58 @@ public fun Markdown(
     enabled: Boolean = true,
     renderingDispatcher: CoroutineDispatcher = Dispatchers.Default,
     onUrlClick: (String) -> Unit = {},
-    onTextClick: () -> Unit = {},
+    @Suppress("UnusedParameter", "RedundantSuppression") onTextClick: () -> Unit = {},
+    markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
+    processor: MarkdownProcessor = JewelTheme.markdownProcessor,
+    blockRenderer: MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(markdownStyling),
+) {
+    Markdown(
+        markdown,
+        modifier,
+        selectable,
+        enabled,
+        renderingDispatcher,
+        onUrlClick,
+        markdownStyling,
+        processor,
+        blockRenderer,
+    )
+}
+
+/**
+ * A Composable that renders a Markdown string.
+ *
+ * For large amounts of Markdown, such as documents, you can consider using [LazyMarkdown] instead to get better
+ * performance.
+ *
+ * @param markdown The Markdown string to render.
+ * @param modifier The modifier to apply to this layout node.
+ * @param selectable Whether the text can be selected.
+ * @param enabled Whether the rendered content is enabled.
+ * @param processingDispatcher The dispatcher to use for processing the Markdown.
+ * @param onUrlClick The callback to be invoked when a URL is clicked.
+ * @param markdownStyling The styling to use for the rendered Markdown.
+ * @param processor The processor to use for parsing the Markdown.
+ * @param blockRenderer The renderer to use for rendering the Markdown blocks.
+ * @see Markdown
+ */
+@ApiStatus.Experimental
+@ExperimentalJewelApi
+@Composable
+public fun Markdown(
+    @Language("Markdown") markdown: String,
+    modifier: Modifier = Modifier,
+    selectable: Boolean = false,
+    enabled: Boolean = true,
+    processingDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    onUrlClick: (String) -> Unit = {},
     markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
     processor: MarkdownProcessor = JewelTheme.markdownProcessor,
     blockRenderer: MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(markdownStyling),
 ) {
     var markdownBlocks by remember { mutableStateOf(emptyList<MarkdownBlock>()) }
     LaunchedEffect(markdown, processor) {
-        markdownBlocks = withContext(renderingDispatcher) { processor.processMarkdownDocument(markdown) }
+        markdownBlocks = withContext(processingDispatcher) { processor.processMarkdownDocument(markdown) }
     }
 
     Markdown(
@@ -59,12 +129,36 @@ public fun Markdown(
         selectable = selectable,
         enabled = enabled,
         onUrlClick = onUrlClick,
-        onTextClick = onTextClick,
         markdownStyling = markdownStyling,
         blockRenderer = blockRenderer,
     )
 }
 
+/**
+ * A Composable that renders a list of [MarkdownBlock]s in a column.
+ *
+ * For large amounts of Markdown, such as documents, you can consider using [LazyMarkdown] instead to get better
+ * performance.
+ *
+ * Note: the [onTextClick] parameter is ignored in this overload.
+ *
+ * @param markdownBlocks The list of Markdown blocks to render.
+ * @param markdown The original Markdown string.
+ * @param modifier The modifier to apply to this layout node.
+ * @param enabled Whether the rendered content is enabled.
+ * @param selectable Whether the text can be selected.
+ * @param onUrlClick The callback to be invoked when a URL is clicked.
+ * @param onTextClick This parameter is ignored and is only here for binary/source compat reasons.
+ * @param markdownStyling The styling to use for the rendered Markdown.
+ * @param blockRenderer The renderer to use for rendering the Markdown blocks.
+ * @see Markdown
+ */
+@Deprecated(
+    "Use the Markdown overload without onTextClick instead.",
+    ReplaceWith(
+        "Markdown(markdownBlocks, markdown, modifier, enabled, selectable, onUrlClick, markdownStyling, blockRenderer)"
+    ),
+)
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @Composable
@@ -75,31 +169,80 @@ public fun Markdown(
     enabled: Boolean = true,
     selectable: Boolean = false,
     onUrlClick: (String) -> Unit = {},
-    onTextClick: () -> Unit = {},
+    @Suppress("UnusedParameter", "RedundantSuppression") onTextClick: () -> Unit = {},
     markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
     blockRenderer: MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(markdownStyling),
 ) {
-    if (selectable) {
-        SelectionContainer(Modifier.semantics { rawMarkdown = markdown }) {
-            @Suppress("ModifierNotUsedAtRoot") // Intentional
-            Column(modifier, verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing)) {
-                for (block in markdownBlocks) {
-                    blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier)
-                }
-            }
-        }
-    } else {
+    Markdown(markdownBlocks, markdown, modifier, enabled, selectable, onUrlClick, markdownStyling, blockRenderer)
+}
+
+/**
+ * A Composable that renders a list of [MarkdownBlock]s in a column.
+ *
+ * For large amounts of Markdown, such as documents, you can consider using [LazyMarkdown] instead to get better
+ * performance.
+ *
+ * @param markdownBlocks The list of Markdown blocks to render.
+ * @param markdown The original Markdown string.
+ * @param modifier The modifier to apply to this layout node.
+ * @param enabled Whether the rendered content is enabled.
+ * @param selectable Whether the text can be selected.
+ * @param onUrlClick The callback to be invoked when a URL is clicked.
+ * @param markdownStyling The styling to use for the rendered Markdown.
+ * @param blockRenderer The renderer to use for rendering the Markdown blocks.
+ * @see Markdown
+ */
+@ApiStatus.Experimental
+@ExperimentalJewelApi
+@Composable
+public fun Markdown(
+    markdownBlocks: List<MarkdownBlock>,
+    markdown: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    selectable: Boolean = false,
+    onUrlClick: (String) -> Unit = {},
+    markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
+    blockRenderer: MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(markdownStyling),
+) {
+    // We keep the existing behavior in terms of where the rawMarkdown semantic is applied to
+    MaybeSelectable(selectable, Modifier.thenIf(selectable) { semantics { rawMarkdown = markdown } }) {
+        @Suppress("ModifierNotUsedAtRoot") // Intentional
         Column(
-            modifier = modifier.semantics { rawMarkdown = markdown },
+            modifier.thenIf(!selectable) { semantics { rawMarkdown = markdown } },
             verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
         ) {
             for (block in markdownBlocks) {
-                blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier)
+                blockRenderer.RenderBlock(block, enabled, onUrlClick, Modifier)
             }
         }
     }
 }
 
+/**
+ * A Composable that renders a list of [MarkdownBlock]s in a lazy-loading column.
+ *
+ * For small amounts of Markdown, such as UI text, you should consider using [Markdown] instead to get better
+ * performance.
+ *
+ * @param markdownBlocks The list of Markdown blocks to render.
+ * @param modifier The modifier to apply to this layout node.
+ * @param contentPadding The padding to apply to the content.
+ * @param state The state of the lazy list.
+ * @param enabled Whether the rendered content is enabled.
+ * @param selectable Whether the text can be selected.
+ * @param onUrlClick The callback to be invoked when a URL is clicked.
+ * @param onTextClick This parameter is ignored and is only here for binary/source compat reasons.
+ * @param markdownStyling The styling to use for the rendered Markdown.
+ * @param blockRenderer The renderer to use for rendering the Markdown blocks.
+ */
+@Deprecated(
+    "Use the LazyMarkdown overload without onTextClick instead.",
+    ReplaceWith(
+        "LazyMarkdown(markdownBlocks, modifier, contentPadding, state, enabled, selectable, onUrlClick, " +
+            "markdownStyling, blockRenderer)"
+    ),
+)
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @Composable
@@ -111,30 +254,70 @@ public fun LazyMarkdown(
     enabled: Boolean = true,
     selectable: Boolean = false,
     onUrlClick: (String) -> Unit = {},
-    onTextClick: () -> Unit = {},
+    @Suppress("UnusedParameter", "RedundantSuppression", "RedundantSuppression") onTextClick: () -> Unit = {},
     markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
     blockRenderer: MarkdownBlockRenderer = JewelTheme.markdownBlockRenderer,
 ) {
-    if (selectable) {
-        SelectionContainer(modifier) {
-            LazyColumn(
-                state = state,
-                contentPadding = contentPadding,
-                verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
-            ) {
-                items(markdownBlocks) { block ->
-                    blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier)
-                }
-            }
-        }
-    } else {
+    LazyMarkdown(
+        markdownBlocks,
+        modifier,
+        contentPadding,
+        state,
+        enabled,
+        selectable,
+        onUrlClick,
+        markdownStyling,
+        blockRenderer,
+    )
+}
+
+/**
+ * A Composable that renders a list of [MarkdownBlock]s in a lazy-loading column.
+ *
+ * For small amounts of Markdown, such as UI text, you should consider using [Markdown] instead to get better
+ * performance.
+ *
+ * @param blocks The list of Markdown blocks to render.
+ * @param modifier The modifier to apply to this layout node.
+ * @param contentPadding The padding to apply to the content.
+ * @param state The state of the lazy list.
+ * @param enabled Whether the rendered content is enabled.
+ * @param selectable Whether the text can be selected.
+ * @param onUrlClick The callback to be invoked when a URL is clicked.
+ * @param markdownStyling The styling to use for the rendered Markdown.
+ * @param blockRenderer The renderer to use for rendering the Markdown blocks.
+ */
+@ApiStatus.Experimental
+@ExperimentalJewelApi
+@Composable
+public fun LazyMarkdown(
+    blocks: List<MarkdownBlock>,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    state: LazyListState = rememberLazyListState(),
+    enabled: Boolean = true,
+    selectable: Boolean = false,
+    onUrlClick: (String) -> Unit = {},
+    markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
+    blockRenderer: MarkdownBlockRenderer = JewelTheme.markdownBlockRenderer,
+) {
+    MaybeSelectable(selectable, modifier) {
         LazyColumn(
-            modifier = modifier,
             state = state,
             contentPadding = contentPadding,
             verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
         ) {
-            items(markdownBlocks) { block -> blockRenderer.render(block, enabled, onUrlClick, onTextClick, Modifier) }
+            items(blocks) { block -> blockRenderer.RenderBlock(block, enabled, onUrlClick, Modifier) }
         }
+    }
+}
+
+@Composable
+private fun MaybeSelectable(selectable: Boolean, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    val movableContent = remember { movableContentOf(content) }
+    if (selectable) {
+        SelectionContainer(modifier) { movableContent() }
+    } else {
+        movableContent()
     }
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/ImageRendererExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/ImageRendererExtension.kt
@@ -6,9 +6,22 @@ import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
 
-/** An extension for the Jewel images rendering engine. */
+/**
+ * Extension for rendering images in Jewel Markdown.
+ *
+ * Implement this interface to provide a custom renderer for images. This is useful for handling image loading from
+ * different sources (e.g., network, local files) or for applying custom visual treatments to images.
+ *
+ * The [renderImageContent] function will be called for each image found in the Markdown content.
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public interface ImageRendererExtension {
-    @Composable public fun renderImagesContent(image: InlineMarkdown.Image): InlineTextContent
+    /**
+     * Renders an image from a Markdown document.
+     *
+     * @param image The image data, containing information like the image URL and alt text.
+     * @return An [InlineTextContent] that will be embedded in the text flow, which will be used to display the image.
+     */
+    @Composable public fun renderImageContent(image: InlineMarkdown.Image): InlineTextContent
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
@@ -9,12 +9,27 @@ import org.jetbrains.jewel.markdown.MarkdownBlock.CustomBlock
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 
-/** An extension for [MarkdownBlockRenderer] that can render one or more [MarkdownBlock.CustomBlock]s. */
+/**
+ * An extension for [MarkdownBlockRenderer] that can render one or more [MarkdownBlock.CustomBlock]s.
+ *
+ * This is the primary way to handle custom Markdown elements that are not part of the standard Markdown syntax.
+ * Implement this interface to define how a specific type of [CustomBlock] should be rendered.
+ *
+ * If you want to customize how a standard block is rendered, you can create a new [MarkdownBlockRenderer] with the
+ * required custom behavior. Extending [org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer] is the
+ * simplest choice in that case.
+ *
+ * Implementations are responsible for both checking if they can render a given block, through the [canRender] method,
+ * and for providing the Composable content for it, through the [RenderCustomBlock] method.
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public interface MarkdownBlockRendererExtension {
     /**
      * Check whether the provided [block] can be rendered by this extension.
+     *
+     * This method is called by the [MarkdownBlockRenderer] to determine which extension should handle a given
+     * [CustomBlock].
      *
      * @param block The block to check for renderability.
      * @return `true` if this extension can render the given [block], `false` otherwise.
@@ -30,9 +45,13 @@ public interface MarkdownBlockRendererExtension {
      * @param inlineRenderer The [InlineMarkdownRenderer] to use to render inline elements if necessary.
      * @param enabled Whether The rendered content should be enabled.
      * @param modifier The modifier to be applied to the composable.
-     * @param onUrlClick The callback to invoke when an URL is clicked.
-     * @param onTextClick The callback to invoke when a text part is clicked.
+     * @param onUrlClick The callback to invoke when a URL is clicked.
+     * @param onTextClick The callback to invoke when a text part is clicked. **Ignored.**
      */
+    @Deprecated(
+        "Use RenderCustomBlock instead; the onTextClick parameter is no longer supported.",
+        ReplaceWith("RenderCustomBlock(block, blockRenderer, inlineRenderer, enabled, modifier, onUrlClick)"),
+    )
     @Suppress("ComposableNaming")
     @Composable
     public fun render(
@@ -43,5 +62,31 @@ public interface MarkdownBlockRendererExtension {
         modifier: Modifier,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+    ) {
+        RenderCustomBlock(block, blockRenderer, inlineRenderer, enabled, modifier, onUrlClick)
+    }
+
+    /**
+     * Renders a [MarkdownBlock.CustomBlock] as a native Composable.
+     *
+     * Note that if [canRender] returns `false` for a given [block], the implementation of this method may throw an
+     * exception.
+     *
+     * @param block The [MarkdownBlock.CustomBlock] to render.
+     * @param blockRenderer The [MarkdownBlockRenderer] to use to render other blocks if necessary.
+     * @param inlineRenderer The [InlineMarkdownRenderer] to use to render inline elements if necessary.
+     * @param enabled Whether the rendered content should be interactive. When `false`, components like links will not
+     *   be clickable.
+     * @param modifier The modifier to be applied to the composable.
+     * @param onUrlClick The callback to invoke when a URL is clicked.
+     */
+    @Composable
+    public fun RenderCustomBlock(
+        block: CustomBlock,
+        blockRenderer: MarkdownBlockRenderer,
+        inlineRenderer: InlineMarkdownRenderer,
+        enabled: Boolean,
+        modifier: Modifier,
+        onUrlClick: (String) -> Unit,
     )
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
@@ -7,7 +7,7 @@ import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 
 /**
- * Renders a sequence of [InlineMarkdown] elements into an [AnnotatedString].
+ * Renders a series of [InlineMarkdown] elements into an [AnnotatedString].
  *
  * This renderer is responsible for handling inline-level Markdown elements like text, emphasis, links, and code spans.
  * It translates these elements into a single, styled `AnnotatedString` that can be displayed in a Compose UI.
@@ -18,7 +18,7 @@ import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 @ExperimentalJewelApi
 public interface InlineMarkdownRenderer {
     /**
-     * Renders a sequence of [InlineMarkdown] elements into a single [AnnotatedString], applying the provided [styling].
+     * Renders a series of [InlineMarkdown] elements into a single [AnnotatedString], applying the provided [styling].
      *
      * @param inlineMarkdown The sequence of [InlineMarkdown] elements to be rendered.
      * @param styling The [InlinesStyling] that defines the visual appearance of the different inline elements.

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
@@ -24,7 +24,6 @@ import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
  * @param rendererExtensions The [MarkdownRendererExtension]s used to render [MarkdownBlock.CustomBlock]s.
  * @param inlineRenderer The [InlineMarkdownRenderer] used to render
  *   [inline content][org.jetbrains.jewel.markdown.InlineMarkdown].
- * @see render
  */
 @Suppress("ComposableNaming")
 @ApiStatus.Experimental
@@ -40,16 +39,34 @@ public interface MarkdownBlockRenderer {
      * @param blocks The list of blocks to render.
      * @param enabled True if the blocks should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the root composable (usually, a `Column` or `LazyColumn`).
-     * @see render
      */
+    @Deprecated("Use RenderBlocks instead.", ReplaceWith("RenderBlocks(blocks, enabled, onUrlClick, modifier)"))
     @Composable
     public fun render(
         blocks: List<MarkdownBlock>,
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderBlocks(blocks, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a list of [MarkdownBlock]s into a Compose UI.
+     *
+     * @param blocks The list of blocks to render.
+     * @param enabled True if the blocks should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the root composable (usually, a `Column` or `LazyColumn`).
+     */
+    @Composable
+    public fun RenderBlocks(
+        blocks: List<MarkdownBlock>,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -59,10 +76,10 @@ public interface MarkdownBlockRenderer {
      * @param block The block to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated("Use RenderBlock instead.", ReplaceWith("RenderBlock(block, enabled, onUrlClick, modifier)"))
     @Composable
     public fun render(
         block: MarkdownBlock,
@@ -70,7 +87,20 @@ public interface MarkdownBlockRenderer {
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
         modifier: Modifier,
-    )
+    ) {
+        RenderBlock(block, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [MarkdownBlock] into a Compose UI.
+     *
+     * @param block The block to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderBlock(block: MarkdownBlock, enabled: Boolean, onUrlClick: (String) -> Unit, modifier: Modifier)
 
     /**
      * Renders a [Paragraph] into a Compose UI.
@@ -79,10 +109,13 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`Paragraph`][MarkdownStyling.Paragraph] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated(
+        "Use RenderParagraph instead.",
+        ReplaceWith("RenderParagraph(block, styling, enabled, onUrlClick, modifier)"),
+    )
     @Composable
     public fun render(
         block: Paragraph,
@@ -90,6 +123,26 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderParagraph(block, styling, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [Paragraph] into a Compose UI.
+     *
+     * @param block The paragraph to render.
+     * @param styling The [`Paragraph`][MarkdownStyling.Paragraph] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderParagraph(
+        block: Paragraph,
+        styling: MarkdownStyling.Paragraph,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -100,10 +153,13 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`Heading`][MarkdownStyling.Heading] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated(
+        "Use RenderHeading instead.",
+        ReplaceWith("RenderHeading(block, styling, enabled, onUrlClick, modifier)"),
+    )
     @Composable
     public fun render(
         block: MarkdownBlock.Heading,
@@ -111,6 +167,26 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderHeading(block, styling, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [MarkdownBlock.Heading] into a Compose UI.
+     *
+     * @param block The heading to render.
+     * @param styling The [`Heading`][MarkdownStyling.Heading] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderHeading(
+        block: MarkdownBlock.Heading,
+        styling: MarkdownStyling.Heading,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -121,10 +197,13 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`Heading.HN`][MarkdownStyling.Heading.HN] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated(
+        "Use RenderHeading instead.",
+        ReplaceWith("RenderHeading(block, styling, enabled, onUrlClick, modifier)"),
+    )
     @Composable
     public fun render(
         block: MarkdownBlock.Heading,
@@ -132,6 +211,26 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderHeading(block, styling, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [MarkdownBlock.Heading] into a Compose UI, using a specific [`HN`][MarkdownStyling.Heading.HN] styling.
+     *
+     * @param block The heading to render.
+     * @param styling The [`Heading.HN`][MarkdownStyling.Heading.HN] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderHeading(
+        block: MarkdownBlock.Heading,
+        styling: MarkdownStyling.Heading.HN,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -142,10 +241,13 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`BlockQuote`][MarkdownStyling.BlockQuote] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated(
+        "Use RenderBlockQuote instead.",
+        ReplaceWith("RenderBlockQuote(block, styling, enabled, onUrlClick, modifier)"),
+    )
     @Composable
     public fun render(
         block: BlockQuote,
@@ -153,6 +255,26 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderBlockQuote(block, styling, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [BlockQuote] into a Compose UI.
+     *
+     * @param block The blockquote to render.
+     * @param styling The [`BlockQuote`][MarkdownStyling.BlockQuote] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderBlockQuote(
+        block: BlockQuote,
+        styling: MarkdownStyling.BlockQuote,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -163,10 +285,10 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`List`][MarkdownStyling.List] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated("Use RenderList instead.", ReplaceWith("RenderList(block, styling, enabled, onUrlClick, modifier)"))
     @Composable
     public fun render(
         block: ListBlock,
@@ -174,6 +296,26 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderList(block, styling, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [ListBlock] into a Compose UI.
+     *
+     * @param block The list to render.
+     * @param styling The [`List`][MarkdownStyling.List] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderList(
+        block: ListBlock,
+        styling: MarkdownStyling.List,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -184,10 +326,13 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`List.Ordered`][MarkdownStyling.List.Ordered] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated(
+        "Use RenderOrderedList instead.",
+        ReplaceWith("RenderOrderedList(block, styling, enabled, onUrlClick, modifier)"),
+    )
     @Composable
     public fun render(
         block: OrderedList,
@@ -195,6 +340,26 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderOrderedList(block, styling, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [OrderedList] into a Compose UI.
+     *
+     * @param block The ordered list to render.
+     * @param styling The [`List.Ordered`][MarkdownStyling.List.Ordered] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderOrderedList(
+        block: OrderedList,
+        styling: MarkdownStyling.List.Ordered,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -205,10 +370,13 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`List.Unordered`][MarkdownStyling.List.Unordered] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated(
+        "Use RenderUnorderedList instead.",
+        ReplaceWith("RenderUnorderedList(block, styling, enabled, onUrlClick, modifier)"),
+    )
     @Composable
     public fun render(
         block: UnorderedList,
@@ -216,6 +384,26 @@ public interface MarkdownBlockRenderer {
         enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        RenderUnorderedList(block, styling, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [UnorderedList] into a Compose UI.
+     *
+     * @param block The unordered list to render.
+     * @param styling The [`List.Unordered`][MarkdownStyling.List.Unordered] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderUnorderedList(
+        block: UnorderedList,
+        styling: MarkdownStyling.List.Unordered,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
         modifier: Modifier,
     )
 
@@ -225,10 +413,10 @@ public interface MarkdownBlockRenderer {
      * @param block The list item to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param onUrlClick The callback invoked when the user clicks on a URL.
-     * @param onTextClick The callback invoked when the user clicks on a text.
+     * @param onTextClick The callback invoked when the user clicks on a text. **Ignored.**
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated("Use RenderListItem instead.", ReplaceWith("RenderListItem(block, enabled, onUrlClick, modifier)"))
     @Composable
     public fun render(
         block: ListItem,
@@ -236,30 +424,78 @@ public interface MarkdownBlockRenderer {
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
         modifier: Modifier,
-    )
+    ) {
+        RenderListItem(block, enabled, onUrlClick, modifier)
+    }
+
+    /**
+     * Renders a [ListItem] into a Compose UI.
+     *
+     * @param block The list item to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param onUrlClick The callback invoked when the user clicks on a URL.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderListItem(block: ListItem, enabled: Boolean, onUrlClick: (String) -> Unit, modifier: Modifier)
 
     /**
      * Renders a [CodeBlock] into a Compose UI.
      *
-     * @param block The heading to render.
+     * @param block The code block to render.
      * @param styling The [`Code`][MarkdownStyling.Code] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
-    @Composable public fun render(block: CodeBlock, styling: MarkdownStyling.Code, enabled: Boolean, modifier: Modifier)
+    @Deprecated("Use RenderCodeBlock instead.", ReplaceWith("RenderCodeBlock(block, styling, enabled, modifier)"))
+    @Composable
+    public fun render(block: CodeBlock, styling: MarkdownStyling.Code, enabled: Boolean, modifier: Modifier) {
+        RenderCodeBlock(block, styling, enabled, modifier)
+    }
+
+    /**
+     * Renders a [CodeBlock] into a Compose UI.
+     *
+     * @param block The code block to render.
+     * @param styling The [`Code`][MarkdownStyling.Code] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderCodeBlock(block: CodeBlock, styling: MarkdownStyling.Code, enabled: Boolean, modifier: Modifier)
 
     /**
      * Renders a [IndentedCodeBlock] into a Compose UI.
      *
-     * @param block The heading to render.
+     * @param block The indented code block to render.
      * @param styling The [`Code.Indented`][MarkdownStyling.Code.Indented] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param modifier The modifier to be applied to the composable.
-     * @see render
      */
+    @Deprecated(
+        "Use RenderIndentedCodeBlock instead.",
+        ReplaceWith("RenderIndentedCodeBlock(block, styling, enabled, modifier)"),
+    )
     @Composable
     public fun render(
+        block: IndentedCodeBlock,
+        styling: MarkdownStyling.Code.Indented,
+        enabled: Boolean,
+        modifier: Modifier,
+    ) {
+        RenderIndentedCodeBlock(block, styling, enabled, modifier)
+    }
+
+    /**
+     * Renders a [IndentedCodeBlock] into a Compose UI.
+     *
+     * @param block The indented code block to render.
+     * @param styling The [`Code.Indented`][MarkdownStyling.Code.Indented] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
+     */
+    @Composable
+    public fun RenderIndentedCodeBlock(
         block: IndentedCodeBlock,
         styling: MarkdownStyling.Code.Indented,
         enabled: Boolean,
@@ -268,17 +504,40 @@ public interface MarkdownBlockRenderer {
 
     /**
      * Renders a [FencedCodeBlock] into a Compose UI. If the fenced block defines a language, it can be
-     * syntax-highlighted by the the [org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter].
+     * syntax-highlighted by the [org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter].
      *
-     * @param block The heading to render.
+     * @param block The fenced code block to render.
      * @param styling The [`Code.Fenced`][MarkdownStyling.Code.Fenced] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param modifier The modifier to be applied to the composable.
-     * @see render
+     * @see org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
+     */
+    @Deprecated(
+        "Use RenderFencedCodeBlock instead.",
+        ReplaceWith("RenderFencedCodeBlock(block, styling, enabled, modifier)"),
+    )
+    @Composable
+    public fun render(
+        block: FencedCodeBlock,
+        styling: MarkdownStyling.Code.Fenced,
+        enabled: Boolean,
+        modifier: Modifier,
+    ) {
+        RenderFencedCodeBlock(block, styling, enabled, modifier)
+    }
+
+    /**
+     * Renders a [FencedCodeBlock] into a Compose UI. If the fenced block defines a language, it can be
+     * syntax-highlighted by the [org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter].
+     *
+     * @param block The fenced code block to render.
+     * @param styling The [`Code.Fenced`][MarkdownStyling.Code.Fenced] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
      * @see org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
      */
     @Composable
-    public fun render(
+    public fun RenderFencedCodeBlock(
         block: FencedCodeBlock,
         styling: MarkdownStyling.Code.Fenced,
         enabled: Boolean,
@@ -291,23 +550,54 @@ public interface MarkdownBlockRenderer {
      * @param styling The [`ThematicBreak`][MarkdownStyling.ThematicBreak] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param modifier The modifier to be applied to the composable.
-     * @see render
+     */
+    @Deprecated("Use RenderThematicBreak instead.", ReplaceWith("RenderThematicBreak(styling, enabled, modifier)"))
+    @Composable
+    public fun renderThematicBreak(styling: MarkdownStyling.ThematicBreak, enabled: Boolean, modifier: Modifier) {
+        RenderThematicBreak(styling, enabled, modifier)
+    }
+
+    /**
+     * Renders a thematic break (horizontal divider) into a Compose UI.
+     *
+     * @param styling The [`ThematicBreak`][MarkdownStyling.ThematicBreak] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
      */
     @Composable
-    public fun renderThematicBreak(styling: MarkdownStyling.ThematicBreak, enabled: Boolean, modifier: Modifier)
+    public fun RenderThematicBreak(styling: MarkdownStyling.ThematicBreak, enabled: Boolean, modifier: Modifier)
 
     /**
      * Renders a [HtmlBlock] into a Compose UI. Since Compose can't render HTML out of the box, this might result in a
      * no-op (e.g., in [DefaultMarkdownBlockRenderer.render]).
      *
-     * @param block The heading to render.
-     * @param styling The [`Code`][MarkdownStyling.Code] styling to use to render.
+     * @param block The HTML block to render.
+     * @param styling The [`HtmlBlock`][MarkdownStyling.HtmlBlock] styling to use to render.
      * @param enabled True if the block should be enabled, false otherwise.
      * @param modifier The modifier to be applied to the composable.
-     * @see render
+     */
+    @Deprecated("Use RenderHtmlBlock instead.", ReplaceWith("RenderHtmlBlock(block, styling, enabled, modifier)"))
+    @Composable
+    public fun render(block: HtmlBlock, styling: MarkdownStyling.HtmlBlock, enabled: Boolean, modifier: Modifier) {
+        RenderHtmlBlock(block, styling, enabled, modifier)
+    }
+
+    /**
+     * Renders a [HtmlBlock] into a Compose UI. Since Compose can't render HTML out of the box, this might result in a
+     * no-op (e.g., in [DefaultMarkdownBlockRenderer.render]).
+     *
+     * @param block The HTML block to render.
+     * @param styling The [`HtmlBlock`][MarkdownStyling.HtmlBlock] styling to use to render.
+     * @param enabled True if the block should be enabled, false otherwise.
+     * @param modifier The modifier to be applied to the composable.
      */
     @Composable
-    public fun render(block: HtmlBlock, styling: MarkdownStyling.HtmlBlock, enabled: Boolean, modifier: Modifier)
+    public fun RenderHtmlBlock(
+        block: HtmlBlock,
+        styling: MarkdownStyling.HtmlBlock,
+        enabled: Boolean,
+        modifier: Modifier,
+    )
 
     /**
      * Creates a copy of this instance, using the provided non-null parameters, or the current values for the null ones.

--- a/platform/jewel/markdown/extensions/autolink/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/autolink/AutolinkProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/autolink/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/autolink/AutolinkProcessorExtension.kt
@@ -6,6 +6,13 @@ import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 
+/**
+ * A [MarkdownProcessorExtension] that adds support for auto-linking URLs and email addresses.
+ *
+ * For example, `https://www.jetbrains.com` will be rendered as a link.
+ *
+ * See the [GitHub Flavored Markdown specs](https://github.github.com/gfm/#autolinks-extension-).
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public object AutolinkProcessorExtension : MarkdownProcessorExtension {

--- a/platform/jewel/markdown/extensions/gfm-alerts/api-dump-experimental.txt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/api-dump-experimental.txt
@@ -93,8 +93,8 @@
 - org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
 - sf:$stable:I
 - <init>(org.jetbrains.jewel.markdown.extensions.github.alerts.AlertStyling,org.jetbrains.jewel.markdown.rendering.MarkdownStyling):V
+- RenderCustomBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function1,androidx.compose.runtime.Composer,I):V
 - canRender(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock):Z
-- render(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.runtime.Composer,I):V
 *f:org.jetbrains.jewel.markdown.extensions.github.alerts.GitHubAlertIcons
 - sf:$stable:I
 - sf:INSTANCE:org.jetbrains.jewel.markdown.extensions.github.alerts.GitHubAlertIcons

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/AlertBlock.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/AlertBlock.kt
@@ -1,0 +1,16 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.alerts
+
+import org.commonmark.node.CustomBlock
+
+internal sealed class AlertBlock : CustomBlock() {
+    class Note : AlertBlock()
+
+    class Tip : AlertBlock()
+
+    class Important : AlertBlock()
+
+    class Warning : AlertBlock()
+
+    class Caution : AlertBlock()
+}

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlert.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlert.kt
@@ -4,18 +4,30 @@ import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 
+/**
+ * A GitHub-style alert, such as `[!NOTE]`.
+ *
+ * See the
+ * [GitHub documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github).
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public sealed interface GitHubAlert : MarkdownBlock.CustomBlock {
+    /** The content of the alert. */
     public val content: List<MarkdownBlock>
 
+    /** A `[!NOTE]` alert. */
     public data class Note(override val content: List<MarkdownBlock>) : GitHubAlert
 
+    /** A `[!TIP]` alert. */
     public data class Tip(override val content: List<MarkdownBlock>) : GitHubAlert
 
+    /** An `[!IMPORTANT]` alert. */
     public data class Important(override val content: List<MarkdownBlock>) : GitHubAlert
 
+    /** A `[!WARNING]` alert. */
     public data class Warning(override val content: List<MarkdownBlock>) : GitHubAlert
 
+    /** A `[!CAUTION]` alert. */
     public data class Caution(override val content: List<MarkdownBlock>) : GitHubAlert
 }

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
@@ -31,6 +31,7 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.Text
 
+/** A [MarkdownBlockRendererExtension] that renders [GitHubAlert] blocks. */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private val rootStyling: MarkdownStyling) :
@@ -38,14 +39,13 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
     override fun canRender(block: CustomBlock): Boolean = block is GitHubAlert
 
     @Composable
-    override fun render(
+    override fun RenderCustomBlock(
         block: CustomBlock,
         blockRenderer: MarkdownBlockRenderer,
         inlineRenderer: InlineMarkdownRenderer,
         enabled: Boolean,
         modifier: Modifier,
         onUrlClick: (String) -> Unit,
-        onTextClick: () -> Unit,
     ) {
         // Smart cast doesn't work in this case, and then the detection for redundant suppression is
         // also borked
@@ -53,11 +53,11 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
         val alert = block as? GitHubAlert
 
         when (alert) {
-            is Caution -> Alert(alert, styling.caution, enabled, blockRenderer, onUrlClick, onTextClick, modifier)
-            is Important -> Alert(alert, styling.important, enabled, blockRenderer, onUrlClick, onTextClick, modifier)
-            is Note -> Alert(alert, styling.note, enabled, blockRenderer, onUrlClick, onTextClick, modifier)
-            is Tip -> Alert(alert, styling.tip, enabled, blockRenderer, onUrlClick, onTextClick, modifier)
-            is Warning -> Alert(alert, styling.warning, enabled, blockRenderer, onUrlClick, onTextClick, modifier)
+            is Caution -> Alert(alert, styling.caution, enabled, blockRenderer, onUrlClick, modifier)
+            is Important -> Alert(alert, styling.important, enabled, blockRenderer, onUrlClick, modifier)
+            is Note -> Alert(alert, styling.note, enabled, blockRenderer, onUrlClick, modifier)
+            is Tip -> Alert(alert, styling.tip, enabled, blockRenderer, onUrlClick, modifier)
+            is Warning -> Alert(alert, styling.warning, enabled, blockRenderer, onUrlClick, modifier)
             else -> error("Unsupported block of type ${block.javaClass.name} cannot be rendered")
         }
     }
@@ -69,7 +69,6 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
         enabled: Boolean,
         blockRenderer: MarkdownBlockRenderer,
         onUrlClick: (String) -> Unit,
-        onTextClick: () -> Unit,
         modifier: Modifier = Modifier,
     ) {
         Column(
@@ -115,7 +114,7 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
             CompositionLocalProvider(
                 LocalContentColor provides styling.textColor.takeOrElse { LocalContentColor.current }
             ) {
-                blockRenderer.render(block.content, enabled, onUrlClick, onTextClick, Modifier)
+                blockRenderer.RenderBlocks(block.content, enabled, onUrlClick, Modifier)
             }
         }
     }

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension.kt
@@ -19,17 +19,20 @@ import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.extensions.MarkdownBlockProcessorExtension
-import org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
-import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertBlock.Caution
 import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertBlock.Important
 import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertBlock.Note
 import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertBlock.Tip
 import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertBlock.Warning
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
-import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
+/**
+ * A [MarkdownProcessorExtension] that adds support for GFM alerts.
+ *
+ * See the
+ * [GitHub documentation]https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/).
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public object GitHubAlertProcessorExtension : MarkdownProcessorExtension {
@@ -59,13 +62,6 @@ public object GitHubAlertProcessorExtension : MarkdownProcessorExtension {
             }
         }
     }
-}
-
-@ApiStatus.Experimental
-@ExperimentalJewelApi
-public class GitHubAlertRendererExtension(alertStyling: AlertStyling, rootStyling: MarkdownStyling) :
-    MarkdownRendererExtension {
-    override val blockRenderer: MarkdownBlockRendererExtension = GitHubAlertBlockRenderer(alertStyling, rootStyling)
 }
 
 private object GitHubAlertCommonMarkExtension : ParserExtension, TextContentRendererExtension {
@@ -155,16 +151,4 @@ private class AlertTextContentNodeRenderer(private val context: TextContentNodeR
             child = child.next
         }
     }
-}
-
-internal sealed class AlertBlock : CustomBlock() {
-    class Note : AlertBlock()
-
-    class Tip : AlertBlock()
-
-    class Important : AlertBlock()
-
-    class Warning : AlertBlock()
-
-    class Caution : AlertBlock()
 }

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertRendererExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertRendererExtension.kt
@@ -1,0 +1,15 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.alerts
+
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
+import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
+import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
+
+@ApiStatus.Experimental
+@ExperimentalJewelApi
+public class GitHubAlertRendererExtension(alertStyling: AlertStyling, rootStyling: MarkdownStyling) :
+    MarkdownRendererExtension {
+    override val blockRenderer: MarkdownBlockRendererExtension = GitHubAlertBlockRenderer(alertStyling, rootStyling)
+}

--- a/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertStyling.kt
+++ b/platform/jewel/markdown/extensions/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertStyling.kt
@@ -11,6 +11,15 @@ import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 import org.jetbrains.jewel.ui.icon.IconKey
 
+/**
+ * Styling for the different types of GFM alerts.
+ *
+ * @param note Styling for the "note" alert.
+ * @param tip Styling for the "tip" alert.
+ * @param important Styling for the "important" alert.
+ * @param warning Styling for the "warning" alert.
+ * @param caution Styling for the "caution" alert.
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @GenerateDataFunctions
@@ -58,6 +67,19 @@ public class AlertStyling(
     public companion object
 }
 
+/**
+ * Base styling for a GFM alert.
+ *
+ * @property padding The padding to apply to the entire alert.
+ * @property lineWidth The width of the vertical line on the side of the alert.
+ * @property lineColor The color of the vertical line on the side of the alert.
+ * @property pathEffect The path effect to apply to the vertical line, e.g., for dashed lines.
+ * @property strokeCap The stroke cap to use for the vertical line.
+ * @property titleTextStyle The text style for the alert's title.
+ * @property titleIconKey The icon to use in the title.
+ * @property titleIconTint The tint to apply to the title icon.
+ * @property textColor The text color for the body of the alert.
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 public sealed interface BaseAlertStyling {
@@ -72,6 +94,7 @@ public sealed interface BaseAlertStyling {
     public val textColor: Color
 }
 
+/** Styling for a "note" GFM alert. */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @GenerateDataFunctions
@@ -135,6 +158,7 @@ public class NoteAlertStyling(
     public companion object
 }
 
+/** Styling for a "tip" GFM alert. */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @GenerateDataFunctions
@@ -198,6 +222,7 @@ public class TipAlertStyling(
     public companion object
 }
 
+/** Styling for an "important" GFM alert. */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @GenerateDataFunctions
@@ -261,6 +286,7 @@ public class ImportantAlertStyling(
     public companion object
 }
 
+/** Styling for a "warning" GFM alert. */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @GenerateDataFunctions
@@ -324,6 +350,7 @@ public class WarningAlertStyling(
     public companion object
 }
 
+/** Styling for a "caution" GFM alert. */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @GenerateDataFunctions

--- a/platform/jewel/markdown/extensions/gfm-tables/api-dump-experimental.txt
+++ b/platform/jewel/markdown/extensions/gfm-tables/api-dump-experimental.txt
@@ -28,12 +28,6 @@
 - f:getMetrics():org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableMetrics
 - hashCode():I
 *f:org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableStyling$Companion
-*f:org.jetbrains.jewel.markdown.extensions.github.tables.GitHubTableBlockRenderer
-- org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
-- sf:$stable:I
-- <init>(org.jetbrains.jewel.markdown.rendering.MarkdownStyling,org.jetbrains.jewel.markdown.extensions.github.tables.GfmTableStyling):V
-- canRender(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock):Z
-- render(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function0,androidx.compose.runtime.Composer,I):V
 *f:org.jetbrains.jewel.markdown.extensions.github.tables.GitHubTableProcessorExtension
 - org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 - sf:$stable:I

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableBlockRenderer.kt
@@ -22,9 +22,15 @@ import org.jetbrains.jewel.markdown.rendering.InlinesStyling
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
+/**
+ * Renders a [TableBlock] as a [BasicTableLayout].
+ *
+ * @param rootStyling The root styling to use.
+ * @param tableStyling The styling to use for the table.
+ */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
-public class GitHubTableBlockRenderer(
+internal class GitHubTableBlockRenderer(
     private val rootStyling: MarkdownStyling,
     private val tableStyling: GfmTableStyling,
 ) : MarkdownBlockRendererExtension {
@@ -32,14 +38,13 @@ public class GitHubTableBlockRenderer(
 
     @Suppress("LambdaParameterEventTrailing")
     @Composable
-    override fun render(
+    override fun RenderCustomBlock(
         block: CustomBlock,
         blockRenderer: MarkdownBlockRenderer,
         inlineRenderer: InlineMarkdownRenderer,
         enabled: Boolean,
         modifier: Modifier,
         onUrlClick: (String) -> Unit,
-        onTextClick: () -> Unit,
     ) {
         val tableBlock = block as TableBlock
 
@@ -81,7 +86,6 @@ public class GitHubTableBlockRenderer(
                                 enabled = enabled,
                                 paragraphStyling = headerRenderer.rootStyling.paragraph,
                                 onUrlClick = onUrlClick,
-                                onTextClick = onTextClick,
                             )
                         }
                     }
@@ -110,7 +114,6 @@ public class GitHubTableBlockRenderer(
                                     enabled = enabled,
                                     paragraphStyling = rootStyling.paragraph,
                                     onUrlClick = onUrlClick,
-                                    onTextClick = onTextClick,
                                 )
                             }
                         }
@@ -154,18 +157,16 @@ public class GitHubTableBlockRenderer(
         enabled: Boolean,
         paragraphStyling: MarkdownStyling.Paragraph,
         onUrlClick: (String) -> Unit,
-        onTextClick: () -> Unit,
     ) {
         Box(
             modifier = Modifier.background(backgroundColor).padding(padding),
             contentAlignment = (cell.alignment ?: defaultAlignment).asContentAlignment(),
         ) {
-            blockRenderer.render(
+            blockRenderer.RenderParagraph(
                 block = MarkdownBlock.Paragraph(cell.content),
                 styling = paragraphStyling,
                 enabled = enabled,
                 onUrlClick = onUrlClick,
-                onTextClick = onTextClick,
                 modifier = Modifier,
             )
         }

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
@@ -18,15 +18,11 @@ import org.commonmark.renderer.text.TextContentRenderer
 import org.commonmark.renderer.text.TextContentRenderer.TextContentRendererExtension
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
-import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.extensions.MarkdownBlockProcessorExtension
-import org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
-import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
 import org.jetbrains.jewel.markdown.processing.readInlineMarkdown
-import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 
 /**
  * Adds support for table parsing. Tables are a GitHub Flavored Markdown extension, defined
@@ -130,39 +126,3 @@ private object GitHubTablesCommonMarkExtension : ParserExtension, TextContentRen
         rendererBuilder.extensions(listOf(TablesExtension.create()))
     }
 }
-
-@ApiStatus.Experimental
-@ExperimentalJewelApi
-public class GitHubTableRendererExtension(tableStyling: GfmTableStyling, rootStyling: MarkdownStyling) :
-    MarkdownRendererExtension {
-    override val blockRenderer: MarkdownBlockRendererExtension = GitHubTableBlockRenderer(rootStyling, tableStyling)
-}
-
-internal data class TableBlock(val header: TableHeader, val rows: List<TableRow>) : MarkdownBlock.CustomBlock {
-    val rowCount: Int = rows.size + 1 // We always have a header
-    val columnCount: Int
-
-    init {
-        require(header.cells.isNotEmpty()) { "Header cannot be empty" }
-        val headerColumns = header.cells.size
-
-        if (rows.isNotEmpty()) {
-            val bodyColumns = rows.first().cells.size
-            require(rows.all { it.cells.size == bodyColumns }) { "Inconsistent cell count in table body" }
-            require(headerColumns == bodyColumns) { "Inconsistent cell count between table body and header" }
-        }
-
-        columnCount = headerColumns
-    }
-}
-
-internal data class TableHeader(val cells: List<TableCell>) : MarkdownBlock.CustomBlock
-
-internal data class TableRow(val rowIndex: Int, val cells: List<TableCell>) : MarkdownBlock.CustomBlock
-
-internal data class TableCell(
-    val rowIndex: Int,
-    val columnIndex: Int,
-    val content: List<InlineMarkdown>,
-    val alignment: Alignment.Horizontal?,
-) : MarkdownBlock.CustomBlock

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableRendererExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableRendererExtension.kt
@@ -1,0 +1,21 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.tables
+
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
+import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
+import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
+
+/**
+ * An extension that provides a renderer for GFM tables.
+ *
+ * @param tableStyling The styling to use for the table.
+ * @param rootStyling The root styling to use.
+ */
+@ApiStatus.Experimental
+@ExperimentalJewelApi
+public class GitHubTableRendererExtension(tableStyling: GfmTableStyling, rootStyling: MarkdownStyling) :
+    MarkdownRendererExtension {
+    override val blockRenderer: MarkdownBlockRendererExtension = GitHubTableBlockRenderer(rootStyling, tableStyling)
+}

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableBlock.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableBlock.kt
@@ -1,0 +1,22 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.tables
+
+import org.jetbrains.jewel.markdown.MarkdownBlock
+
+internal data class TableBlock(val header: TableHeader, val rows: List<TableRow>) : MarkdownBlock.CustomBlock {
+    val rowCount: Int = rows.size + 1 // We always have a header
+    val columnCount: Int
+
+    init {
+        require(header.cells.isNotEmpty()) { "Header cannot be empty" }
+        val headerColumns = header.cells.size
+
+        if (rows.isNotEmpty()) {
+            val bodyColumns = rows.first().cells.size
+            require(rows.all { it.cells.size == bodyColumns }) { "Inconsistent cell count in table body" }
+            require(headerColumns == bodyColumns) { "Inconsistent cell count between table body and header" }
+        }
+
+        columnCount = headerColumns
+    }
+}

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableCell.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableCell.kt
@@ -1,0 +1,13 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.tables
+
+import androidx.compose.ui.Alignment
+import org.jetbrains.jewel.markdown.InlineMarkdown
+import org.jetbrains.jewel.markdown.MarkdownBlock
+
+internal data class TableCell(
+    val rowIndex: Int,
+    val columnIndex: Int,
+    val content: List<InlineMarkdown>,
+    val alignment: Alignment.Horizontal?,
+) : MarkdownBlock.CustomBlock

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableHeader.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableHeader.kt
@@ -1,0 +1,6 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.tables
+
+import org.jetbrains.jewel.markdown.MarkdownBlock
+
+internal data class TableHeader(val cells: List<TableCell>) : MarkdownBlock.CustomBlock

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableRow.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/TableRow.kt
@@ -1,0 +1,6 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.tables
+
+import org.jetbrains.jewel.markdown.MarkdownBlock
+
+internal data class TableRow(val rowIndex: Int, val cells: List<TableCell>) : MarkdownBlock.CustomBlock

--- a/platform/jewel/markdown/extensions/images/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImpl.kt
+++ b/platform/jewel/markdown/extensions/images/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImpl.kt
@@ -36,7 +36,7 @@ import org.jetbrains.jewel.ui.component.Tooltip
  */
 internal class Coil3ImageRendererExtensionImpl(private val imageLoader: ImageLoader) : ImageRendererExtension {
     @Composable
-    override fun renderImagesContent(image: InlineMarkdown.Image): InlineTextContent {
+    override fun renderImageContent(image: InlineMarkdown.Image): InlineTextContent {
         var knownSize by remember(image.source) { mutableStateOf<DpSize?>(null) }
 
         return InlineTextContent(

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -406,7 +406,11 @@ private fun RowScope.ColumnTwo(project: Project) {
 @Composable
 private fun MarkdownExample(project: Project) {
     var enabled by remember { mutableStateOf(true) }
-    CheckboxRow("Enabled", enabled, { enabled = it })
+    var selectable by remember { mutableStateOf(false) }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        CheckboxRow("Enabled", enabled, { enabled = it })
+        CheckboxRow("Selectable", selectable, { selectable = it })
+    }
 
     val contentColor = if (enabled) JewelTheme.globalColors.text.normal else JewelTheme.globalColors.text.disabled
     CompositionLocalProvider(LocalContentColor provides contentColor) {
@@ -435,6 +439,7 @@ private fun MarkdownExample(project: Project) {
                     .border(1.dp, JBUI.CurrentTheme.Banner.INFO_BORDER_COLOR.toComposeColor(), RoundedCornerShape(8.dp))
                     .padding(8.dp),
                 enabled = enabled,
+                selectable = selectable,
                 onUrlClick = { url -> BrowserUtil.open(url) },
             )
         }

--- a/platform/jewel/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/markdown/MarkdownPreview.kt
+++ b/platform/jewel/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/markdown/MarkdownPreview.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import coil3.compose.LocalPlatformContext
-import java.awt.Desktop
-import java.net.URI
+import java.awt.Desktop.getDesktop
+import java.net.URI.create
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.jewel.foundation.code.highlighting.NoOpCodeHighlighter
@@ -115,16 +115,14 @@ internal fun MarkdownPreview(rawMarkdown: CharSequence, modifier: Modifier = Mod
         val lazyListState = rememberLazyListState()
         VerticallyScrollableContainer(lazyListState, modifier.background(background)) {
             LazyMarkdown(
-                markdownBlocks = markdownBlocks,
+                blocks = markdownBlocks,
                 modifier = Modifier.background(background),
                 contentPadding =
                     PaddingValues(start = 8.dp, top = 8.dp, end = 8.dp + scrollbarContentSafePadding(), bottom = 8.dp),
                 state = lazyListState,
                 selectable = true,
-                onUrlClick = onUrlClick(),
+                onUrlClick = { url: String -> getDesktop().browse(create(url)) },
             )
         }
     }
 }
-
-private fun onUrlClick(): (String) -> Unit = { url -> Desktop.getDesktop().browse(URI.create(url)) }


### PR DESCRIPTION
This fixes the issue that is present when some selectable `Markdown` (i.e., when the content is wrapped in a `SelectionContainer`) also has one or more links. In that case, the `clickable` added to the `Text` composables used to render paragraphs steals the drag events and makes it impossible to start selecting text from said `Text` components.

 Before | After
 --- | ---
 ![Before](https://github.com/user-attachments/assets/7fee1696-395d-44a4-80a4-51cfafebc435) | ![After](https://github.com/user-attachments/assets/6b73df19-2ded-4ea2-a1c5-9ff99a952ae9)


This in turn has a wide-ranging impact in that it makes the `onTextClick` parameter unused throughout the Markdown APIs. Turns out that the original use case (making clickable Markdown-based components such as checkboxes) would be better served by a custom block renderer. So in this change I removed the `clickable` modifier and `onTextClick` from all Markdown rendering APIs.

Given this is a large change, even if this is an experimental API, I decided to still keep the old APIs around for backwards compatibility. I also took the opportunity to rename the `render` APIs to names that are more descriptive and respect Compose naming conventions.

Then, I fixed a subtle bug where disabled fenced code blocks would be more "transparent" than indented ones (we applied `alpha` twice!).

 Before | After
 --- | ---
 <img width="273" height="153" alt="Before" src="https://github.com/user-attachments/assets/39c548a9-0abb-49f8-9a7a-4420b1b5af52" /> | <img width="274" height="152" alt="image" src="https://github.com/user-attachments/assets/586b99e6-d140-4dfe-8698-411d2f739bc8" />

Lastly, I have added a bunch of KDoc around, and cleaned up a lot of duplication in the `Markdown`/`LazyMarkdown` code, also making sure a change in `selectable` doesn't lose state.

## Release notes

### ⚠️ Important Changes
 * All the experimental `*.render` APIs have been renamed and have lost the `onTextClick` parameter (non-breaking change). They now all have a default implementation that delegates to the new counterparts, ignoring `onTextClick`
 * The experimental `Markdown` and `LazyMarkdown` composables have lost the `onTextClick` parameter (non-breaking change)
 * The experimental API `ImageRendererExtension.renderImagesContent` was renamed to `renderImageContent` (singular "image") in a **breaking** manner
 * The experimental `GitHubTableBlockRenderer` has been made private

### Bug fixes
 * Fixed a bug that made it impossible to select text in a Markdown paragraph that contains one or more links
 * Fixed a bug where disabled fenced code blocks in Markdown would look "lighter" than indented code blocks

### Deprecated API
 * All `MarkdownBlockRenderer.render` APIs have been deprecated in favour of the new APIs with better naming, and no `onTextClick` parameter
 * `Markdown` and `LazyMarkdown` overloads with the `onTextClick` parameter have been deprecated