### PR TITLE
[JEWEL-972] Fixing crash in the "NoIndication"

### DIFF
--- a/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.kt
+++ b/platform/jewel/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.NoInspectorInfo
 import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -135,7 +137,13 @@ internal fun DecoratedWindowScope.TitleBarImpl(
         )
     }
 
-    Spacer(Modifier.layoutId(TITLE_BAR_BORDER_LAYOUT_ID).height(1.dp).fillMaxWidth().background(style.colors.border))
+    Spacer(
+        Modifier.layoutId(TITLE_BAR_BORDER_LAYOUT_ID)
+            .height(1.dp)
+            .fillMaxWidth()
+            .background(style.colors.border)
+            .semantics { hideFromAccessibility() }
+    )
 }
 
 internal class TitleBarMeasurePolicy(

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ChipsAndTree.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ChipsAndTree.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlin.random.Random
 import kotlinx.coroutines.Dispatchers
@@ -51,17 +53,26 @@ import org.jetbrains.jewel.ui.theme.colorPalette
 @Composable
 public fun ChipsAndTrees(modifier: Modifier = Modifier) {
     Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column(
+            Modifier.weight(1f).semantics { isTraversalGroup = true },
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             GroupHeader(text = "Chips", modifier = Modifier.fillMaxWidth())
             ChipsSample(Modifier.padding(8.dp))
         }
 
-        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column(
+            Modifier.weight(1f).semantics { isTraversalGroup = true },
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             GroupHeader("Tree", modifier = Modifier.fillMaxWidth())
             TreeSample()
         }
 
-        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column(
+            Modifier.weight(1f).semantics { isTraversalGroup = true },
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             GroupHeader("SelectableLazyColumn", modifier = Modifier.width(300.dp))
             SelectableLazyColumnSample()
         }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Divider.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Divider.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.takeOrElse
 import org.jetbrains.jewel.foundation.modifier.thenIf
@@ -39,5 +41,6 @@ public fun Divider(
             .thenIf(startIndent.value != 0f) { padding(start = startIndent.takeOrElse { style.metrics.startIndent }) }
             .then(orientationModifier)
             .background(color = lineColor)
+            .semantics { hideFromAccessibility() }
     )
 }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
@@ -1,10 +1,13 @@
 package org.jetbrains.jewel.ui.theme
 
-import androidx.compose.foundation.Indication
+import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.DelegatableNode
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.theme.JewelTheme
@@ -206,4 +209,10 @@ public fun BaseJewelTheme(
     }
 }
 
-private object NoIndication : Indication
+private object NoIndication : IndicationNodeFactory {
+    override fun create(interactionSource: InteractionSource): DelegatableNode = object : Modifier.Node() {}
+
+    override fun hashCode(): Int = System.identityHashCode(this)
+
+    override fun equals(other: Any?): Boolean = this === other
+}


### PR DESCRIPTION
- Updated implementation to use the 'IndicationNodeFactory'
- Updated Divider and TitleBar dividers to be hidden from accessibility
- Minor update to the chips and tree sample to make it easier to navigate with keyboard

## Release notes

### ⚠️ Important Changes
 * Updated dividers so they are not accessible by screen readers
