### PR TITLE
Fix Path.of() InvalidPathException on Windows in MavenSystemIndicesMa…

### DIFF
--- a/plugins/maven/src/main/java/org/jetbrains/idea/maven/indices/MavenSystemIndicesManager.kt
+++ b/plugins/maven/src/main/java/org/jetbrains/idea/maven/indices/MavenSystemIndicesManager.kt
@@ -35,6 +35,7 @@ import org.jetbrains.idea.maven.utils.MavenProgressIndicator
 import org.jetbrains.idea.maven.utils.MavenUtil
 import java.net.URI
 import java.net.URISyntaxException
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -184,7 +185,12 @@ class MavenSystemIndicesManager(val cs: CoroutineScope) : PersistentStateCompone
 
 
   private fun getCanonicalUrl(repo: MavenRepositoryInfo): String {
-    if (Path.of(repo.url).isDirectory()) return Path.of(repo.url).toCanonicalPath()
+    try {
+      if (Path.of(repo.url).isDirectory()) return Path.of(repo.url).toCanonicalPath()
+    } catch (e: InvalidPathException) {
+      // Path.of() may throw InvalidPathException on Windows for URLs containing ':' character, continue with URI parsing
+    }
+    
     try {
       val uri = URI(repo.url)
       if (uri.scheme == null || uri.scheme.lowercase() == "file") {


### PR DESCRIPTION
Fix Path.of() InvalidPathException on Windows in MavenSystemIndicesManager

- Add try-catch block around Path.of() call to handle InvalidPathException
- Path.of() throws InvalidPathException on Windows for URLs containing ':' character
- Maintain existing logic by continuing with URI parsing when Path.of() fails
- Fixes Windows-specific crash when processing Maven repository URLs

Fixes: InvalidPathException when checking Maven repository URLs on Windows