### PR TITLE
[IJPL-149653] Fix Apply button in Run/Debug configs always enabled

### DIFF
--- a/platform/execution-impl/src/com/intellij/execution/impl/ConfigurationSettingsEditor.java
+++ b/platform/execution-impl/src/com/intellij/execution/impl/ConfigurationSettingsEditor.java
@@ -2,6 +2,7 @@
 
 package com.intellij.execution.impl;
 
+import com.intellij.configurationStore.SerializableScheme;
 import com.intellij.execution.ExecutionBundle;
 import com.intellij.execution.Executor;
 import com.intellij.execution.RunnerAndConfigurationSettings;
@@ -23,6 +24,7 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.update.Activatable;
 import com.intellij.util.ui.update.UiNotifyConnector;
+import org.jdom.Element;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +42,7 @@ public final class ConfigurationSettingsEditor extends CompositeSettingsEditor<R
   private final Map<ProgramRunner, List<SettingsEditor>> myRunner2UnwrappedEditors = new HashMap<>();
   private RunnersEditorComponent myRunnersComponent;
   private final RunConfiguration myConfiguration;
+  private final RunnerAndConfigurationSettings myOriginalSettings;
   private final SettingsEditor<RunConfiguration> myConfigurationEditor;
   private SettingsEditorGroup<RunnerAndConfigurationSettings> myCompound;
   private GroupSettingsBuilder<RunnerAndConfigurationSettings> myGroupSettingsBuilder;
@@ -203,20 +206,25 @@ public final class ConfigurationSettingsEditor extends CompositeSettingsEditor<R
     myConfigurationEditor = configurationEditor;
     myConfigurationEditor.addSettingsEditorListener(editor -> fireEditorStateChanged());
     Disposer.register(this, myConfigurationEditor);
+    myOriginalSettings = settings;
     myConfiguration = settings.getConfiguration();
   }
 
   @Override
   public @NotNull RunnerAndConfigurationSettings getSnapshot() throws ConfigurationException {
-    RunnerAndConfigurationSettings settings = getFactory().create();
-    settings.setName(myConfiguration.getName());
+    RunnerAndConfigurationSettingsImpl snapshot = (RunnerAndConfigurationSettingsImpl) getFactory().create();
+    Element originalXml = ((SerializableScheme) myOriginalSettings).writeScheme();
+    boolean inDotIdea = myOriginalSettings.isStoredInDotIdeaFolder();
+    String arbitraryPath = myOriginalSettings.getPathIfStoredInArbitraryFileInProject();
+    snapshot.readExternal(originalXml, inDotIdea, arbitraryPath);
+
     if (myConfigurationEditor instanceof CheckableRunConfigurationEditor) {
-      ((CheckableRunConfigurationEditor)myConfigurationEditor).checkEditorData(settings.getConfiguration());
+      ((CheckableRunConfigurationEditor)myConfigurationEditor).checkEditorData(snapshot.getConfiguration());
     }
     else {
-      applyTo(settings);
+      applyTo(snapshot);
     }
-    return settings;
+    return snapshot;
   }
 
   boolean supportsSnapshots() {

--- a/platform/execution-impl/src/com/intellij/execution/impl/RunnerAndConfigurationSettingsImpl.kt
+++ b/platform/execution-impl/src/com/intellij/execution/impl/RunnerAndConfigurationSettingsImpl.kt
@@ -428,7 +428,11 @@ class RunnerAndConfigurationSettingsImpl @JvmOverloads constructor(
   override fun getType() = factory.type
 
   public override fun clone(): RunnerAndConfigurationSettingsImpl {
-    val copy = RunnerAndConfigurationSettingsImpl(manager, _configuration!!.clone())
+    val clonedConfiguration = _configuration!!.clone()
+    clonedConfiguration.isAllowRunningInParallel = _configuration!!.isAllowRunningInParallel
+    clonedConfiguration.beforeRunTasks = _configuration!!.beforeRunTasks
+
+    val copy = RunnerAndConfigurationSettingsImpl(manager, clonedConfiguration)
     copy.importRunnerAndConfigurationSettings(this)
 
     copy.level = this.level
@@ -444,6 +448,11 @@ class RunnerAndConfigurationSettingsImpl @JvmOverloads constructor(
     isEditBeforeRun = template.isEditBeforeRun
     isActivateToolWindowBeforeRun = template.isActivateToolWindowBeforeRun
     isFocusToolWindowBeforeRun = template.isFocusToolWindowBeforeRun
+    folderName = template.folderName
+    wasSingletonSpecifiedExplicitly = template.wasSingletonSpecifiedExplicitly
+
+    runnerSettings.copyMetaFrom(template.runnerSettings)
+    configurationPerRunnerSettings.copyMetaFrom(template.configurationPerRunnerSettings)
   }
 
   private fun <T> importFromTemplate(templateItem: RunnerItem<T>, item: RunnerItem<T>) {
@@ -509,6 +518,19 @@ class RunnerAndConfigurationSettingsImpl @JvmOverloads constructor(
     private var unloadedSettings: MutableList<Element>? = null
     // to avoid changed files
     private val loadedIds = HashSet<String>()
+
+    fun copyMetaFrom(other: RunnerItem<*>) {
+      loadedIds.addAll(other.loadedIds)
+      val otherUnloaded = other.unloadedSettings
+      if (otherUnloaded != null) {
+        if (unloadedSettings == null) {
+          unloadedSettings = SmartList()
+        }
+        for (element in otherUnloaded) {
+          unloadedSettings!!.add(element.clone())
+        }
+      }
+    }
 
     fun loadState(element: Element) {
       settings.clear()

--- a/platform/execution-impl/src/com/intellij/execution/ui/RunnerAndConfigurationSettingsEditor.java
+++ b/platform/execution-impl/src/com/intellij/execution/ui/RunnerAndConfigurationSettingsEditor.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.execution.ui;
 
+import com.intellij.configurationStore.SerializableScheme;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.RunConfigurationBase;
 import com.intellij.execution.impl.RunConfigurationStorageUi;
@@ -12,6 +13,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.ui.JBInsets;
 import com.intellij.util.ui.JBUI;
+import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,10 +26,12 @@ public final class RunnerAndConfigurationSettingsEditor extends SettingsEditor<R
   private final RunConfigurationFragmentedEditor<RunConfigurationBase<?>> myConfigurationEditor;
   private final @Nullable RunConfigurationStorageUi myRCStorageUi;
   private final RunOnTargetPanel myRunOnTargetPanel;
+  private final RunnerAndConfigurationSettings myOriginalSettings;
 
   public RunnerAndConfigurationSettingsEditor(RunnerAndConfigurationSettings settings,
                                               RunConfigurationFragmentedEditor<RunConfigurationBase<?>> configurationEditor) {
     super(settings.createFactory());
+    myOriginalSettings = settings;
     myConfigurationEditor = configurationEditor;
     myConfigurationEditor.addSettingsEditorListener(editor -> fireEditorStateChanged());
     Disposer.register(this, myConfigurationEditor);
@@ -84,6 +88,23 @@ public final class RunnerAndConfigurationSettingsEditor extends SettingsEditor<R
       myRCStorageUi.apply(s);
       myRunOnTargetPanel.apply();
     }
+  }
+
+  @Override
+  public @NotNull RunnerAndConfigurationSettings getSnapshot() throws ConfigurationException {
+    RunnerAndConfigurationSettingsImpl snapshot = (RunnerAndConfigurationSettingsImpl) getFactory().create();
+    Element originalXml = ((SerializableScheme) myOriginalSettings).writeScheme();
+    boolean inDotIdea = myOriginalSettings.isStoredInDotIdeaFolder();
+    String arbitraryPath = myOriginalSettings.getPathIfStoredInArbitraryFileInProject();
+    snapshot.readExternal(originalXml, inDotIdea, arbitraryPath);
+
+    myConfigurationEditor.applyEditorTo(snapshot);
+    myConfigurationEditor.applyTo((RunConfigurationBase<?>) snapshot.getConfiguration());
+    if (myRCStorageUi != null) {
+      myRCStorageUi.apply(snapshot);
+      myRunOnTargetPanel.apply();
+    }
+    return snapshot;
   }
 
   @Override


### PR DESCRIPTION
**Description**

This PR fixes an issue where 'Run/Debug Configurations' dialog's Apply button is enabled without any change in 'IDEA' run configuration in IDEA project.

**The Problem**

When selecting 'IDEA' run configuration in IDEA project and opening 'Run/Debug Configurations' dialog, the 'Apply' button should be disabled, since there were no changes made to the configuration yet. However, it was enabled without any modifications to the configuration. The core issue was incorrect creation of the configuration snapshot, which was compared to the original configuration - certain elements of the XML were omitted, and therefore the comparison resulted in a false positive.

**Related Issue:**

Fixes [IJPL-149653](https://youtrack.jetbrains.com/issue/IJPL-149653/Run-Debug-Configurations-dialogs-Apply-button-is-enabled-without-any-change)