### PR TITLE
[JEWEL-962] Resetting combo box scroll position on dismiss popup

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -187,6 +188,7 @@ public fun <T : Any> ListComboBox(
         popupContent = {
             PopupContent(
                 items = items,
+                currentlySelectedIndex = selectedIndex,
                 previewSelectedItemIndex = previewSelectedIndex,
                 listState = listState,
                 popupMaxHeight = popupMaxHeight,
@@ -334,6 +336,7 @@ public fun ListComboBox(
     ) {
         PopupContent(
             items = items,
+            currentlySelectedIndex = selectedIndex,
             previewSelectedItemIndex = previewSelectedIndex,
             listState = listState,
             popupMaxHeight = popupMaxHeight,
@@ -491,6 +494,7 @@ public fun EditableListComboBox(
         popupContent = {
             PopupContent(
                 items = items,
+                currentlySelectedIndex = selectedIndex,
                 previewSelectedItemIndex = previewSelectedIndex,
                 listState = listState,
                 popupMaxHeight = popupMaxHeight,
@@ -554,6 +558,7 @@ public fun <T> SelectableLazyListState.selectedItemIndex(items: List<T>, itemKey
 @Composable
 private fun <T : Any> PopupContent(
     items: List<T>,
+    currentlySelectedIndex: Int,
     previewSelectedItemIndex: Int,
     listState: SelectableLazyListState,
     popupMaxHeight: Dp,
@@ -605,4 +610,6 @@ private fun <T : Any> PopupContent(
             )
         }
     }
+
+    DisposableEffect(Unit) { onDispose { listState.lazyListState.requestScrollToItem(currentlySelectedIndex) } }
 }


### PR DESCRIPTION
- Reopening the ComboBox was keeping the previous scroll position
- Added `DisposableEffect` to 'snap' scroll position to last selected index when closing the popup

## Evidences

| Before | After | 
| --- | --- |
| <video src="https://github.com/user-attachments/assets/95684ba9-2404-4007-94ea-4714309af2d0" /> | <video src="https://github.com/user-attachments/assets/b69080e0-11eb-4522-a03d-cd4e8d057c66" /> |

## Release notes

### Bug fixes
 * The ListComboBox now resets the scroll position on dismissing the popup