### PR TITLE
fix: Look in callee to determine no return state

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/codeInsight/controlflow/CallInstruction.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/codeInsight/controlflow/CallInstruction.kt
@@ -1,6 +1,9 @@
 package com.jetbrains.python.codeInsight.controlflow
 
 import com.intellij.codeInsight.controlflow.ControlFlowBuilder
+import com.intellij.codeInsight.controlflow.Instruction
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import com.intellij.codeInsight.controlflow.impl.InstructionImpl
 import com.jetbrains.python.psi.PyCallExpression
 import com.jetbrains.python.psi.PyFunction
@@ -20,6 +23,11 @@ class CallInstruction(builder: ControlFlowBuilder, call: PyCallExpression) : Ins
       if (pyFunction is PyFunction && hasReturnTypeAnnotation(pyFunction)) {
         return context.getReturnType(pyFunction) is PyNeverType
       }
+      // Fallback: look into the callee's body control-flow. If the function cannot
+      // complete normally (no path reaches the function exit), treat it as no-return.
+      if (pyFunction is PyFunction) {
+        return functionIsEffectivelyNoReturn(pyFunction)
+      }
     }
     return false
   }
@@ -27,4 +35,50 @@ class CallInstruction(builder: ControlFlowBuilder, call: PyCallExpression) : Ins
 
 private fun hasReturnTypeAnnotation(function: PyFunction): Boolean {
   return function.annotation != null || function.typeCommentAnnotation != null
+}
+
+private fun functionIsEffectivelyNoReturn(function: PyFunction): Boolean {
+  // Cache per-function, drop on any PSI modification
+  val manager = CachedValuesManager.getManager(function.project)
+  return manager.getCachedValue(function) {
+    val flow = ControlFlowCache.getControlFlow(function)
+    val instructions = flow.instructions
+
+    // Heuristic/performance guard: don't analyze very large CFGs
+    // (extremely unlikely small helper functions will exceed this)
+    val maxInstructionsToAnalyze = 1000
+    val result = if (instructions.isEmpty() || instructions.size > maxInstructionsToAnalyze) {
+      false
+    } else {
+      !exitIsReachable(instructions)
+    }
+
+    CachedValueProvider.Result.create(result, function)
+  }
+}
+
+private fun exitIsReachable(instructions: Array<Instruction>): Boolean {
+  // Start is always at index 0; exit node is the last instruction
+  val start = instructions.first()
+  val exit = instructions.last()
+  // Simple iterative DFS without version checks (consistent with CFG text tests)
+  val visited = BooleanArray(instructions.size)
+  val stack = java.util.ArrayDeque<Instruction>()
+  stack.addFirst(start)
+
+  var steps = 0
+  val maxSteps = 20000 // safety guard against pathological graphs
+
+  while (!stack.isEmpty() && steps++ < maxSteps) {
+    val insn = stack.removeFirst()
+    val num = insn.num()
+    if (visited[num]) continue
+    visited[num] = true
+    if (insn === exit) return true
+    val succs = insn.allSucc()
+    for (succ in succs) {
+      if (!visited[succ.num()]) stack.addFirst(succ)
+    }
+  }
+  return visited[exit.num()]
 }

--- a/python/testData/codeInsight/controlflow/ControlFlowIsAbruptAfterRaisingCallee.py
+++ b/python/testData/codeInsight/controlflow/ControlFlowIsAbruptAfterRaisingCallee.py
@@ -1,0 +1,5 @@
+def die():
+    raise RuntimeError('no way')
+
+die()
+print("ureachable")

--- a/python/testData/codeInsight/controlflow/ControlFlowIsAbruptAfterRaisingCallee.txt
+++ b/python/testData/codeInsight/controlflow/ControlFlowIsAbruptAfterRaisingCallee.txt
@@ -1,0 +1,8 @@
+0(1) element: null
+1(2) element: PyFunction('die')
+2(3) WRITE ACCESS: die
+3(4) element: PyExpressionStatement
+4(5) READ ACCESS: die
+5(6) element: PyCallExpression: die
+6(7) element: PyPrintStatement
+7() element: null

--- a/python/testSrc/com/jetbrains/python/PyControlFlowBuilderTest.java
+++ b/python/testSrc/com/jetbrains/python/PyControlFlowBuilderTest.java
@@ -544,6 +544,11 @@ public class PyControlFlowBuilderTest extends LightMarkedTestCase {
     doTest();
   }
 
+  // PY-72253
+  public void testControlFlowIsAbruptAfterRaisingCallee() {
+    doTest();
+  }
+
   // TODO migrate this test class to Python 3 SDK by default to make this test work
   // PY-53703
   //public void testControlFlowIsAbruptAfterNever() {


### PR DESCRIPTION
Would you consider such a hacky way to look into callees?

Fixes https://youtrack.jetbrains.com/issue/PY-72253/False-positive-Local-variable-x-might-be-referenced-before-assignment-after-try-except-block-when-a-function-call-in-except

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When a call target lacks a never-return annotation, analyze the callee’s control-flow to treat calls as no-return if the function’s exit is unreachable, with caching and limits; adds a test for a raising callee.
> 
> - **Control flow analysis**
>   - Update `CallInstruction.kt` to detect no-return calls by inspecting callee CFG when no explicit return type is provided.
>   - Add cached `functionIsEffectivelyNoReturn` and DFS-based `exitIsReachable` with safety limits to avoid large/complex graphs.
> - **Tests**
>   - Add `ControlFlowIsAbruptAfterRaisingCallee.py/.txt` test data.
>   - Register `testControlFlowIsAbruptAfterRaisingCallee` in `PyControlFlowBuilderTest.java`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4ceedd5d9d1801c18a1d96c449776c7dcdb08d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->