### PR TITLE
Remove vestigial Compose runtime lib

### DIFF
--- a/libraries/compose-runtime-desktop/intellij.libraries.compose.runtime.desktop.iml
+++ b/libraries/compose-runtime-desktop/intellij.libraries.compose.runtime.desktop.iml
@@ -11,9 +11,6 @@
       <library name="jetbrains.compose.runtime.desktop" type="repository">
         <properties maven-id="org.jetbrains.compose.runtime:runtime-desktop:1.9.0-beta03">
           <verification>
-            <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/compose/runtime/runtime-desktop/1.9.0-beta03/runtime-desktop-1.9.0-beta03.jar">
-              <sha256sum>05f5570c0a7ea8addd6fe9507a70f293efa7f1450d8b9b16dc3c8fee21cc6127</sha256sum>
-            </artifact>
             <artifact url="file://$MAVEN_REPOSITORY$/androidx/compose/runtime/runtime-desktop/1.9.0-rc01/runtime-desktop-1.9.0-rc01.jar">
               <sha256sum>ae657e4332fb72fa1b437ce5caa486c6b4a5e17588aaef0267aa92918bba7458</sha256sum>
             </artifact>
@@ -36,17 +33,13 @@
           </exclude>
         </properties>
         <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/compose/runtime/runtime-desktop/1.9.0-beta03/runtime-desktop-1.9.0-beta03.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/androidx/compose/runtime/runtime-desktop/1.9.0-rc01/runtime-desktop-1.9.0-rc01.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/androidx/collection/collection-jvm/1.5.0/collection-jvm-1.5.0.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/androidx/annotation/annotation-jvm/1.9.1/annotation-jvm-1.9.1.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/androidx/compose/runtime/runtime-annotation-jvm/1.9.0-rc01/runtime-annotation-jvm-1.9.0-rc01.jar!/" />
         </CLASSES>
-        <JAVADOC>
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/compose/runtime/runtime-desktop/1.9.0-beta03/runtime-desktop-1.9.0-beta03-javadoc.jar!/" />
-        </JAVADOC>
+        <JAVADOC />
         <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/compose/runtime/runtime-desktop/1.9.0-beta03/runtime-desktop-1.9.0-beta03-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/androidx/compose/runtime/runtime-desktop/1.9.0-rc01/runtime-desktop-1.9.0-rc01-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/androidx/collection/collection-jvm/1.5.0/collection-jvm-1.5.0-sources.jar!/" />
           <root url="jar://$MAVEN_REPOSITORY$/androidx/annotation/annotation-jvm/1.9.1/annotation-jvm-1.9.1-sources.jar!/" />


### PR DESCRIPTION
This Compose runtime-desktop lib contains no classes. It appears to be a vestige of the transition from org.jetbrains.compose.runtime to androidx.compose.runtime.

This lib contains META-INF/runtime.kotlin_module which conflicts with the correct metadata inside androidx.compose.runtime:runtime-desktop. This conflict breaks compilation in third party plugins using Compose.

cc @rock3r