### PR TITLE
Parenthesize multi-line expression when using extract method

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/refactoring/extractmethod/PyExtractMethodUtil.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/refactoring/extractmethod/PyExtractMethodUtil.java
@@ -580,7 +580,7 @@ public final class PyExtractMethodUtil {
     boolean needsParens =
       (expression instanceof PyYieldExpression) ||
       (expression instanceof PyGeneratorExpression) ||
-      ((originalText.contains("\n") || originalText.contains("\r")) && !isBracketedExpression((PyExpression)expression));
+      ((originalText.contains("\n") || originalText.contains("\r")) && !isParenthesizedExpression((PyExpression)expression));
 
     final String text = needsParens ? "(" + originalText + ")" : originalText;
 
@@ -588,7 +588,7 @@ public final class PyExtractMethodUtil {
     return builder.buildFunction();
   }
 
-  private static boolean isBracketedExpression(@NotNull PyExpression e) {
+  private static boolean isParenthesizedExpression(@NotNull PyExpression e) {
     return e instanceof PyParenthesizedExpression
         || e instanceof PyListLiteralExpression
         || e instanceof PyDictLiteralExpression
@@ -596,7 +596,9 @@ public final class PyExtractMethodUtil {
         || e instanceof PyTupleExpression
         || e instanceof PyListCompExpression
         || e instanceof PyDictCompExpression
-        || e instanceof PySetCompExpression;
+        || e instanceof PySetCompExpression
+        || e instanceof PyGeneratorExpression
+        || e instanceof PyCallExpression;
   }
 
   private static @NotNull PyFunction generateMethodFromElements(final @NotNull PyExtractMethodSettings methodSettings,

--- a/python/python-psi-impl/src/com/jetbrains/python/refactoring/extractmethod/PyExtractMethodUtil.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/refactoring/extractmethod/PyExtractMethodUtil.java
@@ -579,8 +579,8 @@ public final class PyExtractMethodUtil {
 
     boolean needsParens =
       (expression instanceof PyYieldExpression) ||
-      (expression instanceof PyGeneratorExpression) ||
-      ((originalText.contains("\n") || originalText.contains("\r")) && !isParenthesizedExpression((PyExpression)expression));
+      ((originalText.contains("\n") || originalText.contains("\r")) &&
+       ((expression instanceof PyGeneratorExpression) || !isParenthesizedExpression((PyExpression)expression)));
 
     final String text = needsParens ? "(" + originalText + ")" : originalText;
 
@@ -590,15 +590,15 @@ public final class PyExtractMethodUtil {
 
   private static boolean isParenthesizedExpression(@NotNull PyExpression e) {
     return e instanceof PyParenthesizedExpression
-        || e instanceof PyListLiteralExpression
-        || e instanceof PyDictLiteralExpression
-        || e instanceof PySetLiteralExpression
-        || e instanceof PyTupleExpression
-        || e instanceof PyListCompExpression
-        || e instanceof PyDictCompExpression
-        || e instanceof PySetCompExpression
-        || e instanceof PyGeneratorExpression
-        || e instanceof PyCallExpression;
+           || e instanceof PyListLiteralExpression
+           || e instanceof PyDictLiteralExpression
+           || e instanceof PySetLiteralExpression
+           || e instanceof PyTupleExpression
+           || e instanceof PyListCompExpression
+           || e instanceof PyDictCompExpression
+           || e instanceof PySetCompExpression
+           || e instanceof PyGeneratorExpression
+           || e instanceof PyCallExpression;
   }
 
   private static @NotNull PyFunction generateMethodFromElements(final @NotNull PyExtractMethodSettings methodSettings,

--- a/python/testData/refactoring/extractmethod/BracketedLiteralMultiline.after.py
+++ b/python/testData/refactoring/extractmethod/BracketedLiteralMultiline.after.py
@@ -1,0 +1,10 @@
+def test_():
+    y = consume(
+        extracted()
+    )
+
+
+def extracted():
+    return [1,
+            2,
+            3]

--- a/python/testData/refactoring/extractmethod/BracketedLiteralMultiline.before.py
+++ b/python/testData/refactoring/extractmethod/BracketedLiteralMultiline.before.py
@@ -1,0 +1,6 @@
+def test_():
+    y = consume(
+        <selection>[1,
+         2,
+         3]</selection>
+    )

--- a/python/testData/refactoring/extractmethod/MultilineConditionalAllParenthesized.after.py
+++ b/python/testData/refactoring/extractmethod/MultilineConditionalAllParenthesized.after.py
@@ -1,0 +1,7 @@
+def test_():
+    _ = extracted()
+
+
+def extracted():
+    return [1,
+            2] if (True) else [3]

--- a/python/testData/refactoring/extractmethod/MultilineConditionalAllParenthesized.before.py
+++ b/python/testData/refactoring/extractmethod/MultilineConditionalAllParenthesized.before.py
@@ -1,0 +1,3 @@
+def test_():
+    _ = <selection>[1,
+            2] if (True) else [3]</selection>

--- a/python/testData/refactoring/extractmethod/MultilineExpressionInCall.after.py
+++ b/python/testData/refactoring/extractmethod/MultilineExpressionInCall.after.py
@@ -1,0 +1,11 @@
+def test_():
+    a, b, c = 1, 2, 3
+    y = (
+        extracted(a, b, c)
+    )
+
+
+def extracted(a_new, b_new, c_new):
+    return (a_new +
+            b_new +
+            c_new)

--- a/python/testData/refactoring/extractmethod/MultilineExpressionInCall.before.py
+++ b/python/testData/refactoring/extractmethod/MultilineExpressionInCall.before.py
@@ -1,0 +1,7 @@
+def test_():
+    a, b, c = 1, 2, 3
+    y = (
+        <selection>a +
+        b +
+        c</selection>
+    )

--- a/python/testData/refactoring/extractmethod/MultilineGeneratorInCall.after.py
+++ b/python/testData/refactoring/extractmethod/MultilineGeneratorInCall.after.py
@@ -1,0 +1,11 @@
+def test_():
+    items = ["type:abc"]
+    assert set(
+        extracted(items)
+    )
+
+
+def extracted(items_new):
+    return (item.split(":")[0]
+            for item in items_new
+            if not item.startswith("type:"))

--- a/python/testData/refactoring/extractmethod/MultilineGeneratorInCall.before.py
+++ b/python/testData/refactoring/extractmethod/MultilineGeneratorInCall.before.py
@@ -1,0 +1,7 @@
+def test_():
+    items = ["type:abc"]
+    assert set(
+        <selection>item.split(":")[0]
+        for item in items
+        if not item.startswith("type:")</selection>
+    )

--- a/python/testData/refactoring/extractmethod/MultilineSubscription.after.py
+++ b/python/testData/refactoring/extractmethod/MultilineSubscription.after.py
@@ -1,0 +1,8 @@
+def test_():
+    arr = [10, 20, 30]
+    _ = extracted(arr)
+
+
+def extracted(arr_new):
+    return arr_new[1,
+    2]

--- a/python/testData/refactoring/extractmethod/MultilineSubscription.before.py
+++ b/python/testData/refactoring/extractmethod/MultilineSubscription.before.py
@@ -1,0 +1,4 @@
+def test_():
+    arr = [10, 20, 30]
+    _ = <selection>arr[1,
+            2]</selection>

--- a/python/testData/refactoring/extractmethod/ParenthesizedGeneratorAssigned.after.py
+++ b/python/testData/refactoring/extractmethod/ParenthesizedGeneratorAssigned.after.py
@@ -1,0 +1,8 @@
+#  Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+def test_():
+    _ = extracted()
+
+
+def extracted():
+    return (print(x) for x in [1, 2])

--- a/python/testData/refactoring/extractmethod/ParenthesizedGeneratorAssigned.before.py
+++ b/python/testData/refactoring/extractmethod/ParenthesizedGeneratorAssigned.before.py
@@ -1,0 +1,4 @@
+#  Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+def test_():
+    _ = <selection>(print(x) for x in [1, 2])</selection>

--- a/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
@@ -408,4 +408,14 @@ public class PyExtractMethodTest extends LightMarkedTestCase {
   public void testParenthesizedGeneratorAssigned() {
     doTest("extracted");
   }
+
+  // // PY-54512
+  public void testMultilineConditionalAllParenthesized() {
+    doTest("extracted");
+  }
+
+  // // PY-54512
+  public void testMultilineSubscription() {
+    doTest("extracted");
+  }
 }

--- a/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
@@ -388,4 +388,19 @@ public class PyExtractMethodTest extends LightMarkedTestCase {
   public void testPreserveWhitespaceBetweenStatements() {
     doTest("extracted");
   }
+
+  // PY-54512
+  public void testMultilineGeneratorInCall() {
+    doTest("extracted");
+  }
+
+  // PY-54512
+  public void testMultilineExpressionInCall() {
+    doTest("extracted");
+  }
+
+  // PY-54512
+  public void testBracketedLiteralMultiline() {
+    doTest("extracted");
+  }
 }

--- a/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
@@ -403,4 +403,9 @@ public class PyExtractMethodTest extends LightMarkedTestCase {
   public void testBracketedLiteralMultiline() {
     doTest("extracted");
   }
+
+  // PY-54512
+  public void testParenthesizedGeneratorAssigned() {
+    doTest("extracted");
+  }
 }

--- a/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
@@ -27,11 +27,13 @@ public class PyExtractMethodTest extends LightMarkedTestCase {
     PyExtractMethodUtil.setAddTypeAnnotations(myFixture.getProject(), false);
     performExtractMethod(newName, beforeName, afterName);
 
-    // perform with type annotations
-    FileDocumentManager.getInstance().reloadFromDisk(myFixture.getDocument(myFixture.getFile()), myFixture.getProject());
-    PyExtractMethodUtil.setAddTypeAnnotations(myFixture.getProject(), true);
-    performExtractMethod(newName, beforeName, withTypeExists ? afterWithTypesName : afterName);
-    PyExtractMethodUtil.setAddTypeAnnotations(myFixture.getProject(), false);
+    // perform with type annotations only if expected file exists
+    if (withTypeExists) {
+      FileDocumentManager.getInstance().reloadFromDisk(myFixture.getDocument(myFixture.getFile()), myFixture.getProject());
+      PyExtractMethodUtil.setAddTypeAnnotations(myFixture.getProject(), true);
+      performExtractMethod(newName, beforeName, afterWithTypesName);
+      PyExtractMethodUtil.setAddTypeAnnotations(myFixture.getProject(), false);
+    }
   }
 
   private void performExtractMethod(@NotNull String newName, @NotNull String beforeName, @NotNull String afterName) {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/PY-54512/Extract-method-omits-backslashes-when-extracting-from-a-parenthesized-expression-spanning-multiple-lines