### PR TITLE
[JEWEL-842] Fix Ligatures Not Mirroring IDE Settings

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeText.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeText.kt
@@ -70,7 +70,7 @@ public fun retrieveEditorTextStyle(): TextStyle {
             fontFamily = font.asComposeFontFamily(),
             fontSize = editorColorScheme.editorFontSize.sp,
             lineHeight = (computedLineHeight * EDITOR_LINE_HEIGHT_FACTOR).coerceAtLeast(1f).sp,
-            fontFeatureSettings = if (!editorColorScheme.isUseLigatures) "liga 0" else "liga 1",
+            fontFeatureSettings = if (!editorColorScheme.isUseLigatures) "liga 0, calt 0" else "liga 1, calt 1",
         )
 }
 


### PR DESCRIPTION
# Bug

On bridge, if the user changes the IDE current font's ligature settings, the markdown styling kinda just ignores it. This PR fixes this.

# Evidences

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e6b29b0a-d4d3-4aef-b777-f22fc5169469" width="400" /> | <video src="https://github.com/user-attachments/assets/8b515a2e-672c-4572-9487-3bfb040c3904" width="400" /> | 