### PR TITLE
Add action to toggle Show Layout Bounds in Compose UI

### DIFF
--- a/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/ComposeUtil.kt
+++ b/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/ComposeUtil.kt
@@ -1,0 +1,68 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.internal.inspector.compose
+
+import com.intellij.openapi.diagnostic.thisLogger
+import java.awt.Component
+import java.awt.Container
+import java.awt.Window
+
+internal object ComposeUtil {
+    private val logger = thisLogger()
+
+    fun findComposePanels(): List<Container> {
+        val result = mutableListOf<Container>()
+        try {
+            Window.getWindows().forEach { win -> walkGenericAWT(win, result) }
+        } catch (_: Exception) {}
+        return result
+    }
+
+    private fun walkGenericAWT(comp: Component, list: MutableList<Container>) {
+        val name = comp.javaClass.name
+        val isComposePanel = "ComposePanel" in name && "JewelComposePanel" !in name
+        val isComposeWindow = "ComposeWindow" in name
+        if ((isComposePanel || isComposeWindow) && comp is Container) {
+            list.add(comp)
+        }
+        if (comp is Container) {
+            try {
+                comp.components.forEach { walkGenericAWT(it, list) }
+            } catch (_: Exception) {}
+        }
+    }
+
+    fun Container.onEachRootNode(action: (Any) -> Unit) {
+        val composeContainer = ReflectHelper.getFieldValue(this, "_composeContainer")
+        val mediator = ReflectHelper.getFieldValue(composeContainer!!, "mediator")
+        val sceneDelegate = ReflectHelper.getFieldValue(mediator!!, $$"scene$delegate")
+        val scene = (sceneDelegate as Lazy<*>).value
+
+        if (scene == null) {
+            logger.warn("Could not find internal 'scene'.")
+            return
+        }
+
+        val rootNode = findRootLayoutNode(scene)
+        if (rootNode == null) {
+            logger.warn("Could not find generic root LayoutNode.")
+            return
+        }
+
+        action(rootNode)
+    }
+
+    private fun findRootLayoutNode(scene: Any): Any? {
+        ReflectHelper.getFieldValue(scene, "root")?.let {
+            return it
+        }
+        val mainOwner = ReflectHelper.getFieldValue(scene, "mainOwner")
+        if (mainOwner != null) {
+            ReflectHelper.getFieldValue(mainOwner, "root")?.let {
+                return it
+            }
+            val owner = ReflectHelper.getFieldValue(mainOwner, "_owner")
+            return ReflectHelper.getFieldValue(owner!!, "root")
+        }
+        return null
+    }
+}

--- a/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/LayoutBoundsToggler.kt
+++ b/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/LayoutBoundsToggler.kt
@@ -1,0 +1,60 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.internal.inspector.compose
+
+import com.intellij.internal.inspector.compose.ComposeUtil.onEachRootNode
+import com.intellij.openapi.diagnostic.thisLogger
+import java.awt.Component
+import java.awt.event.AWTEventListener
+import java.awt.event.HierarchyEvent
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+internal object LayoutBoundsToggler {
+    private val logger = thisLogger()
+
+    fun setShowLayoutBoundsEnabled(enabled: Boolean) {
+        for (panel in ComposeUtil.findComposePanels()) {
+            try {
+                panel.onEachRootNode {
+                    val owner = ReflectHelper.getFieldValue(it, "owner")
+                    ReflectHelper.setFieldValue(owner!!, "showLayoutBounds", enabled)
+                    invalidate(owner)
+                }
+                panel.revalidate()
+                SwingUtilities.invokeLater { panel.repaint() }
+            } catch (t: Throwable) {
+                logger.error("Could not set layout bounds flag for panel $panel", t)
+            }
+        }
+    }
+
+    private fun invalidate(owner: Any) {
+        if (owner.javaClass.name != "androidx.compose.ui.node.RootNodeOwner") {
+            logger.info("${owner} is not a RootNodeOwner, can't invalidate")
+            return
+        }
+
+        try {
+            val ownerLayerManager = ReflectHelper.getFieldValue(owner, "ownedLayerManager")
+            ReflectHelper.callMethod(ownerLayerManager!!, "invalidate")
+        } catch (t: Throwable) {
+            logger.error("Could not invoke invalidate layer manager for root node owner $owner", t)
+        }
+    }
+
+    fun createAwtListener(onAttach: (Component) -> Unit): AWTEventListener = AWTEventListener { event ->
+        // We only care about HierarchyEvents
+        if (event !is HierarchyEvent) return@AWTEventListener
+
+        // Filter for PARENT_CHANGED events (attachment/detachment)
+        if ((event.getChangeFlags() and HierarchyEvent.PARENT_CHANGED.toLong()) != 0L) {
+            val component: Component = event.component
+
+            // Filter specifically for JPanels (or any other criteria)
+            // If parent is not null, it was just attached.
+            if (component is JPanel && component.getParent() != null) {
+                onAttach(component)
+            }
+        }
+    }
+}

--- a/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/ReflectHelper.kt
+++ b/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/ReflectHelper.kt
@@ -1,0 +1,49 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.internal.inspector.compose
+
+import java.lang.reflect.Field
+import java.util.concurrent.ConcurrentHashMap
+
+internal object ReflectHelper {
+    // Cache fields for performance in hot paths like recomposition tracking
+    private val fieldCache = ConcurrentHashMap<String, Field>()
+
+    fun getFieldValue(obj: Any, fieldName: String): Any? {
+        val field = findField(obj, fieldName)
+        return field?.get(obj)
+    }
+
+    fun setFieldValue(obj: Any, fieldName: String, value: Any?): Any? {
+        val field = findField(obj, fieldName)
+        return field?.set(obj, value)
+    }
+
+    private fun findField(obj: Any, fieldName: String): Field? {
+        val key = "${obj.javaClass.name}.$fieldName"
+        var field = fieldCache[key]
+        if (field == null) {
+            var cls = obj.javaClass
+            while (cls != Object::class.java) {
+                try {
+                    field = cls.getDeclaredField(fieldName)
+                    field!!.isAccessible = true
+                    fieldCache[key] = field
+                    break
+                } catch (_: NoSuchFieldException) {
+                    cls = cls.superclass ?: return null
+                }
+            }
+        }
+        return field
+    }
+
+    fun callMethod(obj: Any, methodName: String, vararg args: Any?): Any? {
+        try {
+            val method = obj.javaClass.getMethod(methodName)
+            method.isAccessible = true
+            return method.invoke(obj, *args)
+        } catch (_: Exception) {
+            return null
+        }
+    }
+}

--- a/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/ToggleComposeLayoutBoundsAction.kt
+++ b/platform/platform-impl/ui-inspector/src/com/intellij/internal/inspector/compose/ToggleComposeLayoutBoundsAction.kt
@@ -1,0 +1,36 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.internal.inspector.compose
+
+import com.intellij.ide.lightEdit.LightEditCompatible
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import java.awt.AWTEvent
+import java.awt.Toolkit
+import java.awt.event.AWTEventListener
+import org.jetbrains.annotations.ApiStatus
+
+@ApiStatus.Internal
+class ToggleComposeLayoutBoundsAction : DumbAwareAction(), LightEditCompatible {
+    private var listener: AWTEventListener? = null
+    private val showLayoutBounds
+        get() = listener != null
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
+
+    override fun actionPerformed(e: AnActionEvent) {
+        if (!showLayoutBounds) {
+            listener = LayoutBoundsToggler.createAwtListener { LayoutBoundsToggler.setShowLayoutBoundsEnabled(true) }
+            Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.HIERARCHY_EVENT_MASK)
+            LayoutBoundsToggler.setShowLayoutBoundsEnabled(true)
+        } else {
+            Toolkit.getDefaultToolkit().removeAWTEventListener(listener)
+            listener = null
+            LayoutBoundsToggler.setShowLayoutBoundsEnabled(false)
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.text = if (!showLayoutBounds) "Show Compose Layout Bounds" else "Hide Compose Layout Bounds"
+    }
+}

--- a/platform/platform-resources-en/src/messages/ActionsBundle.properties
+++ b/platform/platform-resources-en/src/messages/ActionsBundle.properties
@@ -2324,6 +2324,7 @@ action.MoveFileToAnotherModule.text=Move File to Another Module
 action.PerformGC.text=Perform GC
 action.LogFocusRequests.text=Log Focus Requests
 action.UiInspector.text=UI &Inspector
+action.ToggleComposeLayoutBounds.text=Toggle Compose &Layout Bounds
 action.CopyUiLabel.text=Copy UI Label
 action.UiThemeColorPickerAction.text=Enable UI Theme Color Picker
 action.GrayFilterConfig.text=&GrayFilter

--- a/platform/platform-resources/src/idea/PlatformActions.xml
+++ b/platform/platform-resources/src/idea/PlatformActions.xml
@@ -1436,6 +1436,7 @@
           <abbreviation value="uii"/>
           <mouse-shortcut keymap="$default" keystroke="control alt button1"/>
         </action>
+        <action id="ToggleComposeLayoutBounds" internal="true" class="com.intellij.internal.inspector.compose.ToggleComposeLayoutBoundsAction" />
         <action id="CopyUiLabel" internal="true" class="com.intellij.internal.inspector.CopyUiLabelAction">
           <mouse-shortcut keymap="$default" keystroke="control alt button3"/>
           <mouse-shortcut keymap="$default" keystroke="control alt shift button3"/>


### PR DESCRIPTION
This adds an action to the ui-inspector module that toggles the showLayoutBounds value for all currently attached ComposePanels. It also registers an AWT hierarchy listener, if the toggle is on, to capture when a new ComposePanel is added to the hierarchy and make sure the setting is respected in cases where panels are detached and then re-attached (the setting is lost when the panel is detached as it disposes a lot of internal state).

https://github.com/user-attachments/assets/7aa637c1-dca7-42b7-9d0c-caaf388bdc6c

When toggled, the action also tries to cause a recomposition in all the panels so that the bounds do start showing right away, but it doesn't seem to always work/cause a full redraw. Any interaction or change in bounds on the panels will cause the panels to redraw, and that is mostly good enough for now.

Given the approach is reflection-heavy, it is prone to breaking if there are changes in CMP internals; when we have a better, [official API](https://youtrack.jetbrains.com/issue/CMP-9264/Expose-API-on-ComposePanel-to-toggle-showLayoutBounds) for it, we'll be able to have a more robust impl.

CC @igordmn @batya239 @jreznot 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an internal action that toggles `showLayoutBounds` for all Compose panels, using reflection, auto-updates on panel attach via AWT listener, and registers the action in resources.
> 
> - **UI Inspector / Compose**:
>   - Add `ToggleComposeLayoutBoundsAction` to toggle `showLayoutBounds` across active Compose containers; updates presentation text based on state.
>   - Implement `LayoutBoundsToggler` to reflectively set `owner.showLayoutBounds`, invalidate layers, trigger revalidate/repaint, and listen for AWT `HierarchyEvent` attachments.
>   - Introduce `ComposeUtil` to locate Compose containers (`ComposePanel`/`ComposeWindow`) and traverse to root layout nodes via reflection.
>   - Add `ReflectHelper` for cached reflective field/method access.
> - **Action Registration / Resources**:
>   - Register action `ToggleComposeLayoutBounds` in `PlatformActions.xml` under internal UI tools.
>   - Add action text key `action.ToggleComposeLayoutBounds.text` to `ActionsBundle.properties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0033818689a97ee48f9c7cc273ecde31697e8667. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->