### PR TITLE
[JEWEL-914] Fix Chips height to use defaultMinHeight

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Chip.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Chip.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
@@ -295,8 +294,7 @@ private fun ChipImpl(
     Row(
         modifier =
             modifier
-                .defaultMinSize(style.metrics.minSize.width)
-                .height(style.metrics.minSize.height)
+                .defaultMinSize(style.metrics.minSize.width, style.metrics.minSize.height)
                 .background(colors.backgroundFor(chipState).value, shape)
                 .thenIf(!chipState.isFocused) { border(Stroke.Alignment.Inside, borderWidth, borderColor, shape) }
                 .focusOutline(chipState, shape)


### PR DESCRIPTION
- In the #3239 PR, I've fixed the sizes to match the IDE implementation, however, it was breaking on changing screen density on MacOS
- Updated the height to be `defaultMinSize` to ensure it can grow if needed
- Retested the IDE to ensure it still matches the same size from the IDE

## Evidences

| Before | After |
| --- | --- |
| <img width="1824" height="1424" alt="image" src="https://github.com/user-attachments/assets/bf740126-fdff-4a9d-867d-82831caddcc1" /> | <img width="1824" height="1424" alt="image" src="https://github.com/user-attachments/assets/ed663d93-8e92-4c1f-8dba-7faffc54023e" /> | 

| IDE Jewel | IDE Swing |
| --- | --- |
| <img width="646" alt="image" src="https://github.com/user-attachments/assets/9fb20d51-34c8-4e9c-9076-12f85f016c12" /> | <img width="646" alt="image" src="https://github.com/user-attachments/assets/eb93cbb4-7bf4-4cdb-a290-d00c9f92104c" />

