### PR TITLE
[JEWEL-986] Bump Jewel API version to 0.30.0

### DIFF
--- a/build/src/org/jetbrains/intellij/build/JewelMavenArtifacts.kt
+++ b/build/src/org/jetbrains/intellij/build/JewelMavenArtifacts.kt
@@ -2,6 +2,8 @@
 package org.jetbrains.intellij.build
 
 import com.intellij.util.text.SemVer
+import kotlin.io.path.exists
+import kotlin.io.path.name
 import org.apache.maven.model.Developer
 import org.apache.maven.model.License
 import org.apache.maven.model.Model
@@ -9,12 +11,14 @@ import org.apache.maven.model.Scm
 import org.jetbrains.intellij.build.BuildPaths.Companion.COMMUNITY_ROOT
 import org.jetbrains.intellij.build.dependencies.DependenciesProperties
 import org.jetbrains.intellij.build.impl.libraries.isLibraryModule
-import org.jetbrains.intellij.build.impl.maven.*
+import org.jetbrains.intellij.build.impl.maven.DependencyScope
+import org.jetbrains.intellij.build.impl.maven.GeneratedMavenArtifacts
+import org.jetbrains.intellij.build.impl.maven.MavenArtifactDependency
+import org.jetbrains.intellij.build.impl.maven.MavenCentralPublication
+import org.jetbrains.intellij.build.impl.maven.MavenCoordinates
 import org.jetbrains.jps.model.java.JavaSourceRootType
 import org.jetbrains.jps.model.module.JpsModule
 import org.jetbrains.jps.model.module.JpsModuleDependency
-import kotlin.io.path.exists
-import kotlin.io.path.name
 
 internal object JewelMavenArtifacts {
   private const val GROUP_ID: String = "org.jetbrains.jewel"
@@ -42,7 +46,7 @@ internal object JewelMavenArtifacts {
   private val transitiveJewelDependencies = mapOf(
     "jewel-foundation" to emptySet(),
     "jewel-ui" to emptySet(),
-    "jewel-decorated-window" to setOf("jewel-foundation", "jewel-ui"),
+    "jewel-decorated-window" to setOf("jewel-foundation"),
     "jewel-markdown-core" to setOf("jewel-foundation"),
     "jewel-markdown-extensions-autolink" to setOf("jewel-foundation", "jewel-ui"),
     "jewel-markdown-extensions-gfm-alerts" to setOf("jewel-foundation", "jewel-ui"),
@@ -108,6 +112,13 @@ internal object JewelMavenArtifacts {
         }
         coordinates.groupId == "org.commonmark" -> {
           // Add CommonMark dependencies as "compile" dependencies when present
+          add(dependency.withTransitiveDependencies(DependencyScope.COMPILE))
+        }
+        coordinates.groupId == "io.coil-kt.coil3" -> {
+          // Add Coil 3 dependencies as "compile" dependencies when present
+          add(dependency.withTransitiveDependencies(DependencyScope.COMPILE))
+        }
+        coordinates.groupId == "org.jetbrains.compose.components" -> {
           add(dependency.withTransitiveDependencies(DependencyScope.COMPILE))
         }
 

--- a/platform/jewel/foundation/src/main/generated-kotlin/org/jetbrains/jewel/foundation/JewelApiVersion.kt
+++ b/platform/jewel/foundation/src/main/generated-kotlin/org/jetbrains/jewel/foundation/JewelApiVersion.kt
@@ -5,4 +5,4 @@ package org.jetbrains.jewel.foundation
 
 /** The Jewel API version for this build, expressed as a string. E.g.: "0.30.0" */
 public val JewelBuild.apiVersionString: String
-    get() = "0.29.0"
+    get() = "0.30.0"

--- a/platform/jewel/gradle.properties
+++ b/platform/jewel/gradle.properties
@@ -9,4 +9,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
 jdk.level=21
 ijp.target=251
-jewel.release.version=0.29.0
+jewel.release.version=0.30.0

--- a/platform/jewel/scripts/jewel-version-updater.main.kts
+++ b/platform/jewel/scripts/jewel-version-updater.main.kts
@@ -49,7 +49,7 @@ private val jewelApiVersionTemplate =
     |
     |/** The Jewel API version for this build, expressed as a string. E.g.: "0.30.0" */
     |public val JewelBuild.apiVersionString: String
-    |    get() = "0.29.0"
+    |    get() = "%%JEWEL_VERSION%%"
     |
     """
         .trimMargin()


### PR DESCRIPTION
This change bumps the Jewel API version to 0.30.0, while fixing a bug in the version updater script. It also adds the missing Compose Resources dependencies from the UI module's POM, and Coil from the Markdown Images extension's (also fixed in the CMP 1.9.0-beta03 branch).

## Release notes

### Bug fixes
 * Added missing CMP Resources transitive dependency to the `ui` module's POM