### PR TITLE
Improve inference for classes defined inside fixtures

### DIFF
--- a/python/testData/testPytestFixtureResolving/testInferenceForInnerClass/conftest.py
+++ b/python/testData/testPytestFixtureResolving/testInferenceForInnerClass/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture
+def data():
+    class TestData:
+        key = "value"
+
+    return TestData

--- a/python/testData/testPytestFixtureResolving/testInferenceForInnerClass/test_.py
+++ b/python/testData/testPytestFixtureResolving/testInferenceForInnerClass/test_.py
@@ -1,0 +1,2 @@
+def test_(data):
+    assert data.ke<caret>y

--- a/python/testSrc/com/jetbrains/python/testing/PyTestFixtureResolvingTest.kt
+++ b/python/testSrc/com/jetbrains/python/testing/PyTestFixtureResolvingTest.kt
@@ -1,10 +1,12 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.python.testing
 
+import com.intellij.idea.TestFor
 import com.intellij.psi.*
 import com.jetbrains.python.fixture.PythonCommonTestCase
 import com.jetbrains.python.fixtures.PyTestCase
 import com.jetbrains.python.psi.PyNamedParameter
+import com.jetbrains.python.psi.PyTargetExpression
 import com.jetbrains.python.psi.resolve.ImportedResolveResult
 import com.jetbrains.python.psi.types.TypeEvalContext
 import com.jetbrains.python.testing.pyTestFixtures.*
@@ -105,6 +107,8 @@ class PyTestFixtureResolvingTest : PyTestCase() {
     const val PARAMETRIZED_DIR = "/testParameters"
     const val TEST_PARAMETER_TYPES = "/test_parameter_types.py"
 
+    const val INNER_CLASS_TYPE_DIR = "/testInferenceForInnerClass"
+    const val INNER_CLASS_TYPE_FILE = "/test_.py"
   }
 
   override fun getTestDataPath() = super.getTestDataPath() + TESTS_SUBDIR
@@ -140,6 +144,14 @@ class PyTestFixtureResolvingTest : PyTestCase() {
     val resolve = getResolve(dirName, fileName) as PyNamedParameter
     val element = getCaretElement(dirName, fileName)
     TestCase.assertNotNull(element)
+    val context = TypeEvalContext.codeAnalysis(element!!.project, element.containingFile)
+    assertType(typeName, resolve, context)
+  }
+
+  private fun assertCorrectAttributeType(dirName: String, fileName: String, typeName: String = STR_TYPE_NAME) {
+    val resolve = getResolve(dirName, fileName) as PyTargetExpression
+    val element = getCaretElement(dirName, fileName)
+    assertNotNull(element)
     val context = TypeEvalContext.codeAnalysis(element!!.project, element.containingFile)
     assertType(typeName, resolve, context)
   }
@@ -352,4 +364,10 @@ class PyTestFixtureResolvingTest : PyTestCase() {
   fun testNamedParameterTypes() {
     assertCorrectType(PARAMETRIZED_DIR, TEST_PARAMETER_TYPES, INT_STR_UNION)
   }
+
+  @TestFor(issues = ["PY-66245"])
+  fun testInferenceForInnerClass() {
+    assertCorrectAttributeType(INNER_CLASS_TYPE_DIR, INNER_CLASS_TYPE_FILE)
+  }
+
 }


### PR DESCRIPTION
Previously, the provider guarded type inference with context.maySwitchToAST(func) where func is the test function that declares the parameter. If that context couldn’t switch to AST for the actual fixture function’s file (commonly conftest.py), context.getReturnType(fixtureFunc) wouldn’t look into the fixture body, so the return type degraded to unknown.

Fixes https://youtrack.jetbrains.com/issue/PY-66245/Does-not-render-documentation-for-pytest-fixtures