### PR TITLE
Fix py 82962

### DIFF
--- a/python/testSrc/com/jetbrains/python/PyNavigationTest.kt
+++ b/python/testSrc/com/jetbrains/python/PyNavigationTest.kt
@@ -402,6 +402,27 @@ class PyNavigationTest : PyTestCase() {
     }
   }
 
+  // PY-82962
+  fun testGoToDeclarationOnNewTypeAliasCall() {
+    myFixture.configureByText(
+      "a.py",
+      """
+      from typing import NewType
+      
+      JobId = NewType("JobId", str)
+      
+      def f():
+          x = Jo<caret>bId("1")
+      """.trimIndent()
+    )
+    val target = PyGotoDeclarationHandler().getGotoDeclarationTarget(elementAtCaret, myFixture.editor)
+    assertNotNull(target)
+    assertInstanceOf(target, PyTargetExpression::class.java)
+    val targetExpr = target as PyTargetExpression
+    assertEquals("JobId", targetExpr.name)
+  }
+
+
   fun `test multi with pyi`() {
     myFixture.copyDirectoryToProject("test_multi_with_pyi", "")
     val (stubbed, local) = checkMulti(

--- a/python/testSrc/com/jetbrains/python/PyNavigationTest.kt
+++ b/python/testSrc/com/jetbrains/python/PyNavigationTest.kt
@@ -402,7 +402,7 @@ class PyNavigationTest : PyTestCase() {
     }
   }
 
-  // PY-82962
+  // PY-82962 - NewType
   fun testGoToDeclarationOnNewTypeAliasCall() {
     myFixture.configureByText(
       "a.py",
@@ -420,6 +420,113 @@ class PyNavigationTest : PyTestCase() {
     assertInstanceOf(target, PyTargetExpression::class.java)
     val targetExpr = target as PyTargetExpression
     assertEquals("JobId", targetExpr.name)
+  }
+
+  // PY-82962: collections.namedtuple
+  fun testGoToDeclarationOnCollectionsNamedTupleAliasCall() {
+    myFixture.configureByText(
+      "a.py",
+      """
+      from collections import namedtuple
+
+      Point = namedtuple("Point", ["x", "y"]) 
+
+      def f():
+          p = Po<caret>int(1, 2)
+      """.trimIndent()
+    )
+    val target = PyGotoDeclarationHandler().getGotoDeclarationTarget(elementAtCaret, myFixture.editor)
+    assertNotNull(target)
+    assertInstanceOf(target, PyTargetExpression::class.java)
+    val targetExpr = target as PyTargetExpression
+    assertEquals("Point", targetExpr.name)
+  }
+
+  // PY-82962: typing.NamedTuple
+  fun testGoToDeclarationOnTypingNamedTupleFunctionalCall() {
+    myFixture.configureByText(
+      "a.py",
+      """
+      from typing import NamedTuple
+
+      Point = NamedTuple("Point", [("x", int), ("y", int)])
+
+      def f():
+          p = Po<caret>int(1, 2)
+      """.trimIndent()
+    )
+    val target = PyGotoDeclarationHandler().getGotoDeclarationTarget(elementAtCaret, myFixture.editor)
+    assertNotNull(target)
+    assertInstanceOf(target, PyTargetExpression::class.java)
+    val targetExpr = target as PyTargetExpression
+    assertEquals("Point", targetExpr.name)
+  }
+
+  // PY-82962: typing.TypedDict
+  fun testGoToDeclarationOnTypedDictFunctionalCall() {
+    myFixture.configureByText(
+      "a.py",
+      """
+      from typing import TypedDict
+
+      Movie = TypedDict("Movie", {"name": str})
+
+      def f():
+          m = Mo<caret>vie(name="x")
+      """.trimIndent()
+    )
+    val target = PyGotoDeclarationHandler().getGotoDeclarationTarget(elementAtCaret, myFixture.editor)
+    assertNotNull(target)
+    assertInstanceOf(target, PyTargetExpression::class.java)
+    val targetExpr = target as PyTargetExpression
+    assertEquals("Movie", targetExpr.name)
+  }
+
+  // PY-82962: enum.Enum
+  fun testGoToDeclarationOnEnumFunctionalCall() {
+    myFixture.configureByText(
+      "a.py",
+      """
+      from enum import Enum
+
+      Color = Enum("Color", "RED GREEN")
+
+      def f():
+          c = Co<caret>lor(1)
+      """.trimIndent()
+    )
+    val target = PyGotoDeclarationHandler().getGotoDeclarationTarget(elementAtCaret, myFixture.editor)
+    assertNotNull(target)
+    assertInstanceOf(target, PyTargetExpression::class.java)
+    val targetExpr = target as PyTargetExpression
+    assertEquals("Color", targetExpr.name)
+  }
+
+
+  // PY-82962: Cross-module import of alias
+  fun testGoToDeclarationOnAliasCallImportedFromOtherModule() {
+    myFixture.addFileToProject(
+      "m.py",
+      """
+      from collections import namedtuple
+      Point = namedtuple("Point", ["x", "y"]) 
+      """.trimIndent()
+    )
+    myFixture.configureByText(
+      "main.py",
+      """
+      from m import Point
+
+      def f():
+          p = Po<caret>int(1, 2)
+      """.trimIndent()
+    )
+    val target = PyGotoDeclarationHandler().getGotoDeclarationTarget(elementAtCaret, myFixture.editor)
+    assertNotNull(target)
+    assertInstanceOf(target, PyTargetExpression::class.java)
+    val targetExpr = target as PyTargetExpression
+    assertEquals("Point", targetExpr.name)
+    assertEquals("m.py", targetExpr.containingFile.name)
   }
 
 


### PR DESCRIPTION
When you assign a name to the result of a factory function that produces a class/callable, and then use that name as a callee, navigation tends to follow the factory function (often in stubs) instead of the user’s alias assignment.

This PR fixes this behaviour for:
- NewType
- namedtuple
- Enum
- TypedDict
