### PR TITLE
Allow asyncio.create_task() to be called without await

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/inspections/PyAsyncCallInspection.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/inspections/PyAsyncCallInspection.kt
@@ -67,7 +67,11 @@ class PyAsyncCallInspection : PyInspection() {
       AWAITABLE, COROUTINE
     }
 
-    val ignoreReturnedType = listOf("asyncio.tasks.Task")
+    val ignoreReturnedType = listOf(
+      "asyncio.tasks.Task",
+      "asyncio.Task",
+      "_asyncio.Task"
+    )
     val ignoreBuiltinFunctions = listOf("asyncio.events.AbstractEventLoop.run_in_executor",
                                         "asyncio.tasks.ensure_future",
                                         "asyncio.ensure_future")

--- a/python/testData/inspections/PyAsyncCallInspection/createTaskIsOk.py
+++ b/python/testData/inspections/PyAsyncCallInspection/createTaskIsOk.py
@@ -1,0 +1,9 @@
+import asyncio
+
+
+async def do() -> None:
+    pass
+
+
+async def test() -> None:
+    asyncio.create_task(do())

--- a/python/testSrc/com/jetbrains/python/inspections/PyAsyncCallInspectionTest.java
+++ b/python/testSrc/com/jetbrains/python/inspections/PyAsyncCallInspectionTest.java
@@ -47,6 +47,11 @@ public class PyAsyncCallInspectionTest extends PyInspectionTestCase {
     doMultiFileTest("a.py");
   }
 
+  // PY-84027
+  public void testCreateTaskIsOk() {
+    doTest();
+  }
+
   @NotNull
   @Override
   protected Class<? extends PyInspection> getInspectionClass() {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/PY-84027/False-positive-Coroutine-createtask-is-not-awaited

Depending how the `Task` type actually resolves, Pycharm might see different qualified names.

In CPython, the concrete implementation of Task lives in the C accelerator module _asyncio (a binary module). The pure-Python asyncio.tasks.Task is effectively an alias to that implementation. PyCharm builds “binary skeletons” for extension modules. When type inference resolves the class coming from your interpreter’s standard library, it often prefers those skeletons. As a result, the qualified name for Task is taken from the binary module where it’s actually defined: _asyncio.Task. Typeshed stubs reflect this too (depending on Python version). They define/alias Task so that asyncio.tasks.Task, asyncio.Task, and _asyncio.Task can all refer to the same runtime class. Which one PyCharm reports as typeQName depends on how resolution landed: through the binary skeleton (_asyncio) vs the re-exported names in the asyncio package.