### PR TITLE
[JEWEL-1013,JEWEL-1016] Using compose drop shadow APIs for popups

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/component/JBPopupRenderer.kt
@@ -146,6 +146,7 @@ private fun JBPopup(
             .setCancelOnClickOutside(currentProperties.dismissOnClickOutside)
             .setCancelOnWindowDeactivation(currentProperties.dismissOnClickOutside)
             .setLocateWithinScreenBounds(false)
+            .setShowShadow(false)
             .setKeyEventHandler { event ->
                 val composeEvent = event.toComposeKeyEvent()
                 val consumed =

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
@@ -195,7 +195,7 @@ private fun JPopupImpl(
             rootPane.isOpaque = false
             background = Color(0, 0, 0, 0)
             contentPane.background = Color(0, 0, 0, 0)
-            rootPane.putClientProperty("Window.shadow", true)
+            rootPane.putClientProperty("Window.shadow", false)
         }
     }
 

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
@@ -40,7 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -48,6 +48,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.key.Key
@@ -59,6 +60,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupPositionProvider
@@ -236,11 +238,13 @@ public fun MenuContent(
     Box(
         modifier =
             modifier
-                .shadow(
-                    elevation = style.metrics.shadowSize,
-                    shape = menuShape,
-                    ambientColor = colors.shadow,
-                    spotColor = colors.shadow,
+                .dropShadow(
+                    RoundedCornerShape(style.metrics.cornerSize),
+                    Shadow(
+                        radius = style.metrics.shadowSize,
+                        color = colors.shadow,
+                        offset = DpOffset(0.dp, style.metrics.shadowSize / 2),
+                    ),
                 )
                 .border(Stroke.Alignment.Inside, style.metrics.borderWidth, colors.border, menuShape)
                 .background(colors.background, menuShape)

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PopupContainer.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PopupContainer.kt
@@ -6,8 +6,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.jewel.foundation.Stroke
@@ -46,11 +49,13 @@ public fun PopupContainer(
             Box(
                 modifier =
                     modifier
-                        .shadow(
-                            elevation = style.metrics.shadowSize,
-                            shape = popupShape,
-                            ambientColor = colors.shadow,
-                            spotColor = colors.shadow,
+                        .dropShadow(
+                            RoundedCornerShape(style.metrics.cornerSize),
+                            Shadow(
+                                radius = style.metrics.shadowSize,
+                                color = colors.shadow,
+                                offset = DpOffset(0.dp, style.metrics.shadowSize / 2),
+                            ),
                         )
                         .border(Stroke.Alignment.Inside, style.metrics.borderWidth, colors.border, popupShape)
                         .background(colors.background, popupShape)

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
@@ -15,9 +15,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -174,11 +174,13 @@ private fun TooltipImpl(
     ) {
         Box(
             modifier =
-                Modifier.shadow(
-                        elevation = style.metrics.shadowSize,
-                        shape = RoundedCornerShape(style.metrics.cornerSize),
-                        ambientColor = style.colors.shadow,
-                        spotColor = Color.Transparent,
+                Modifier.dropShadow(
+                        RoundedCornerShape(style.metrics.cornerSize),
+                        Shadow(
+                            radius = style.metrics.shadowSize,
+                            color = style.colors.shadow,
+                            offset = DpOffset(0.dp, style.metrics.shadowSize / 2),
+                        ),
                     )
                     .background(color = style.colors.background, shape = RoundedCornerShape(style.metrics.cornerSize))
                     .border(


### PR DESCRIPTION
- Disabled native shadow APIs for JBPopupRenderer and JDialogRenderer
- Using the drop shadow API to replicate the same UI style

## Evidences

| Where | Before | Swing Shadow | CfD Drop Shadow |
| --- | --- | --- | --- |
| IDE | - | <img width="189" height="71" alt="image" src="https://github.com/user-attachments/assets/51b910b3-daf8-45c4-848b-a77db6810e3a" /> | <img width="187" height="72" alt="image" src="https://github.com/user-attachments/assets/254d31fb-eb50-4971-9ec8-ab870c914745" />
| Stand Alone | <img width="180" height="73" alt="image" src="https://github.com/user-attachments/assets/2fba7c56-e565-48b4-8c65-accedc02d5cd" /> | <img width="178" height="70" alt="image" src="https://github.com/user-attachments/assets/5c384238-bb17-4157-9d89-9da9022ff55b" /> | <img width="183" height="71" alt="image" src="https://github.com/user-attachments/assets/864b9231-36a8-4bcb-a40d-6c3605d71d24" />

