### PR TITLE
Set skiko.library.path jvm arg at launch

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildContextImpl.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildContextImpl.kt
@@ -373,6 +373,7 @@ class BuildContextImpl internal constructor(
     jvmArgs += "-Djna.noclasspath=true"
     jvmArgs += "-Dpty4j.preferred.native.folder=${macroName}/lib/pty4j".let { if (isScript) '"' + it + '"' else it }
     jvmArgs += "-Dio.netty.allocator.type=pooled"
+    jvmArgs += "-Dskiko.library.path=${macroName}/lib/skiko-awt-runtime-all"
 
     if (useModularLoader || generateRuntimeModuleRepository) {
       jvmArgs += "-Dintellij.platform.runtime.repository.path=${macroName}/${MODULE_DESCRIPTORS_COMPACT_PATH}".let { if (isScript) '"' + it + '"' else it }


### PR DESCRIPTION
Currently, this gets set in JewelComposePanelWrapper at runtime. This has the potential for causing issues if the UI uses `ComposePanel` without wrapping it in a  `JewelComposePanelWrapper` before the JVM property gets set - causing failures when initiliaizing skiko. While this is not fully supported it shouldn't break the IDE.

This became an issue in 2025.2, when the skiko OS level binaries began being shipped separately for each OS platform outside of the module inside the lib/skiko-awt-runtime-all directory instead of being bundled in the intellij.libraries.skiko.jar in commit 74527c8.

Change-Id: I44e7ed265181254070e7bf645de4d68b7b42654c