### PR TITLE
Update JIRA ID pattern to include digits and underscores

### DIFF
--- a/plugins/tasks/tasks-core/jira/src/com/intellij/tasks/jira/JiraRepository.java
+++ b/plugins/tasks/tasks-core/jira/src/com/intellij/tasks/jira/JiraRepository.java
@@ -55,7 +55,7 @@ public final class JiraRepository extends BaseRepositoryImpl {
   private static final boolean BASIC_AUTH_ONLY = Boolean.getBoolean("tasks.jira.basic.auth.only");
   private static final boolean REDISCOVER_API = Boolean.getBoolean("tasks.jira.rediscover.api");
 
-  public static final Pattern JIRA_ID_PATTERN = Pattern.compile("\\p{javaUpperCase}+-\\d+");
+  public static final Pattern JIRA_ID_PATTERN = Pattern.compile("[\\p{javaUpperCase}\\p{Digit}_]+-\\d+");
   public static final String AUTH_COOKIE_NAME = "JSESSIONID";
 
   /**


### PR DESCRIPTION
Resolves (probably) [IJPL-221819](https://youtrack.jetbrains.com/issue/IJPL-221819) Cannot connect to Jira Cloud

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the `JIRA_ID_PATTERN` to accept digits and underscores in project keys.
> 
> - **JIRA task parsing**:
>   - Update `JIRA_ID_PATTERN` in `JiraRepository` from `\p{javaUpperCase}+-\d+` to `[\p{javaUpperCase}\p{Digit}_]+-\d+` to recognize issue keys with digits/underscores in the project part.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 646349afb77ec32f8c15b1053014dbb5e6ce91c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->