### PR TITLE
[JEWEL-965] Make Jewel Detekt rules only apply to Jewel

### DIFF
--- a/platform/jewel/detekt-plugin/src/main/kotlin/org/jetbrains/jewel/detekt/rules/EqualityMembersRule.kt
+++ b/platform/jewel/detekt-plugin/src/main/kotlin/org/jetbrains/jewel/detekt/rules/EqualityMembersRule.kt
@@ -47,6 +47,8 @@ class EqualityMembersRule(config: Config) : Rule(config) {
     override fun visitClass(klass: KtClass) {
         super.visitClass(klass)
 
+        if (!klass.isJewelSymbol()) return
+
         if (annotated.isNotEmpty() && !hasAnnotations(klass, annotated.toSet())) {
             return
         }

--- a/platform/jewel/detekt-plugin/src/main/kotlin/org/jetbrains/jewel/detekt/rules/MissingApiStatusAnnotationRule.kt
+++ b/platform/jewel/detekt-plugin/src/main/kotlin/org/jetbrains/jewel/detekt/rules/MissingApiStatusAnnotationRule.kt
@@ -44,46 +44,56 @@ class MissingApiStatusAnnotationRule(config: Config) : Rule(config) {
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         super.visitClassOrObject(classOrObject)
+        if (!classOrObject.isJewelSymbol()) return
+
         checkAnnotations(classOrObject)
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
+        if (!function.isJewelSymbol()) return
         checkAnnotations(function)
     }
 
     override fun visitProperty(property: KtProperty) {
         super.visitProperty(property)
+        if (!property.isJewelSymbol()) return
         checkAnnotations(property)
     }
 
     override fun visitTypeAlias(typeAlias: KtTypeAlias) {
         super.visitTypeAlias(typeAlias)
+        if (!typeAlias.isJewelSymbol()) return
         checkAnnotations(typeAlias)
     }
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         super.visitPrimaryConstructor(constructor)
+        if (!constructor.isJewelSymbol()) return
         checkAnnotations(constructor)
     }
 
     override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {
         super.visitSecondaryConstructor(constructor)
+        if (!constructor.isJewelSymbol()) return
         checkAnnotations(constructor)
     }
 
     override fun visitClassInitializer(initializer: KtClassInitializer) {
         super.visitClassInitializer(initializer)
+        if (!initializer.isJewelSymbol()) return
         checkAnnotations(initializer)
     }
 
     override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
         super.visitPropertyAccessor(accessor)
+        if (!accessor.isJewelSymbol()) return
         checkAnnotations(accessor)
     }
 
     override fun visitParameter(parameter: KtParameter) {
         super.visitParameter(parameter)
+        if (!parameter.isJewelSymbol()) return
         checkAnnotations(parameter)
     }
 

--- a/platform/jewel/detekt-plugin/src/main/kotlin/org/jetbrains/jewel/detekt/rules/Utils.kt
+++ b/platform/jewel/detekt-plugin/src/main/kotlin/org/jetbrains/jewel/detekt/rules/Utils.kt
@@ -1,0 +1,25 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.detekt.rules
+
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.isSubpackageOf
+import org.jetbrains.kotlin.psi.KtPureElement
+
+private val jewelRootFqName = FqName("org.jetbrains.jewel")
+
+internal fun KtPureElement.isJewelSymbol(): Boolean {
+    val file = containingKtFile
+    val packageFqName = file.packageFqName
+
+    // Allow files in the exact Jewel package or its subpackages
+    if (packageFqName == jewelRootFqName || packageFqName.isSubpackageOf(jewelRootFqName)) {
+        return true
+    }
+
+    // Allow files with no package declaration (for test code)
+    if (packageFqName.isRoot) {
+        return true
+    }
+
+    return false
+}

--- a/platform/jewel/detekt-plugin/src/test/kotlin/org/jetbrains/jewel/detekt/UtilsTest.kt
+++ b/platform/jewel/detekt-plugin/src/test/kotlin/org/jetbrains/jewel/detekt/UtilsTest.kt
@@ -1,0 +1,178 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.detekt
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.jewel.detekt.rules.EqualityMembersRule
+import org.jetbrains.jewel.detekt.rules.MissingApiStatusAnnotationRule
+import org.junit.jupiter.api.Test
+
+class UtilsTest {
+    @Test
+    fun `isJewelSymbol should return true for exact org_jetbrains_jewel package`() {
+        val rule = EqualityMembersRule(TestConfig())
+        val code =
+            """
+            |package org.jetbrains.jewel
+            |
+            |annotation class GenerateDataFunctions
+            |
+            |@GenerateDataFunctions
+            |class TestClass(val prop: String)
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should find the missing methods, which means the rule ran
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `isJewelSymbol should return true for org_jetbrains_jewel subpackages`() {
+        val rule = EqualityMembersRule(TestConfig())
+        val code =
+            """
+            |package org.jetbrains.jewel.foundation
+            |
+            |annotation class GenerateDataFunctions
+            |
+            |@GenerateDataFunctions
+            |class TestClass(val prop: String)
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should find the missing methods, which means the rule ran
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `isJewelSymbol should return true for deeply nested org_jetbrains_jewel subpackages`() {
+        val rule = EqualityMembersRule(TestConfig())
+        val code =
+            """
+            |package org.jetbrains.jewel.ui.component
+            |
+            |annotation class GenerateDataFunctions
+            |
+            |@GenerateDataFunctions
+            |class TestClass(val prop: String)
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should find the missing methods, which means the rule ran
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `isJewelSymbol should return true for no package declaration`() {
+        val rule = EqualityMembersRule(TestConfig())
+        val code =
+            """
+            |annotation class GenerateDataFunctions
+            |
+            |@GenerateDataFunctions
+            |class TestClass(val prop: String)
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should find the missing methods, which means the rule ran
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `isJewelSymbol should return false for non-jewel packages`() {
+        val rule = EqualityMembersRule(TestConfig())
+        val code =
+            """
+            |package com.example.other
+            |
+            |annotation class GenerateDataFunctions
+            |
+            |@GenerateDataFunctions
+            |class TestClass(val prop: String)
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should NOT find anything, which means the rule didn't run
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `MissingApiStatusAnnotationRule should work with exact org_jetbrains_jewel package`() {
+        val rule = MissingApiStatusAnnotationRule(TestConfig())
+        val code =
+            """
+            |package org.jetbrains.jewel
+            |
+            |import org.jetbrains.jewel.foundation.InternalJewelApi
+            |
+            |@InternalJewelApi
+            |class TestClass
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should find the missing @ApiStatus.Internal annotation
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `MissingApiStatusAnnotationRule should work with Jewel subpackages`() {
+        val rule = MissingApiStatusAnnotationRule(TestConfig())
+        val code =
+            """
+            |package org.jetbrains.jewel.foundation
+            |
+            |import org.jetbrains.jewel.foundation.InternalJewelApi
+            |
+            |@InternalJewelApi
+            |class TestClass
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should find the missing @ApiStatus.Internal annotation
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `MissingApiStatusAnnotationRule should work with root package`() {
+        val rule = MissingApiStatusAnnotationRule(TestConfig())
+        val code =
+            """
+            |import org.jetbrains.jewel.foundation.InternalJewelApi
+            |
+            |@InternalJewelApi
+            |class TestClass
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should find the missing @ApiStatus.Internal annotation
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `MissingApiStatusAnnotationRule should not run for non-jewel packages`() {
+        val rule = MissingApiStatusAnnotationRule(TestConfig())
+        val code =
+            """
+            |package com.example.other
+            |
+            |import org.jetbrains.jewel.foundation.InternalJewelApi
+            |
+            |@InternalJewelApi
+            |class TestClass
+            """
+                .trimMargin()
+
+        val findings = rule.compileAndLint(code)
+        // Should NOT find anything because the rule shouldn't run
+        assertThat(findings).isEmpty()
+    }
+}


### PR DESCRIPTION
This change makes sure that the Jewel rules only apply to code in the org.jetbrains.jewel package. This avoids false positives flagged in the rest of the IJP code.