### PR TITLE
[JEWEL-741] Use TextMate as Fallback for Languages Without Parsers

### DIFF
--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/MimeType.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/MimeType.kt
@@ -4,17 +4,22 @@ import org.jetbrains.jewel.foundation.code.MimeType.Known.AGSL
 import org.jetbrains.jewel.foundation.code.MimeType.Known.AIDL
 import org.jetbrains.jewel.foundation.code.MimeType.Known.C
 import org.jetbrains.jewel.foundation.code.MimeType.Known.CPP
+import org.jetbrains.jewel.foundation.code.MimeType.Known.CSS
 import org.jetbrains.jewel.foundation.code.MimeType.Known.DART
 import org.jetbrains.jewel.foundation.code.MimeType.Known.DIFF
 import org.jetbrains.jewel.foundation.code.MimeType.Known.GO
 import org.jetbrains.jewel.foundation.code.MimeType.Known.GRADLE
 import org.jetbrains.jewel.foundation.code.MimeType.Known.GRADLE_KTS
 import org.jetbrains.jewel.foundation.code.MimeType.Known.GROOVY
+import org.jetbrains.jewel.foundation.code.MimeType.Known.HTML
 import org.jetbrains.jewel.foundation.code.MimeType.Known.JAVA
 import org.jetbrains.jewel.foundation.code.MimeType.Known.JAVASCRIPT
 import org.jetbrains.jewel.foundation.code.MimeType.Known.JSON
+import org.jetbrains.jewel.foundation.code.MimeType.Known.JSON5
+import org.jetbrains.jewel.foundation.code.MimeType.Known.JSON_LINES
 import org.jetbrains.jewel.foundation.code.MimeType.Known.KOTLIN
 import org.jetbrains.jewel.foundation.code.MimeType.Known.MANIFEST
+import org.jetbrains.jewel.foundation.code.MimeType.Known.OBJECTIVE_C
 import org.jetbrains.jewel.foundation.code.MimeType.Known.PATCH
 import org.jetbrains.jewel.foundation.code.MimeType.Known.PROGUARD
 import org.jetbrains.jewel.foundation.code.MimeType.Known.PROPERTIES
@@ -22,6 +27,7 @@ import org.jetbrains.jewel.foundation.code.MimeType.Known.PROTO
 import org.jetbrains.jewel.foundation.code.MimeType.Known.PYTHON
 import org.jetbrains.jewel.foundation.code.MimeType.Known.REGEX
 import org.jetbrains.jewel.foundation.code.MimeType.Known.RESOURCE
+import org.jetbrains.jewel.foundation.code.MimeType.Known.RUBY
 import org.jetbrains.jewel.foundation.code.MimeType.Known.RUST
 import org.jetbrains.jewel.foundation.code.MimeType.Known.SHELL
 import org.jetbrains.jewel.foundation.code.MimeType.Known.SQL
@@ -31,8 +37,46 @@ import org.jetbrains.jewel.foundation.code.MimeType.Known.TOML
 import org.jetbrains.jewel.foundation.code.MimeType.Known.TYPESCRIPT
 import org.jetbrains.jewel.foundation.code.MimeType.Known.UNKNOWN
 import org.jetbrains.jewel.foundation.code.MimeType.Known.VERSION_CATALOG
+import org.jetbrains.jewel.foundation.code.MimeType.Known.XHTML
 import org.jetbrains.jewel.foundation.code.MimeType.Known.XML
 import org.jetbrains.jewel.foundation.code.MimeType.Known.YAML
+
+private val ALREADY_NORMALIZED_BUILTIN_TYPES =
+    listOf(
+        AGSL,
+        AIDL,
+        C,
+        CPP,
+        DART,
+        DIFF,
+        GO,
+        GRADLE,
+        GRADLE_KTS,
+        GROOVY,
+        JAVA,
+        JAVASCRIPT,
+        JSON,
+        KOTLIN,
+        MANIFEST,
+        PATCH,
+        PROGUARD,
+        PROPERTIES,
+        PROTO,
+        PYTHON,
+        REGEX,
+        RESOURCE,
+        RUST,
+        SHELL,
+        SQL,
+        SVG,
+        TEXT,
+        TOML,
+        TYPESCRIPT,
+        UNKNOWN,
+        VERSION_CATALOG,
+        XML,
+        YAML,
+    )
 
 /**
  * Represents the language and dialect of a source snippet, as an RFC 2046 mime type.
@@ -56,7 +100,7 @@ import org.jetbrains.jewel.foundation.code.MimeType.Known.YAML
 @JvmInline
 public value class MimeType(private val mimeType: String) {
     public fun displayName(): String =
-        when (normalizeString()) {
+        when (getBaseMimeType()) {
             KOTLIN.mimeType -> if (isGradle()) "Gradle DSL" else "Kotlin"
             JAVA.mimeType -> "Java"
             XML.mimeType -> {
@@ -67,12 +111,14 @@ public value class MimeType(private val mimeType: String) {
                         val folderType = getAttribute(ATTR_FOLDER_TYPE)
                         folderType?.capitalizeAsciiOnly() ?: "XML"
                     }
-
                     else -> "XML"
                 }
             }
-
+            HTML.mimeType -> "HTML"
+            XHTML.mimeType -> "XHTML"
             JSON.mimeType -> "JSON"
+            JSON5.mimeType -> "JSON5"
+            JSON_LINES.mimeType -> "JSON Lines"
             TEXT.mimeType -> "Text"
             REGEX.mimeType -> "Regular Expression"
             GROOVY.mimeType -> if (isGradle()) "Gradle" else "Groovy"
@@ -96,92 +142,98 @@ public value class MimeType(private val mimeType: String) {
             else -> mimeType
         }
 
+    public fun toFileExtensionIfKnown(): String? =
+        when (mimeType) {
+            AGSL.mimeType -> "agsl"
+            AIDL.mimeType -> "aidl"
+            C.mimeType -> "c"
+            CPP.mimeType -> "cpp"
+            CSS.mimeType -> "css"
+            DART.mimeType -> "dart"
+            GO.mimeType -> "go"
+            GRADLE.mimeType -> "gradle"
+            GRADLE_KTS.mimeType -> "kts"
+            GROOVY.mimeType -> "groovy"
+            JAVA.mimeType -> "java"
+            JAVASCRIPT.mimeType -> "js"
+            JSON.mimeType -> "json"
+            JSON5.mimeType -> "json5"
+            JSON_LINES.mimeType -> "jsonl"
+            KOTLIN.mimeType -> "kt"
+            MANIFEST.mimeType -> "xml" // Manifest files
+            PROGUARD.mimeType -> "pro"
+            PROPERTIES.mimeType -> "properties"
+            PROTO.mimeType -> "proto"
+            PYTHON.mimeType -> "py"
+            REGEX.mimeType -> "regex"
+            RESOURCE.mimeType -> "xml" // Resource files
+            RUST.mimeType -> "rs"
+            SHELL.mimeType -> "sh"
+            SQL.mimeType -> "sql"
+            SVG.mimeType -> "svg"
+            TEXT.mimeType -> "txt"
+            TOML.mimeType -> "toml"
+            TYPESCRIPT.mimeType -> "ts"
+            VERSION_CATALOG.mimeType -> "toml"
+            XML.mimeType -> "xml"
+            YAML.mimeType -> "yaml"
+            RUBY.mimeType -> "rb"
+            OBJECTIVE_C.mimeType -> "m"
+            "text/x-erlang" -> "erl"
+            else -> null
+        }
+
+    private fun getBaseMimeType(): String {
+        val baseMimeType = base().toString()
+        // Built-ins are already normalized, don't do string and sorting work
+        if (this in ALREADY_NORMALIZED_BUILTIN_TYPES) return baseMimeType
+
+        return when (baseMimeType) {
+            "text/x-java-source",
+            "application/x-java",
+            "text/x-java" -> JAVA.mimeType
+
+            "application/kotlin-source",
+            "text/x-kotlin",
+            "text/x-kotlin-source" -> KOTLIN.mimeType
+
+            "application/xml" -> XML.mimeType
+            "application/json",
+            "application/vnd.api+json",
+            "application/hal+json",
+            "application/ld+json" -> JSON.mimeType
+
+            "image/svg+xml" -> XML.mimeType
+            "text/x-python",
+            "application/x-python-script" -> PYTHON.mimeType
+
+            "text/dart",
+            "text/x-dart",
+            "application/dart",
+            "application/x-dart" -> DART.mimeType
+
+            "application/javascript",
+            "application/x-javascript",
+            "text/ecmascript",
+            "application/ecmascript",
+            "application/x-ecmascript" -> JAVASCRIPT.mimeType
+
+            "application/typescript" + "application/x-typescript" -> TYPESCRIPT.mimeType
+            "text/x-rust",
+            "application/x-rust" -> RUST.mimeType
+
+            "text/x-sksl" -> AGSL.mimeType
+            "application/yaml",
+            "text/x-yaml",
+            "application/x-yaml" -> YAML.mimeType
+            "application/x-patch" -> PATCH.mimeType
+
+            else -> baseMimeType
+        }
+    }
+
     private fun normalizeString(): String {
-        when (this) {
-            // Built-ins are already normalized, don't do string and sorting work
-            AGSL,
-            AIDL,
-            C,
-            CPP,
-            DART,
-            DIFF,
-            GO,
-            GRADLE,
-            GRADLE_KTS,
-            GROOVY,
-            JAVA,
-            JAVASCRIPT,
-            JSON,
-            KOTLIN,
-            MANIFEST,
-            PATCH,
-            PROGUARD,
-            PROPERTIES,
-            PROTO,
-            PYTHON,
-            REGEX,
-            RESOURCE,
-            RUST,
-            SHELL,
-            SQL,
-            SVG,
-            TEXT,
-            TOML,
-            TYPESCRIPT,
-            UNKNOWN,
-            VERSION_CATALOG,
-            XML,
-            YAML -> return this.mimeType
-        }
-
-        val baseEnd = mimeType.indexOf(';')
-        val normalizedBase =
-            when (val base = if (baseEnd == -1) mimeType else mimeType.substring(0, baseEnd)) {
-                "text/x-java-source",
-                "application/x-java",
-                "text/x-java" -> JAVA.mimeType
-
-                "application/kotlin-source",
-                "text/x-kotlin",
-                "text/x-kotlin-source" -> KOTLIN.mimeType
-
-                "application/xml" -> XML.mimeType
-                "application/json",
-                "application/vnd.api+json",
-                "application/hal+json",
-                "application/ld+json" -> JSON.mimeType
-
-                "image/svg+xml" -> XML.mimeType
-                "text/x-python",
-                "application/x-python-script" -> PYTHON.mimeType
-
-                "text/dart",
-                "text/x-dart",
-                "application/dart",
-                "application/x-dart" -> DART.mimeType
-
-                "application/javascript",
-                "application/x-javascript",
-                "text/ecmascript",
-                "application/ecmascript",
-                "application/x-ecmascript" -> JAVASCRIPT.mimeType
-
-                "application/typescript" + "application/x-typescript" -> TYPESCRIPT.mimeType
-                "text/x-rust",
-                "application/x-rust" -> RUST.mimeType
-
-                "text/x-sksl" -> AGSL.mimeType
-                "application/yaml",
-                "text/x-yaml",
-                "application/x-yaml" -> YAML.mimeType
-                "application/x-patch" -> PATCH.mimeType
-
-                else -> base
-            }
-
-        if (baseEnd == -1) {
-            return normalizedBase
-        }
+        val normalizedBase = getBaseMimeType()
 
         val attributes =
             mimeType
@@ -297,7 +349,12 @@ public value class MimeType(private val mimeType: String) {
         public val XML: MimeType = MimeType("text/xml")
         public val PROPERTIES: MimeType = MimeType("text/properties")
         public val TOML: MimeType = MimeType("text/toml")
+        public val HTML: MimeType = MimeType("text/html")
+        public val XHTML: MimeType = MimeType("application/xhtml+xml")
+        public val CSS: MimeType = MimeType("text/css")
         public val JSON: MimeType = MimeType("text/json")
+        public val JSON5: MimeType = MimeType("text/json5")
+        public val JSON_LINES: MimeType = MimeType("application/x-ndjson")
         public val REGEX: MimeType = MimeType("text/x-regex-source")
         public val GROOVY: MimeType = MimeType("text/groovy")
         public val C: MimeType = MimeType("text/c")
@@ -316,6 +373,9 @@ public value class MimeType(private val mimeType: String) {
         public val SHELL: MimeType = MimeType("application/x-sh")
         public val YAML: MimeType = MimeType("text/yaml")
         public val GO: MimeType = MimeType("text/go")
+        public val RUBY: MimeType = MimeType("text/x-ruby")
+        public val CLOJURE: MimeType = MimeType("text/x-clojure")
+        public val OBJECTIVE_C: MimeType = MimeType("text/x-objectivec")
 
         /** Note that most resource files will also have a folder type, so don't use equality on this mime type */
         public val RESOURCE: MimeType = MimeType("$XML; $ATTR_ROLE=resource")
@@ -326,21 +386,27 @@ public value class MimeType(private val mimeType: String) {
         public val DIFF: MimeType = MimeType("text/x-diff")
         public val PATCH: MimeType = MimeType("text/x-patch")
 
-        /** Maps from a markdown language [name] back to a mime type. */
+        /** Maps from a Markdown language [name] back to a mime type. */
         public fun fromMarkdownLanguageName(name: String): MimeType? =
             when (name) {
                 "kotlin",
                 "kt",
                 "kts" -> KOTLIN
-
+                "clj",
+                "cljs",
+                "cljr",
+                "cljc",
+                "cljd" -> CLOJURE
                 "java" -> JAVA
-                "xml" -> XML
-                "json",
-                "json5" -> JSON
-
+                "html" -> HTML
+                "xhtml" -> XHTML
+                "css" -> CSS
+                "json" -> JSON
+                "json5" -> JSON5
+                "json lines",
+                "jsonl" -> JSON_LINES
                 "regex",
                 "regexp" -> REGEX
-
                 "groovy" -> GROOVY
                 "toml" -> TOML
                 "c" -> C
@@ -354,28 +420,23 @@ public value class MimeType(private val mimeType: String) {
                 "python3",
                 "py",
                 "python" -> PYTHON
-
                 "dart" -> DART
                 "rust" -> RUST
                 "js",
                 "javascript" -> JAVASCRIPT
-
+                "ts",
                 "typescript" -> TYPESCRIPT
                 "sksl" -> AGSL
                 "sh",
                 "bash",
                 "zsh",
                 "shell" -> SHELL
-
                 "yaml",
                 "yml" -> YAML
-
                 "go",
-                "golang" -> YAML
-
+                "golang" -> GO
                 "diff" -> DIFF
                 "patch" -> PATCH
-
                 else -> null
             }
     }

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.flow.Flow
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
-import org.jetbrains.jewel.foundation.code.MimeType
 
 @ApiStatus.Experimental
 @ExperimentalJewelApi
@@ -26,7 +25,7 @@ public interface CodeHighlighter {
      *
      * @see [NoOpCodeHighlighter]
      */
-    public fun highlight(code: String, mimeType: MimeType?): Flow<AnnotatedString>
+    public fun highlight(code: String, langName: String?): Flow<AnnotatedString>
 }
 
 public val LocalCodeHighlighter: ProvidableCompositionLocal<CodeHighlighter> = staticCompositionLocalOf {

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter.kt
@@ -3,8 +3,7 @@ package org.jetbrains.jewel.foundation.code.highlighting
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import org.jetbrains.jewel.foundation.code.MimeType
 
 public object NoOpCodeHighlighter : CodeHighlighter {
-    override fun highlight(code: String, mimeType: MimeType?): Flow<AnnotatedString> = flowOf(AnnotatedString(code))
+    override fun highlight(code: String, langName: String?): Flow<AnnotatedString> = flowOf(AnnotatedString(code))
 }

--- a/platform/jewel/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/code/MimeTypeTest.kt
+++ b/platform/jewel/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/code/MimeTypeTest.kt
@@ -1,0 +1,237 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.foundation.code
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class MimeTypeTest {
+    @Test
+    fun `displayName should handle simple cases`() {
+        assertEquals("Kotlin", MimeType.Known.KOTLIN.displayName())
+        assertEquals("Java", MimeType.Known.JAVA.displayName())
+        assertEquals("XML", MimeType.Known.XML.displayName())
+        assertEquals("HTML", MimeType.Known.HTML.displayName())
+        assertEquals("XHTML", MimeType.Known.XHTML.displayName())
+        assertEquals("JSON", MimeType.Known.JSON.displayName())
+        assertEquals("JSON5", MimeType.Known.JSON5.displayName())
+        assertEquals("JSON Lines", MimeType.Known.JSON_LINES.displayName())
+        assertEquals("Text", MimeType.Known.TEXT.displayName())
+        assertEquals("Regular Expression", MimeType.Known.REGEX.displayName())
+        assertEquals("Groovy", MimeType.Known.GROOVY.displayName())
+        assertEquals("TOML", MimeType.Known.TOML.displayName())
+        assertEquals("C", MimeType.Known.C.displayName())
+        assertEquals("C++", MimeType.Known.CPP.displayName())
+        assertEquals("SVG", MimeType.Known.SVG.displayName())
+        assertEquals("AIDL", MimeType.Known.AIDL.displayName())
+        assertEquals("SQL", MimeType.Known.SQL.displayName())
+        assertEquals("Shrinker Config", MimeType.Known.PROGUARD.displayName())
+        assertEquals("Properties", MimeType.Known.PROPERTIES.displayName())
+        assertEquals("Protobuf", MimeType.Known.PROTO.displayName())
+        assertEquals("Python", MimeType.Known.PYTHON.displayName())
+        assertEquals("Dart", MimeType.Known.DART.displayName())
+        assertEquals("Rust", MimeType.Known.RUST.displayName())
+        assertEquals("JavaScript", MimeType.Known.JAVASCRIPT.displayName())
+        assertEquals("Android Graphics Shading Language", MimeType.Known.AGSL.displayName())
+        assertEquals("Shell Script", MimeType.Known.SHELL.displayName())
+        assertEquals("YAML", MimeType.Known.YAML.displayName())
+        assertEquals("Go", MimeType.Known.GO.displayName())
+    }
+
+    @Test
+    fun `displayName should handle conditional cases`() {
+        assertEquals("Gradle DSL", MimeType.Known.GRADLE_KTS.displayName())
+        assertEquals("Gradle", MimeType.Known.GRADLE.displayName())
+        assertEquals("Version Catalog", MimeType.Known.VERSION_CATALOG.displayName())
+    }
+
+    @Test
+    fun `displayName should parse attributes correctly for XML roles`() {
+        // Basic Manifest role
+        assertEquals("Manifest", MimeType.Known.MANIFEST.displayName())
+
+        // Resource role with specified folderType
+        val resourceWithFolderType = MimeType("text/xml; role=resource folderType=layout")
+        assertEquals("Layout", resourceWithFolderType.displayName())
+
+        // Resource file without a folderType
+        val resourceWithoutFolderType = MimeType("text/xml; role=resource")
+        assertEquals("XML", resourceWithoutFolderType.displayName())
+
+        // XML base without role
+        assertEquals("XML", MimeType.Known.XML.displayName())
+
+        // XML with unknown role
+        val resourceWithUnknownRole = MimeType("text/xml; role=randomRole")
+        assertEquals("XML", resourceWithoutFolderType.displayName())
+    }
+
+    @Test
+    fun `fromMarkdownLanguageName should resolve expected names`() {
+        assertEquals(MimeType.Known.KOTLIN, MimeType.Known.fromMarkdownLanguageName("kotlin"))
+        assertEquals(MimeType.Known.KOTLIN, MimeType.Known.fromMarkdownLanguageName("kt"))
+        assertEquals(MimeType.Known.KOTLIN, MimeType.Known.fromMarkdownLanguageName("kts"))
+
+        assertEquals(MimeType.Known.JAVA, MimeType.Known.fromMarkdownLanguageName("java"))
+        assertEquals(MimeType.Known.HTML, MimeType.Known.fromMarkdownLanguageName("html"))
+        assertEquals(MimeType.Known.XHTML, MimeType.Known.fromMarkdownLanguageName("xhtml"))
+        assertEquals(MimeType.Known.CSS, MimeType.Known.fromMarkdownLanguageName("css"))
+        assertEquals(MimeType.Known.JSON, MimeType.Known.fromMarkdownLanguageName("json"))
+        assertEquals(MimeType.Known.JSON5, MimeType.Known.fromMarkdownLanguageName("json5"))
+
+        assertEquals(MimeType.Known.JSON_LINES, MimeType.Known.fromMarkdownLanguageName("json lines"))
+        assertEquals(MimeType.Known.JSON_LINES, MimeType.Known.fromMarkdownLanguageName("jsonl"))
+
+        assertEquals(MimeType.Known.REGEX, MimeType.Known.fromMarkdownLanguageName("regex"))
+        assertEquals(MimeType.Known.REGEX, MimeType.Known.fromMarkdownLanguageName("regexp"))
+
+        assertEquals(MimeType.Known.GROOVY, MimeType.Known.fromMarkdownLanguageName("groovy"))
+        assertEquals(MimeType.Known.TOML, MimeType.Known.fromMarkdownLanguageName("toml"))
+        assertEquals(MimeType.Known.C, MimeType.Known.fromMarkdownLanguageName("c"))
+        assertEquals(MimeType.Known.CPP, MimeType.Known.fromMarkdownLanguageName("c++"))
+        assertEquals(MimeType.Known.SVG, MimeType.Known.fromMarkdownLanguageName("svg"))
+        assertEquals(MimeType.Known.AIDL, MimeType.Known.fromMarkdownLanguageName("aidl"))
+        assertEquals(MimeType.Known.SQL, MimeType.Known.fromMarkdownLanguageName("sql"))
+        assertEquals(MimeType.Known.PROPERTIES, MimeType.Known.fromMarkdownLanguageName("properties"))
+        assertEquals(MimeType.Known.PROTO, MimeType.Known.fromMarkdownLanguageName("protobuf"))
+
+        assertEquals(MimeType.Known.PYTHON, MimeType.Known.fromMarkdownLanguageName("python"))
+        assertEquals(MimeType.Known.PYTHON, MimeType.Known.fromMarkdownLanguageName("python2"))
+        assertEquals(MimeType.Known.PYTHON, MimeType.Known.fromMarkdownLanguageName("python3"))
+        assertEquals(MimeType.Known.PYTHON, MimeType.Known.fromMarkdownLanguageName("py"))
+
+        assertEquals(MimeType.Known.DART, MimeType.Known.fromMarkdownLanguageName("dart"))
+        assertEquals(MimeType.Known.RUST, MimeType.Known.fromMarkdownLanguageName("rust"))
+
+        assertEquals(MimeType.Known.JAVASCRIPT, MimeType.Known.fromMarkdownLanguageName("javascript"))
+        assertEquals(MimeType.Known.JAVASCRIPT, MimeType.Known.fromMarkdownLanguageName("js"))
+
+        assertEquals(MimeType.Known.TYPESCRIPT, MimeType.Known.fromMarkdownLanguageName("typescript"))
+        assertEquals(MimeType.Known.TYPESCRIPT, MimeType.Known.fromMarkdownLanguageName("ts"))
+
+        assertEquals(MimeType.Known.AGSL, MimeType.Known.fromMarkdownLanguageName("sksl"))
+
+        assertEquals(MimeType.Known.SHELL, MimeType.Known.fromMarkdownLanguageName("sh"))
+        assertEquals(MimeType.Known.SHELL, MimeType.Known.fromMarkdownLanguageName("bash"))
+        assertEquals(MimeType.Known.SHELL, MimeType.Known.fromMarkdownLanguageName("zsh"))
+        assertEquals(MimeType.Known.SHELL, MimeType.Known.fromMarkdownLanguageName("shell"))
+
+        assertEquals(MimeType.Known.YAML, MimeType.Known.fromMarkdownLanguageName("yaml"))
+        assertEquals(MimeType.Known.YAML, MimeType.Known.fromMarkdownLanguageName("yml"))
+
+        assertEquals(MimeType.Known.GO, MimeType.Known.fromMarkdownLanguageName("golang"))
+        assertEquals(MimeType.Known.GO, MimeType.Known.fromMarkdownLanguageName("go"))
+
+        assertEquals(MimeType.Known.DIFF, MimeType.Known.fromMarkdownLanguageName("diff"))
+        assertEquals(MimeType.Known.PATCH, MimeType.Known.fromMarkdownLanguageName("patch"))
+    }
+
+    @Test
+    fun `fromMarkdownLanguageName should return null for unknown languages`() {
+        assertNull(MimeType.Known.fromMarkdownLanguageName("unknown-language"))
+    }
+
+    @Test
+    fun `isKotlin should be true for both plain Kotlin and Gradle KTS`() {
+        assertTrue(MimeType.Known.KOTLIN.isKotlin())
+        assertTrue(MimeType.Known.GRADLE_KTS.isKotlin())
+    }
+
+    @Test
+    fun `isJava should be true for MimeTypes with Java`() {
+        val mimeType = MimeType("text/java")
+        assertTrue(mimeType.isJava())
+    }
+
+    @Test
+    fun `isJava should be false for MimeTypes without Java`() {
+        val mimeType = MimeType("text/not-java")
+        assertFalse(mimeType.isJava())
+    }
+
+    @Test
+    fun `isXml should be true for MimeTypes with Xml`() {
+        val mimeType = MimeType("text/xml")
+        assertTrue(mimeType.isXml())
+    }
+
+    @Test
+    fun `isXml should be false for MimeTypes without Xml`() {
+        val mimeType = MimeType("text/not-xml")
+        assertFalse(mimeType.isXml())
+    }
+
+    @Test
+    fun `isGradle should be true for MimeTypes with Gradle role`() {
+        val mimeType = MimeType("text/x-cool-type; role=gradle")
+        assertTrue(mimeType.isGradle())
+    }
+
+    @Test
+    fun `isGradle should be false for MimeTypes without Gradle role`() {
+        val mimeType = MimeType("text/x-cool-type")
+        assertFalse(mimeType.isGradle())
+    }
+
+    @Test
+    fun `isVersionCatalog should be true for MimeTypes with version-catalog role`() {
+        val mimeType = MimeType("text/x-cool-type; role=version-catalog")
+        assertTrue(mimeType.isVersionCatalog())
+    }
+
+    @Test
+    fun `isVersionCatalog should be false for MimeTypes without version-catalog role`() {
+        val mimeType = MimeType("text/x-cool-type")
+        assertFalse(mimeType.isVersionCatalog())
+    }
+
+    @Test
+    fun `isManifest should be true for MimeTypes with manifest role`() {
+        val mimeType = MimeType("text/x-cool-type; role=manifest")
+        assertTrue(mimeType.isManifest())
+    }
+
+    @Test
+    fun `isManifest should be false for MimeTypes without manifest role`() {
+        val mimeType = MimeType("text/x-cool-type")
+        assertFalse(mimeType.isManifest())
+    }
+
+    @Test
+    fun `isSql should be true for MimeTypes with SQL base`() {
+        val mimeType = MimeType("text/x-sql")
+        assertTrue(mimeType.isSql())
+    }
+
+    @Test
+    fun `isSql should be false for MimeTypes without SQL base`() {
+        val mimeType = MimeType("text/x-not-sql")
+        assertFalse(mimeType.isSql())
+    }
+
+    @Test
+    fun `isRegex should be true for MimeTypes with RegEx base`() {
+        val mimeType = MimeType("text/x-regex-source")
+        assertTrue(mimeType.isRegex())
+    }
+
+    @Test
+    fun `isRegex should be false for MimeTypes without RegEx base`() {
+        val mimeType = MimeType("text/x-not-regex-source")
+        assertFalse(mimeType.isRegex())
+    }
+
+    @Test
+    fun `isProto should be true for MimeTypes with Protobuf base`() {
+        val mimeType = MimeType("text/x-protobuf")
+        assertTrue(mimeType.isProto())
+    }
+
+    @Test
+    fun `isProto should be false for MimeTypes without Protobuf base`() {
+        val mimeType = MimeType("text/x-not-protobuf")
+        assertFalse(mimeType.isProto())
+    }
+}

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
+import com.intellij.lexer.EmptyLexer
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.markup.EffectType
@@ -29,19 +30,45 @@ import org.jetbrains.jewel.bridge.toComposeColorOrUnspecified
 import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
 
+private val langAliases =
+    mapOf(
+        "js" to "javascript",
+        "py" to "python",
+        "kt" to "kotlin",
+        "kts" to "kotlin",
+        "yml" to "yaml",
+        "sh" to "shell",
+        "bash" to "shell",
+        "zsh" to "shell",
+        // ... other languages
+    )
+
 internal class LexerBasedCodeHighlighter(
     private val project: Project,
     private val reHighlightingRequests: Flow<Unit>,
     private val highlightDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : CodeHighlighter {
-    override fun highlight(code: String, mimeType: MimeType?): Flow<AnnotatedString> {
-        val language = mimeType?.toLanguageOrNull() ?: return flowOf(AnnotatedString(code))
-        val fileExtension = language.associatedFileType?.defaultExtension ?: return flowOf(AnnotatedString(code))
+    override fun highlight(code: String, langName: String?): Flow<AnnotatedString> {
+        langName ?: return flowOf(AnnotatedString(code))
+
+        val canonicalName = langAliases[langName.lowercase()] ?: langName.lowercase()
+        val nativeLanguage = LanguageUtil.findRegisteredLanguage(canonicalName)
+
+        val (language, fileExtension) =
+            if (nativeLanguage != null) {
+                val extension = nativeLanguage.associatedFileType?.defaultExtension ?: canonicalName
+                nativeLanguage to extension
+            } else {
+                val textmateLanguage = Language.findLanguageByID("textmate") ?: return flowOf(AnnotatedString(code))
+                textmateLanguage to langName
+            }
+
         val virtualFile = LightVirtualFile("markdown_code_block_${code.hashCode()}.$fileExtension", language, code)
         val colorScheme = EditorColorsManager.getInstance().globalScheme
         val highlighter =
-            SyntaxHighlighterFactory.getSyntaxHighlighter(language, project, virtualFile)
-                ?: return flowOf(AnnotatedString(code))
+            SyntaxHighlighterFactory.getSyntaxHighlighter(language, project, virtualFile)?.takeIf {
+                it.highlightingLexer !is EmptyLexer
+            } ?: return flowOf(AnnotatedString(code))
 
         return flow {
             highlightAndEmit(highlighter, code, colorScheme)
@@ -76,7 +103,11 @@ internal class LexerBasedCodeHighlighter(
         }
     }
 
-    private fun MimeType.toLanguageOrNull(): Language? = LanguageUtil.findRegisteredLanguage(displayName().lowercase())
+    private fun MimeType.toLanguageOrNull(): Language? =
+        when (this) {
+            MimeType.Known.REGEX -> LanguageUtil.findRegisteredLanguage("RegExp")
+            else -> LanguageUtil.findRegisteredLanguage(displayName().lowercase())
+        }
 
     private fun AnnotatedString.Builder.withTextAttributes(
         textAttributes: TextAttributes?,
@@ -101,4 +132,29 @@ internal class LexerBasedCodeHighlighter(
                     else -> null
                 },
         )
+
+    private fun getHighlightingParams(code: String, mimeType: MimeType): HighlightingParams? {
+        val existingLanguage = mimeType.toLanguageOrNull()
+        println("mimeType: $mimeType")
+        val language = existingLanguage ?: Language.findLanguageByID("textmate") ?: return null
+
+        val fileExtension =
+            if (existingLanguage == null) {
+                mimeType.toFileExtensionIfKnown() ?: mimeType.toString().removePrefix("text/x-")
+            } else {
+                language.associatedFileType?.defaultExtension
+            } ?: return null
+
+        val virtualFile = LightVirtualFile("markdown_code_block_${code.hashCode()}.$fileExtension", language, code)
+        val colorScheme = EditorColorsManager.getInstance().globalScheme
+
+        val highlighter =
+            SyntaxHighlighterFactory.getSyntaxHighlighter(language, project, virtualFile)?.takeIf {
+                it.highlightingLexer !is EmptyLexer
+            } ?: return null
+
+        return HighlightingParams(highlighter, colorScheme)
+    }
+
+    private data class HighlightingParams(val highlighter: SyntaxHighlighter, val colorScheme: EditorColorsScheme)
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
@@ -3,7 +3,6 @@ package org.jetbrains.jewel.markdown
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
-import org.jetbrains.jewel.foundation.code.MimeType
 
 @ApiStatus.Experimental
 @ExperimentalJewelApi
@@ -54,7 +53,7 @@ public sealed interface MarkdownBlock {
         @ApiStatus.Experimental
         @ExperimentalJewelApi
         @GenerateDataFunctions
-        public class FencedCodeBlock(override val content: String, public val mimeType: MimeType?) : CodeBlock {
+        public class FencedCodeBlock(override val content: String, public val info: String?) : CodeBlock {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
                 if (javaClass != other?.javaClass) return false
@@ -62,18 +61,18 @@ public sealed interface MarkdownBlock {
                 other as FencedCodeBlock
 
                 if (content != other.content) return false
-                if (mimeType != other.mimeType) return false
+                if (info != other.info) return false
 
                 return true
             }
 
             override fun hashCode(): Int {
                 var result = content.hashCode()
-                result = 31 * result + (mimeType?.hashCode() ?: 0)
+                result = 31 * result + (info?.hashCode() ?: 0)
                 return result
             }
 
-            override fun toString(): String = "FencedCodeBlock(content='$content', mimeType=$mimeType)"
+            override fun toString(): String = "FencedCodeBlock(content='$content', info=$info)"
         }
     }
 

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
@@ -277,7 +277,7 @@ public class MarkdownProcessor(
     }
 
     private fun FencedCodeBlock.toMarkdownCodeBlockOrNull(): CodeBlock.FencedCodeBlock =
-        CodeBlock.FencedCodeBlock(content = literal.removeSuffix("\n"), mimeType = languageRecognizer(info))
+        CodeBlock.FencedCodeBlock(content = literal.removeSuffix("\n"), info = info)
 
     private fun IndentedCodeBlock.toMarkdownCodeBlockOrNull(): CodeBlock.IndentedCodeBlock =
         CodeBlock.IndentedCodeBlock(literal.trimEnd('\n'))

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.unit.LayoutDirection.Ltr
 import androidx.compose.ui.unit.dp
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
-import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter
 import org.jetbrains.jewel.foundation.modifier.thenIf
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
@@ -435,7 +434,7 @@ public open class DefaultMarkdownBlockRenderer(
         enabled: Boolean,
         modifier: Modifier,
     ) {
-        val mimeType = block.mimeType ?: MimeType.Known.UNKNOWN
+        val langName = block.info
         MaybeScrollingContainer(
             isScrollable = styling.scrollsHorizontally,
             modifier
@@ -447,7 +446,7 @@ public open class DefaultMarkdownBlockRenderer(
             Column(Modifier.padding(styling.padding)) {
                 if (styling.infoPosition.verticalAlignment == Alignment.Top) {
                     FencedBlockInfo(
-                        mimeType.displayName(),
+                        langName,
                         styling.infoPosition.horizontalAlignment
                             ?: error("No horizontal alignment for position ${styling.infoPosition.name}"),
                         styling.infoTextStyle,
@@ -455,11 +454,11 @@ public open class DefaultMarkdownBlockRenderer(
                     )
                 }
 
-                renderCodeWithMimeType(block, mimeType, styling, enabled)
+                renderCodeWithMimeType(block, langName, styling, enabled)
 
                 if (styling.infoPosition.verticalAlignment == Alignment.Bottom) {
                     FencedBlockInfo(
-                        mimeType.displayName(),
+                        langName,
                         styling.infoPosition.horizontalAlignment
                             ?: error("No horizontal alignment for position ${styling.infoPosition.name}"),
                         styling.infoTextStyle,
@@ -473,13 +472,13 @@ public open class DefaultMarkdownBlockRenderer(
     @Composable
     internal open fun renderCodeWithMimeType(
         block: FencedCodeBlock,
-        mimeType: MimeType,
+        langName: String?,
         styling: MarkdownStyling.Code.Fenced,
         enabled: Boolean,
     ) {
         val content = block.content
         val highlighter = LocalCodeHighlighter.current
-        val highlightedCode by highlighter.highlight(content, mimeType).collectAsState(AnnotatedString(content))
+        val highlightedCode by highlighter.highlight(content, langName).collectAsState(AnnotatedString(content))
         Text(
             text = highlightedCode,
             style = styling.editorTextStyle,
@@ -492,7 +491,7 @@ public open class DefaultMarkdownBlockRenderer(
 
     @Composable
     private fun FencedBlockInfo(
-        infoText: String,
+        infoText: String?,
         alignment: Alignment.Horizontal,
         textStyle: TextStyle,
         modifier: Modifier = Modifier,
@@ -500,7 +499,7 @@ public open class DefaultMarkdownBlockRenderer(
         Column(modifier, horizontalAlignment = alignment) {
             DisableSelection {
                 Text(
-                    text = infoText,
+                    text = infoText ?: "",
                     style = textStyle,
                     color = textStyle.color.takeOrElse { LocalContentColor.current },
                     modifier = Modifier.focusProperties { canFocus = false },

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollSyncMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/scrolling/ScrollSyncMarkdownBlockRenderer.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.AnnotatedString
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
-import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
@@ -114,20 +113,21 @@ public open class ScrollSyncMarkdownBlockRenderer(
     @Composable
     override fun renderCodeWithMimeType(
         block: FencedCodeBlock,
-        mimeType: MimeType,
+        langName: String?,
         styling: MarkdownStyling.Code.Fenced,
         enabled: Boolean,
     ) {
+        val langName = block.info
         val synchronizer =
             (JewelTheme.markdownMode as? MarkdownMode.EditorPreview)?.scrollingSynchronizer
                 ?: run {
-                    super.renderCodeWithMimeType(block, mimeType, styling, enabled)
+                    super.renderCodeWithMimeType(block, langName, styling, enabled)
                     return
                 }
 
         val content = block.content
         val highlightedCode by
-            LocalCodeHighlighter.current.highlight(content, block.mimeType).collectAsState(AnnotatedString(content))
+            LocalCodeHighlighter.current.highlight(content, langName).collectAsState(AnnotatedString(content))
         val uniqueBlock = localUniqueBlock.current?.takeIf { it.originalBlock == block } ?: block
         val actualBlock by rememberUpdatedState(uniqueBlock)
         AutoScrollableBlock(actualBlock, synchronizer) {

--- a/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
+++ b/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.jewel.markdown
 
-import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.markdown.InlineMarkdown.Code
 import org.jetbrains.jewel.markdown.InlineMarkdown.Emphasis
 import org.jetbrains.jewel.markdown.InlineMarkdown.HardLineBreak
@@ -426,7 +425,7 @@ public class MarkdownProcessorDocumentParsingTest {
          * <pre><code class="language-foo+bar">foo
          * </code></pre>
          */
-        parsed.assertEquals(fencedCodeBlock("foo", MimeType.Known.fromMarkdownLanguageName("foo\\+bar")))
+        parsed.assertEquals(fencedCodeBlock("foo", "foo\\+bar"))
     }
 
     @Test
@@ -589,7 +588,7 @@ public class MarkdownProcessorDocumentParsingTest {
          * <pre><code class="language-föö">foo
          * </code></pre>
          */
-        parsed.assertEquals(fencedCodeBlock("foo", mimeType = MimeType.Known.fromMarkdownLanguageName("föö")))
+        parsed.assertEquals(fencedCodeBlock("foo", langName = "föö"))
     }
 
     @Test
@@ -2726,9 +2725,7 @@ public class MarkdownProcessorDocumentParsingTest {
          * end
          * </code></pre>
          */
-        parsed.assertEquals(
-            fencedCodeBlock("def foo(x)\n  return 3\nend", mimeType = MimeType.Known.fromMarkdownLanguageName("ruby"))
-        )
+        parsed.assertEquals(fencedCodeBlock("def foo(x)\n  return 3\nend", langName = "ruby"))
     }
 
     @Test
@@ -2752,9 +2749,7 @@ public class MarkdownProcessorDocumentParsingTest {
          * end
          * </code></pre>
          */
-        parsed.assertEquals(
-            fencedCodeBlock("def foo(x)\n  return 3\nend", mimeType = MimeType.Known.fromMarkdownLanguageName("ruby"))
-        )
+        parsed.assertEquals(fencedCodeBlock("def foo(x)\n  return 3\nend", langName = "ruby"))
     }
 
     @Test
@@ -2772,7 +2767,7 @@ public class MarkdownProcessorDocumentParsingTest {
          * Expected HTML:
          * <pre><code class="language-;"></code></pre>
          */
-        parsed.assertEquals(fencedCodeBlock("", mimeType = MimeType.Known.fromMarkdownLanguageName(";")))
+        parsed.assertEquals(fencedCodeBlock("", langName = ";"))
     }
 
     @Test
@@ -2811,7 +2806,7 @@ public class MarkdownProcessorDocumentParsingTest {
          * <pre><code class="language-aa">foo
          * </code></pre>
          */
-        parsed.assertEquals(fencedCodeBlock("foo", mimeType = MimeType.Known.fromMarkdownLanguageName("aa")))
+        parsed.assertEquals(fencedCodeBlock("foo", langName = "aa"))
     }
 
     @Test

--- a/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
+++ b/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.jewel.markdown
 
-import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.markdown.MarkdownBlock.BlockQuote
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock.FencedCodeBlock
@@ -91,11 +90,11 @@ private fun diffHtmlBlock(actual: HtmlBlock, expected: MarkdownBlock, indent: St
 }
 
 private fun diffFencedCodeBlock(actual: FencedCodeBlock, expected: MarkdownBlock, indent: String) = buildList {
-    if (actual.mimeType != (expected as FencedCodeBlock).mimeType) {
+    if (actual.info != (expected as FencedCodeBlock).info) {
         add(
             "$indent * Fenced code block mime type mismatch.\n\n" +
-                "$indent     Actual:   ${actual.mimeType}\n" +
-                "$indent     Expected: ${expected.mimeType}"
+                "$indent     Actual:   ${actual.info}\n" +
+                "$indent     Expected: ${expected.info}"
         )
     }
 
@@ -177,8 +176,8 @@ public fun heading(level: Int, vararg inlineContent: InlineMarkdown): Heading =
 
 public fun indentedCodeBlock(content: String): IndentedCodeBlock = IndentedCodeBlock(content)
 
-public fun fencedCodeBlock(content: String, mimeType: MimeType? = null): FencedCodeBlock =
-    FencedCodeBlock(content, mimeType)
+public fun fencedCodeBlock(content: String, langName: String? = null): FencedCodeBlock =
+    FencedCodeBlock(content, langName)
 
 public fun blockQuote(vararg contents: MarkdownBlock): BlockQuote = BlockQuote(contents.toList())
 

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -423,8 +423,58 @@ private fun MarkdownExample(project: Project) {
                 |    * But I'm not!
                 |       * Have fun indenting your lists as your heart pleases!
                 |
-                |```kotlin
-                |fun hello() = "World"
+                |```kt
+                |class CoolClass {
+                |    fun main() {
+                |        println("This is some Kotlin code!")
+                |    }
+                |}
+                |```
+                |
+                |```py
+                |def main():
+                |    print("This is some Python code!")
+                |
+                |if __name__ == "__main__":
+                |    main()
+                |```
+                |
+                |```python
+                |def main():
+                |    print("This is some Python code!")
+                |
+                |if __name__ == "__main__":
+                |    main()
+                |```
+                |
+                |```js
+                |function main() {
+                |    console.log("This is some JavaScript code!")
+                |}
+                |```
+                |
+                |```bat
+                |@echo off
+                |echo Hello, World!
+                |pause
+                |```
+                |
+                |```clj
+                |(print "Hello, World!")
+                |```
+                |
+                |```dockerfile
+                |WORKDIR /app
+                |COPY . /app
+                |RUN pip install --no-cache-dir -r requirements.txt
+                |```
+                |
+                |```html
+                |<h1>This is heading 1</h1>
+                |```
+                |
+                |```RegExp
+                |/```(. *?)```/gs
                 |```
                 |
                 |    Indented code here!


### PR DESCRIPTION
## DRAFT PR!

I opted to open this PR as draft so we can discuss the best approach for this problem before I continue implementing it, since there are quite a few options.

First of all, you can ignore most of the changed code for now (tons of breaking changes and dubious code currently 😎) Focus on `LexerBasedCodeHighlighter`. I'll start explaining the problem, then the path I'm more inclined to take, then I'll talk briefly about other options. Bear with me here, please.

## Problem

Our syntax highlighting code for Markdown code blocks currently only highlights code that the IDE has a plugin that support it. So, if you open PyCharm for instance, it'll render python code blocks but not Kotlin. The idea here is to fallback to using [TextMate](https://www.jetbrains.com/help/idea/textmate.html) to highlight code in such cases.

## Current solution

We have a `MimeType` class that maps to a given programming language declared in the `Known` companion object:

```kt
public val KOTLIN: MimeType = MimeType("text/kotlin")
public val JAVA: MimeType = MimeType("text/java")
public val XML: MimeType = MimeType("text/xml")
public val SQL: MimeType = MimeType("text/x-sql")
```
