### PR TITLE
Fix py 84718

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/refactoring/PyPsiRefactoringUtil.java
+++ b/python/python-psi-impl/src/com/jetbrains/python/refactoring/PyPsiRefactoringUtil.java
@@ -293,7 +293,7 @@ public final class PyPsiRefactoringUtil {
     generator.createFromText(LanguageLevel.PYTHON34, PyClass.class, "class foo(object, metaclass=Foo): pass").getSuperClassExpressionList();
     if (paramExpressions != null) {
       for (final String paramExpression : paramExpressions) {
-        superClassExpressionList.addArgument(generator.createParameter(paramExpression));
+        superClassExpressionList.addArgument(generator.createExpressionFromText(languageLevel, paramExpression));
       }
     }
 
@@ -367,17 +367,66 @@ public final class PyPsiRefactoringUtil {
                                      final @NotNull PyClass clazz,
                                      final PyClass @NotNull ... superClasses) {
 
-    final Collection<String> superClassNames = new ArrayList<>();
-
+    final Collection<String> superClassExpressions = new ArrayList<>();
+    final PsiFile file = clazz.getContainingFile();
+    final PyFile pyFile = file instanceof PyFile ? (PyFile)file : null;
 
     for (final PyClass superClass : Collections2.filter(Arrays.asList(superClasses), NotNullPredicate.INSTANCE)) {
-      if (superClass.getName() != null) {
-        superClassNames.add(superClass.getName());
+      final String superName = superClass.getName();
+      if (superName == null) continue;
+
+      String expressionToAdd = superName; // default: bare name, may require import
+      boolean needImport = true;
+
+      // Try to respect existing imports in the target file
+      if (pyFile != null) {
+        final QualifiedName qname = QualifiedNameFinder.findCanonicalImportPath(superClass, clazz);
+        if (qname != null && isValidQualifiedName(qname)) {
+          final String importedName = getOriginalName(superClass);
+          final QualifiedName containingQName = qname; // module containing the class
+
+          // 1) from <module> import <importedName> [as alias]
+          for (PyFromImportStatement from : pyFile.getFromImports()) {
+            final QualifiedName src = from.getImportSourceQName();
+            if (src != null && src.equals(containingQName)) {
+              for (PyImportElement elt : from.getImportElements()) {
+                final QualifiedName eltQn = elt.getImportedQName();
+                final String asName = elt.getAsName();
+                if (eltQn != null && importedName != null && importedName.equals(eltQn.getLastComponent())) {
+                  expressionToAdd = asName != null ? asName : importedName;
+                  needImport = false; // name already available
+                  break;
+                }
+              }
+              if (!needImport) break;
+            }
+          }
+
+          // 2) import <module> [as alias]
+          if (needImport) {
+            for (PyImportElement imp : pyFile.getImportTargets()) {
+              final QualifiedName impQn = imp.getImportedQName();
+              if (impQn != null && (impQn.equals(containingQName) || impQn.equals(containingQName.append(importedName)))) {
+                final String alias = imp.getAsName();
+                final String moduleRef = alias != null ? alias : impQn.getLastComponent();
+                if (moduleRef != null) {
+                  expressionToAdd = moduleRef + "." + importedName;
+                  needImport = false; // can use qualified reference
+                  break;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      superClassExpressions.add(expressionToAdd);
+      if (needImport) {
         insertImport(clazz, superClass);
       }
     }
 
-    addSuperClassExpressions(project, clazz, superClassNames, null);
+    addSuperClassExpressions(project, clazz, superClassExpressions, null);
   }
 
   public static boolean shouldCopyAnnotations(@NotNull PsiElement copiedElement, @NotNull PsiFile destFile) {

--- a/python/testData/inspections/PyAbstractClassInspection/quickFix/AddABCToSuperclassesCaretAtAbstractMethod/main.py
+++ b/python/testData/inspections/PyAbstractClassInspection/quickFix/AddABCToSuperclassesCaretAtAbstractMethod/main.py
@@ -1,7 +1,7 @@
-import abc
+from abc import abstractmethod
 
 
 class A:
-    @abc.ab<caret>stractmethod
+    @ab<caret>stractmethod
     def meth(self):
         ...

--- a/python/testData/inspections/PyAbstractClassInspection/quickFix/AddABCToSuperclassesCaretAtAbstractMethod/main_after.py
+++ b/python/testData/inspections/PyAbstractClassInspection/quickFix/AddABCToSuperclassesCaretAtAbstractMethod/main_after.py
@@ -1,8 +1,7 @@
-import abc
-from abc import ABC
+from abc import abstractmethod, ABC
 
 
 class A(ABC):
-    @abc.abstractmethod
+    @abstractmethod
     def meth(self):
         ...

--- a/python/testData/inspections/PyAbstractClassInspection/quickFix/AddAliasedModuleImportedABCToSuperclasses/main.py
+++ b/python/testData/inspections/PyAbstractClassInspection/quickFix/AddAliasedModuleImportedABCToSuperclasses/main.py
@@ -1,0 +1,9 @@
+import abc as a
+
+class A1(metaclass=a.ABCMeta):
+    @a.abstractmethod
+    def foo(self):
+        pass
+
+class A<caret>2(A1):
+    pass

--- a/python/testData/inspections/PyAbstractClassInspection/quickFix/AddAliasedModuleImportedABCToSuperclasses/main_after.py
+++ b/python/testData/inspections/PyAbstractClassInspection/quickFix/AddAliasedModuleImportedABCToSuperclasses/main_after.py
@@ -1,0 +1,9 @@
+import abc as a
+
+class A1(metaclass=a.ABCMeta):
+    @a.abstractmethod
+    def foo(self):
+        pass
+
+class A2(A1, a.ABC):
+    pass

--- a/python/testData/inspections/PyAbstractClassInspection/quickFix/AddModuleImportedABCToSuperclasses/main.py
+++ b/python/testData/inspections/PyAbstractClassInspection/quickFix/AddModuleImportedABCToSuperclasses/main.py
@@ -1,0 +1,10 @@
+import abc
+
+class A1(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def foo(self):
+        pass
+
+
+class A<caret>2(A1):
+    pass

--- a/python/testData/inspections/PyAbstractClassInspection/quickFix/AddModuleImportedABCToSuperclasses/main_after.py
+++ b/python/testData/inspections/PyAbstractClassInspection/quickFix/AddModuleImportedABCToSuperclasses/main_after.py
@@ -1,0 +1,10 @@
+import abc
+
+class A1(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def foo(self):
+        pass
+
+
+class A2(A1, abc.ABC):
+    pass

--- a/python/testSrc/com/jetbrains/python/Py3QuickFixTest.java
+++ b/python/testSrc/com/jetbrains/python/Py3QuickFixTest.java
@@ -155,6 +155,24 @@ public class Py3QuickFixTest extends PyTestCase {
                      true);
   }
 
+  // PY-84718: Respect existing `import abc` when adding ABC to superclasses
+  public void testAddModuleImportedABCToSuperclasses() {
+    doInspectionTest("PyAbstractClassInspection/quickFix/AddModuleImportedABCToSuperclasses/main.py",
+                     PyAbstractClassInspection.class,
+                     "Add '" + PyNames.ABC + "' to superclasses",
+                     true,
+                     true);
+  }
+
+  // PY-84718: Respect existing alias `import abc as a` when adding ABC to superclasses
+  public void testAddAliasedModuleImportedABCToSuperclasses() {
+    doInspectionTest("PyAbstractClassInspection/quickFix/AddAliasedModuleImportedABCToSuperclasses/main.py",
+                     PyAbstractClassInspection.class,
+                     "Add '" + PyNames.ABC + "' to superclasses",
+                     true,
+                     true);
+  }
+
   // PY-30789
   public void testSetABCMetaAsMetaclassPy3() {
     final String[] testFiles = {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/PY-84718/Add-abc.ABC-to-superclasses-quickfix-does-not-respect-existing-imports