### PR TITLE
[JEWEL-956] Clean up scripts

### DIFF
--- a/platform/jewel/RELEASE NOTES.md
+++ b/platform/jewel/RELEASE NOTES.md
@@ -1,6 +1,6 @@
 # Jewel Release Notes
 
-## 0.29 (2025-07-22)
+## v0.29 (2025-07-22)
 
 | Supported IJP versions | Compose Multiplatform version |
 |------------------------|-------------------------------|

--- a/platform/jewel/scripts/utils.main.kts
+++ b/platform/jewel/scripts/utils.main.kts
@@ -21,23 +21,113 @@ fun getPrNumber() = checkNotNull(System.getenv("PR_NUMBER")?.trim()) { "PR numbe
 fun requireGhTool() {
     if (checkGhTool()) return
 
-    echoErr("ERROR: the GitHub CLI tool must be present on the PATH.")
+    printlnErr("ERROR: the GitHub CLI tool must be present on the PATH.")
     exitProcess(1)
 }
 
 fun requirePrNumber() {
     if (checkPrNumber()) return
 
-    echoErr("ERROR: PR_NUMBER environment variable not set.")
+    printlnErr("ERROR: PR_NUMBER environment variable not set.")
     exitProcess(2)
 }
 
-fun echoErr(message: String) {
-    System.err.println("\u001b[0;31m$message\u001b[0m")
+private val CODE_ERR = "\u001b[0;31m"
+private val CODE_WARN = "\u001b[0;33m"
+private val CODE_CLEAR = "\u001b[0m"
+
+fun printlnErr(message: String) {
+    System.err.println(message.asError())
 }
 
-fun echoWarn(message: String) {
-    System.err.println("\u001b[0;33m$message\u001b[0m")
+fun printlnWarn(message: String) {
+    System.err.println(message.asWarning())
+}
+
+fun String.asWarning() = "$CODE_WARN$this$CODE_CLEAR"
+
+fun String.asError() = "$CODE_ERR$this$CODE_CLEAR"
+
+/**
+ * Detects if the current terminal likely supports OSC 8 hyperlinks by checking for known environment variables.
+ *
+ * @return `true` if a compatible terminal is detected, `false` otherwise.
+ */
+private fun doesTerminalSupportHyperlinks(): Boolean {
+    // Check for iTerm, VSCode, Hyper, WezTerm, etc.
+    val termProgram = System.getenv("TERM_PROGRAM")
+    if (termProgram != null) {
+        return when (termProgram) {
+            "iTerm.app",
+            "vscode",
+            "WezTerm",
+            "Hyper" -> true
+            else -> false
+        }
+    }
+
+    // Check for VTE-based terminals (GNOME Terminal, Tilix)
+    // Support was added in version 0.50 -> 5000
+    val vteVersion = System.getenv("VTE_VERSION")?.toIntOrNull()
+    if (vteVersion != null && vteVersion >= 5000) {
+        return true
+    }
+
+    // Check for IntelliJ's built-in terminal
+    if (System.getenv("TERMINAL_EMULATOR") == "JetBrains-JediTerm") {
+        return true
+    }
+
+    // Fallback if no known terminal is detected
+    return false
+}
+
+fun String.asLink(url: String): String {
+    if (!doesTerminalSupportHyperlinks()) return this
+
+    val esc = '\u001B' // Escape character
+    val bell = '\u0007' // Bell character (acts as separator)
+    return "$esc]8;;$url$bell$this$esc]8;;$bell"
+}
+
+/**
+ * Gets the current terminal width by executing `tput cols`, `stty size`, or checking COLUMNS, or using a fallback
+ * value.
+ *
+ * @return The terminal width in columns.
+ */
+fun getTerminalWidth(): Int {
+    try {
+        val tputCols = runBlocking { runCommand(command = "tput cols", workingDir = null, exitOnError = false) }
+        if (tputCols.isSuccess) return tputCols.output.trim().toInt()
+
+        val sttySize = runBlocking { runCommand(command = "stty size", workingDir = null, exitOnError = false) }
+        if (sttySize.isSuccess) return sttySize.output.trim().split(" ").last().toInt()
+
+        return System.getenv("COLUMNS")?.toIntOrNull() ?: 80
+    } catch (_: Exception) {
+        return 80
+    }
+}
+
+val isVerbose = args.contains("--verbose") || args.contains("-v")
+
+fun getArg(name: String, shortName: String? = null): String? {
+    val nameFlag = "--$name"
+    val shortNameFlag = shortName?.let { "-$it" }
+
+    val values =
+        args
+            .asSequence()
+            .mapIndexedNotNull { index, s ->
+                if (s == nameFlag || s == shortNameFlag) {
+                    args.getOrNull(index + 1)
+                } else {
+                    null
+                }
+            }
+            .toList()
+    return values.firstOrNull()
 }
 
 suspend fun runCommand(
@@ -61,7 +151,7 @@ suspend fun runCommand(
         CmdResult.Success(output)
     } else {
         if (exitOnError) {
-            echoErr("Command '$command' failed with exit code ${result.resultCode}:\n$output")
+            printlnErr("Command '$command' failed with exit code ${result.resultCode}:\n$output")
             exitProcess(result.resultCode)
         }
         CmdResult.Failure(output)

--- a/platform/jewel/scripts/utils.sh
+++ b/platform/jewel/scripts/utils.sh
@@ -17,11 +17,26 @@ fail_check() {
   local message=$1
   echoerr "$message"
 
-  if [[ -n "$PR_NUMBER" && -n "$GITHUB_TOKEN" ]]; then
-    if ! gh pr comment "$PR_NUMBER" --body "$message"; then
-      echowarn "Failed to post comment to PR #$PR_NUMBER. Continuing..."
-    fi
-  else
-    echowarn "PR_NUMBER or GITHUB_TOKEN not set, skipping posting PR comment."
+# TODO figure out how to reliably post comments to PRs from forks
+#  if [[ -n "$PR_NUMBER" && -n "$GITHUB_TOKEN" ]]; then
+#    if ! gh pr comment "$PR_NUMBER" --body "$message"; then
+#      echowarn "Failed to post comment to PR #$PR_NUMBER. Continuing..."
+#    fi
+#  else
+#    echowarn "PR_NUMBER or GITHUB_TOKEN not set, skipping posting PR comment."
+#  fi
+}
+
+check_gh_tool() {
+  if ! command -v gh &>/dev/null; then
+    echoerr "ERROR: The GitHub CLI (gh) is not installed. Please install it to continue."
+    exit 1
+  fi
+}
+
+check_pr_number() {
+  if [ -z "$PR_NUMBER" ]; then
+    echoerr "ERROR: PR_NUMBER environment variable not set."
+    exit 1
   fi
 }

--- a/platform/jewel/scripts/validate-api-dump-changes.main.kts
+++ b/platform/jewel/scripts/validate-api-dump-changes.main.kts
@@ -169,7 +169,7 @@ private val baseCommit = runBlocking {
         requireGhTool()
         runCommand("gh pr view ${getPrNumber()} --json baseRefOid -q .baseRefOid", baseDir).getOrThrow().trim()
     } else {
-        echoWarn("GitHub PR number not found, falling back to checking against HEAD~1 instead")
+        printlnWarn("GitHub PR number not found, falling back to checking against HEAD~1 instead")
         runCommand("git rev-parse HEAD~1", baseDir).getOrThrow().trim()
     }
 }
@@ -210,7 +210,7 @@ runBlocking {
         summaryFile.writeText(summary)
         println("Summary written to ${summaryFile.absolutePath}")
     } else {
-        echoWarn("GITHUB_STEP_SUMMARY environment variable not set")
+        printlnWarn("GITHUB_STEP_SUMMARY environment variable not set")
     }
 }
 

--- a/platform/jewel/scripts/validate-commit-message.sh
+++ b/platform/jewel/scripts/validate-commit-message.sh
@@ -5,15 +5,9 @@ set -o pipefail
 
 source "$(dirname "$0")/utils.sh"
 
-if ! command -v gh &>/dev/null; then
-  echoerr "ERROR: The GitHub CLI (gh) is not installed. Please install it to continue."
-  exit 1
-fi
-
-if [ -z "$PR_NUMBER" ]; then
-  echoerr "ERROR: PR_NUMBER environment variable not set."
-  exit 1
-fi
+# Precondition checks: gh tool on path, and PR_NUMBER env
+check_gh_tool
+check_pr_number
 
 echo "Checking commit messages for PR #$PR_NUMBER"
 

--- a/platform/jewel/scripts/validate-pr-commits.sh
+++ b/platform/jewel/scripts/validate-pr-commits.sh
@@ -4,15 +4,9 @@ set -o pipefail
 
 source "$(dirname "$0")/utils.sh"
 
-if ! command -v gh &> /dev/null; then
-    echo "ERROR: The GitHub CLI (gh) could not be found. Please install it to continue." >&2
-    exit 1
-fi
-
-if [ -z "$PR_NUMBER" ]; then
-  echo "ERROR: The PR_NUMBER environment variable is not set." >&2
-  exit 1
-fi
+# Precondition checks: gh tool on path, and PR_NUMBER env
+check_gh_tool
+check_pr_number
 
 echo "Checking commit count for PR #$PR_NUMBER"
 


### PR DESCRIPTION
This cleans up a number of small issues with the scripts:
* Release notes script
  * Ensure it's run from the `jewel` folder
  * Add support for nested release note bullet points
  * Add warnings when there are "orphan" Jewel commits have no matching PR information attached
  * Fix a number of bugs
* Fix version number in release notes doc to work with the release notes script
* Extract common checks from other scripts to utils.sh
* Temporarily remove the ability to post PR comments as it won't work across forks anyway


Example run of the release notes extractor:

<img width="934" height="1108" alt="image" src="https://github.com/user-attachments/assets/19bbc3af-aebc-4388-8ba0-63e8d311a0e1" />
