### PR TITLE
Remove stray angle bracket in Python highlighting code sample

### DIFF
--- a/python/python-syntax/src/com/jetbrains/python/highlighting/PythonColorsPage.java
+++ b/python/python-syntax/src/com/jetbrains/python/highlighting/PythonColorsPage.java
@@ -152,7 +152,7 @@ public class PythonColorsPage implements RainbowColorSettingsPage, InspectionCol
       "        <self>self</self>.sense = <param>whatever</param>\n" +
       "\n" +
       "x = <builtin>len</builtin>('abc')\n" +
-      "type my_int< = <builtin>int</builtin>\n" +
+      "type my_int = <builtin>int</builtin>\n" +
       "print(f.<predefinedUsage>__doc__</predefinedUsage>)"
     ;
   }


### PR DESCRIPTION
Hello! This PR just corrects a small typo noticed in day-to-day use : )