### PR TITLE
[JEWEL-944] Annotate breaking changes in API dumps

### DIFF
--- a/.github/workflows/jewel-checks.yml
+++ b/.github/workflows/jewel-checks.yml
@@ -92,13 +92,32 @@ jobs:
 
       - name: Validate PR has single commit
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/validate-pr-commits.sh
 
       - name: Validate commit message
         env:
+          GH_TOKEN: ${{ github.token }}
           JEWEL_YT_TOKEN: ${{ secrets.JEWEL_YT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/validate-commit-message.sh
+
+  breaking_api_changes:
+    name: Check for breaking API changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '2'
+        name: Check out repository
+
+      - name: Grant execute permission for validation script
+        run: chmod +x ./scripts/validate-api-dump-changes.main.kts
+
+      - name: Annotate breaking API changes
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/validate-api-dump-changes.main.kts

--- a/platform/jewel/scripts/utils.main.kts
+++ b/platform/jewel/scripts/utils.main.kts
@@ -1,0 +1,91 @@
+@file:DependsOn("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+@file:DependsOn("com.github.pgreze:kotlin-process:1.5.1")
+@file:Suppress("RAW_RUN_BLOCKING")
+
+import com.github.pgreze.process.Redirect
+import com.github.pgreze.process.process
+import kotlin.system.exitProcess
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.intellij.lang.annotations.Language
+import java.io.File
+
+fun checkGhTool() = runBlocking { runCommand(command = "which gh", workingDir = null, exitOnError = false).isSuccess }
+
+fun checkPrNumber() = System.getenv("PR_NUMBER")?.trim()?.toIntOrNull() != null
+
+fun getPrNumber() = checkNotNull(System.getenv("PR_NUMBER")?.trim()) { "PR number not set" }
+
+fun requireGhTool() {
+    if (checkGhTool()) return
+
+    echoErr("ERROR: the GitHub CLI tool must be present on the PATH.")
+    exitProcess(1)
+}
+
+fun requirePrNumber() {
+    if (checkPrNumber()) return
+
+    echoErr("ERROR: PR_NUMBER environment variable not set.")
+    exitProcess(2)
+}
+
+fun echoErr(message: String) {
+    System.err.println("\u001b[0;31m$message\u001b[0m")
+}
+
+fun echoWarn(message: String) {
+    System.err.println("\u001b[0;33m$message\u001b[0m")
+}
+
+suspend fun runCommand(
+    @Language("shell") command: String,
+    workingDir: File?,
+    timeoutAmount: Duration = 60.seconds,
+    exitOnError: Boolean = true,
+): CmdResult {
+    val result =
+        withTimeout(timeoutAmount) {
+            process(
+                command = command.split(" ").toTypedArray(),
+                stdout = Redirect.CAPTURE,
+                stderr = Redirect.CAPTURE,
+                directory = workingDir,
+            )
+        }
+
+    val output = result.output.joinToString("\n")
+    return if (result.resultCode == 0) {
+        CmdResult.Success(output)
+    } else {
+        if (exitOnError) {
+            echoErr("Command '$command' failed with exit code ${result.resultCode}:\n$output")
+            exitProcess(result.resultCode)
+        }
+        CmdResult.Failure(output)
+    }
+}
+
+// Similar to Kotlin's Result, but always carries output
+sealed interface CmdResult {
+    val output: String
+
+    val isSuccess: Boolean
+        get() = this is Success
+
+    val isFailure: Boolean
+        get() = this is Failure
+
+    fun getOrThrow(): String =
+        if (isSuccess) {
+            output
+        } else {
+            throw UnsupportedOperationException("Command failed with output $output")
+        }
+
+    data class Success(override val output: String) : CmdResult
+
+    data class Failure(override val output: String) : CmdResult
+}

--- a/platform/jewel/scripts/validate-api-dump-changes.main.kts
+++ b/platform/jewel/scripts/validate-api-dump-changes.main.kts
@@ -1,0 +1,220 @@
+#!/usr/bin/env kotlin
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+@file:Import("utils.main.kts")
+
+// Coroutine dependency for KTS scripts — we don't actually need it but the script doesn't compile without
+// _some_ depends on annotation for whatever reason
+@file:DependsOn("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+@file:Suppress("RAW_RUN_BLOCKING")
+
+import kotlin.system.exitProcess
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+private val baseDir = File("").absoluteFile
+
+require(baseDir.isDirectory && baseDir.name == "jewel") { "This script must be run from the platform/jewel folder" }
+
+private data class ValidationResult(val file: File, val log: CharSequence, val foundBreakages: Boolean)
+
+private val samplesDir: String = File(baseDir, "samples").absolutePath
+
+private suspend fun validateDumps(experimental: Boolean, dumpsFilter: (File) -> Boolean): Boolean {
+    val apiDumpFiles =
+        baseDir
+            .walkTopDown()
+            // Avoid picking up dumps in the samples dir. This is a naive check that assumes no symlinks.
+            // If we have symlinks we need to use canonicalPath and walk up the tree to have a reliable check.
+            .filter { dumpsFilter(it) && !it.absolutePath.startsWith(samplesDir) }
+            .toList()
+
+    println()
+
+    println("Detected API dumps:\n${apiDumpFiles.joinToString("\n") { " * ${it.toRelativeString(baseDir)}" }}")
+
+    val results = coroutineScope {
+        apiDumpFiles
+            .map { file ->
+                async {
+                    var foundBreakages = false
+                    val log = buildString {
+                        appendLine("\n  Checking ${file.toRelativeString(baseDir)}")
+
+                        val isModifiedResult =
+                            runCommand(
+                                "git diff --quiet $baseCommit -- ${file.absolutePath}",
+                                baseDir,
+                                exitOnError = false,
+                            )
+
+                        if ("--verbose" in args) {
+                            appendLine("    First diff result:\n${isModifiedResult.output}")
+                        }
+
+                        if (isModifiedResult.isFailure) {
+                            appendLine("    Detected changes, investigating...")
+
+                            val command = "git --no-pager diff --unified=0 $baseCommit -- ${file.absolutePath}"
+                            if ("--verbose" in args) {
+                                appendLine("      Running: $command...")
+                            }
+
+                            val diffResult = runCommand(command, baseDir)
+                            if ("--verbose" in args) {
+                                appendLine("      Second diff result:\n${isModifiedResult.output}")
+                            }
+
+                            foundBreakages = processDiff(diffResult.output, file, experimental, this)
+                        }
+                    }
+                    ValidationResult(file, log, foundBreakages)
+                }
+            }
+            .awaitAll()
+    }
+
+    results.forEach { result -> print(result.log) }
+    return results.any { it.foundBreakages }
+}
+
+private val chunkHeaderRegex = "^@@ \\-([0-9]+)(?:,[0-9]+)? \\+([0-9]+)".toRegex()
+
+private fun processDiff(diff: String, file: File, experimental: Boolean, log: StringBuilder): Boolean {
+    var foundBreakages = false
+    var oldLineNum = 0
+    var newLineNum = 0
+    var lastLineWasRemoval = false
+
+    diff.lines().forEach { line ->
+        when {
+            line.startsWith("@@") -> {
+                val match = chunkHeaderRegex.find(line)
+                if (match != null) {
+                    oldLineNum = match.groupValues[1].toInt()
+                    newLineNum = match.groupValues[2].toInt()
+                }
+                lastLineWasRemoval = false
+            }
+
+            line.startsWith("-") && !line.startsWith("---") -> {
+                // We only annotate once per block of removals — but log all removals anyway
+                reportBreakage(file, line, log, oldLineNum, newLineNum, experimental, annotate = !lastLineWasRemoval)
+                foundBreakages = true
+                oldLineNum++
+                lastLineWasRemoval = true
+            }
+
+            line.startsWith("+") -> {
+                newLineNum++
+                lastLineWasRemoval = false
+            }
+
+            line.startsWith(" ") -> {
+                oldLineNum++
+                newLineNum++
+                lastLineWasRemoval = false
+            }
+        }
+    }
+
+    return foundBreakages
+}
+
+private fun reportBreakage(
+    file: File,
+    line: String,
+    log: StringBuilder,
+    oldLineNum: Int,
+    newLineNum: Int,
+    experimental: Boolean,
+    annotate: Boolean,
+) {
+    val lineContent =
+        line
+            .substring(1) // Skip the first character (either + or -)
+            .replace("%", "%25") // Escape the % character
+            .replace("\r", "%0D") // Escape the \r character
+            .replace("\n", "%0A") // Escape the \n character
+
+    val color = if (experimental) "\u001b[0;33m" else "\u001b[0;31m"
+    val type = if (experimental) "experimental" else "stable"
+    log.appendLine("    $color⚠️ Breaking $type API change:\n       line $oldLineNum removed: $lineContent\u001b[0m")
+
+    if (!annotate) return
+
+    // Emit an error or warning annotation on the GitHub action using workflow-commands
+    val severity = if (experimental) "warning" else "error"
+    log.append("::$severity ")
+    log.append("file=${file.toRelativeString(baseDir.absoluteFile.parentFile.parentFile)},")
+
+    // For a removal, GitHub annotations must be on a line that exists in the new file.
+    // For a pure deletion, this is the line *before* the deletion. For a modification,
+    // this is the first line of the new modified block. The `newLineNum` from the
+    // hunk header gives us exactly this information.
+    val annotationLine = newLineNum
+    log.append("line=$annotationLine,")
+
+    val title = if (experimental) "Breaking experimental API change" else "Breaking API change"
+    log.appendLine("title=$title::This looks like a breaking API change, make sure it's intended.")
+}
+
+private val hasPrNumber = checkPrNumber()
+
+private val baseCommit = runBlocking {
+    if (hasPrNumber) {
+        requireGhTool()
+        runCommand("gh pr view ${getPrNumber()} --json baseRefOid -q .baseRefOid", baseDir).getOrThrow().trim()
+    } else {
+        echoWarn("GitHub PR number not found, falling back to checking against HEAD~1 instead")
+        runCommand("git rev-parse HEAD~1", baseDir).getOrThrow().trim()
+    }
+}
+
+println("Checking against base commit: $baseCommit")
+
+println("\nValidating stable API dumps...")
+
+private val stableViolations = runBlocking { validateDumps(experimental = false) { it.name == "api-dump.txt" } }
+
+println("\nValidating experimental API dumps...")
+
+private val experimentalViolations = runBlocking {
+    validateDumps(experimental = true) { it.name == "api-dump-experimental.txt" }
+}
+
+println("\nWriting summary...")
+
+runBlocking {
+    val summary = buildString {
+        appendLine("## Binary check result")
+        if (!stableViolations && !experimentalViolations) {
+            appendLine("✅ No API breakages found.")
+        } else {
+            if (stableViolations) {
+                appendLine("❌ Stable API breakages found.")
+            }
+            if (experimentalViolations) {
+                appendLine("⚠️ Experimental API breakages found.")
+            }
+        }
+    }
+
+    println(summary.prependIndent())
+
+    val summaryFile = System.getenv("GITHUB_STEP_SUMMARY")?.takeIf { !it.isBlank() }?.let { File(it) }
+    if (summaryFile != null) {
+        summaryFile.writeText(summary)
+        println("Summary written to ${summaryFile.absolutePath}")
+    } else {
+        echoWarn("GITHUB_STEP_SUMMARY environment variable not set")
+    }
+}
+
+println("\nDone processing API dumps")
+
+// Fail the check for stable API violations
+if (stableViolations) exitProcess(1)


### PR DESCRIPTION
This adds a script that's run by the GitHub CI to validate that the PR is not introducing binary changes, and if it finds any, it adds annotations that show on the PR code. For stable API breaking changes, this will also fail the check.

This script should be able to be used locally as well, as when there is no PR_NUMBER env set, it just checks against HEAD~1 (assumes our changes are always at most one commit — we have other checks for that).

With this script, we get annotations in the PR for breakages.

* Dumps with issues get highlighted in the file tree:
  <img width="279" src="https://github.com/user-attachments/assets/4c7b9f4c-964d-4c95-94b1-1024aacf7648" />
  <br/>
* Stable breaking API changes get an error annotation:
  <img width="848" height="239" src="https://github.com/user-attachments/assets/b5bde721-0ebe-4db0-a755-7a8123096b5b" />
  <br/>
* Experimental breaking API changes get an error annotation:
  <img width="841" height="244" src="https://github.com/user-attachments/assets/069f08ba-6443-4325-b1d8-ee41711cf44a" />
  <br/>
* It also appends a summary to the Actions run:
  <img width="386" height="175" alt="image" src="https://github.com/user-attachments/assets/73d5b3b3-420b-4ec9-8720-0725b1a1f8da" />

 

### Notes
 * This only leaves annotations for experimental API changes, it does not fail the build. Its goal is to call out such changes so that the reviewers can evaluate them properly
 * The checks are naive; if an API is moved in the same file, it will still be considered broken. This should not be a big issue, since it is only posting annotations
 * We only get one annotation per removal "block" — i.e., if multiple consecutive rows are deleted, we only get one annotation. The log will contain all of them, however
 * The check explicitly skips the samples folder as those are not published modules and do not have any guarantees whatsoever. They should not have dumps to begin with...