### PR TITLE
Inline code with correct indentation

### DIFF
--- a/python/testData/refactoring/inlineFunction/nestedIfElseIndentation/main.after.py
+++ b/python/testData/refactoring/inlineFunction/nestedIfElseIndentation/main.after.py
@@ -1,0 +1,21 @@
+class OrderProcessor:
+    def process_order(self):
+        order_total = 0
+        if True:
+            if order_total > 100:
+                order_total += 25
+            else:
+                order_total += 15
+        else:
+            order_total += 8.50
+        return order_total
+
+    def add_shipping(self, expedited, order_total):
+        if expedited:
+            if order_total > 100:
+                order_total += 25
+            else:
+                order_total += 15
+        else:
+            order_total += 8.50
+        return order_total

--- a/python/testData/refactoring/inlineFunction/nestedIfElseIndentation/main.py
+++ b/python/testData/refactoring/inlineFunction/nestedIfElseIndentation/main.py
@@ -1,0 +1,15 @@
+class OrderProcessor:
+    def process_order(self):
+        order_total = 0
+        order_total = self.add_shipping<caret>(True, order_total)
+        return order_total
+
+    def add_shipping(self, expedited, order_total):
+        if expedited:
+            if order_total > 100:
+                order_total += 25
+            else:
+                order_total += 15
+        else:
+            order_total += 8.50
+        return order_total

--- a/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
@@ -130,4 +130,5 @@ class PyInlineFunctionTest : PyTestCase() {
   fun testUsedAsDecorator() = doTestError("The function foo is used as a decorator and cannot be inlined. The function definition will not be removed", isReferenceError = true)
   fun testUsedAsReference() = doTestError("The function foo is used as a reference and cannot be inlined. The function definition will not be removed", isReferenceError = true)
   fun testUsesArgumentUnpacking() = doTestError("The function foo uses argument unpacking and cannot be inlined. The function definition will not be removed", isReferenceError = true)
+  fun testNestedIfElseIndentation() = doTest()
 }


### PR DESCRIPTION
Formatting was applied to a detached block and then per-statement after insertion, which broke Python suite indentation and disturbed nearby comments.

Now:
  - Perform one context-aware indentation adjustment (adjustLineIndent) over the contiguous inserted range after insertion; commit/unblock the document first.
  - Detect and delete redundant self-assignment (e.g., `x = x`) from single-return inlining.

Fixes https://youtrack.jetbrains.com/issue/PY-83746/Inline-refactoring-deletes-code
Fixes https://youtrack.jetbrains.com/issue/PY-83747/Inline-refactoring-creates-syntax-error-with-wrong-indentation