### PR TITLE
[JEWEL-952] Ensuring only one submenu is active at the same time

### DIFF
--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
@@ -296,7 +296,11 @@ private fun JPopupImpl(
                     }
                 }
                 is WindowEvent -> {
-                    if (event.id == WindowEvent.WINDOW_LOST_FOCUS && event.window == dialog) {
+                    if (
+                        event.id == WindowEvent.WINDOW_LOST_FOCUS &&
+                            event.window == dialog &&
+                            !dialog.isAncestorOf(event.oppositeWindow)
+                    ) {
                         currentOnDismissRequest?.invoke()
                     }
                 }

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Buttons.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Buttons.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.samples.showcase.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,6 +28,7 @@ import org.jetbrains.jewel.ui.component.DefaultSplitButton
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.IconActionButton
 import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.MenuScope
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.OutlinedSplitButton
 import org.jetbrains.jewel.ui.component.SelectableIconActionButton
@@ -202,7 +204,11 @@ private fun SplitButtons() {
         val items = remember { listOf("This is", "---", "A menu", "---", "Item 3") }
         var selected by remember { mutableStateOf(items.first()) }
 
-        Row(Modifier.height(150.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        FlowRow(
+            Modifier.height(150.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
             OutlinedSplitButton(
                 onClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button clicked") },
                 secondaryOnClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button chevron clicked") },
@@ -246,7 +252,7 @@ private fun SplitButtons() {
                 enabled = false,
                 onClick = {},
                 secondaryOnClick = {},
-                content = { Text("Disabled button") },
+                content = { Text("Disabled outline split button") },
                 menuContent = {},
             )
             DefaultSplitButton(
@@ -266,8 +272,51 @@ private fun SplitButtons() {
                 enabled = false,
                 onClick = {},
                 secondaryOnClick = {},
-                content = { Text("Disabled button") },
+                content = { Text("Disabled default split button") },
                 menuContent = {},
+            )
+            DefaultSplitButton(
+                onClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button clicked") },
+                secondaryOnClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button chevron clicked") },
+                content = { Text("Sub menus") },
+                menuContent = {
+                    fun MenuScope.buildSubmenus(stack: List<Int>) {
+                        val stackStr = stack.joinToString(".").let { if (stack.isEmpty()) it else "$it." }
+
+                        repeat(5) {
+                            val number = it + 1
+                            val itemStr = "$stackStr$number"
+
+                            if (stack.size == 4) {
+                                selectableItem(
+                                    selected = selected == itemStr,
+                                    onClick = {
+                                        selected = itemStr
+                                        JewelLogger.getInstance("Jewel").warn("Item clicked: $itemStr")
+                                    },
+                                ) {
+                                    Text("Item $itemStr")
+                                }
+                            } else {
+                                submenu(
+                                    submenu = { buildSubmenus(stack + number) },
+                                    content = { Text("Submenu $itemStr") },
+                                )
+                            }
+                        }
+
+                        separator()
+
+                        items(
+                            10,
+                            isSelected = { false },
+                            onItemClick = { JewelLogger.getInstance("Jewel").warn("Item clicked: $it") },
+                            content = { Text("Other Item ${it + 1}") },
+                        )
+                    }
+
+                    buildSubmenus(emptyList())
+                },
             )
         }
     }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -214,7 +215,16 @@ public fun MenuContent(
                 .onHover { localMenuController.onHoveredChange(it) }
     ) {
         Column(Modifier.verticalScroll(scrollState).padding(style.metrics.contentPadding)) {
-            items.forEach { MenuItem(it, anyItemHasIcon, anyItemHasKeybinding) }
+            var selectedSubMenu by remember { mutableStateOf<SubmenuItem?>(null) }
+            items.forEach { item ->
+                MenuItem(
+                    item = item,
+                    showIcons = anyItemHasIcon,
+                    showKeybindings = anyItemHasKeybinding,
+                    selectedSubMenu = selectedSubMenu,
+                    setSelectedSubMenu = { selectedSubMenu = it },
+                )
+            }
         }
 
         Box(modifier = Modifier.matchParentSize()) {
@@ -227,7 +237,23 @@ public fun MenuContent(
 }
 
 @Composable
-private fun MenuItem(item: MenuItem, showIcons: Boolean, showKeybindings: Boolean) {
+private fun MenuItem(
+    item: MenuItem,
+    showIcons: Boolean,
+    showKeybindings: Boolean,
+    selectedSubMenu: SubmenuItem?,
+    setSelectedSubMenu: (SubmenuItem?) -> Unit,
+) {
+    val currentSetSelectedSubMenu by rememberUpdatedState(setSelectedSubMenu)
+
+    fun deselectSubmenu() {
+        currentSetSelectedSubMenu(null)
+    }
+
+    fun selectSubmenu(item: SubmenuItem) {
+        currentSetSelectedSubMenu(item)
+    }
+
     when (item) {
         is MenuSelectableItem ->
             if (item.itemOptionAction != null) {
@@ -239,7 +265,10 @@ private fun MenuItem(item: MenuItem, showIcons: Boolean, showKeybindings: Boolea
                     canShowIcon = showIcons,
                     canShowKeybinding = showKeybindings,
                     enabled = item.isEnabled,
-                    content = item.content,
+                    content = {
+                        LaunchedEffect(it.isHovered) { if (it.isHovered) deselectSubmenu() }
+                        item.content()
+                    },
                 )
             } else {
                 MenuItem(
@@ -250,17 +279,24 @@ private fun MenuItem(item: MenuItem, showIcons: Boolean, showKeybindings: Boolea
                     canShowIcon = showIcons,
                     canShowKeybinding = showKeybindings,
                     enabled = item.isEnabled,
-                    content = item.content,
+                    content = {
+                        LaunchedEffect(it.isHovered) { if (it.isHovered) deselectSubmenu() }
+                        item.content()
+                    },
                 )
             }
 
         is SubmenuItem ->
             MenuSubmenuItem(
                 showIcons,
+                selected = item == selectedSubMenu,
                 enabled = item.isEnabled,
                 submenu = item.submenu,
                 iconKey = item.iconKey,
-                content = item.content,
+                content = {
+                    LaunchedEffect(it.isHovered) { if (it.isHovered) selectSubmenu(item) }
+                    item.content()
+                },
             )
 
         else -> item.content()
@@ -558,7 +594,7 @@ private fun MenuItem(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     style: MenuStyle = JewelTheme.menuStyle,
-    content: @Composable () -> Unit,
+    @Suppress("DEPRECATION") content: @Composable (itemState: MenuItemState) -> Unit,
 ) {
     val shortcutHintProvider = LocalMenuItemShortcutHintProvider.current
 
@@ -589,7 +625,7 @@ private fun MenuItem(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     style: MenuStyle = JewelTheme.menuStyle,
-    content: @Composable () -> Unit,
+    @Suppress("DEPRECATION") content: @Composable (itemState: MenuItemState) -> Unit,
 ) {
     MenuItemBase(
         selected = selected,
@@ -623,7 +659,7 @@ internal fun MenuItemBase(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     style: MenuStyle = JewelTheme.menuStyle,
-    content: @Composable () -> Unit,
+    @Suppress("DEPRECATION") content: @Composable (itemState: MenuItemState) -> Unit,
 ) {
     var itemState by
         remember(interactionSource) {
@@ -704,7 +740,7 @@ internal fun MenuItemBase(
                     }
                 }
 
-                Box(modifier = Modifier.weight(1f, true)) { content() }
+                Box(modifier = Modifier.weight(1f, true)) { content(itemState) }
 
                 if (canShowKeybinding) {
                     Text(
@@ -731,23 +767,26 @@ public fun MenuSubmenuItem(
     submenu: MenuScope.() -> Unit,
     content: @Composable () -> Unit,
 ) {
-    MenuSubmenuItem(canShowIcon, submenu, modifier, enabled, iconKey, interactionSource, style, content)
+    MenuSubmenuItem(canShowIcon, selected = false, submenu, modifier, enabled, iconKey, interactionSource, style) {
+        content()
+    }
 }
 
 @Composable
 internal fun MenuSubmenuItem(
     showIcon: Boolean,
+    selected: Boolean,
     submenu: MenuScope.() -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     iconKey: IconKey? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     style: MenuStyle = JewelTheme.menuStyle,
-    content: @Composable () -> Unit,
+    @Suppress("DEPRECATION") content: @Composable (itemState: MenuItemState) -> Unit,
 ) {
     var itemState by
         remember(interactionSource) {
-            @Suppress("DEPRECATION") mutableStateOf(MenuItemState.of(selected = false, enabled = enabled))
+            @Suppress("DEPRECATION") mutableStateOf(MenuItemState.of(selected = selected, enabled = enabled))
         }
 
     remember(enabled) { itemState = itemState.copy(selected = false, enabled = enabled) }
@@ -761,17 +800,16 @@ internal fun MenuSubmenuItem(
                 is PressInteraction.Cancel,
                 is PressInteraction.Release -> itemState = itemState.copy(pressed = false)
 
-                is HoverInteraction.Enter -> {
-                    itemState = itemState.copy(hovered = true, selected = true)
-                    focusRequester.requestFocus()
-                }
-
+                is HoverInteraction.Enter -> itemState = itemState.copy(hovered = true)
                 is HoverInteraction.Exit -> itemState = itemState.copy(hovered = false)
                 is FocusInteraction.Focus -> itemState = itemState.copy(focused = true)
                 is FocusInteraction.Unfocus -> itemState = itemState.copy(focused = false)
             }
         }
     }
+
+    remember(selected) { itemState = itemState.copy(selected = selected) }
+    LaunchedEffect(itemState.isSelected) { if (itemState.isSelected) focusRequester.requestFocus() }
 
     val itemColors = style.colors.itemColors
     val menuMetrics = style.metrics
@@ -812,7 +850,7 @@ internal fun MenuSubmenuItem(
                     }
                 }
 
-                Box(Modifier.weight(1f)) { content() }
+                Box(Modifier.weight(1f)) { content(itemState) }
 
                 Icon(
                     key = style.icons.submenuChevron,
@@ -897,9 +935,10 @@ internal fun Submenu(
         onDismissRequest = { menuController.closeAll(InputMode.Touch, false) },
         properties = PopupProperties(focusable = true),
         onPreviewKeyEvent = { false },
+        cornerSize = style.metrics.cornerSize,
         onKeyEvent = {
-            val currentFocusManager = checkNotNull(focusManager) { "FocusManager must not be null" }
-            val currentInputModeManager = checkNotNull(inputModeManager) { "InputModeManager must not be null" }
+            val currentFocusManager = focusManager ?: return@Popup false
+            val currentInputModeManager = inputModeManager ?: return@Popup false
             handlePopupMenuOnKeyEvent(it, currentFocusManager, currentInputModeManager, menuController)
         },
     ) {

--- a/plugins/devkit/intellij.devkit.compose/src/demo/ComponentShowcaseTab.kt
+++ b/plugins/devkit/intellij.devkit.compose/src/demo/ComponentShowcaseTab.kt
@@ -26,6 +26,7 @@ import org.jetbrains.jewel.foundation.modifier.trackActivation
 import org.jetbrains.jewel.foundation.modifier.trackComponentActivation
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
+import org.jetbrains.jewel.foundation.util.JewelLogger
 import org.jetbrains.jewel.intui.markdown.bridge.ProvideMarkdownStyling
 import org.jetbrains.jewel.markdown.Markdown
 import org.jetbrains.jewel.ui.Orientation
@@ -215,6 +216,48 @@ private fun RowScope.ColumnOne() {
         }
       }
     }
+
+    DefaultSplitButton(
+      onClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button clicked") },
+      secondaryOnClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button chevron clicked") },
+      content = { Text("Sub menus") },
+      menuContent = {
+        fun MenuScope.buildSubmenus(stack: List<Int>) {
+          val stackStr = stack.joinToString(".").let { if (stack.isEmpty()) it else "$it." }
+
+          repeat(5) {
+            val number = it + 1
+            val itemStr = "$stackStr$number"
+
+            if (stack.size == 4) {
+              selectableItem(
+                selected = false,
+                onClick = {
+                  JewelLogger.getInstance("Jewel").warn("Item clicked: $itemStr") },
+              ) {
+                Text("Item $itemStr")
+              }
+            } else {
+              submenu(
+                submenu = { buildSubmenus(stack + number) },
+                content = { Text("Submenu $itemStr") },
+              )
+            }
+          }
+
+          separator()
+
+          items(
+            10,
+            isSelected = { false },
+            onItemClick = { JewelLogger.getInstance("Jewel").warn("Item clicked: $it") },
+            content = { Text("Other Item ${it + 1}") },
+          )
+        }
+
+        buildSubmenus(emptyList())
+      },
+    )
   }
 }
 


### PR DESCRIPTION
The problem:

- The submenus' opening was controlled by each "submenu item"
- The "activation" was based on hover, but the "deactivation" was based on dismissing the new submenu popup

The fix:
- Hoisting the selected submenu state to the MenuContent
- With that, we can ensure that only one submenu from that menu is active at the same time

> [!WARNING]
> This fix only works in the custom popup implementations. Using the compose popups has other issues that will be reported to the CMP team

## Evidences

| Case | Video | 
| --- | --- |
| Stand-alone Before | ![Screen Recording 2025-08-27 at 09 27 51](https://github.com/user-attachments/assets/a313df41-99cf-4293-bbe9-e7685e5429b4) 
| Stand-alone After | ![Screen Recording 2025-08-27 at 09 24 36](https://github.com/user-attachments/assets/ba47bcd1-d375-4d5f-992f-dfc4e9931d76)
| IDE Before | ![Screen Recording 2025-08-27 at 09 28 56](https://github.com/user-attachments/assets/12186dbd-cab2-4874-a3f5-1891b1b84800) |
| IDE After | ![Screen Recording 2025-08-27 at 09 26 13](https://github.com/user-attachments/assets/1d5bcac0-6fa5-481a-9ed4-3199f3e9736f)

## Release notes

### Bug fixes
 * Fixed an issue with multiple sub-menus being presented at the same time