### PR TITLE
Changed maven search from `search.maven.org` to `central.sonatype.com`

### DIFF
--- a/java/java-impl/src/com/intellij/jarFinder/MavenCentralSourceSearcher.java
+++ b/java/java-impl/src/com/intellij/jarFinder/MavenCentralSourceSearcher.java
@@ -22,11 +22,11 @@ public class MavenCentralSourceSearcher extends SourceSearcher {
                               @NotNull String version,
                               @NotNull VirtualFile classesJar) throws SourceSearchException {
     try {
-      indicator.setText(IdeCoreBundle.message("progress.message.connecting.to", "https://search.maven.org"));
+      indicator.setText(IdeCoreBundle.message("progress.message.connecting.to", "https://central.sonatype.com"));
 
       indicator.checkCanceled();
 
-      String url = "https://search.maven.org/solrsearch/select?rows=3&wt=xml&q=";
+      String url = "https://central.sonatype.com/solrsearch/select?rows=3&wt=xml&q=";
       final String groupId = findMavenGroupId(classesJar, artifactId);
       if (groupId != null) {
         url += "g:%22" + groupId + "%22%20AND%20";
@@ -38,7 +38,7 @@ public class MavenCentralSourceSearcher extends SourceSearcher {
       }
 
       if (artifactList.size() == 1) {
-        return "https://search.maven.org/remotecontent?filepath=" +
+        return "https://central.sonatype.com/remotecontent?filepath=" +
                artifactList.get(0).getValue().replace('.', '/') + '/' +
                artifactId + '/' +
                version + '/' +

--- a/plugins/kotlin/maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenArchetypesProvider.kt
+++ b/plugins/kotlin/maven/src/org/jetbrains/kotlin/idea/maven/KotlinMavenArchetypesProvider.kt
@@ -108,7 +108,7 @@ private fun mavenSearchUrl(
     )
         .filter { it.second != null }.joinToString(separator = " AND ") { "${it.first}:\"${it.second}\"" }
 
-    return "https://search.maven.org/solrsearch/select?q=${q.encodeURL()}&core=gav&rows=$rowsLimit&wt=json"
+    return "https://central.sonatype.com/solrsearch/select?q=${q.encodeURL()}&core=gav&rows=$rowsLimit&wt=json"
 }
 
 private fun String.encodeURL(): String = URLEncoder.encode(this, "UTF-8")

--- a/plugins/kotlin/plugin/common/resources/META-INF/jvm.xml
+++ b/plugins/kotlin/plugin/common/resources/META-INF/jvm.xml
@@ -6,7 +6,7 @@
     <registryKey
             key="repo.with.kotlin.versions.url"
             description="URL of a JSON file with Kotlin versions"
-            defaultValue="https://search.maven.org/solrsearch/select?q=g:%22org.jetbrains.kotlin%22+AND+a:%22kotlin-stdlib%22&amp;core=gav&amp;rows=20&amp;wt=json"
+            defaultValue="https://central.sonatype.com/solrsearch/select?q=g:%22org.jetbrains.kotlin%22+AND+a:%22kotlin-stdlib%22&amp;core=gav&amp;rows=20&amp;wt=json"
             restartRequired="false"/>
 
     <registryKey key="kotlin.not.configured.show.notification"


### PR DESCRIPTION
Since February 2023, it is advisable to use central.sonatype.com for Maven-related API requests.

> See: https://central.sonatype.org/faq/what-happened-to-search-maven-org/#is-it-possible-to-continue-using-searchmavenorg

`search.maven.org` experiences periodic downtime, which can prevent or even interrupt the downloading of dependencies. With an uptime of around 92%, it is considered unreliable and unstable. This can be confirmed on the following page: https://status.maven.org.

To ensure developers can download Maven dependencies without interruptions, the new official search domain should be used.

> See: https://central.sonatype.org/search/

New API is backward compatible.