### PR TITLE
[JEWEL-989] Fix Markdown styling XML dependencies

### DIFF
--- a/platform/jewel/markdown/ide-laf-bridge-styling/src/main/resources/intellij.platform.jewel.markdown.ideLafBridgeStyling.xml
+++ b/platform/jewel/markdown/ide-laf-bridge-styling/src/main/resources/intellij.platform.jewel.markdown.ideLafBridgeStyling.xml
@@ -1,13 +1,10 @@
 <idea-plugin>
-  <dependencies>
-    <module name="intellij.platform.jewel.foundation" />
-    <module name="intellij.platform.jewel.ui" />
-    <module name="intellij.platform.jewel.ideLafBridge" />
-    <module name="intellij.platform.jewel.markdown.core" />
-    <module name="intellij.platform.jewel.markdown.extensions.autolink" />
-    <module name="intellij.platform.jewel.markdown.extensions.gfmAlerts" />
-    <module name="intellij.platform.jewel.markdown.extensions.gfmTables" />
-    <module name="intellij.platform.jewel.markdown.extensions.gfmStrikethrough" />
-    <module name="intellij.platform.jewel.markdown.extensions.images" />
-  </dependencies>
+    <dependencies>
+        <module name="intellij.platform.jewel.foundation"/>
+        <module name="intellij.platform.jewel.ui"/>
+        <module name="intellij.platform.jewel.ideLafBridge"/>
+        <module name="intellij.platform.jewel.markdown.core"/>
+        <module name="intellij.platform.jewel.markdown.extensions.gfmAlerts"/>
+        <module name="intellij.platform.jewel.markdown.extensions.gfmTables"/>
+    </dependencies>
 </idea-plugin>

--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/resources/intellij.platform.jewel.markdown.intUiStandaloneStyling.xml
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/resources/intellij.platform.jewel.markdown.intUiStandaloneStyling.xml
@@ -5,5 +5,6 @@
         <module name="intellij.platform.jewel.foundation"/>
         <module name="intellij.platform.jewel.intUi.standalone"/>
         <module name="intellij.platform.jewel.markdown.extensions.gfmAlerts"/>
+        <module name="intellij.platform.jewel.markdown.extensions.gfmTables"/>
     </dependencies>
 </idea-plugin>


### PR DESCRIPTION
The `ideLafBridgeStyling` module's xml manifest is depending on the strikethrough and image extensions for no reason (there is no corresponding dependency set up in the project structure), and the `intUiStandaloneStyling.xml` module is missing the (provided) dependency on the tables extension.

This fixes both issues.

## Release notes

### Bug fixes
 * Fixed `plugin.xml` dependencies for the Markdown styling modules — both standalone and bridge
   * Removed unnecessary dependency on the strikethrough and images extensions from bridge styling module
   * Added missing dependency on the tables extension to the standalone styling module