### PR TITLE
Add Goose MCP client detection and configuration support

### DIFF
--- a/plugins/mcp-server/src/com/intellij/mcpserver/clientConfiguration/clientsConfigs.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/clientConfiguration/clientsConfigs.kt
@@ -38,7 +38,7 @@ class ExistingConfig(
   val command: String? = null,
   val args: List<String>? = null,
   val env: Map<String, String>? = null,
-  @JsonNames("url", "serverUrl")
+  @JsonNames("url", "serverUrl", "uri")
   val url: String? = null,
   val type: String? = null,
 )

--- a/plugins/mcp-server/src/com/intellij/mcpserver/impl/McpClientDetector.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/impl/McpClientDetector.kt
@@ -41,6 +41,9 @@ object McpClientDetector {
     runCatching {
       globalClients.addIfNotNull(detectWindsurf())
     }
+    runCatching {
+      globalClients.addIfNotNull(detectGoose())
+    }
 
     return globalClients
   }
@@ -159,6 +162,23 @@ object McpClientDetector {
 
     if (looksLikeMcpJson(claudeCodeConfigPath)) {
       return McpClient(MCPClientNames.CLAUDE_CODE_PROJECT, claudeCodeConfigPath)
+    }
+    return null
+  }
+
+  private fun detectGoose(): McpClient? {
+    val configPath = when {
+      SystemInfo.isMac -> "~/.config/goose/config.yaml"
+      SystemInfo.isWindows -> System.getenv("APPDATA")?.let { "$it/goose/config.yaml" }
+      SystemInfo.isLinux -> "~/.config/goose/config.yaml"
+      else -> null
+    }
+    if (configPath == null) return null
+    val path = Paths.get(FileUtil.expandUserHome(configPath))
+    
+    // Check if Goose config directory exists (parent of config.yaml)
+    if (path.parent.exists() && path.parent.toFile().isDirectory()) {
+      return GooseClient(path)
     }
     return null
   }


### PR DESCRIPTION
## Summary
This PR adds support for detecting and configuring the Goose AI assistant as an MCP client in IntelliJ IDEA.

## Changes
- Added `GooseClient` class to handle Goose's YAML-based configuration format
- Implemented detection of Goose config at:
  - macOS/Linux: `~/.config/goose/config.yaml`
  - Windows: `%APPDATA%/goose/config.yaml`
- Added YAML parsing logic to check for `jetbrains2` extension presence and enabled status
- Implemented `configure()` method to add/update `jetbrains2` extension in YAML config
- Added Goose to `MCPClientNames` enum and detection flow

## Technical Details
Unlike other MCP clients that use JSON configuration, Goose uses YAML format with an `extensions` section. The implementation:
- Reads and writes YAML configuration without requiring additional dependencies
- Checks for the `jetbrains2` extension in the extensions section
- Adds or updates the extension with proper STDIO settings when configuring
- Returns empty map for `readMcpServers()` since Goose doesn't use JSON mcpServers structure

## Testing
- Verified detection works when Goose config directory exists
- Tested configuration adds/updates the `jetbrains2` extension correctly
- Ensured no impact on existing MCP client detection

## Related
- Similar to existing support for Cursor, VSCode, Claude, etc.
- Follows the same pattern but adapted for YAML configuration format