### PR TITLE
[JEWEL-1006] Fix on JDialogRendered for submenus

### DIFF
--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
@@ -272,6 +272,11 @@ private fun JPopupImpl(
             when (event) {
                 is MouseEvent -> {
                     if (event.button != MouseEvent.NOBUTTON && currentProperties.dismissOnClickOutside) {
+                        if (dialog.isAncestorOf(event.component)) {
+                            // When clicking a child popup (like a submenu), skip the click outside callback
+                            return@AWTEventListener
+                        }
+
                         val mousePosition = event.locationOnScreen
                         if (!dialog.bounds.contains(mousePosition)) {
                             currentOnDismissRequest?.invoke()

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Buttons.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Buttons.kt
@@ -307,12 +307,20 @@ private fun SplitButtons() {
 
                         separator()
 
-                        items(
-                            10,
-                            isSelected = { false },
-                            onItemClick = { JewelLogger.getInstance("Jewel").warn("Item clicked: $it") },
-                            content = { Text("Other Item ${it + 1}") },
-                        )
+                        repeat(10) {
+                            val number = it + 1
+                            val itemStr = "${stackStr}other.$number"
+
+                            selectableItem(
+                                selected = selected == itemStr,
+                                onClick = {
+                                    selected = itemStr
+                                    JewelLogger.getInstance("Jewel").warn("Item clicked: $itemStr")
+                                },
+                            ) {
+                                Text("Other Item ${it + 1}")
+                            }
+                        }
                     }
 
                     buildSubmenus(emptyList())

--- a/plugins/devkit/intellij.devkit.compose/src/demo/ComponentShowcaseTab.kt
+++ b/plugins/devkit/intellij.devkit.compose/src/demo/ComponentShowcaseTab.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.*
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -217,6 +218,7 @@ private fun RowScope.ColumnOne() {
       }
     }
 
+    var selected by remember { mutableStateOf("") }
     DefaultSplitButton(
       onClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button clicked") },
       secondaryOnClick = { JewelLogger.getInstance("Jewel").warn("Outlined split button chevron clicked") },
@@ -231,8 +233,9 @@ private fun RowScope.ColumnOne() {
 
             if (stack.size == 4) {
               selectableItem(
-                selected = false,
+                selected = selected == itemStr,
                 onClick = {
+                  selected = itemStr
                   JewelLogger.getInstance("Jewel").warn("Item clicked: $itemStr") },
               ) {
                 Text("Item $itemStr")
@@ -247,12 +250,20 @@ private fun RowScope.ColumnOne() {
 
           separator()
 
-          items(
-            10,
-            isSelected = { false },
-            onItemClick = { JewelLogger.getInstance("Jewel").warn("Item clicked: $it") },
-            content = { Text("Other Item ${it + 1}") },
-          )
+          repeat(10) {
+            val number = it + 1
+            val itemStr = "${stackStr}other.$number"
+
+            selectableItem(
+              selected = selected == itemStr,
+              onClick = {
+                selected = itemStr
+                JewelLogger.getInstance("Jewel").warn("Item clicked: $itemStr")
+              },
+            ) {
+              Text("Other Item ${it + 1}")
+            }
+          }
         }
 
         buildSubmenus(emptyList())


### PR DESCRIPTION
- Updated the click outside check the see if the click happened in any of the child components

## Evidences

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/871e9955-9e3b-45e6-92cb-2964d205ece4" /> | <video src="https://github.com/user-attachments/assets/8180d5e4-9318-4fcc-8f16-127803720e87" /> |

## Release notes

### Bug fixes
 * Fixed an issue in the custom popup renderer `JDialogRenderer` that was not checking for clicks on child popups, triggering the click outside callback