### PR TITLE
[JEWEL-990] Fix GitHub CI after ide-plugin was moved

### DIFF
--- a/.github/workflows/jewel-checks.yml
+++ b/.github/workflows/jewel-checks.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run :check task
         # Run checks for all modules except the IDE plugin sample, as that is bound to have missing APIs issues
-        run: ./gradlew check -x :samples:ide-plugin:check --continue --no-daemon
+        run: ./gradlew check --continue --no-daemon
 
       - name: Annotate JUnit test failures
         uses: mikepenz/action-junit-report@v5


### PR DESCRIPTION
The ide-plugin sample was moved to devkit in IJPL-174837, but the GitHub CI was not updated and it's failing as it's trying to exclude a now non-existent module's task.

This fixes the issue.