### PR TITLE
[JEWEL-987] Fix Detekt issues in ide-plugin module

### DIFF
--- a/.github/workflows/jewel-checks.yml
+++ b/.github/workflows/jewel-checks.yml
@@ -47,9 +47,9 @@ jobs:
           path: '**/build/test-results/test/TEST-*.xml'
           retention-days: 7
 
-      - name: Run detektMain and detektTest tasks
+      - name: Run detekt tasks
         # Run detekt checks for all modules except the IDE plugin sample, as that is bound to have missing APIs issues
-        run: ./gradlew detektMain detektTest -x :samples:ide-plugin:detektMain -x :samples:ide-plugin:detektTest --continue --no-daemon
+        run: ./gradlew detekt detektMain detektTest -x :samples:ide-plugin:detektMain -x :samples:ide-plugin:detektTest --continue --no-daemon
 
       - name: Run ktfmt and ktlint checks on IDE plugin
         # We can only use static analysis that doesn't depend on compilation in the IDE plugin

--- a/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/releasessample/ReleasesSampleCompose.kt
+++ b/platform/jewel/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/releasessample/ReleasesSampleCompose.kt
@@ -102,7 +102,7 @@ internal fun ReleasesSampleCompose(project: Project) {
 }
 
 @Composable
-private fun LeftColumn(project: Project, modifier: Modifier = Modifier, onSelectedItemChange: (ContentItem?) -> Unit) {
+private fun LeftColumn(project: Project, onSelectedItemChange: (ContentItem?) -> Unit, modifier: Modifier = Modifier) {
     val service = remember(project) { project.service<ReleasesSampleService>() }
     val currentContentSource by service.content.collectAsState()
 
@@ -341,7 +341,7 @@ private fun OverflowMenu(currentContentSource: ContentSource<*>, onContentSource
 }
 
 @Composable
-private fun RightColumn(selectedItem: ContentItem?, modifier: Modifier) {
+private fun RightColumn(selectedItem: ContentItem?, modifier: Modifier = Modifier) {
     if (selectedItem == null) {
         Box(modifier, contentAlignment = Alignment.Center) {
             Text("Nothing to see here", color = JBUI.CurrentTheme.Label.disabledForeground().toComposeColor())
@@ -435,18 +435,22 @@ private fun ItemDetailsText(selectedItem: ContentItem) {
 
 @Composable
 private fun AndroidReleaseDetails(item: ContentItem.AndroidRelease) {
-    TextWithLabel("Codename:", item.codename ?: "N/A")
-    TextWithLabel("Version:", item.versionName)
-    TextWithLabel("API level:", item.apiLevel.toString())
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        TextWithLabel("Codename:", item.codename ?: "N/A")
+        TextWithLabel("Version:", item.versionName)
+        TextWithLabel("API level:", item.apiLevel.toString())
+    }
 }
 
 @Composable
 private fun AndroidStudioReleaseDetails(item: ContentItem.AndroidStudio) {
-    TextWithLabel("Channel:", item.channel.name)
-    TextWithLabel("Version:", item.versionName)
-    TextWithLabel("IntelliJ Platform version:", item.platformVersion)
-    TextWithLabel("IntelliJ Platform build:", item.platformBuild)
-    TextWithLabel("Full build number:", item.build)
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        TextWithLabel("Channel:", item.channel.name)
+        TextWithLabel("Version:", item.versionName)
+        TextWithLabel("IntelliJ Platform version:", item.platformVersion)
+        TextWithLabel("IntelliJ Platform build:", item.platformBuild)
+        TextWithLabel("Full build number:", item.build)
+    }
 }
 
 @Composable


### PR DESCRIPTION
The checks were not being run so a few slipped through. This fixes them and makes sure some basic Detekt form is run on the GitHub CI as well, to avoid repeats.

This happened because we can't run detektMain/detektTest as they require the module to compile, but it can't. IDE plugins need to reference released builds of the platform, which are bound not to have the stuff we haven't released yet.