### PR TITLE
Fix fqname for ByteBuddyDynamicAttach

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/mergeJars.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/mergeJars.kt
@@ -338,7 +338,7 @@ private fun getIgnoredNames(): Set<String> {
     }
   }
 
-  set.add("kotlinx/coroutines/debug/internal/ByteBuddyDynamicAttach.class")
+  set.add("kotlinx/coroutines/debug/ByteBuddyDynamicAttach.class")
   set.add("kotlin/coroutines/jvm/internal/DebugProbesKt.class")
 
   /**


### PR DESCRIPTION
The reference to ByteBuddyDynamicAttach was originally added in IntelliJ commit c175babc14, but the class was later renamed by commit https://github.com/Kotlin/kotlinx.coroutines/commit/1500c83c62.

Without this change, invocations of DebugProbes.install() in IDE plugin tests can result in an error from bytebuddy:

    "class redefinition failed: attempted to delete a method"

For more background see https://youtrack.jetbrains.com/issue/IJPL-166.

cc @develar @sellmair 