### PR TITLE
Keep annotations as-is when renaming a fixture from its declaration site

### DIFF
--- a/python/testData/testCompletion/after_rename_preserve_qualified_annotation.txt
+++ b/python/testData/testCompletion/after_rename_preserve_qualified_annotation.txt
@@ -1,0 +1,11 @@
+import types
+import pytest
+
+
+@pytest.fixture()
+def abc():
+    return types.SimpleNamespace(get=lambda: None)
+
+
+def test(abc: types.SimpleNamespace):
+    assert True

--- a/python/testData/testCompletion/test_rename_preserve_qualified_annotation.py
+++ b/python/testData/testCompletion/test_rename_preserve_qualified_annotation.py
@@ -1,0 +1,11 @@
+import types
+import pytest
+
+
+@pytest.fixture()
+def client<caret>():
+    return types.SimpleNamespace(get=lambda: None)
+
+
+def test(client: types.SimpleNamespace):
+    assert True

--- a/python/testSrc/com/jetbrains/python/testing/PyTestFixtureAndParametrizedTest.kt
+++ b/python/testSrc/com/jetbrains/python/testing/PyTestFixtureAndParametrizedTest.kt
@@ -98,4 +98,10 @@ class PyTestFixtureAndParametrizedTest : PyTestCase() {
     myFixture.renameElementAtCaret("second")
     myFixture.checkResultByFile("after_rename_multiple_parametrization_second_param.txt")
   }
+
+  fun testRenamePreserveQualifiedAnnotation() {
+    myFixture.configureByFile("test_rename_preserve_qualified_annotation.py")
+    myFixture.renameElementAtCaret("abc")
+    myFixture.checkResultByFile("after_rename_preserve_qualified_annotation.txt")
+  }
 }


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/PY-83215