### PR TITLE
[JEWEL-968] Fix ligatures for console text style in bridge

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeText.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeText.kt
@@ -98,7 +98,7 @@ public fun retrieveConsoleTextStyle(): TextStyle {
             fontFamily = font.asComposeFontFamily(),
             fontSize = fontSize,
             lineHeight = (baseLineHeight * editorColorScheme.lineSpacing).coerceAtLeast(1f).sp,
-            fontFeatureSettings = if (!editorColorScheme.isUseLigatures) "liga 0" else "liga 1",
+            fontFeatureSettings = if (!editorColorScheme.isUseLigatures) "liga 0, calt 0" else "liga 1, calt 1",
         )
 }
 


### PR DESCRIPTION
The fix in [JEWEL-842](https://github.com/JetBrains/intellij-community/pull/3163) was only applied to the editor text style, not to the console text style. This remediates the omission.

## Release notes

### Bug fixes
 * Fixed the Markdown console font ligatures settings to match user's IDE settings with all fonts