### PR TITLE
Only display docstring if type can be resolved

### DIFF
--- a/python/testData/quickdoc/AttributeOnUnknownQualifier.py
+++ b/python/testData/quickdoc/AttributeOnUnknownQualifier.py
@@ -1,0 +1,13 @@
+# Simulate an unrelated symbol that has the same attribute name with proper docs
+class Response:
+    """
+
+    :ivar trigger_id: Identifier for the trigger associated with the response.
+    :type trigger_id: int
+    """
+    trigger_id: int = 1
+
+
+# In another scope, use an untyped parameter and access the same attribute name
+def do(dto=None):
+    dto.trig<the_ref>ger_id

--- a/python/testData/quickdoc/ModuleAttributeFunction/m.py
+++ b/python/testData/quickdoc/ModuleAttributeFunction/m.py
@@ -1,0 +1,7 @@
+def foo():
+    """Foo from module m."""
+    pass
+
+
+BAR: int = 42
+"""BAR from module m."""

--- a/python/testData/quickdoc/ModuleAttributeFunction/use_module.py
+++ b/python/testData/quickdoc/ModuleAttributeFunction/use_module.py
@@ -1,0 +1,3 @@
+import m
+
+m.fo<the_ref>o

--- a/python/testData/quickdoc/ModuleAttributeVariable/m.py
+++ b/python/testData/quickdoc/ModuleAttributeVariable/m.py
@@ -1,0 +1,9 @@
+"""Module m."""
+
+
+def foo():
+    """Foo from module m."""
+    pass
+
+BAR: int = 42
+"""BAR from module m."""

--- a/python/testData/quickdoc/ModuleAttributeVariable/use_module.py
+++ b/python/testData/quickdoc/ModuleAttributeVariable/use_module.py
@@ -1,0 +1,3 @@
+import m
+
+m.BA<the_ref>R

--- a/python/testData/quickdoc/OptionalBoxPropertyAllowed.py
+++ b/python/testData/quickdoc/OptionalBoxPropertyAllowed.py
@@ -1,0 +1,9 @@
+class Box:
+    @property
+    def value(self) -> int:
+        """Box.value doc."""
+        return 0
+
+
+x: Box | None
+x.va<the_ref>lue

--- a/python/testData/quickdoc/UnionCommonDefinitionAllowed.py
+++ b/python/testData/quickdoc/UnionCommonDefinitionAllowed.py
@@ -1,0 +1,13 @@
+class Common:
+    def a(self):
+        """Common.a doc."""
+        pass
+
+class A(Common):
+    pass
+
+class B(Common):
+    pass
+
+x: A | B
+x.a<the_ref>

--- a/python/testSrc/com/jetbrains/python/Py3QuickDocTest.java
+++ b/python/testSrc/com/jetbrains/python/Py3QuickDocTest.java
@@ -877,6 +877,92 @@ public class Py3QuickDocTest extends LightMarkedTestCase {
     });
   }
 
+  // PY-84088
+  public void testAttributeOnUnknownQualifier() {
+    Map<String, PsiElement> marks = loadTest();
+    final PsiElement originalElement = marks.get("<the_ref>");
+    assertNotNull("<the_ref> marker is missing in test data", originalElement);
+    final DocumentationManager manager = DocumentationManager.getInstance(myFixture.getProject());
+    final PsiElement target = manager.findTargetElement(myFixture.getEditor(),
+                                                        originalElement.getTextOffset(),
+                                                        myFixture.getFile(),
+                                                        originalElement);
+    final String html = myProvider.generateDoc(target, originalElement);
+    if (html == null) return; // empty help is acceptable/preferred
+    assertFalse("Quick Doc must not include unrelated attribute docstring when qualifier type is unknown/Any",
+                html.contains("Identifier for the trigger associated with the response."));
+  }
+
+  // PY-84088
+  public void testModuleAttributeFunction() {
+    // Preload the module file into the temp project so that `import m` resolves
+    myFixture.copyFileToProject(getTestName(false) + "/m.py", "m.py");
+
+    final Map<String, PsiElement> marks = configureByFile(getTestName(false) + "/use_module.py");
+    final PsiElement originalElement = marks.get("<the_ref>");
+    assertNotNull("<the_ref> marker is missing in test data", originalElement);
+    final DocumentationManager manager = DocumentationManager.getInstance(myFixture.getProject());
+    final PsiElement target = manager.findTargetElement(myFixture.getEditor(),
+                                                        originalElement.getTextOffset(),
+                                                        myFixture.getFile(),
+                                                        originalElement);
+    final String html = myProvider.generateDoc(target, originalElement);
+    assertNotNull("Quick Doc should be available for module attribute access", html);
+    assertTrue("Quick Doc should include module function docstring",
+               html.contains("Foo from module m."));
+  }
+
+  // Module attribute access — variable
+  public void testModuleAttributeVariable() {
+    // Preload the module file into the temp project so that `import m` resolves
+    myFixture.copyFileToProject(getTestName(false) + "/m.py", "m.py");
+
+    final Map<String, PsiElement> marks = configureByFile(getTestName(false) + "/use_module.py");
+    final PsiElement originalElement = marks.get("<the_ref>");
+    assertNotNull("<the_ref> marker is missing in test data", originalElement);
+    final DocumentationManager manager = DocumentationManager.getInstance(myFixture.getProject());
+    final PsiElement target = manager.findTargetElement(myFixture.getEditor(),
+                                                        originalElement.getTextOffset(),
+                                                        myFixture.getFile(),
+                                                        originalElement);
+    final String html = myProvider.generateDoc(target, originalElement);
+    assertNotNull("Quick Doc should be available for module attribute access", html);
+    assertTrue("Quick Doc should include module variable doc/comment",
+               html.contains("BAR from module m."));
+  }
+
+  // PY-84088
+  public void testUnionCommonDefinitionAllowed() {
+    final Map<String, PsiElement> marks = configureByFile(getTestName(false) + ".py");
+    final PsiElement originalElement = marks.get("<the_ref>");
+    assertNotNull("<the_ref> marker is missing in test data", originalElement);
+    final DocumentationManager manager = DocumentationManager.getInstance(myFixture.getProject());
+    final PsiElement target = manager.findTargetElement(myFixture.getEditor(),
+                                                        originalElement.getTextOffset(),
+                                                        myFixture.getFile(),
+                                                        originalElement);
+    final String html = myProvider.generateDoc(target, originalElement);
+    assertNotNull("Quick Doc should be available for Union[A, B].a where both resolve to Common.a", html);
+    assertTrue("Quick Doc should include Common.a docstring",
+               html.contains("Common.a doc."));
+  }
+
+  // PY-84088
+  public void testOptionalBoxPropertyAllowed() {
+    final Map<String, PsiElement> marks = configureByFile(getTestName(false) + ".py");
+    final PsiElement originalElement = marks.get("<the_ref>");
+    assertNotNull("<the_ref> marker is missing in test data", originalElement);
+    final DocumentationManager manager = DocumentationManager.getInstance(myFixture.getProject());
+    final PsiElement target = manager.findTargetElement(myFixture.getEditor(),
+                                                        originalElement.getTextOffset(),
+                                                        myFixture.getFile(),
+                                                        originalElement);
+    final String html = myProvider.generateDoc(target, originalElement);
+    assertNotNull("Quick Doc should be available for Optional[Box].value", html);
+    assertTrue("Quick Doc should include Box.value docstring",
+               html.contains("Box.value doc."));
+  }
+
   @Override
   protected String getTestDataPath() {
     return super.getTestDataPath() + "/quickdoc/";


### PR DESCRIPTION
Avoid resolving attribute references for documentation when the qualifier type is unknown/Any, and instead render empty help (or just the variable name/inferred type block) for such cases.

Fixes https://youtrack.jetbrains.com/issue/PY-84088/Renders-random-docstring-if-attribute-type-is-any