### PR TITLE
Add support for multiple projects in the MCP Server

### DIFF
--- a/plugins/mcp-server/resources/META-INF/plugin.xml
+++ b/plugins/mcp-server/resources/META-INF/plugin.xml
@@ -43,6 +43,7 @@
     <mcpServer.mcpToolset implementation="com.intellij.mcpserver.toolsets.general.TextToolset" />
     <mcpServer.mcpToolset implementation="com.intellij.mcpserver.toolsets.general.CodeInsightToolset" />
     <mcpServer.mcpToolset implementation="com.intellij.mcpserver.toolsets.general.RefactoringToolset" />
+    <mcpServer.mcpToolset implementation="com.intellij.mcpserver.toolsets.general.ProjectToolset" />
 
     <registryKey defaultValue="false"
                  description="Detect MCP clients to suggest enable MCP server on project startup"

--- a/plugins/mcp-server/resources/messages/McpServerBundle.properties
+++ b/plugins/mcp-server/resources/messages/McpServerBundle.properties
@@ -83,3 +83,4 @@ tool.activity.listing.modules=Listing modules
 tool.activity.checking.dependencies=Checking dependencies
 tool.activity.building.project=Building project
 tool.activity.rebuilding.project=Rebuilding project
+tool.activity.listing.projects=Listing projects

--- a/plugins/mcp-server/src/com/intellij/mcpserver/McpTool.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/McpTool.kt
@@ -42,6 +42,16 @@ class McpToolCallResult(val content: Array<McpToolCallResultContent>, val struct
 open class McpExpectedError(val mcpErrorText: String) : Exception(mcpErrorText)
 
 /**
+ * Exception thrown when a project with the specified name is not found
+ */
+class ProjectNotFoundException(message: String) : McpExpectedError(message)
+
+/**
+ * Exception thrown when multiple projects have the same name, making resolution ambiguous
+ */
+class AmbiguousProjectNameException(message: String) : McpExpectedError(message)
+
+/**
  * Throws [McpExpectedError] with [message]
  *
  * The exception is caught by MCP server and returned to client as a well-rendered error

--- a/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/Constants.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/Constants.kt
@@ -4,6 +4,8 @@ import com.intellij.mcpserver.util.TruncateMode
 
 object Constants {
   const val RELATIVE_PATH_IN_PROJECT_DESCRIPTION: String = "Path relative to the project root"
+  const val PROJECT_NAME_DESCRIPTION: String = "Name of the project to operate on. If not specified, uses the current project context. Use list_projects tool to get available project names."
+  const val PROJECT_PATH_DESCRIPTION: String = "Full path to the project directory. Takes precedence over projectName if both are specified. Use list_projects tool to get available project paths."
   const val TIMEOUT_MILLISECONDS_DESCRIPTION: String = "Timeout in milliseconds"
   const val TIMED_OUT_DESCRIPTION: String = "Indicates whether the operation was timed out. 'true' value may mean that the results may be incomplete or partial. " +
                                             "'false', 'null' or missing value means that the operation has not been timed out."

--- a/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/AnalysisToolset.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/AnalysisToolset.kt
@@ -204,9 +204,14 @@ class AnalysisToolset : McpToolset {
     |Get a list of all dependencies defined in the project.
     |Returns structured information about project library names.
   """)
-  suspend fun get_project_dependencies(): ProjectDependenciesResult {
+  suspend fun get_project_dependencies(
+    @McpDescription(Constants.PROJECT_NAME_DESCRIPTION)
+    projectName: String? = null,
+    @McpDescription(Constants.PROJECT_PATH_DESCRIPTION)
+    projectPath: String? = null,
+  ): ProjectDependenciesResult {
     currentCoroutineContext().reportToolActivity(McpServerBundle.message("tool.activity.checking.dependencies"))
-    val project = currentCoroutineContext().project
+    val project = currentCoroutineContext().getProjectByNameOrPath(projectName, projectPath)
 
     val dependencies = readAction {
       val moduleManager = ModuleManager.getInstance(project)

--- a/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/ExecutionToolset.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/ExecutionToolset.kt
@@ -39,9 +39,14 @@ class ExecutionToolset : McpToolset {
     |
     |Use this tool to query the list of available run configurations in the current project.
   """)
-  suspend fun get_run_configurations(): RunConfigurationsList {
+  suspend fun get_run_configurations(
+    @McpDescription(Constants.PROJECT_NAME_DESCRIPTION)
+    projectName: String? = null,
+    @McpDescription(Constants.PROJECT_PATH_DESCRIPTION)
+    projectPath: String? = null,
+  ): RunConfigurationsList {
     currentCoroutineContext().reportToolActivity(McpServerBundle.message("tool.activity.getting.run.configurations"))
-    val project = currentCoroutineContext().project
+    val project = currentCoroutineContext().getProjectByNameOrPath(projectName, projectPath)
     val runManager = RunManager.getInstance(project)
 
     val configurations = readAction {
@@ -75,9 +80,13 @@ class ExecutionToolset : McpToolset {
     maxLinesCount: Int = Constants.MAX_LINES_COUNT_VALUE,
     @McpDescription(Constants.TRUNCATE_MODE_DESCRIPTION)
     truncateMode: TruncateMode = Constants.TRUCATE_MODE_VALUE,
+    @McpDescription(Constants.PROJECT_NAME_DESCRIPTION)
+    projectName: String? = null,
+    @McpDescription(Constants.PROJECT_PATH_DESCRIPTION)
+    projectPath: String? = null,
     ): RunConfigurationResult {
     currentCoroutineContext().reportToolActivity(McpServerBundle.message("tool.activity.executing.run.configuration", configurationName))
-    val project = currentCoroutineContext().project
+    val project = currentCoroutineContext().getProjectByNameOrPath(projectName, projectPath)
     val runManager = RunManager.getInstance(project)
 
     val runnerAndConfigurationSettings = readAction { runManager.allSettings.find { it.name == configurationName } } ?: mcpFail("Run configuration with name '$configurationName' not found.")

--- a/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/FileToolset.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/FileToolset.kt
@@ -201,9 +201,13 @@ class FileToolset : McpToolset {
   suspend fun open_file_in_editor(
     @McpDescription(Constants.RELATIVE_PATH_IN_PROJECT_DESCRIPTION)
     filePath: String,
+    @McpDescription(Constants.PROJECT_NAME_DESCRIPTION)
+    projectName: String? = null,
+    @McpDescription(Constants.PROJECT_PATH_DESCRIPTION)
+    projectPath: String? = null,
   ) {
     currentCoroutineContext().reportToolActivity(McpServerBundle.message("tool.activity.opening.file", filePath))
-    val project = currentCoroutineContext().project
+    val project = currentCoroutineContext().getProjectByNameOrPath(projectName, projectPath)
     val resolvedPath = project.resolveInProject(filePath)
 
     val file = LocalFileSystem.getInstance().findFileByNioFile(resolvedPath)
@@ -253,9 +257,13 @@ class FileToolset : McpToolset {
     text: String? = null,
     @McpDescription("Whether to overwrite an existing file if exists. If false, an exception is thrown in case of a conflict.")
     overwrite: Boolean = false,
+    @McpDescription(Constants.PROJECT_NAME_DESCRIPTION)
+    projectName: String? = null,
+    @McpDescription(Constants.PROJECT_PATH_DESCRIPTION)
+    projectPath: String? = null,
   ) {
     currentCoroutineContext().reportToolActivity(McpServerBundle.message("tool.activity.creating.file", pathInProject))
-    val project = currentCoroutineContext().project
+    val project = currentCoroutineContext().getProjectByNameOrPath(projectName, projectPath)
 
     val path = project.resolveInProject(pathInProject)
     try {

--- a/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/ProjectToolset.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/ProjectToolset.kt
@@ -1,0 +1,49 @@
+@file:Suppress("FunctionName", "unused")
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.intellij.mcpserver.toolsets.general
+
+import com.intellij.mcpserver.*
+import com.intellij.mcpserver.annotations.McpDescription
+import com.intellij.mcpserver.annotations.McpTool
+import com.intellij.openapi.project.ProjectManager
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+
+class ProjectToolset : McpToolset {
+
+  @McpTool
+  @McpDescription("""
+    |Returns a list of all open projects in the IDE.
+    |Use this tool to discover available projects and their basic information.
+    |This is useful when you need to work with multiple projects and want to specify which project to operate on.
+  """)
+  suspend fun list_projects(): ProjectsList {
+    currentCoroutineContext().reportToolActivity(McpServerBundle.message("tool.activity.listing.projects"))
+    
+    val projects = ProjectManager.getInstance().openProjects.map { project ->
+      ProjectInfo(
+        name = project.name,
+        basePath = project.basePath ?: "",
+        isDefault = project.isDefault
+      )
+    }
+    
+    return ProjectsList(projects)
+  }
+
+  @Serializable
+  data class ProjectsList(
+    val projects: List<ProjectInfo>
+  )
+
+  @Serializable
+  data class ProjectInfo(
+    val name: String,
+    val basePath: String,
+    @EncodeDefault(mode = EncodeDefault.Mode.NEVER)
+    val isDefault: Boolean? = null
+  )
+}

--- a/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/TextToolset.kt
+++ b/plugins/mcp-server/src/com/intellij/mcpserver/toolsets/general/TextToolset.kt
@@ -49,9 +49,13 @@ class TextToolset : McpToolset {
     truncateMode: TruncateMode = TruncateMode.START,
     @McpDescription("Max number of lines to return. Truncation will be performed depending on truncateMode.")
     maxLinesCount: Int = 1000,
+    @McpDescription(Constants.PROJECT_NAME_DESCRIPTION)
+    projectName: String? = null,
+    @McpDescription(Constants.PROJECT_PATH_DESCRIPTION)
+    projectPath: String? = null,
   ): String {
     currentCoroutineContext().reportToolActivity(McpServerBundle.message("tool.activity.reading.file", pathInProject))
-    val project = currentCoroutineContext().project
+    val project = currentCoroutineContext().getProjectByNameOrPath(projectName, projectPath)
     val resolvedPath = project.resolveInProject(pathInProject)
 
     val file = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(resolvedPath)

--- a/plugins/mcp-server/test/com/intellij/mcpserver/MultiProjectTest.kt
+++ b/plugins/mcp-server/test/com/intellij/mcpserver/MultiProjectTest.kt
@@ -1,0 +1,82 @@
+@file:Suppress("TestFunctionName")
+
+package com.intellij.mcpserver
+
+import com.intellij.mcpserver.toolsets.general.FileToolset
+import com.intellij.mcpserver.toolsets.general.ProjectToolset
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.fixture.projectFixture
+import io.kotest.common.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.platform.commons.annotation.Testable
+import kotlin.io.path.Path
+
+@Testable
+@TestApplication
+class MultiProjectTest {
+  companion object {
+    @BeforeAll
+    @JvmStatic
+    fun init() {
+      System.setProperty("java.awt.headless", "false")
+    }
+  }
+
+  // Create two separate project fixtures to simulate multiple projects
+  private val project1Fixture = projectFixture(openAfterCreation = true)
+  private val project1 by project1Fixture
+  private val module1Fixture = project1Fixture.moduleFixture("testModule1")
+  private val sourceRoot1Fixture = module1Fixture.sourceRootFixture(pathFixture = project1Fixture.pathInProjectFixture(Path("src")))
+  private val file1Fixture = sourceRoot1Fixture.virtualFileFixture("Test1.java", "Test1.java content")
+
+  private val project2Fixture = projectFixture(openAfterCreation = true)
+  private val project2 by project2Fixture
+  private val module2Fixture = project2Fixture.moduleFixture("testModule2")
+  private val sourceRoot2Fixture = module2Fixture.sourceRootFixture(pathFixture = project2Fixture.pathInProjectFixture(Path("src")))
+  private val file2Fixture = sourceRoot2Fixture.virtualFileFixture("Test2.java", "Test2.java content")
+
+  @Test
+  fun test_list_projects_shows_multiple_projects() = runBlocking {
+    // This test verifies that list_projects returns information about multiple open projects
+    val testBase = object : McpToolsetTestBase() {
+      override val projectFixture = project1Fixture
+    }
+    
+    testBase.testMcpTool(
+      ProjectToolset::list_projects.name,
+      buildJsonObject { },
+    ) { result ->
+      val textContent = result.textContent
+      // The result should contain multiple projects
+      assert(textContent.text.contains("projects")) { "Result should contain projects array" }
+      // Should contain both project names (though we can't predict the exact names)
+      assert(textContent.text.contains("name")) { "Result should contain project names" }
+      assert(textContent.text.contains("basePath")) { "Result should contain project base paths" }
+    }
+  }
+
+  @Test
+  fun test_project_aware_file_operations() = runBlocking {
+    // This test verifies that tools can work with specific projects when projectName is specified
+    val testBase = object : McpToolsetTestBase() {
+      override val projectFixture = project1Fixture
+    }
+    
+    // Test creating a file with projectPath parameter (more reliable than projectName)
+    testBase.testMcpTool(
+      FileToolset::create_new_file.name,
+      buildJsonObject {
+        put("pathInProject", JsonPrimitive("test-multi-project.txt"))
+        put("text", JsonPrimitive("Multi-project test content"))
+        put("projectPath", JsonPrimitive(project1.basePath ?: ""))
+      },
+    ) { result ->
+      // Should succeed without error
+      val textContent = result.textContent
+      assert(!result.isError) { "File creation should succeed" }
+    }
+  }
+}

--- a/plugins/mcp-server/test/com/intellij/mcpserver/ProjectResolutionTest.kt
+++ b/plugins/mcp-server/test/com/intellij/mcpserver/ProjectResolutionTest.kt
@@ -1,0 +1,123 @@
+@file:Suppress("TestFunctionName")
+
+package com.intellij.mcpserver
+
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.fixture.projectFixture
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.platform.commons.annotation.Testable
+import kotlin.coroutines.EmptyCoroutineContext
+
+@Testable
+@TestApplication
+class ProjectResolutionTest {
+  companion object {
+    @BeforeAll
+    @JvmStatic
+    fun init() {
+      System.setProperty("java.awt.headless", "false")
+    }
+  }
+
+  private val projectFixture = projectFixture(openAfterCreation = true)
+  private val project by projectFixture
+
+  @Test
+  fun test_getProjectByNameOrPath_with_valid_name() = runTest {
+    // Create a mock MCP call context
+    val callInfo = McpCallInfo(
+      callId = 1,
+      clientInfo = ClientInfo("test", "1.0"),
+      project = project,
+      mcpToolDescriptor = McpToolDescriptor("test", "test", McpToolSchema.ofPropertiesMap(emptyMap(), emptySet(), emptyMap())),
+      rawArguments = kotlinx.serialization.json.buildJsonObject { },
+      meta = kotlinx.serialization.json.buildJsonObject { }
+    )
+
+    val context = EmptyCoroutineContext + McpCallAdditionalDataElement(callInfo)
+
+    // Test with valid project name
+    val resolvedProject = context.getProjectByNameOrPathOrNull(project.name, null)
+    assert(resolvedProject == project) { "Should resolve to the correct project" }
+  }
+
+  @Test
+  fun test_getProjectByNameOrPath_with_invalid_name() = runTest {
+    // Create a mock MCP call context
+    val callInfo = McpCallInfo(
+      callId = 1,
+      clientInfo = ClientInfo("test", "1.0"),
+      project = project,
+      mcpToolDescriptor = McpToolDescriptor("test", "test", McpToolSchema.ofPropertiesMap(emptyMap(), emptySet(), emptyMap())),
+      rawArguments = kotlinx.serialization.json.buildJsonObject { },
+      meta = kotlinx.serialization.json.buildJsonObject { }
+    )
+
+    val context = EmptyCoroutineContext + McpCallAdditionalDataElement(callInfo)
+
+    // Test with invalid project name
+    val resolvedProject = context.getProjectByNameOrPathOrNull("nonexistent-project", null)
+    assert(resolvedProject == null) { "Should return null for nonexistent project" }
+  }
+
+  @Test
+  fun test_getProjectByNameOrPath_throws_for_invalid_name() = runTest {
+    // Create a mock MCP call context
+    val callInfo = McpCallInfo(
+      callId = 1,
+      clientInfo = ClientInfo("test", "1.0"),
+      project = project,
+      mcpToolDescriptor = McpToolDescriptor("test", "test", McpToolSchema.ofPropertiesMap(emptyMap(), emptySet(), emptyMap())),
+      rawArguments = kotlinx.serialization.json.buildJsonObject { },
+      meta = kotlinx.serialization.json.buildJsonObject { }
+    )
+
+    val context = EmptyCoroutineContext + McpCallAdditionalDataElement(callInfo)
+
+    // Test that getProjectByNameOrPath throws for invalid project name
+    assertThrows<ProjectNotFoundException> {
+      context.getProjectByNameOrPath("nonexistent-project", null)
+    }
+  }
+
+  @Test
+  fun test_getProjectByNameOrPath_with_null_name_falls_back() = runTest {
+    // Create a mock MCP call context
+    val callInfo = McpCallInfo(
+      callId = 1,
+      clientInfo = ClientInfo("test", "1.0"),
+      project = project,
+      mcpToolDescriptor = McpToolDescriptor("test", "test", McpToolSchema.ofPropertiesMap(emptyMap(), emptySet(), emptyMap())),
+      rawArguments = kotlinx.serialization.json.buildJsonObject { },
+      meta = kotlinx.serialization.json.buildJsonObject { }
+    )
+
+    val context = EmptyCoroutineContext + McpCallAdditionalDataElement(callInfo)
+
+    // Test with null project name should fall back to context project
+    val resolvedProject = context.getProjectByNameOrPathOrNull(null, null)
+    assert(resolvedProject == project) { "Should fall back to context project when name is null" }
+  }
+
+  @Test
+  fun test_getProjectByNameOrPath_with_valid_path() = runTest {
+    // Create a mock MCP call context
+    val callInfo = McpCallInfo(
+      callId = 1,
+      clientInfo = ClientInfo("test", "1.0"),
+      project = project,
+      mcpToolDescriptor = McpToolDescriptor("test", "test", McpToolSchema.ofPropertiesMap(emptyMap(), emptySet(), emptyMap())),
+      rawArguments = kotlinx.serialization.json.buildJsonObject { },
+      meta = kotlinx.serialization.json.buildJsonObject { }
+    )
+
+    val context = EmptyCoroutineContext + McpCallAdditionalDataElement(callInfo)
+
+    // Test with valid project path
+    val resolvedProject = context.getProjectByNameOrPathOrNull(null, project.basePath)
+    assert(resolvedProject == project) { "Should resolve to the correct project by path" }
+  }
+}

--- a/plugins/mcp-server/test/com/intellij/mcpserver/toolsets/ProjectToolsetTest.kt
+++ b/plugins/mcp-server/test/com/intellij/mcpserver/toolsets/ProjectToolsetTest.kt
@@ -1,0 +1,26 @@
+@file:Suppress("TestFunctionName")
+
+package com.intellij.mcpserver.toolsets
+
+import com.intellij.mcpserver.McpToolsetTestBase
+import com.intellij.mcpserver.toolsets.general.ProjectToolset
+import io.kotest.common.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.jupiter.api.Test
+
+class ProjectToolsetTest : McpToolsetTestBase() {
+  
+  @Test
+  fun list_projects() = runBlocking {
+    testMcpTool(
+      ProjectToolset::list_projects.name,
+      buildJsonObject { },
+    ) { result ->
+      val textContent = result.textContent
+      // The result should contain project information
+      assert(textContent.text.contains("projects")) { "Result should contain projects array" }
+      assert(textContent.text.contains("name")) { "Result should contain project name" }
+      assert(textContent.text.contains("basePath")) { "Result should contain project basePath" }
+    }
+  }
+}


### PR DESCRIPTION
Based on https://github.com/JetBrains/mcp-server-plugin/pull/30 which was originally based on https://github.com/JetBrains/mcp-server-plugin/pull/27 by @Lewik this adds support for having multiple plugins at once to the MCP Server. 

Addressing https://github.com/JetBrains/mcp-server-plugin/issues/16

Using multiple projects at once is by far the most common way to use AI so this is really a critical feature