### PR TITLE
When extracting a method into a class, only validate against the clas…

### DIFF
--- a/python/testData/refactoring/extractmethod/MethodNameCanShadowModuleFunction.after.py
+++ b/python/testData/refactoring/extractmethod/MethodNameCanShadowModuleFunction.after.py
@@ -1,0 +1,9 @@
+def _require_instance(type_):
+    ...
+
+class C:
+    def do(self):
+        self._require_instance()
+
+    def _require_instance(self):
+        print("x")

--- a/python/testData/refactoring/extractmethod/MethodNameCanShadowModuleFunction.after.withTypes.py
+++ b/python/testData/refactoring/extractmethod/MethodNameCanShadowModuleFunction.after.withTypes.py
@@ -1,0 +1,9 @@
+def _require_instance(type_):
+    ...
+
+class C:
+    def do(self):
+        self._require_instance()
+
+    def _require_instance(self):
+        print("x")

--- a/python/testData/refactoring/extractmethod/MethodNameCanShadowModuleFunction.before.py
+++ b/python/testData/refactoring/extractmethod/MethodNameCanShadowModuleFunction.before.py
@@ -1,0 +1,6 @@
+def _require_instance(type_):
+    ...
+
+class C:
+    def do(self):
+        <selection>print("x")</selection>

--- a/python/testData/refactoring/extractmethod/NameCollisionInnerFunction.after.py
+++ b/python/testData/refactoring/extractmethod/NameCollisionInnerFunction.after.py
@@ -1,0 +1,4 @@
+class A:
+    def foo(self):
+        def bar():
+            <caret>print('bar')

--- a/python/testData/refactoring/extractmethod/NameCollisionInnerFunction.before.py
+++ b/python/testData/refactoring/extractmethod/NameCollisionInnerFunction.before.py
@@ -1,0 +1,4 @@
+class A:
+    def foo(self):
+        def bar():
+            <selection>print('bar')</selection>

--- a/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
@@ -391,4 +391,9 @@ public class PyExtractMethodTest extends LightMarkedTestCase {
   public void testMethodNameCanShadowModuleFunction() {
     doTest("_require_instance");
   }
+
+  // PY-61591
+  public void testNameCollisionInnerFunction() {
+    doFail("bar", "The method name clashes with an already existing name");
+  }
 }

--- a/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyExtractMethodTest.java
@@ -386,4 +386,9 @@ public class PyExtractMethodTest extends LightMarkedTestCase {
   public void testPreserveWhitespaceBetweenStatements() {
     doTest("extracted");
   }
+
+  // PY-61591
+  public void testMethodNameCanShadowModuleFunction() {
+    doTest("_require_instance");
+  }
 }


### PR DESCRIPTION
…s’ own namespace

The name-clash validator in the Python Extract Method utility used to check all enclosing scopes outward up to the module and treated any declaration it finds as a conflict, including module-level declarations.

Fixes https://youtrack.jetbrains.com/issue/PY-61591/Refactor-Extract-method-for-instance-class-complains-about-existing-symbol-in-module