### PR TITLE
[JEWEL-980] Add missing internal annotations

### DIFF
--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -3897,7 +3897,5 @@ f:org.jetbrains.jewel.ui.util.ColorExtensionsKt
 - sf:toRgbaHexString-8_81llA(J):java.lang.String
 - sf:toRgbaHexString-ek8zF_U(J,Z,Z):java.lang.String
 - bs:toRgbaHexString-ek8zF_U$default(J,Z,Z,I,java.lang.Object):java.lang.String
-f:org.jetbrains.jewel.ui.util.MessageResourceResolverKt
-- sf:getLocalMessageResourceResolverProvider():androidx.compose.runtime.ProvidableCompositionLocal
 f:org.jetbrains.jewel.ui.util.ModifierExtensionsKt
 - sf:thenIf(androidx.compose.ui.Modifier,Z,kotlin.jvm.functions.Function1):androidx.compose.ui.Modifier

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/util/MessageResourceResolver.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/util/MessageResourceResolver.kt
@@ -25,6 +25,8 @@ public interface MessageResourceResolver {
     public fun resolveIdeBundleMessage(key: String): String
 }
 
+@InternalJewelApi
+@get:ApiStatus.Internal
 public val LocalMessageResourceResolverProvider: ProvidableCompositionLocal<MessageResourceResolver> =
     staticCompositionLocalOf {
         error("No LocalMessageResourceResolverProvider provided. Have you forgotten the theme?")


### PR DESCRIPTION
We had forgotten to annotate `LocalMessageResourceResolverProvider` as internal and it was leaking the (correctly annotated as internal) `MessageResourceResolver` interface onto the public API.

I found this by pure chance while testing metalava locally.