### PR TITLE
[JEWEL-146] Added fallback values for all calls to retrieveInsetsAsPaddingValues

### DIFF
--- a/platform/jewel/ide-laf-bridge/api-dump.txt
+++ b/platform/jewel/ide-laf-bridge/api-dump.txt
@@ -40,6 +40,7 @@ f:org.jetbrains.jewel.bridge.BridgeUtilsKt
 - sf:retrieveEditorColorScheme():com.intellij.openapi.editor.colors.EditorColorsScheme
 - sf:retrieveInsetsAsPaddingValues(java.lang.String,androidx.compose.foundation.layout.PaddingValues):androidx.compose.foundation.layout.PaddingValues
 - bs:retrieveInsetsAsPaddingValues$default(java.lang.String,androidx.compose.foundation.layout.PaddingValues,I,java.lang.Object):androidx.compose.foundation.layout.PaddingValues
+- sf:retrieveInsetsAsPaddingValuesOrNull(java.lang.String):androidx.compose.foundation.layout.PaddingValues
 - sf:retrieveIntAsDp-3F_vd3o(java.lang.String,androidx.compose.ui.unit.Dp):F
 - bs:retrieveIntAsDp-3F_vd3o$default(java.lang.String,androidx.compose.ui.unit.Dp,I,java.lang.Object):F
 - sf:retrieveIntAsDpOrUnspecified(java.lang.String):F

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
@@ -210,7 +210,16 @@ public fun retrieveIntAsNonNegativeDpOrUnspecified(key: String): Dp =
  * @throws JewelBridgeException if the key is not found and no default is provided.
  */
 public fun retrieveInsetsAsPaddingValues(key: String, default: PaddingValues? = null): PaddingValues =
-    UIManager.getInsets(key)?.toPaddingValues() ?: default ?: keyNotFound(key, "Insets")
+    retrieveInsetsAsPaddingValuesOrNull(key) ?: default ?: keyNotFound(key, "Insets")
+
+/**
+ * Retrieves insets from the current LaF as [PaddingValues], or null if not found.
+ *
+ * @param key The key to look up the insets with.
+ * @return The insets from the LaF as [PaddingValues], or null if the key is not found.
+ */
+public fun retrieveInsetsAsPaddingValuesOrNull(key: String): PaddingValues? =
+    UIManager.getInsets(key)?.toPaddingValues()
 
 /**
  * Converts a [Insets] to [PaddingValues]. If the receiver is a [JBInsets] instance, this function delegates to the

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeComboBox.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeComboBox.kt
@@ -52,7 +52,11 @@ internal fun readDefaultComboBoxStyle(): ComboBoxStyle {
                 arrowAreaSize = DpSize(arrowWidth, minimumSize.height),
                 minSize = DpSize(minimumSize.width + arrowWidth, minimumSize.height),
                 cornerSize = componentArc,
-                contentPadding = retrieveInsetsAsPaddingValues("ComboBox.padding"),
+                contentPadding =
+                    retrieveInsetsAsPaddingValues(
+                        "ComboBox.padding",
+                        PaddingValues(horizontal = 6.dp, vertical = 3.dp),
+                    ),
                 popupContentPadding = PaddingValues(vertical = 6.dp),
                 borderWidth = borderWidth,
                 maxPopupHeight = Dp.Unspecified,

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeDropdown.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeDropdown.kt
@@ -57,7 +57,11 @@ internal fun readDefaultDropdownStyle(menuStyle: MenuStyle): DropdownStyle {
                 arrowMinSize = DpSize(arrowWidth, minimumSize.height),
                 minSize = DpSize(minimumSize.width + arrowWidth, minimumSize.height),
                 cornerSize = componentArc,
-                contentPadding = retrieveInsetsAsPaddingValues("ComboBox.padding"),
+                contentPadding =
+                    retrieveInsetsAsPaddingValues(
+                        "ComboBox.padding",
+                        PaddingValues(horizontal = 6.dp, vertical = 3.dp),
+                    ),
                 borderWidth = borderWidth,
             ),
         icons = DropdownIcons(chevronDown = AllIconsKeys.General.ChevronDown),

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeSpeedSearch.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeSpeedSearch.kt
@@ -1,7 +1,9 @@
 // Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package org.jetbrains.jewel.bridge.theme
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.unit.dp
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.UIUtil
 import org.jetbrains.jewel.bridge.retrieveColor
@@ -35,6 +37,6 @@ internal fun readSpeedSearchStyle(): SpeedSearchStyle =
                         retrieveColor("SearchField.errorForeground", JBColor.RED.toComposeColor())
                     },
             ),
-        metrics = SpeedSearchMetrics(contentPadding = retrieveInsetsAsPaddingValues("SpeedSearch.borderInsets")),
+        metrics = SpeedSearchMetrics(retrieveInsetsAsPaddingValues("SpeedSearch.borderInsets", PaddingValues(4.dp))),
         icons = SpeedSearchIcons(AllIconsKeys.Actions.Search),
     )

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTab.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeTab.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.bridge.theme
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
@@ -48,7 +49,7 @@ internal fun readDefaultTabStyle(): TabStyle {
             TabMetrics(
                 underlineThickness =
                     retrieveIntAsNonNegativeDpOrUnspecified("TabbedPane.tabSelectionHeight").takeOrElse { 2.dp },
-                tabPadding = retrieveInsetsAsPaddingValues("TabbedPane.tabInsets"),
+                tabPadding = retrieveInsetsAsPaddingValues("TabbedPane.tabInsets", PaddingValues(horizontal = 8.dp)),
                 closeContentGap = 4.dp,
                 tabContentSpacing = 4.dp,
                 tabHeight = retrieveIntAsNonNegativeDpOrUnspecified("TabbedPane.tabHeight").takeOrElse { 24.dp },
@@ -102,7 +103,7 @@ internal fun readEditorTabStyle(): TabStyle {
             TabMetrics(
                 underlineThickness =
                     retrieveIntAsNonNegativeDpOrUnspecified("TabbedPane.tabSelectionHeight").takeOrElse { 2.dp },
-                tabPadding = retrieveInsetsAsPaddingValues("TabbedPane.tabInsets"),
+                tabPadding = retrieveInsetsAsPaddingValues("TabbedPane.tabInsets", PaddingValues(horizontal = 8.dp)),
                 closeContentGap = 4.dp,
                 tabContentSpacing = 4.dp,
                 tabHeight = retrieveIntAsNonNegativeDpOrUnspecified("TabbedPane.tabHeight").takeOrElse { 24.dp },


### PR DESCRIPTION
- The Jewel ToolWindow was crashing as it was failing to get some theme values
- Added a fallback for other places using the same APIs

## Release notes

### Bug fixes
 * Updated the calls to get `ComboBox.padding`, `TabbedPane.tabInsets`, and `SpeedSearch.borderInsets` values from IDE theme to prevent crashes