### PR TITLE
[JEWEL-951] Fixed markdown sample file picker

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -8469,27 +8469,6 @@ jvm_import(
 )
 
 jvm_import(
-  name = "platform-jewel-samples-standalone-com-darkrockstudios-mpfilepicker",
-  jar = "@mpfilepicker-3_1_0_http//file",
-  source_jar = "@mpfilepicker-3_1_0-sources_http//file",
-  visibility = ["//visibility:public"]
-)
-
-jvm_import(
-  name = "platform-jewel-samples-standalone-com-darkrockstudios-mpfilepicker-jvm",
-  jar = "@mpfilepicker-jvm-3_1_0_http//file",
-  source_jar = "@mpfilepicker-jvm-3_1_0-sources_http//file",
-  visibility = ["//visibility:public"]
-)
-
-jvm_import(
-  name = "platform-jewel-samples-standalone-org-lwjgl-lwjgl",
-  jar = "@lwjgl-3_3_1_http//file",
-  source_jar = "@lwjgl-3_3_1-sources_http//file",
-  visibility = ["//visibility:public"]
-)
-
-jvm_import(
   name = "platform-jewel-samples-standalone-org-lwjgl-lwjgl-tinyfd",
   jar = "@lwjgl-tinyfd-3_3_1_http//file",
   source_jar = "@lwjgl-tinyfd-3_3_1-sources_http//file",

--- a/lib/MODULE.bazel
+++ b/lib/MODULE.bazel
@@ -12229,48 +12229,6 @@ http_file(
 )
 
 http_file(
-  name = "mpfilepicker-3_1_0_http",
-  url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/com/darkrockstudios/mpfilepicker/3.1.0/mpfilepicker-3.1.0.jar",
-  sha256 = "93e571b342f2bc87aa192fc7eb6d177ac5075415617824674b0d5fa063840f4e",
-  downloaded_file_path = "mpfilepicker-3.1.0.jar"
-)
-
-http_file(
-  name = "mpfilepicker-3_1_0-sources_http",
-  url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/com/darkrockstudios/mpfilepicker/3.1.0/mpfilepicker-3.1.0-sources.jar",
-  sha256 = "d43eca88638794d8ff756d327ed1090632dcfed8ecc43424062932dba3cb212c",
-  downloaded_file_path = "mpfilepicker-3.1.0-sources.jar"
-)
-
-http_file(
-  name = "mpfilepicker-jvm-3_1_0_http",
-  url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/com/darkrockstudios/mpfilepicker-jvm/3.1.0/mpfilepicker-jvm-3.1.0.jar",
-  sha256 = "65bb8c814bc66faf28395e7f9d51c74f5cc35d70919c50ea8639388ec46cef2d",
-  downloaded_file_path = "mpfilepicker-jvm-3.1.0.jar"
-)
-
-http_file(
-  name = "mpfilepicker-jvm-3_1_0-sources_http",
-  url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/com/darkrockstudios/mpfilepicker-jvm/3.1.0/mpfilepicker-jvm-3.1.0-sources.jar",
-  sha256 = "1f57b5586f0f260f71b073978d1075f40ec8e73c188975aaa99cbf8e8d7bd4a3",
-  downloaded_file_path = "mpfilepicker-jvm-3.1.0-sources.jar"
-)
-
-http_file(
-  name = "lwjgl-3_3_1_http",
-  url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
-  sha256 = "cf83f90e32fb973ff5edfca4ef35f55ca51bb70a579b6a1f290744f552e8e484",
-  downloaded_file_path = "lwjgl-3.3.1.jar"
-)
-
-http_file(
-  name = "lwjgl-3_3_1-sources_http",
-  url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-sources.jar",
-  sha256 = "30cb8190660bcbe9ce5761690a5abbf45735c9af4d58f61bd568203025fd3a36",
-  downloaded_file_path = "lwjgl-3.3.1-sources.jar"
-)
-
-http_file(
   name = "lwjgl-tinyfd-3_3_1_http",
   url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
   sha256 = "488f51ed95f0fac48d1d87cb0e3bac08c012dcbf6ef3c1688685d708cdbccd56",

--- a/platform/jewel/gradle/libs.versions.toml
+++ b/platform/jewel/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ commonmark-ext-gfm-tables = { module = "org.commonmark:commonmark-ext-gfm-tables
 detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
 detekt-core = { module = "io.gitlab.arturbosch.detekt:detekt-core", version.ref = "detekt" }
 detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
-filePicker = { module = "com.darkrockstudios:mpfilepicker", version.ref = "filepicker" }
 intellijPlatform-icons = { module = "com.jetbrains.intellij.platform:icons", version.ref = "intelliJPlatformBuild" }
 intellijPlatform-util-ui = { module = "com.jetbrains.intellij.platform:util-ui", version.ref = "intelliJPlatformBuild" }
 jbr-api = { module = "org.jetbrains.runtime:jbr-api", version.ref = "jbr" }

--- a/platform/jewel/samples/standalone/BUILD.bazel
+++ b/platform/jewel/samples/standalone/BUILD.bazel
@@ -30,8 +30,6 @@ jvm_library(
     "@lib//:kotlin-stdlib",
     "@lib//:kotlinx-coroutines-core",
     "@lib//:jetbrains-annotations",
-    "@lib//:platform-jewel-samples-standalone-com-darkrockstudios-mpfilepicker",
-    "@lib//:platform-jewel-samples-standalone-com-darkrockstudios-mpfilepicker-jvm",
     "//platform/jewel/markdown/extensions/autolink",
     "//platform/jewel/ui",
     "//platform/jewel/foundation",
@@ -48,13 +46,13 @@ jvm_library(
     "//libraries/compose-foundation-desktop",
     "//platform/jewel/samples/showcase",
     "//platform/icons",
+    "@lib//:jbr-api",
   ],
   runtime_deps = [
     ":standalone_resources",
     "@lib//:platform-jewel-samples-standalone-org-lwjgl-lwjgl-tinyfd",
     "@lib//:platform-jewel-samples-standalone-org-nibor-autolink-autolink",
     "@lib//:jna",
-    "@lib//:platform-jewel-samples-standalone-org-lwjgl-lwjgl",
   ],
   plugins = ["@lib//:compose-plugin"]
 )

--- a/platform/jewel/samples/standalone/build.gradle.kts
+++ b/platform/jewel/samples/standalone/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(compose.components.resources)
     implementation(compose.desktop.currentOs) { exclude(group = "org.jetbrains.compose.material") }
 
-    implementation(libs.filePicker)
+    implementation(libs.jbr.api)
     implementation(libs.intellijPlatform.icons)
     implementation(libs.kotlin.reflect)
 

--- a/platform/jewel/samples/standalone/intellij.platform.jewel.samples.standalone.iml
+++ b/platform/jewel/samples/standalone/intellij.platform.jewel.samples.standalone.iml
@@ -32,42 +32,6 @@
     <orderEntry type="library" name="kotlinx-coroutines-core" level="project" />
     <orderEntry type="library" name="jetbrains-annotations" level="project" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library">
-      <library name="com.darkrockstudios.mpfilepicker" type="repository">
-        <properties include-transitive-deps="false" maven-id="com.darkrockstudios:mpfilepicker:3.1.0">
-          <verification>
-            <artifact url="file://$MAVEN_REPOSITORY$/com/darkrockstudios/mpfilepicker/3.1.0/mpfilepicker-3.1.0.jar">
-              <sha256sum>93e571b342f2bc87aa192fc7eb6d177ac5075415617824674b0d5fa063840f4e</sha256sum>
-            </artifact>
-          </verification>
-        </properties>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/darkrockstudios/mpfilepicker/3.1.0/mpfilepicker-3.1.0.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/darkrockstudios/mpfilepicker/3.1.0/mpfilepicker-3.1.0-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library name="com.darkrockstudios.mpfilepicker.jvm" type="repository">
-        <properties include-transitive-deps="false" maven-id="com.darkrockstudios:mpfilepicker-jvm:3.1.0">
-          <verification>
-            <artifact url="file://$MAVEN_REPOSITORY$/com/darkrockstudios/mpfilepicker-jvm/3.1.0/mpfilepicker-jvm-3.1.0.jar">
-              <sha256sum>65bb8c814bc66faf28395e7f9d51c74f5cc35d70919c50ea8639388ec46cef2d</sha256sum>
-            </artifact>
-          </verification>
-        </properties>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/darkrockstudios/mpfilepicker-jvm/3.1.0/mpfilepicker-jvm-3.1.0.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/darkrockstudios/mpfilepicker-jvm/3.1.0/mpfilepicker-jvm-3.1.0-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
     <orderEntry type="module" module-name="intellij.platform.jewel.markdown.extensions.autolink" />
     <orderEntry type="module" module-name="intellij.platform.jewel.ui" />
     <orderEntry type="module" module-name="intellij.platform.jewel.foundation" />
@@ -120,24 +84,7 @@
     <orderEntry type="module" module-name="intellij.libraries.compose.foundation.desktop" />
     <orderEntry type="module" module-name="intellij.platform.jewel.samples.showcase" />
     <orderEntry type="library" scope="RUNTIME" name="jna" level="project" />
-    <orderEntry type="module-library" scope="RUNTIME">
-      <library name="org.lwjgl.lwjgl" type="repository">
-        <properties include-transitive-deps="false" maven-id="org.lwjgl:lwjgl:3.3.1">
-          <verification>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar">
-              <sha256sum>cf83f90e32fb973ff5edfca4ef35f55ca51bb70a579b6a1f290744f552e8e484</sha256sum>
-            </artifact>
-          </verification>
-        </properties>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
     <orderEntry type="module" module-name="intellij.platform.icons" />
+    <orderEntry type="library" name="jbr-api" level="project" />
   </component>
 </module>


### PR DESCRIPTION
- Removed the old file picker library, which is not maintained anymore
- Replaced implementation with JBR File Picker
- Note that as this is only in the sample app, it does not affect the Library itself

## Evidences

| Video | 
| --- | 
| <video src="https://github.com/user-attachments/assets/581f2a79-7be6-4307-a313-6b7f027dfe59" /> |

