### PR TITLE
[IJPL-190726] Fix(macOS): Handle corrupted PWD from 'open -na' command

### DIFF
--- a/native/XPlatLauncher/src/lib.rs
+++ b/native/XPlatLauncher/src/lib.rs
@@ -30,6 +30,8 @@ variant_size_differences
 )]
 
 use std::env;
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -245,8 +247,11 @@ fn restore_working_directory() -> Result<()> {
     if let Ok(cwd) = cwd_res {
         if cwd == PathBuf::from("/") {
             if let Ok(pwd) = pwd_var {
-                env::set_current_dir(&pwd)
-                    .with_context(|| format!("Cannot set current directory to '{pwd}'"))?;
+              let pwd_bytes: Vec<u8> = pwd.chars().map(|c| c as u8).collect();
+              let restore_pwd = OsStr::from_bytes(&pwd_bytes);
+
+              env::set_current_dir(&restore_pwd)
+                    .with_context(|| format!("Cannot set current directory to '{}'", restore_pwd.to_string_lossy()))?;
             }
         }
     }

--- a/native/XPlatLauncher/tests/default_tests.rs
+++ b/native/XPlatLauncher/tests/default_tests.rs
@@ -397,7 +397,31 @@ mod tests {
         assert!(stdout.contains(&expected), "'{}' is not in the output:\n{}", expected, stdout);
     }
 
-    #[test]
+  #[test]
+  #[cfg(target_os = "macos")]
+  fn macos_adjusting_current_dir_with_non_ascii_pwd() {
+    let test = prepare_test_env(LauncherLocation::Standard);
+
+    let ascii_pwd = test.project_dir.join("한글");
+    let ascii_pwd_str = ascii_pwd.to_str().unwrap();
+    fs::create_dir_all(&ascii_pwd).unwrap();
+
+    let app_bundle_path_str = test.dist_root.parent().unwrap().to_str().unwrap();
+    let debug_mode_var = xplat_launcher::DEBUG_MODE_ENV_VAR.to_string() + "=1";
+    let stdout_path = test.project_dir.join("_stdout.txt");
+    let stdout_path_str = stdout_path.to_str().unwrap();
+    let args = vec!["-Wna", app_bundle_path_str, "--env", &debug_mode_var, "--stdout", stdout_path_str, "--args", "print-cwd"];
+
+    let open_res = std::process::Command::new("/usr/bin/open").args(&args).env("PWD", ascii_pwd_str)
+      .output().unwrap_or_else(|e| panic!("Failed to execute 'open' command: {:?}", e));
+    assert!(open_res.status.success(), "Failed: 'open {:?}':\n{:?}", args, open_res);
+
+    let stdout = fs::read_to_string(&stdout_path).unwrap_or_else(|_| panic!("Cannot read: {:?}", stdout_path));
+    let expected = format!("CWD={}", ascii_pwd.display());
+    assert!(stdout.contains(&expected), "'{}' is not in the output:\n{}", expected, stdout);
+  }
+
+  #[test]
     fn launching_via_external_symlink() {
         let test = prepare_test_env(LauncherLocation::Standard);
 

--- a/native/XPlatLauncher/tests/default_tests.rs
+++ b/native/XPlatLauncher/tests/default_tests.rs
@@ -397,29 +397,29 @@ mod tests {
         assert!(stdout.contains(&expected), "'{}' is not in the output:\n{}", expected, stdout);
     }
 
-  #[test]
-  #[cfg(target_os = "macos")]
-  fn macos_adjusting_current_dir_with_non_ascii_pwd() {
-    let test = prepare_test_env(LauncherLocation::Standard);
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_adjusting_current_dir_with_non_ascii_pwd() {
+        let test = prepare_test_env(LauncherLocation::Standard);
 
-    let ascii_pwd = test.project_dir.join("한글");
-    let ascii_pwd_str = ascii_pwd.to_str().unwrap();
-    fs::create_dir_all(&ascii_pwd).unwrap();
+        let ascii_pwd = test.project_dir.join("한글");
+        let ascii_pwd_str = ascii_pwd.to_str().unwrap();
+        fs::create_dir_all(&ascii_pwd).unwrap();
 
-    let app_bundle_path_str = test.dist_root.parent().unwrap().to_str().unwrap();
-    let debug_mode_var = xplat_launcher::DEBUG_MODE_ENV_VAR.to_string() + "=1";
-    let stdout_path = test.project_dir.join("_stdout.txt");
-    let stdout_path_str = stdout_path.to_str().unwrap();
-    let args = vec!["-Wna", app_bundle_path_str, "--env", &debug_mode_var, "--stdout", stdout_path_str, "--args", "print-cwd"];
+        let app_bundle_path_str = test.dist_root.parent().unwrap().to_str().unwrap();
+        let debug_mode_var = xplat_launcher::DEBUG_MODE_ENV_VAR.to_string() + "=1";
+        let stdout_path = test.project_dir.join("_stdout.txt");
+        let stdout_path_str = stdout_path.to_str().unwrap();
+        let args = vec!["-Wna", app_bundle_path_str, "--env", &debug_mode_var, "--stdout", stdout_path_str, "--args", "print-cwd"];
 
-    let open_res = std::process::Command::new("/usr/bin/open").args(&args).env("PWD", ascii_pwd_str)
-      .output().unwrap_or_else(|e| panic!("Failed to execute 'open' command: {:?}", e));
-    assert!(open_res.status.success(), "Failed: 'open {:?}':\n{:?}", args, open_res);
+        let open_res = std::process::Command::new("/usr/bin/open").args(&args).env("PWD", ascii_pwd_str)
+          .output().unwrap_or_else(|e| panic!("Failed to execute 'open' command: {:?}", e));
+        assert!(open_res.status.success(), "Failed: 'open {:?}':\n{:?}", args, open_res);
 
-    let stdout = fs::read_to_string(&stdout_path).unwrap_or_else(|_| panic!("Cannot read: {:?}", stdout_path));
-    let expected = format!("CWD={}", ascii_pwd.display());
-    assert!(stdout.contains(&expected), "'{}' is not in the output:\n{}", expected, stdout);
-  }
+        let stdout = fs::read_to_string(&stdout_path).unwrap_or_else(|_| panic!("Cannot read: {:?}", stdout_path));
+        let expected = format!("CWD={}", ascii_pwd.display());
+        assert!(stdout.contains(&expected), "'{}' is not in the output:\n{}", expected, stdout);
+    }
 
   #[test]
     fn launching_via_external_symlink() {

--- a/native/XPlatLauncher/tests/default_tests.rs
+++ b/native/XPlatLauncher/tests/default_tests.rs
@@ -421,7 +421,7 @@ mod tests {
         assert!(stdout.contains(&expected), "'{}' is not in the output:\n{}", expected, stdout);
     }
 
-  #[test]
+    #[test]
     fn launching_via_external_symlink() {
         let test = prepare_test_env(LauncherLocation::Standard);
 


### PR DESCRIPTION
### Description
This PR fixes a long-standing issue on macOS where launching the IDE via the Toolbox script fails if the current path contains non-ASCII characters.

### The Problem
The `open -na` command causes a failure when it launches a native executable under the following two conditions:

1. The executable is launched via `open -na`.
2. The `PWD` environment variable passed to the `open` command contains non-ASCII characters (e.g. `한글`Korean).

### **Related Issue:**
Fixes [IJPL-190726](https://youtrack.jetbrains.com/issue/IJPL-190726/Command-line-interface-Korean-UTF-8-paths-appear-incorrectly-ISO-8859-1-encoded)
Duplicate with [IJPL-148652](https://youtrack.jetbrains.com/issue/IJPL-148652)