### PR TITLE
[JEWEL-1018] Speed Searchable ComboBox

### DIFF
--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
@@ -31,7 +31,9 @@ import org.jetbrains.jewel.ui.component.GroupHeader
 import org.jetbrains.jewel.ui.component.ListComboBox
 import org.jetbrains.jewel.ui.component.PopupManager
 import org.jetbrains.jewel.ui.component.SimpleListItem
+import org.jetbrains.jewel.ui.component.SpeedSearchArea
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.search.SpeedSearchableComboBox
 import org.jetbrains.jewel.ui.disabledAppearance
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
@@ -92,7 +94,7 @@ public fun ComboBoxes(modifier: Modifier = Modifier) {
 private fun ListComboBoxes() {
     FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Column(Modifier.weight(1f).widthIn(min = 125.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("String-based API, enabled")
+            Text("String-based API")
             var selectedIndex by remember { mutableIntStateOf(2) }
             val selectedItemText = if (selectedIndex >= 0) stringItems[selectedIndex] else "[none]"
             InfoText(text = "Selected item: $selectedItemText")
@@ -107,7 +109,7 @@ private fun ListComboBoxes() {
         }
 
         Column(Modifier.weight(1f).widthIn(min = 125.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("Generics-based API, enabled")
+            Text("Generics-based API")
             var selectedIndex by remember { mutableIntStateOf(2) }
             val selectedItemText = if (selectedIndex >= 0) languageOptions[selectedIndex].name else "[none]"
             InfoText(text = "Selected item: $selectedItemText")
@@ -132,22 +134,22 @@ private fun ListComboBoxes() {
         }
 
         Column(Modifier.weight(1f).widthIn(min = 125.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("String-based API, disabled")
+            Text("Speed Search API")
             var selectedIndex by remember { mutableIntStateOf(2) }
             val selectedItemText = if (selectedIndex >= 0) stringItems[selectedIndex] else "[none]"
             InfoText(text = "Selected item: $selectedItemText")
 
-            ListComboBox(
-                items = stringItems,
-                selectedIndex = selectedIndex,
-                onSelectedItemChange = { index -> selectedIndex = index },
-                modifier = Modifier.widthIn(max = 200.dp),
-                enabled = false,
-            )
+            SpeedSearchArea(Modifier.widthIn(max = 200.dp)) {
+                SpeedSearchableComboBox(
+                    items = stringItems,
+                    selectedIndex = selectedIndex,
+                    onSelectedItemChange = { index -> selectedIndex = index },
+                )
+            }
         }
 
         Column(Modifier.weight(1f).widthIn(min = 125.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("Generics-based API, disabled")
+            Text("Disabled")
             var selectedIndex by remember { mutableIntStateOf(2) }
             val selectedItemText = if (selectedIndex >= 0) languageOptions[selectedIndex].name else "[none]"
             InfoText(text = "Selected item: $selectedItemText")

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBoxTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBoxTest.kt
@@ -1,0 +1,227 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui.component.search
+
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.ui.component.SpeedSearchArea
+import org.jetbrains.jewel.ui.component.assertCursorAtPosition
+import org.jetbrains.jewel.ui.component.interactions.performKeyPress
+import org.junit.Rule
+
+@Suppress("ImplicitUnitReturnType")
+class SpeedSearchableComboBoxTest {
+    @get:Rule val rule = createComposeRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val comboBox: SemanticsNodeInteraction
+        get() = rule.onNodeWithTag("ComboBox")
+
+    private val ComposeContentTestRule.onSpeedSearchAreaInput
+        get() = onNodeWithTag("SpeedSearchArea.Input")
+
+    private fun ComposeContentTestRule.onComboBoxItem(text: String) =
+        onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.List")) and hasText(text))
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `should show on type text`() = runComposeTest {
+        comboBox.performClick()
+        comboBox.performKeyPress("Item", rule = this)
+        onSpeedSearchAreaInput.assertExists().assertIsDisplayed()
+    }
+
+    @Test
+    fun `should not show on type text before opening the popup`() = runComposeTest {
+        comboBox.performKeyPress("Item", rule = this)
+        onSpeedSearchAreaInput.assertDoesNotExist()
+    }
+
+    @Test
+    fun `should hide on esc press`() = runComposeTest {
+        comboBox.performClick()
+
+        comboBox.performKeyPress("Item", rule = this)
+        onSpeedSearchAreaInput.assertExists().assertIsDisplayed()
+
+        comboBox.performKeyPress(Key.Escape, rule = this)
+        onSpeedSearchAreaInput.assertDoesNotExist()
+    }
+
+    @Test
+    fun `on option navigation, move input cursor`() = runComposeTest {
+        comboBox.performClick()
+
+        comboBox.performKeyPress("Item 42", rule = this)
+
+        comboBox.performKeyPress(Key.DirectionLeft, alt = true, rule = this)
+        onSpeedSearchAreaInput.assertCursorAtPosition(0)
+
+        comboBox.performKeyPress(Key.DirectionRight, alt = true, rule = this)
+        onSpeedSearchAreaInput.assertCursorAtPosition(7)
+    }
+
+    @Test
+    fun `on type, select first occurrence`() = runComposeTest {
+        comboBox.performClick()
+        comboBox.performKeyPress("Item 2", rule = this)
+        onComboBoxItem("Item 2").assertIsDisplayed().assertIsSelected()
+    }
+
+    @Test
+    fun `on type continue typing, continue selecting first occurrence`() = runComposeTest {
+        comboBox.performClick()
+
+        comboBox.performKeyPress("Item 2", rule = this)
+        onComboBoxItem("Item 2").assertIsDisplayed().assertIsSelected()
+
+        onSpeedSearchAreaInput.performKeyPress("4", rule = this)
+        onComboBoxItem("Item 24").assertIsDisplayed().assertIsSelected()
+
+        onSpeedSearchAreaInput.performKeyPress("5", rule = this)
+        onComboBoxItem("Item 245").assertIsDisplayed().assertIsSelected()
+    }
+
+    @Test
+    fun `select closest match if after the current item`() = runComposeTest {
+        comboBox.performClick()
+        comboBox.performKeyPress("Item 245", rule = this)
+        onComboBoxItem("Item 245").assertIsDisplayed().assertIsSelected()
+
+        // Delete the number
+        onSpeedSearchAreaInput.performKeyPress(Key.Backspace, rule = this)
+        onSpeedSearchAreaInput.performKeyPress(Key.Backspace, rule = this)
+        onSpeedSearchAreaInput.performKeyPress(Key.Backspace, rule = this)
+
+        // Add `99` and jumps to next reference matching "99"
+        onSpeedSearchAreaInput.performKeyPress("99", rule = this)
+        onComboBoxItem("Item 299").assertIsDisplayed().assertIsSelected()
+    }
+
+    @Test
+    fun `on arrow up or down, navigate to the next and previous occurrences`() = runComposeTest {
+        comboBox.performClick()
+        comboBox.performKeyPress("Item 9", rule = this)
+        onComboBoxItem("Item 9").assertIsDisplayed().assertIsSelected()
+
+        comboBox.performKeyPress(Key.DirectionDown, rule = this)
+        onComboBoxItem("Item 19").assertIsDisplayed().assertIsSelected()
+
+        comboBox.performKeyPress(Key.DirectionDown, rule = this)
+        onComboBoxItem("Item 29").assertIsDisplayed().assertIsSelected()
+
+        comboBox.performKeyPress(Key.DirectionUp, rule = this)
+        onComboBoxItem("Item 19").assertIsDisplayed().assertIsSelected()
+
+        comboBox.performKeyPress(Key.DirectionUp, rule = this)
+        onComboBoxItem("Item 9").assertIsDisplayed().assertIsSelected()
+    }
+
+    @Test
+    fun `deleting last char should keep current state`() = runComposeTest {
+        comboBox.performClick()
+        comboBox.performKeyPress("Item 42", rule = this)
+        onSpeedSearchAreaInput.assertExists().assertIsDisplayed()
+        onComboBoxItem("Item 42").assertIsDisplayed().assertIsSelected()
+
+        // Remove "2" from "Item 42" to make "Item 4", but keep 42 selected as it matches the search query
+        onSpeedSearchAreaInput.performKeyPress(Key.Backspace, rule = this)
+        onComboBoxItem("Item 42").assertIsDisplayed().assertIsSelected()
+    }
+
+    @Test
+    fun `should handle partial text matching`() = runComposeTest {
+        comboBox.performClick()
+
+        comboBox.performKeyPress("em 1", rule = this)
+        onComboBoxItem("Item 1").assertIsDisplayed().assertIsSelected()
+    }
+
+    @Test
+    fun `should keep text when navigating through matches`() = runComposeTest {
+        comboBox.performClick()
+        comboBox.performKeyPress("Item 9", rule = this)
+        onComboBoxItem("Item 9").assertIsDisplayed().assertIsSelected()
+
+        comboBox.performKeyPress(Key.DirectionDown, rule = this)
+        onComboBoxItem("Item 19").assertIsDisplayed().assertIsSelected()
+        onSpeedSearchAreaInput.assertExists().assertIsDisplayed()
+
+        comboBox.performKeyPress(Key.DirectionDown, rule = this)
+        onComboBoxItem("Item 29").assertIsDisplayed().assertIsSelected()
+        onSpeedSearchAreaInput.assertExists().assertIsDisplayed()
+
+        comboBox.performKeyPress(Key.DirectionUp, rule = this)
+        onComboBoxItem("Item 19").assertIsDisplayed().assertIsSelected()
+        onSpeedSearchAreaInput.assertExists().assertIsDisplayed()
+
+        comboBox.performKeyPress(Key.DirectionUp, rule = this)
+        onComboBoxItem("Item 9").assertIsDisplayed().assertIsSelected()
+        onSpeedSearchAreaInput.assertExists().assertIsDisplayed()
+    }
+
+    private fun runComposeTest(
+        entries: List<String> = List(500) { "Item ${it + 1}" },
+        block: ComposeContentTestRule.() -> Unit,
+    ) {
+        rule.setContent {
+            val focusRequester = remember { FocusRequester() }
+
+            IntUiTheme {
+                var selectedIndex by remember { mutableIntStateOf(0) }
+                SpeedSearchArea(
+                    modifier = Modifier.widthIn(max = 200.dp).focusRequester(focusRequester).testTag("SpeedSearchArea")
+                ) {
+                    SpeedSearchableComboBox(
+                        items = entries,
+                        selectedIndex = selectedIndex,
+                        onSelectedItemChange = { index -> selectedIndex = index },
+                        modifier = Modifier.testTag("ComboBox"),
+                        dispatcher = testDispatcher,
+                    )
+                }
+            }
+
+            LaunchedEffect(Unit) { focusRequester.requestFocus() }
+        }
+
+        rule.block()
+    }
+}

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableLazyColumnTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableLazyColumnTest.kt
@@ -27,9 +27,14 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.jetbrains.jewel.foundation.util.JewelLogger
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
@@ -45,6 +50,8 @@ import org.junit.Rule
 class SpeedSearchableLazyColumnTest {
     @get:Rule val rule = createComposeRule()
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     private val ComposeContentTestRule.onLazyColumn
         get() = onNodeWithTag("LazyColumn")
 
@@ -53,6 +60,16 @@ class SpeedSearchableLazyColumnTest {
 
     private fun ComposeContentTestRule.onLazyColumnItem(text: String) =
         onNode(hasAnyAncestor(hasTestTag("LazyColumn")) and hasText(text))
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun `should show on type text`() = runComposeTest {
@@ -233,7 +250,7 @@ class SpeedSearchableLazyColumnTest {
                     SpeedSearchArea(modifier = Modifier.testTag("SpeedSearchArea")) {
                         SpeedSearchableLazyColumn(
                             modifier = Modifier.size(200.dp).testTag("LazyColumn").focusRequester(focusRequester),
-                            dispatcher = UnconfinedTestDispatcher(),
+                            dispatcher = testDispatcher,
                         ) {
                             items(listEntries, textContent = { it }) { item ->
                                 var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableTreeTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableTreeTest.kt
@@ -30,9 +30,14 @@ import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.jetbrains.jewel.foundation.lazy.tree.buildTree
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
@@ -47,6 +52,8 @@ import org.junit.Rule
 class SpeedSearchableTreeTest {
     @get:Rule val rule = createComposeRule()
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     private val ComposeContentTestRule.onLazyTree
         get() = onNodeWithTag("LazyTree")
 
@@ -55,6 +62,16 @@ class SpeedSearchableTreeTest {
 
     private fun ComposeContentTestRule.onLazyTreeNode(text: String) =
         onNode(hasAnyAncestor(hasTestTag("LazyTree")) and hasText(text))
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun `should show on type text`() = runComposeTest {
@@ -273,7 +290,7 @@ class SpeedSearchableTreeTest {
                             tree = tree,
                             modifier = Modifier.size(200.dp).testTag("LazyTree").focusRequester(focusRequester),
                             nodeText = { it.data },
-                            dispatcher = UnconfinedTestDispatcher(),
+                            dispatcher = testDispatcher,
                         ) {
                             Box(Modifier.fillMaxWidth()) {
                                 var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }

--- a/platform/jewel/ui/api-dump-experimental.txt
+++ b/platform/jewel/ui/api-dump-experimental.txt
@@ -61,10 +61,12 @@ f:org.jetbrains.jewel.ui.component.SpeedSearchAreaKt
 - a:clearSearch():Z
 - a:getHasMatches():Z
 - a:getMatchingIndexes():java.util.List
+- a:getPosition():androidx.compose.ui.Alignment$Vertical
 - a:getSearchText():java.lang.String
 - a:hideSearch():Z
 - a:isVisible():Z
 - a:matchResultForText(java.lang.String):org.jetbrains.jewel.foundation.search.SpeedSearchMatcher$MatchResult
+- a:setPosition(androidx.compose.ui.Alignment$Vertical):V
 f:org.jetbrains.jewel.ui.component.TabStripKt
 - *bsf:TabStrip(java.util.List,org.jetbrains.jewel.ui.component.styling.TabStyle,androidx.compose.ui.Modifier,Z,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.ui.component.TextAreaKt
@@ -78,6 +80,9 @@ f:org.jetbrains.jewel.ui.component.TypographyKt
 f:org.jetbrains.jewel.ui.component.search.HighlightKt
 - *sf:highlightSpeedSearchMatches(androidx.compose.ui.Modifier,androidx.compose.ui.text.TextLayoutResult,org.jetbrains.jewel.ui.component.NodeSearchMatchState,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.Modifier
 - *sf:highlightTextSearch(java.lang.CharSequence,org.jetbrains.jewel.ui.component.NodeSearchMatchState,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.AnnotatedString
+f:org.jetbrains.jewel.ui.component.search.SpeedSearchableComboBoxKt
+- *sf:SpeedSearchableComboBox-C3xArm8(org.jetbrains.jewel.ui.component.SpeedSearchScope,java.util.List,I,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,kotlin.jvm.functions.Function2,androidx.compose.ui.Modifier,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.Outline,F,F,org.jetbrains.jewel.ui.component.styling.ComboBoxStyle,kotlin.jvm.functions.Function1,org.jetbrains.jewel.foundation.lazy.SelectableLazyListState,kotlinx.coroutines.CoroutineDispatcher,kotlin.jvm.functions.Function5,androidx.compose.runtime.Composer,I,I,I):V
+- *sf:SpeedSearchableComboBox-MCfSvGQ(org.jetbrains.jewel.ui.component.SpeedSearchScope,java.util.List,I,kotlin.jvm.functions.Function1,androidx.compose.ui.Modifier,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function2,Z,org.jetbrains.jewel.ui.Outline,F,F,org.jetbrains.jewel.ui.component.styling.ComboBoxStyle,androidx.compose.ui.text.TextStyle,kotlin.jvm.functions.Function1,org.jetbrains.jewel.foundation.lazy.SelectableLazyListState,kotlinx.coroutines.CoroutineDispatcher,androidx.compose.runtime.Composer,I,I,I):V
 f:org.jetbrains.jewel.ui.component.search.SpeedSearchableLazyColumnKt
 - *sf:SpeedSearchableLazyColumn(org.jetbrains.jewel.ui.component.SpeedSearchScope,androidx.compose.ui.Modifier,org.jetbrains.jewel.foundation.lazy.SelectionMode,org.jetbrains.jewel.foundation.lazy.SelectableLazyListState,androidx.compose.foundation.layout.PaddingValues,Z,kotlin.jvm.functions.Function1,androidx.compose.foundation.layout.Arrangement$Vertical,androidx.compose.ui.Alignment$Horizontal,androidx.compose.foundation.gestures.FlingBehavior,org.jetbrains.jewel.foundation.lazy.tree.KeyActions,org.jetbrains.jewel.foundation.lazy.tree.PointerEventActions,kotlinx.coroutines.CoroutineDispatcher,kotlin.jvm.functions.Function1,androidx.compose.runtime.Composer,I,I,I):V
 *:org.jetbrains.jewel.ui.component.search.SpeedSearchableLazyColumnScope

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -957,6 +957,7 @@ org.jetbrains.jewel.ui.component.banner.BannerIconActionScope
 org.jetbrains.jewel.ui.component.banner.BannerLinkActionScope
 - a:action(java.lang.String,kotlin.jvm.functions.Function0):V
 f:org.jetbrains.jewel.ui.component.search.HighlightKt
+f:org.jetbrains.jewel.ui.component.search.SpeedSearchableComboBoxKt
 f:org.jetbrains.jewel.ui.component.search.SpeedSearchableLazyColumnKt
 f:org.jetbrains.jewel.ui.component.search.SpeedSearchableTreeKt
 f:org.jetbrains.jewel.ui.component.styling.BannerColors

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ComboBox.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.takeOrElse
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
@@ -56,9 +57,11 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.ui.Outline
 import org.jetbrains.jewel.ui.component.styling.ComboBoxStyle
+import org.jetbrains.jewel.ui.component.styling.PopupContainerStyle
 import org.jetbrains.jewel.ui.focusOutline
 import org.jetbrains.jewel.ui.outline
 import org.jetbrains.jewel.ui.theme.comboBoxStyle
+import org.jetbrains.jewel.ui.theme.popupContainerStyle
 
 /**
  * A dropdown component that displays a text label and a popup with custom content.
@@ -216,6 +219,48 @@ public fun ComboBox(
     onArrowUpPress: () -> Unit = {},
     popupManager: PopupManager = remember { PopupManager() },
 ) {
+    ComboBoxImpl(
+        labelContent = labelContent,
+        popupContent = popupContent,
+        modifier = modifier,
+        popupModifier = popupModifier,
+        enabled = enabled,
+        outline = outline,
+        maxPopupHeight = maxPopupHeight,
+        maxPopupWidth = maxPopupWidth,
+        interactionSource = interactionSource,
+        style = style,
+        onArrowDownPress = onArrowDownPress,
+        onArrowUpPress = onArrowUpPress,
+        popupManager = popupManager,
+    )
+}
+
+@Composable
+internal fun ComboBoxImpl(
+    labelContent: @Composable (() -> Unit),
+    popupContent: @Composable (() -> Unit),
+    modifier: Modifier = Modifier,
+    popupModifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    outline: Outline = Outline.None,
+    maxPopupHeight: Dp = Dp.Unspecified,
+    maxPopupWidth: Dp = Dp.Unspecified,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    style: ComboBoxStyle = JewelTheme.comboBoxStyle,
+    onArrowDownPress: () -> Unit = {},
+    onArrowUpPress: () -> Unit = {},
+    popupManager: PopupManager = remember { PopupManager() },
+    horizontalPopupAlignment: Alignment.Horizontal = Alignment.Start,
+    popupStyle: PopupContainerStyle = JewelTheme.popupContainerStyle,
+    popupPositionProvider: PopupPositionProvider =
+        AnchorVerticalMenuPositionProvider(
+            contentOffset = popupStyle.metrics.offset,
+            contentMargin = popupStyle.metrics.menuMargin,
+            alignment = horizontalPopupAlignment,
+            density = LocalDensity.current,
+        ),
+) {
     var chevronHovered by remember { mutableStateOf(false) }
 
     val popupVisible by popupManager.isPopupVisible
@@ -348,8 +393,10 @@ public fun ComboBox(
                         .widthIn(min = comboBoxWidth, max = maxPopupWidth.coerceAtLeast(comboBoxWidth))
                         .then(popupModifier)
                         .onClick { popupManager.setPopupVisible(false) },
-                horizontalAlignment = Alignment.Start,
+                horizontalAlignment = horizontalPopupAlignment,
                 popupProperties = PopupProperties(focusable = false),
+                style = popupStyle,
+                popupPositionProvider = popupPositionProvider,
                 content = popupContent,
             )
         }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Popup.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Popup.kt
@@ -194,6 +194,7 @@ internal data class AnchorVerticalMenuPositionProvider(
     val contentMargin: PaddingValues,
     val alignment: Alignment.Horizontal,
     val density: Density,
+    val onPopupPositionDecided: (Alignment.Vertical) -> Unit = {},
 ) : PopupPositionProvider {
     override fun calculatePosition(
         anchorBounds: IntRect,
@@ -234,8 +235,10 @@ internal data class AnchorVerticalMenuPositionProvider(
         // the dropdown menu is displayed below by default.
         val y =
             if (belowSpacing > popupContentSize.height || belowSpacing >= aboveSpacing) {
+                onPopupPositionDecided(Alignment.Bottom)
                 anchorBounds.bottom + contentOffsetY
             } else {
+                onPopupPositionDecided(Alignment.Top)
                 anchorBounds.top - contentOffsetY - popupContentSize.height
             }
 

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/SpeedSearchArea.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/SpeedSearchArea.kt
@@ -99,7 +99,14 @@ public fun SpeedSearchArea(
         scope.content()
 
         if (state.isVisible) {
-            SpeedSearchInput(state.textFieldState, state.hasMatches, styling, textStyle, textFieldStyle)
+            SpeedSearchInput(
+                state = state.textFieldState,
+                hasMatch = state.hasMatches,
+                position = state.position,
+                styling = styling,
+                textStyle = textStyle,
+                textFieldStyle = textFieldStyle,
+            )
         }
     }
 }
@@ -117,6 +124,7 @@ public interface SpeedSearchScope : BoxScope {
 @ExperimentalJewelApi
 @ApiStatus.Experimental
 public interface SpeedSearchState {
+    public var position: Alignment.Vertical
     public val searchText: String
     public val isVisible: Boolean
     public val hasMatches: Boolean
@@ -174,13 +182,22 @@ public fun ProvideSearchMatchState(
 private fun SpeedSearchInput(
     state: TextFieldState,
     hasMatch: Boolean,
+    position: Alignment.Vertical,
     styling: SpeedSearchStyle,
     textStyle: TextStyle,
     textFieldStyle: TextFieldStyle,
 ) {
     val foregroundColor = styling.getCurrentForegroundColor(hasMatch, textFieldStyle, textStyle)
 
-    Popup(popupPositionProvider = rememberComponentRectPositionProvider(Alignment.TopStart, Alignment.TopEnd)) {
+    val (anchor, alignment) =
+        remember(position) {
+            when (position) {
+                Alignment.Bottom -> Alignment.BottomStart to Alignment.BottomEnd
+                else -> Alignment.TopStart to Alignment.TopEnd
+            }
+        }
+
+    Popup(popupPositionProvider = rememberComponentRectPositionProvider(anchor, alignment)) {
         val focusRequester = remember { FocusRequester() }
 
         BasicTextField(
@@ -390,6 +407,8 @@ internal class SpeedSearchStateImpl(private val matcherBuilderState: State<(Stri
     internal val textFieldState = TextFieldState()
     private var allMatches: Map<String?, SpeedSearchMatcher.MatchResult> by mutableStateOf(emptyMap())
     override val searchText: String by derivedStateOf { textFieldState.text.toString() }
+
+    override var position: Alignment.Vertical by mutableStateOf(Alignment.Top)
 
     override var isVisible: Boolean by mutableStateOf(false)
         internal set

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBox.kt
@@ -1,0 +1,272 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.ui.component.search
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.lazy.SelectableLazyListKey
+import org.jetbrains.jewel.foundation.lazy.SelectableLazyListState
+import org.jetbrains.jewel.foundation.lazy.SelectionMode
+import org.jetbrains.jewel.foundation.lazy.rememberSelectableLazyListState
+import org.jetbrains.jewel.foundation.lazy.tree.DefaultSelectableLazyColumnKeyActions
+import org.jetbrains.jewel.foundation.modifier.thenIf
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.Outline
+import org.jetbrains.jewel.ui.component.AnchorVerticalMenuPositionProvider
+import org.jetbrains.jewel.ui.component.ComboBoxLabelText
+import org.jetbrains.jewel.ui.component.ListComboBoxImpl
+import org.jetbrains.jewel.ui.component.ProvideSearchMatchState
+import org.jetbrains.jewel.ui.component.SimpleListItem
+import org.jetbrains.jewel.ui.component.SpeedSearchScope
+import org.jetbrains.jewel.ui.component.SpeedSearchState
+import org.jetbrains.jewel.ui.component.styling.ComboBoxStyle
+import org.jetbrains.jewel.ui.component.takeIfInBoundsOrZero
+import org.jetbrains.jewel.ui.disabledAppearance
+import org.jetbrains.jewel.ui.theme.comboBoxStyle
+import org.jetbrains.jewel.ui.theme.popupContainerStyle
+
+@Composable
+@ExperimentalJewelApi
+@ApiStatus.Experimental
+public fun SpeedSearchScope.SpeedSearchableComboBox(
+    items: List<String>,
+    selectedIndex: Int,
+    onSelectedItemChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    popupModifier: Modifier = Modifier,
+    itemKeys: (Int, String) -> Any = { _, item -> item },
+    enabled: Boolean = true,
+    outline: Outline = Outline.None,
+    maxPopupHeight: Dp = Dp.Unspecified,
+    maxPopupWidth: Dp = Dp.Unspecified,
+    style: ComboBoxStyle = JewelTheme.comboBoxStyle,
+    textStyle: TextStyle = JewelTheme.defaultTextStyle,
+    onPopupVisibleChange: (visible: Boolean) -> Unit = {},
+    listState: SelectableLazyListState =
+        rememberSelectableLazyListState(selectedIndex.takeIfInBoundsOrZero(items.indices)),
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
+    SpeedSearchableComboBoxImpl(
+        items = items,
+        selectedIndex = selectedIndex,
+        onSelectedItemChange = onSelectedItemChange,
+        itemKeys = itemKeys,
+        itemText = { _, item -> item },
+        modifier = modifier,
+        popupModifier = popupModifier,
+        enabled = enabled,
+        outline = outline,
+        maxPopupHeight = maxPopupHeight,
+        maxPopupWidth = maxPopupWidth,
+        style = style,
+        onPopupVisibleChange = onPopupVisibleChange,
+        listState = listState,
+        dispatcher = dispatcher,
+        labelContent = { item -> ComboBoxLabelText(item.orEmpty(), textStyle, style, enabled) },
+    ) { item, isSelected, isActive ->
+        var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+        SimpleListItem(
+            modifier = Modifier.thenIf(!enabled) { disabledAppearance() },
+            textModifier = Modifier.highlightSpeedSearchMatches(textLayoutResult),
+            text = item.highlightTextSearch(),
+            selected = isSelected,
+            active = isActive,
+            iconContentDescription = item,
+            onTextLayout = {
+                @Suppress("AssignedValueIsNeverRead")
+                textLayoutResult = it
+            },
+        )
+    }
+}
+
+@Composable
+@ExperimentalJewelApi
+@ApiStatus.Experimental
+public fun <T : Any> SpeedSearchScope.SpeedSearchableComboBox(
+    items: List<T>,
+    selectedIndex: Int,
+    onSelectedItemChange: (Int) -> Unit,
+    itemKeys: (Int, T) -> Any,
+    itemText: (Int, T) -> String?,
+    modifier: Modifier = Modifier,
+    popupModifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    outline: Outline = Outline.None,
+    maxPopupHeight: Dp = Dp.Unspecified,
+    maxPopupWidth: Dp = Dp.Unspecified,
+    style: ComboBoxStyle = JewelTheme.comboBoxStyle,
+    onPopupVisibleChange: (visible: Boolean) -> Unit = {},
+    listState: SelectableLazyListState =
+        rememberSelectableLazyListState(selectedIndex.takeIfInBoundsOrZero(items.indices)),
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    itemContent: @Composable (item: T, isSelected: Boolean, isActive: Boolean) -> Unit,
+) {
+    SpeedSearchableComboBoxImpl(
+        items = items,
+        selectedIndex = selectedIndex,
+        onSelectedItemChange = onSelectedItemChange,
+        itemKeys = itemKeys,
+        itemText = itemText,
+        modifier = modifier,
+        popupModifier = popupModifier,
+        enabled = enabled,
+        outline = outline,
+        maxPopupHeight = maxPopupHeight,
+        maxPopupWidth = maxPopupWidth,
+        style = style,
+        onPopupVisibleChange = onPopupVisibleChange,
+        listState = listState,
+        dispatcher = dispatcher,
+        labelContent = { item ->
+            if (item != null) {
+                itemContent(item, false, false)
+            }
+        },
+        itemContent = itemContent,
+    )
+}
+
+@Composable
+@ExperimentalJewelApi
+@ApiStatus.Experimental
+private fun <T : Any> SpeedSearchScope.SpeedSearchableComboBoxImpl(
+    items: List<T>,
+    selectedIndex: Int,
+    onSelectedItemChange: (Int) -> Unit,
+    itemKeys: (Int, T) -> Any,
+    itemText: (Int, T) -> String?,
+    labelContent: @Composable (item: T?) -> Unit,
+    modifier: Modifier = Modifier,
+    popupModifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    outline: Outline = Outline.None,
+    maxPopupHeight: Dp = Dp.Unspecified,
+    maxPopupWidth: Dp = Dp.Unspecified,
+    style: ComboBoxStyle = JewelTheme.comboBoxStyle,
+    onPopupVisibleChange: (visible: Boolean) -> Unit = {},
+    listState: SelectableLazyListState =
+        rememberSelectableLazyListState(selectedIndex.takeIfInBoundsOrZero(items.indices)),
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    itemContent: @Composable (item: T, isSelected: Boolean, isActive: Boolean) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val popupStyle = JewelTheme.popupContainerStyle
+
+    val currentItems by rememberUpdatedState(items)
+    val currentKeys by remember { derivedStateOf { currentItems.mapIndexed(itemKeys) } }
+    val currentTexts by remember { derivedStateOf { currentItems.mapIndexed(itemText) } }
+
+    var popupVisible by remember { mutableStateOf(false) }
+
+    val speedSearchKeyActions = remember {
+        SpeedSearchableLazyColumnKeyActions(DefaultSelectableLazyColumnKeyActions, speedSearchState)
+    }
+
+    ListComboBoxImpl(
+        items = items,
+        selectedIndex = selectedIndex,
+        onSelectedItemChange = onSelectedItemChange,
+        itemKeys = itemKeys,
+        modifier =
+            modifier.onPreviewKeyEvent { event ->
+                if (!popupVisible) return@onPreviewKeyEvent false
+
+                if (!processKeyEvent(event) && speedSearchState.isVisibleAndNotEmpty) {
+                    val actionHandled =
+                        speedSearchKeyActions
+                            .handleOnKeyEvent(
+                                event,
+                                currentKeys.map(SelectableLazyListKey::Selectable),
+                                listState,
+                                SelectionMode.Single,
+                            )
+                            .invoke(event)
+                    if (actionHandled) {
+                        scope.launch { listState.lastActiveItemIndex?.let { listState.scrollToItem(it) } }
+                    }
+                    return@onPreviewKeyEvent actionHandled
+                }
+
+                if (event.key == Key.Spacebar) {
+                    // Returning true so we don't close the popup while typing
+                    return@onPreviewKeyEvent true
+                }
+
+                false
+            },
+        popupModifier = popupModifier,
+        enabled = enabled,
+        outline = outline,
+        maxPopupHeight = maxPopupHeight,
+        maxPopupWidth = maxPopupWidth,
+        interactionSource = interactionSource,
+        style = style,
+        onPopupVisibleChange = { visible ->
+            popupVisible = visible
+            onPopupVisibleChange(visible)
+            if (!visible && speedSearchState.isVisible) {
+                speedSearchState.hideSearch()
+            }
+        },
+        popupPositionProvider =
+            AnchorVerticalMenuPositionProvider(
+                contentOffset = popupStyle.metrics.offset,
+                contentMargin = popupStyle.metrics.menuMargin,
+                alignment = Alignment.Start,
+                density = LocalDensity.current,
+                onPopupPositionDecided = {
+                    speedSearchState.position =
+                        when (it) {
+                            Alignment.Top -> Alignment.Bottom
+                            else -> Alignment.Top
+                        }
+                },
+            ),
+        listState = listState,
+        labelContent = labelContent,
+        itemContent = { index, item, isSelected, isActive ->
+            ProvideSearchMatchState(speedSearchState, currentTexts[index], searchMatchStyle) {
+                itemContent(item, isSelected, isActive)
+            }
+        },
+    )
+
+    SpeedSearchableLazyColumnScrollEffect(listState, speedSearchState, currentKeys, dispatcher)
+
+    LaunchedEffect(listState, dispatcher) {
+        val entriesState = MutableStateFlow(emptyList<String?>())
+
+        val entriesFlow = snapshotFlow { currentTexts }
+        async(dispatcher) { entriesFlow.collect(entriesState::emit) }
+
+        speedSearchState.attach(entriesState, dispatcher)
+    }
+}
+
+private val SpeedSearchState.isVisibleAndNotEmpty: Boolean
+    get() = isVisible && searchText.isNotEmpty()


### PR DESCRIPTION
- Created new component supporting String-based and Generic-based APIs
- Added support to choose SpeedSearch input position to support showing in the opposite size of the drop-down
- Added `position` to SpeedSearchState so we can show it in the oposite side of the dropdown
- Added `index` parameter to the `itemContent` to perform scrolling to the selected item

## Evidences

| Basic flow | Inverted dropdown popup |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/092a1130-4ce8-4e79-8c75-597163aa5abf" /> | <video src="https://github.com/user-attachments/assets/33339416-0d70-4ed3-972a-ed1848146b70" />

## Release notes

### New features
 * Added `SpeedSearchableComboBox` component that supports speed search
   * It is available inside a `SpeedSearchArea` and has a similar syntax to a normal ComboBox
   * It has two overloads, supporting string and generic lists