### PR TITLE
[JEWEL-1030] Marking source-compatible deprecated methods with Hidden level

### DIFF
--- a/platform/jewel/ide-laf-bridge/api-dump-experimental.txt
+++ b/platform/jewel/ide-laf-bridge/api-dump-experimental.txt
@@ -4,11 +4,11 @@ f:org.jetbrains.jewel.bridge.BridgeUtilsKt
 - *sf:toNonNegativeDpSize(com.intellij.util.ui.JBDimension):J
 - *sf:toNonNegativeDpSize(java.awt.Dimension):J
 f:org.jetbrains.jewel.bridge.JewelComposePanelWrapperKt
-- *sf:JewelComposeNoThemePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
+- *bsf:JewelComposeNoThemePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - *sf:JewelComposeNoThemePanel(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - *bs:JewelComposeNoThemePanel$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - *bs:JewelComposeNoThemePanel$default(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
-- *sf:composeWithoutTheme(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
+- *bsf:composeWithoutTheme(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - *sf:composeWithoutTheme(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - *bs:composeWithoutTheme$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - *bs:composeWithoutTheme$default(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent

--- a/platform/jewel/ide-laf-bridge/api-dump.txt
+++ b/platform/jewel/ide-laf-bridge/api-dump.txt
@@ -70,16 +70,16 @@ f:org.jetbrains.jewel.bridge.JewelBridgeException$KeysNotFoundException
 - sf:$stable:I
 - <init>(java.util.List,java.lang.String):V
 f:org.jetbrains.jewel.bridge.JewelComposePanelWrapperKt
-- sf:JewelComposePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
+- bsf:JewelComposePanel(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - sf:JewelComposePanel(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - bs:JewelComposePanel$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - bs:JewelComposePanel$default(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
-- sf:compose(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
+- bsf:compose(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - sf:compose(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2):javax.swing.JComponent
 - bs:compose$default(kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 - bs:compose$default(Z,kotlin.jvm.functions.Function1,kotlin.jvm.functions.Function2,I,java.lang.Object):javax.swing.JComponent
 f:org.jetbrains.jewel.bridge.ToolWindowExtensionsKt
-- sf:addComposeTab(com.intellij.openapi.wm.ToolWindow,java.lang.String,Z,Z,kotlin.jvm.functions.Function3):V
+- bsf:addComposeTab(com.intellij.openapi.wm.ToolWindow,java.lang.String,Z,Z,kotlin.jvm.functions.Function3):V
 - sf:addComposeTab(com.intellij.openapi.wm.ToolWindow,java.lang.String,Z,Z,Z,kotlin.jvm.functions.Function3):V
 - bs:addComposeTab$default(com.intellij.openapi.wm.ToolWindow,java.lang.String,Z,Z,kotlin.jvm.functions.Function3,I,java.lang.Object):V
 - bs:addComposeTab$default(com.intellij.openapi.wm.ToolWindow,java.lang.String,Z,Z,Z,kotlin.jvm.functions.Function3,I,java.lang.Object):V

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanelWrapper.kt
@@ -50,7 +50,7 @@ public fun compose(
  * @param config A lambda to configure the underlying [ComposePanel].
  * @param content The Composable content to display.
  */
-@Deprecated("Use the version with 'focusOnClickInside' parameter")
+@Deprecated("Use the version with 'focusOnClickInside' parameter", level = DeprecationLevel.HIDDEN)
 public fun compose(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposePanel(focusOnClickInside = false, config, content)
 
@@ -97,7 +97,7 @@ public fun JewelComposePanel(
  * @param content The Composable content to display.
  */
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-@Deprecated("Use the version with 'focusOnClickInside' parameter")
+@Deprecated("Use the version with 'focusOnClickInside' parameter", level = DeprecationLevel.HIDDEN)
 public fun JewelComposePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposePanel(focusOnClickInside = false, config, content)
 
@@ -134,7 +134,7 @@ public fun composeWithoutTheme(
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @Suppress("ktlint:standard:function-naming") // Swing to Compose bridge API
-@Deprecated("Use the version with 'focusOnClickInside' parameter")
+@Deprecated("Use the version with 'focusOnClickInside' parameter", level = DeprecationLevel.HIDDEN)
 public fun composeWithoutTheme(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposeNoThemePanel(focusOnClickInside = false, config, content)
 
@@ -188,7 +188,7 @@ public fun JewelComposeNoThemePanel(
 @ApiStatus.Experimental
 @ExperimentalJewelApi
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-@Deprecated("Use the version with 'focusOnClickInside' parameter")
+@Deprecated("Use the version with 'focusOnClickInside' parameter", level = DeprecationLevel.HIDDEN)
 public fun JewelComposeNoThemePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     JewelComposeNoThemePanel(focusOnClickInside = false, config, content)
 

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
@@ -51,7 +51,7 @@ public fun ToolWindow.addComposeTab(
  * @param isCloseable Whether the tab can be closed.
  * @param content The Composable content of the tab.
  */
-@Deprecated("Use the version with 'focusOnClickInside' parameter")
+@Deprecated("Use the version with 'focusOnClickInside' parameter", level = DeprecationLevel.HIDDEN)
 public fun ToolWindow.addComposeTab(
     @TabTitle tabDisplayName: String? = null,
     isLockable: Boolean = true,

--- a/plugins/devkit/intellij.devkit.compose/src/demo/JewelDemoToolWindowFactory.kt
+++ b/plugins/devkit/intellij.devkit.compose/src/demo/JewelDemoToolWindowFactory.kt
@@ -16,22 +16,13 @@ internal class JewelDemoToolWindowFactory : ToolWindowFactory, DumbAware {
     // Enable custom popup rendering to use JBPopup instead of the default Compose implementation
     JewelFlags.useCustomPopupRenderer = true
 
-    toolWindow.addComposeTab(
-      DevkitComposeBundle.message("jewel.tw.tab.title.components"),
-      focusOnClickInside = true,
-    ) { ComponentShowcaseTab(project) }
+    toolWindow.addComposeTab(DevkitComposeBundle.message("jewel.tw.tab.title.components")) { ComponentShowcaseTab(project) }
 
-    toolWindow.addComposeTab(
-      DevkitComposeBundle.message("jewel.tw.tab.title.releases.demo"),
-      focusOnClickInside = true,
-    ) { ReleasesSampleCompose(project) }
+    toolWindow.addComposeTab(DevkitComposeBundle.message("jewel.tw.tab.title.releases.demo")) { ReleasesSampleCompose(project) }
 
     toolWindow.addSwingTab(SwingComparisonTabPanel(), DevkitComposeBundle.message("jewel.tw.tab.title.swing.comparison"))
 
-    toolWindow.addComposeTab(
-      DevkitComposeBundle.message("jewel.tw.tab.title.scrollbars.sample"),
-      focusOnClickInside = true,
-    ) { ScrollbarsShowcaseTab() }
+    toolWindow.addComposeTab(DevkitComposeBundle.message("jewel.tw.tab.title.scrollbars.sample")) { ScrollbarsShowcaseTab() }
   }
 
   private fun ToolWindow.addSwingTab(component: JComponent, @TabTitle title: String) {


### PR DESCRIPTION
- Some methods got new params, but kept the source compatible
- Those methods had their visibility changed to Hidden, so they still exist
- But if the users recompile, they will use the new method

## Release notes

### ⚠️ Important Changes
 * A few methods/composable functions that received new parameters, but kept the source compatibility, had their deprecation level changed to `Hidden`
   * Methods that got hidden are:
     * JewelComposeNoThemePanel (method without focusOnClickInside)
     * JewelComposePanel (method without focusOnClickInside)
     * compose (methods without focusOnClickInside)