### PR TITLE
Add standard patch format & full commit message options to `Create Patch...`

### DIFF
--- a/platform/vcs-api/vcs-api-core/resources/messages/VcsBundle.properties
+++ b/platform/vcs-api/vcs-api-core/resources/messages/VcsBundle.properties
@@ -579,6 +579,7 @@ changes.remove.active.title=Delete Active Changelist
 create.patch.loading.content.progress=Loading Content Revisions
 create.patch.reverse.checkbox=&Reverse patch
 create.patch.standard.format.checkbox=Use &standard patch format (no IDEA additional info)
+create.patch.full.commit.message.checkbox=Include &full commit message
 create.patch.file.path=To &file:
 create.patch.to.clipboard=To &clipboard
 create.patch.encoding=&Encoding:

--- a/platform/vcs-api/vcs-api-core/resources/messages/VcsBundle.properties
+++ b/platform/vcs-api/vcs-api-core/resources/messages/VcsBundle.properties
@@ -578,6 +578,7 @@ changes.remove.active.empty.prompt=Select the changelist to make active:
 changes.remove.active.title=Delete Active Changelist
 create.patch.loading.content.progress=Loading Content Revisions
 create.patch.reverse.checkbox=&Reverse patch
+create.patch.standard.format.checkbox=Use &standard patch format (no IDEA additional info)
 create.patch.file.path=To &file:
 create.patch.to.clipboard=To &clipboard
 create.patch.encoding=&Encoding:

--- a/platform/vcs-impl/src/com/intellij/openapi/diff/impl/patch/UnifiedDiffWriter.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/diff/impl/patch/UnifiedDiffWriter.java
@@ -22,6 +22,7 @@ import java.text.MessageFormat;
 import java.util.*;
 
 import static com.intellij.openapi.vcs.changes.patch.PatchWriter.shouldForceUnixLineSeparator;
+import static com.intellij.openapi.vcs.changes.patch.PatchWriter.STANDARD_PATCH_FORMAT_KEY;
 
 public final class UnifiedDiffWriter {
   private static final @NonNls String INDEX_SIGNATURE = "Index: {0}{1}";
@@ -77,6 +78,10 @@ public final class UnifiedDiffWriter {
     boolean forceUnixSeparators = shouldForceUnixLineSeparator(project);
     String headerLineSeparator = forceUnixSeparators ? LineSeparator.LF.getSeparatorString()
                                                      : lineSeparator;
+    boolean standardFormat = commitContext != null && Boolean.TRUE.equals(commitContext.getUserData(STANDARD_PATCH_FORMAT_KEY));
+    if (standardFormat) {
+      throw new UnsupportedOperationException("Standard patch format is not implemented yet");
+    }
 
     // write the patch files without content modifications strictly after the files with content modifications,
     // because GitPatchReader is not ready for mixed style patches

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/actions/CreatePatchFromChangesAction.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/actions/CreatePatchFromChangesAction.java
@@ -143,11 +143,28 @@ public abstract class CreatePatchFromChangesAction extends ExtendableAction impl
   }
 
   public static void createPatch(@NotNull Project project,
+                                 @Nullable String commitMessage,
+                                 @NotNull List<? extends Change> changes,
+                                 boolean silentClipboard,
+                                 @NotNull CommitContext commitContext) {
+    PatchBuilder patchBuilder = new CreatePatchCommitExecutor.DefaultPatchBuilder(project);
+    createPatch(project, commitMessage, changes, silentClipboard, patchBuilder, commitContext);
+  }
+
+  public static void createPatch(@NotNull Project project,
                                   @Nullable String commitMessage,
                                   @NotNull List<? extends Change> changes,
                                   boolean silentClipboard,
                                   @NotNull PatchBuilder patchBuilder) {
-    CommitContext commitContext = new CommitContext();
+    createPatch(project, commitMessage, changes, silentClipboard, patchBuilder, new CommitContext());
+  }
+
+  public static void createPatch(@NotNull Project project,
+                                 @Nullable String commitMessage,
+                                 @NotNull List<? extends Change> changes,
+                                 boolean silentClipboard,
+                                 @NotNull PatchBuilder patchBuilder,
+                                 @NotNull CommitContext commitContext) {
     if (silentClipboard) {
       createIntoClipboard(project, changes, commitMessage, patchBuilder, commitContext);
     }

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchCommitExecutor.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchCommitExecutor.java
@@ -51,6 +51,7 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
   private static final Logger LOG = Logger.getInstance(CreatePatchCommitExecutor.class);
   private static final String VCS_PATCH_PATH_KEY = "vcs.patch.path"; //NON-NLS
   private static final String VCS_PATCH_TO_CLIPBOARD = "vcs.patch.to.clipboard"; //NON-NLS
+  private static final String VCS_PATCH_STANDARD_FORMAT = "vcs.patch.standard.format"; //NON-NLS
 
   private final Project myProject;
 
@@ -114,6 +115,7 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
       myPanel.selectBasePath(PatchWriter.calculateBaseDirForWritingPatch(myProject, changes).toString());
       myPanel.setReversePatch(false);
       myPanel.setReverseEnabledAndVisible(myPatchBuilder.isReverseSupported());
+      myPanel.setStandardPatchFormat(PropertiesComponent.getInstance(myProject).getBoolean(VCS_PATCH_STANDARD_FORMAT, false));
 
       DialogPanel panel = myPanel.getPanel();
       panel.putClientProperty(SessionDialog.VCS_CONFIGURATION_UI_TITLE, VcsBundle.message("create.patch.settings.dialog.title"));
@@ -128,6 +130,7 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
     @Override
     public void execute(@NotNull Collection<? extends Change> changes, @Nullable String commitMessage) {
       PropertiesComponent.getInstance(myProject).setValue(VCS_PATCH_TO_CLIPBOARD, myPanel.isToClipboard());
+      PropertiesComponent.getInstance(myProject).setValue(VCS_PATCH_STANDARD_FORMAT, myPanel.isStandardPatchFormat(), false);
       try {
         Path baseDir = Paths.get(myPanel.getBaseDirName());
         boolean isReverse = myPanel.isReversePatch();
@@ -170,6 +173,8 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
       PropertiesComponent.getInstance(project).setValue(VCS_PATCH_PATH_KEY, valueToStore);
       VcsApplicationSettings.getInstance().PATCH_STORAGE_LOCATION = valueToStore;
 
+      commitContext.putUserData(PatchWriter.STANDARD_PATCH_FORMAT_KEY,
+                                PropertiesComponent.getInstance(project).getBoolean(VCS_PATCH_STANDARD_FORMAT, false) ? Boolean.TRUE : null);
       List<FilePatch> patches = patchBuilder.buildPatches(baseDir, changes, reversePatch, true);
       PatchWriter.writePatches(project, file, baseDir, patches, commitMessage, commitContext, encoding);
 
@@ -340,6 +345,8 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
                                            boolean honorExcludedFromCommit,
                                            @NotNull PatchBuilder patchBuilder,
                                            @NotNull CommitContext commitContext) throws VcsException, IOException {
+    commitContext.putUserData(PatchWriter.STANDARD_PATCH_FORMAT_KEY,
+                              PropertiesComponent.getInstance(project).getBoolean(VCS_PATCH_STANDARD_FORMAT, false) ? Boolean.TRUE : null);
     List<FilePatch> patches = patchBuilder.buildPatches(baseDir, changes, reversePatch, honorExcludedFromCommit);
     PatchWriter.writeAsPatchToClipboard(project, patches, commitMessage, baseDir, commitContext);
     VcsNotifier.getInstance(project).notifySuccess(PATCH_COPIED_TO_CLIPBOARD, "",

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchCommitExecutor.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchCommitExecutor.java
@@ -52,6 +52,7 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
   private static final String VCS_PATCH_PATH_KEY = "vcs.patch.path"; //NON-NLS
   private static final String VCS_PATCH_TO_CLIPBOARD = "vcs.patch.to.clipboard"; //NON-NLS
   private static final String VCS_PATCH_STANDARD_FORMAT = "vcs.patch.standard.format"; //NON-NLS
+  private static final String VCS_PATCH_INCLUDE_FULL_COMMIT_MESSAGE = "vcs.patch.include.full.commit.message"; //NON-NLS
 
   private final Project myProject;
 
@@ -116,6 +117,7 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
       myPanel.setReversePatch(false);
       myPanel.setReverseEnabledAndVisible(myPatchBuilder.isReverseSupported());
       myPanel.setStandardPatchFormat(PropertiesComponent.getInstance(myProject).getBoolean(VCS_PATCH_STANDARD_FORMAT, false));
+      myPanel.setIncludeFullCommitMessage(PropertiesComponent.getInstance(myProject).getBoolean(VCS_PATCH_INCLUDE_FULL_COMMIT_MESSAGE, false));
 
       DialogPanel panel = myPanel.getPanel();
       panel.putClientProperty(SessionDialog.VCS_CONFIGURATION_UI_TITLE, VcsBundle.message("create.patch.settings.dialog.title"));
@@ -131,6 +133,7 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
     public void execute(@NotNull Collection<? extends Change> changes, @Nullable String commitMessage) {
       PropertiesComponent.getInstance(myProject).setValue(VCS_PATCH_TO_CLIPBOARD, myPanel.isToClipboard());
       PropertiesComponent.getInstance(myProject).setValue(VCS_PATCH_STANDARD_FORMAT, myPanel.isStandardPatchFormat(), false);
+      PropertiesComponent.getInstance(myProject).setValue(VCS_PATCH_INCLUDE_FULL_COMMIT_MESSAGE, myPanel.isIncludeFullCommitMessage(), false);
       try {
         Path baseDir = Paths.get(myPanel.getBaseDirName());
         boolean isReverse = myPanel.isReversePatch();
@@ -173,6 +176,8 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
       PropertiesComponent.getInstance(project).setValue(VCS_PATCH_PATH_KEY, valueToStore);
       VcsApplicationSettings.getInstance().PATCH_STORAGE_LOCATION = valueToStore;
 
+      commitContext.putUserData(PatchWriter.INCLUDE_FULL_COMMIT_MESSAGE_KEY,
+                                PropertiesComponent.getInstance(project).getBoolean(VCS_PATCH_INCLUDE_FULL_COMMIT_MESSAGE, false) ? Boolean.TRUE : null);
       commitContext.putUserData(PatchWriter.STANDARD_PATCH_FORMAT_KEY,
                                 PropertiesComponent.getInstance(project).getBoolean(VCS_PATCH_STANDARD_FORMAT, false) ? Boolean.TRUE : null);
       List<FilePatch> patches = patchBuilder.buildPatches(baseDir, changes, reversePatch, true);
@@ -345,6 +350,8 @@ public final class CreatePatchCommitExecutor extends LocalCommitExecutor {
                                            boolean honorExcludedFromCommit,
                                            @NotNull PatchBuilder patchBuilder,
                                            @NotNull CommitContext commitContext) throws VcsException, IOException {
+    commitContext.putUserData(PatchWriter.INCLUDE_FULL_COMMIT_MESSAGE_KEY,
+                              PropertiesComponent.getInstance(project).getBoolean(VCS_PATCH_INCLUDE_FULL_COMMIT_MESSAGE, false) ? Boolean.TRUE : null);
     commitContext.putUserData(PatchWriter.STANDARD_PATCH_FORMAT_KEY,
                               PropertiesComponent.getInstance(project).getBoolean(VCS_PATCH_STANDARD_FORMAT, false) ? Boolean.TRUE : null);
     List<FilePatch> patches = patchBuilder.buildPatches(baseDir, changes, reversePatch, honorExcludedFromCommit);

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchConfigurationPanel.kt
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchConfigurationPanel.kt
@@ -33,6 +33,7 @@ class CreatePatchConfigurationPanel(val project: Project) {
   private lateinit var toClipboardRadioButton: JRadioButton
   private lateinit var reverseCheckBox: JCheckBox
   private lateinit var standardFormatCheckBox: JCheckBox
+  private lateinit var includeFullCommitMessageCheckBox: JCheckBox
   private lateinit var encodingComboBox: ComboBox<Charset>
 
   private var commonParentDir: File? = null
@@ -93,6 +94,9 @@ class CreatePatchConfigurationPanel(val project: Project) {
       row {
         standardFormatCheckBox = checkBox(message("create.patch.standard.format.checkbox")).component
       }
+      row {
+        includeFullCommitMessageCheckBox = checkBox(message("create.patch.full.commit.message.checkbox")).component
+      }
       row(message("create.patch.encoding")) {
         encodingComboBox = comboBox(DefaultComboBoxModel(CharsetToolkit.getAvailableCharsets())).component
         encodingComboBox.selectedItem = EncodingProjectManager.getInstance(project).defaultCharset
@@ -148,6 +152,14 @@ class CreatePatchConfigurationPanel(val project: Project) {
 
   fun setStandardPatchFormat(isStandard: Boolean) {
     standardFormatCheckBox.isSelected = isStandard
+  }
+
+  fun isIncludeFullCommitMessage(): Boolean {
+    return includeFullCommitMessageCheckBox.isSelected
+  }
+
+  fun setIncludeFullCommitMessage(include: Boolean) {
+    includeFullCommitMessageCheckBox.isSelected = include
   }
 
   fun isToClipboard(): Boolean {

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchConfigurationPanel.kt
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/CreatePatchConfigurationPanel.kt
@@ -32,6 +32,7 @@ class CreatePatchConfigurationPanel(val project: Project) {
 
   private lateinit var toClipboardRadioButton: JRadioButton
   private lateinit var reverseCheckBox: JCheckBox
+  private lateinit var standardFormatCheckBox: JCheckBox
   private lateinit var encodingComboBox: ComboBox<Charset>
 
   private var commonParentDir: File? = null
@@ -89,6 +90,9 @@ class CreatePatchConfigurationPanel(val project: Project) {
       row {
         reverseCheckBox = checkBox(message("create.patch.reverse.checkbox")).component
       }
+      row {
+        standardFormatCheckBox = checkBox(message("create.patch.standard.format.checkbox")).component
+      }
       row(message("create.patch.encoding")) {
         encodingComboBox = comboBox(DefaultComboBoxModel(CharsetToolkit.getAvailableCharsets())).component
         encodingComboBox.selectedItem = EncodingProjectManager.getInstance(project).defaultCharset
@@ -136,6 +140,14 @@ class CreatePatchConfigurationPanel(val project: Project) {
   fun setReverseEnabledAndVisible(isAvailable: Boolean) {
     reverseCheckBox.isVisible = isAvailable
     reverseCheckBox.isEnabled = isAvailable
+  }
+
+  fun isStandardPatchFormat(): Boolean {
+    return standardFormatCheckBox.isSelected
+  }
+
+  fun setStandardPatchFormat(isStandard: Boolean) {
+    standardFormatCheckBox.isSelected = isStandard
   }
 
   fun isToClipboard(): Boolean {

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/PatchWriter.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/PatchWriter.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.diff.impl.patch.TextFilePatch;
 import com.intellij.openapi.diff.impl.patch.UnifiedDiffWriter;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vcs.ProjectLevelVcsManager;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.ChangesUtil;
@@ -31,6 +32,9 @@ import java.util.List;
 import static com.intellij.openapi.vcs.VcsType.distributed;
 
 public final class PatchWriter {
+  public static final Key<Boolean> STANDARD_PATCH_FORMAT_KEY =
+    Key.create("com.intellij.openapi.vcs.changes.patch.PatchWriter.STANDARD_PATCH_FORMAT_KEY");
+
   public static void writePatches(@NotNull Project project,
                                   @NotNull Path file,
                                   @NotNull Path basePath,

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/PatchWriter.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/PatchWriter.java
@@ -34,6 +34,8 @@ import static com.intellij.openapi.vcs.VcsType.distributed;
 public final class PatchWriter {
   public static final Key<Boolean> STANDARD_PATCH_FORMAT_KEY =
     Key.create("com.intellij.openapi.vcs.changes.patch.PatchWriter.STANDARD_PATCH_FORMAT_KEY");
+  public static final Key<Boolean> INCLUDE_FULL_COMMIT_MESSAGE_KEY =
+    Key.create("com.intellij.openapi.vcs.changes.patch.PatchWriter.INCLUDE_FULL_COMMIT_MESSAGE_KEY");
 
   public static void writePatches(@NotNull Project project,
                                   @NotNull Path file,
@@ -72,6 +74,10 @@ public final class PatchWriter {
                             @Nullable String commitMessage,
                             @Nullable CommitContext commitContext) throws IOException {
     String lineSeparator = CodeStyle.getSettings(project).getLineSeparator();
+    boolean includeFullCommitMessage = commitContext != null && Boolean.TRUE.equals(commitContext.getUserData(INCLUDE_FULL_COMMIT_MESSAGE_KEY));
+    if (includeFullCommitMessage) {
+      throw new UnsupportedOperationException("Full commit message is not implemented yet");
+    }
     UnifiedDiffWriter.writeCommitMessageHeader(project, writer, lineSeparator, commitMessage);
     UnifiedDiffWriter.write(project, basePath, patches, writer, lineSeparator, commitContext, null);
     BinaryPatchWriter.writeBinaries(basePath, ContainerUtil.findAll(patches, BinaryFilePatch.class), writer);

--- a/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/PatchWriter.java
+++ b/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/patch/PatchWriter.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.diff.impl.patch.UnifiedDiffWriter;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.ProjectLevelVcsManager;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.ChangesUtil;
@@ -34,6 +35,8 @@ import static com.intellij.openapi.vcs.VcsType.distributed;
 public final class PatchWriter {
   public static final Key<Boolean> STANDARD_PATCH_FORMAT_KEY =
     Key.create("com.intellij.openapi.vcs.changes.patch.PatchWriter.STANDARD_PATCH_FORMAT_KEY");
+  public static final Key<String> FULL_COMMIT_MESSAGE_KEY =
+    Key.create("com.intellij.openapi.vcs.changes.patch.PatchWriter.FULL_COMMIT_MESSAGE_KEY");
   public static final Key<Boolean> INCLUDE_FULL_COMMIT_MESSAGE_KEY =
     Key.create("com.intellij.openapi.vcs.changes.patch.PatchWriter.INCLUDE_FULL_COMMIT_MESSAGE_KEY");
 
@@ -76,7 +79,10 @@ public final class PatchWriter {
     String lineSeparator = CodeStyle.getSettings(project).getLineSeparator();
     boolean includeFullCommitMessage = commitContext != null && Boolean.TRUE.equals(commitContext.getUserData(INCLUDE_FULL_COMMIT_MESSAGE_KEY));
     if (includeFullCommitMessage) {
-      throw new UnsupportedOperationException("Full commit message is not implemented yet");
+      String fullCommitMessage = commitContext.getUserData(FULL_COMMIT_MESSAGE_KEY);
+      if (!StringUtil.isEmptyOrSpaces(fullCommitMessage)) {
+        commitMessage = fullCommitMessage;
+      }
     }
     UnifiedDiffWriter.writeCommitMessageHeader(project, writer, lineSeparator, commitMessage);
     UnifiedDiffWriter.write(project, basePath, patches, writer, lineSeparator, commitContext, null);

--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/actions/VcsLogCreatePatchActionProvider.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/actions/VcsLogCreatePatchActionProvider.java
@@ -4,9 +4,14 @@ package com.intellij.vcs.log.ui.actions;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.AnActionExtensionProvider;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.VcsDataKeys;
 import com.intellij.openapi.vcs.changes.Change;
+import com.intellij.openapi.vcs.changes.CommitContext;
 import com.intellij.openapi.vcs.changes.actions.CreatePatchFromChangesAction;
+import com.intellij.openapi.vcs.changes.patch.PatchWriter;
 import com.intellij.openapi.vcs.changes.ui.ChangesBrowserBase;
 import com.intellij.vcs.log.VcsLogCommitSelection;
 import com.intellij.vcs.log.VcsLogDataKeys;
@@ -83,7 +88,11 @@ public class VcsLogCreatePatchActionProvider implements AnActionExtensionProvide
 
     selection.requestFullDetails(details -> {
       List<Change> changes = VcsLogUtil.collectChanges(details);
-      CreatePatchFromChangesAction.createPatch(e.getProject(), commitMessage, changes, mySilentClipboard);
+      CommitContext commitContext = new CommitContext();
+      commitContext.putUserData(PatchWriter.FULL_COMMIT_MESSAGE_KEY, StringUtil.join(details, it -> it.getFullMessage(), "\n\n"));
+      Project project = e.getProject();
+      if (project == null) project = ProjectManager.getInstance().getDefaultProject();
+      CreatePatchFromChangesAction.createPatch(project, commitMessage, changes, mySilentClipboard, commitContext);
     });
   }
 }

--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/actions/history/CreatePatchFromHistoryActionProvider.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/actions/history/CreatePatchFromHistoryActionProvider.java
@@ -6,9 +6,12 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.AnActionExtensionProvider;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.VcsDataKeys;
 import com.intellij.openapi.vcs.changes.Change;
+import com.intellij.openapi.vcs.changes.CommitContext;
 import com.intellij.openapi.vcs.changes.actions.CreatePatchFromChangesAction;
+import com.intellij.openapi.vcs.changes.patch.PatchWriter;
 import com.intellij.vcs.log.VcsLogCommitSelection;
 import com.intellij.vcs.log.VcsLogDataKeys;
 import com.intellij.vcs.log.history.FileHistoryUi;
@@ -80,7 +83,9 @@ public class CreatePatchFromHistoryActionProvider implements AnActionExtensionPr
 
     selection.requestFullDetails(detailsList -> {
       List<Change> changes = VcsLogUtil.collectChanges(detailsList);
-      CreatePatchFromChangesAction.createPatch(project, commitMessage, changes, mySilentClipboard);
+      CommitContext commitContext = new CommitContext();
+      commitContext.putUserData(PatchWriter.FULL_COMMIT_MESSAGE_KEY, StringUtil.join(detailsList, it -> it.getFullMessage(), "\n\n"));
+      CreatePatchFromChangesAction.createPatch(project, commitMessage, changes, mySilentClipboard, commitContext);
     });
   }
 }

--- a/platform/vcs-tests/testSrc/com/intellij/openapi/vcs/diff/impl/patch/CreateApplyPatchSymmetryTest.kt
+++ b/platform/vcs-tests/testSrc/com/intellij/openapi/vcs/diff/impl/patch/CreateApplyPatchSymmetryTest.kt
@@ -108,11 +108,19 @@ class CreateApplyPatchSymmetryTest : HeavyDiffTestCase() {
                         SimpleContentRevision("b\n", filePath, "2"))
     val patches = IdeaTextPatchBuilder.buildPatch(project, listOf(change), basePath, false)
 
-    val includeFullCommitMessage = booleanArrayOf(false)
-    val hasFullCommitMessage = booleanArrayOf(false)
+    val includeFullCommitMessage = booleanArrayOf(false, true)
+    val hasFullCommitMessage = booleanArrayOf(false, true)
     for (includeFull in includeFullCommitMessage) {
       for (hasFull in hasFullCommitMessage) {
-        val commitContext = if (includeFull || hasFull) CommitContext() else null
+        val commitContext = if (includeFull || hasFull) {
+          CommitContext().apply {
+            if (hasFull) putUserData(PatchWriter.FULL_COMMIT_MESSAGE_KEY, "subject\n\nbody")
+            if (includeFull) putUserData(PatchWriter.INCLUDE_FULL_COMMIT_MESSAGE_KEY, true)
+          }
+        }
+        else {
+          null
+        }
 
         val tempDir = Files.createTempDirectory("patch-writer-test")
         try {

--- a/platform/vcs-tests/testSrc/com/intellij/openapi/vcs/diff/impl/patch/UnifiedDiffWriterStandardPatchTest.kt
+++ b/platform/vcs-tests/testSrc/com/intellij/openapi/vcs/diff/impl/patch/UnifiedDiffWriterStandardPatchTest.kt
@@ -1,0 +1,52 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.openapi.vcs.diff.impl.patch
+
+import com.intellij.diff.HeavyDiffTestCase
+import com.intellij.openapi.diff.impl.patch.IdeaTextPatchBuilder
+import com.intellij.openapi.diff.impl.patch.PatchEP
+import com.intellij.openapi.diff.impl.patch.UnifiedDiffWriter
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.changes.Change
+import com.intellij.openapi.vcs.changes.CommitContext
+import com.intellij.openapi.vcs.changes.SimpleContentRevision
+import com.intellij.vcsUtil.VcsUtil
+import java.io.StringWriter
+import java.nio.file.Paths
+
+class UnifiedDiffWriterStandardPatchTest : HeavyDiffTestCase() {
+  fun testPatchHeaders() {
+    val basePath = Paths.get("/base/")
+    val filePath = VcsUtil.getFilePath("/base/some/file.txt", false)
+
+    val change = Change(SimpleContentRevision("a\n", filePath, "1"),
+                        SimpleContentRevision("b\n", filePath, "2"))
+    val patches = IdeaTextPatchBuilder.buildPatch(project, listOf(change), basePath, false)
+
+    val standardFormats = booleanArrayOf(false)
+    val includeAdditionalInfo = booleanArrayOf(false, true)
+    for (standardFormat in standardFormats) {
+      val commitContext: CommitContext? = if (standardFormat) CommitContext() else null
+      for (includeInfo in includeAdditionalInfo) {
+        val ep = object : PatchEP {
+          override fun getName(): String = "TestPatchInfo"
+
+          override fun provideContent(project: Project, path: String, commitContext: CommitContext?): CharSequence? {
+            return if (includeInfo) "test content" else ""
+          }
+
+          override fun consumeContentBeforePatchApplied(project: Project, path: String, content: CharSequence, commitContext: CommitContext?) {
+          }
+        }
+
+        val writer = StringWriter()
+        UnifiedDiffWriter.write(project, basePath, patches, writer, "\n", commitContext, listOf(ep))
+        val text = writer.toString()
+        assertTrue(text.contains("diff --git"))
+        assertEquals(!standardFormat,
+                     text.contains("Index:"))
+        assertEquals(includeInfo && !standardFormat,
+                     text.contains(UnifiedDiffWriter.ADDITIONAL_PREFIX) && text.contains(UnifiedDiffWriter.ADD_INFO_HEADER))
+      }
+    }
+  }
+}

--- a/platform/vcs-tests/testSrc/com/intellij/openapi/vcs/diff/impl/patch/UnifiedDiffWriterStandardPatchTest.kt
+++ b/platform/vcs-tests/testSrc/com/intellij/openapi/vcs/diff/impl/patch/UnifiedDiffWriterStandardPatchTest.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.changes.Change
 import com.intellij.openapi.vcs.changes.CommitContext
 import com.intellij.openapi.vcs.changes.SimpleContentRevision
+import com.intellij.openapi.vcs.changes.patch.PatchWriter
 import com.intellij.vcsUtil.VcsUtil
 import java.io.StringWriter
 import java.nio.file.Paths
@@ -22,10 +23,15 @@ class UnifiedDiffWriterStandardPatchTest : HeavyDiffTestCase() {
                         SimpleContentRevision("b\n", filePath, "2"))
     val patches = IdeaTextPatchBuilder.buildPatch(project, listOf(change), basePath, false)
 
-    val standardFormats = booleanArrayOf(false)
+    val standardFormats = booleanArrayOf(false, true)
     val includeAdditionalInfo = booleanArrayOf(false, true)
     for (standardFormat in standardFormats) {
-      val commitContext: CommitContext? = if (standardFormat) CommitContext() else null
+      val commitContext: CommitContext? = if (standardFormat) {
+        CommitContext().apply { putUserData(PatchWriter.STANDARD_PATCH_FORMAT_KEY, true) }
+      }
+      else {
+        null
+      }
       for (includeInfo in includeAdditionalInfo) {
         val ep = object : PatchEP {
           override fun getName(): String = "TestPatchInfo"


### PR DESCRIPTION
When I’m prototyping changes during GitHub code review, I often want to share results as a patch.
The current "Create Patch" output is hard to share externally because it can include IntelliJ-specific headers (Index: + IDEA additional info: blocks), and commit messages are commonly reduced to a single subject line instead of the full multi-line
message.

#### Fix
This change adds two independent, persisted options to the "Patch File Settings" dialog:

##### Standard patch format
* New checkbox: "Use standard patch format (no IDEA additional info)"
* When enabled, patch output omits IntelliJ-specific patch headers (Index:, IDEA additional info:, and the separator) and keeps a standard unified diff format.


##### Include full commit message
* New checkbox: "Include full commit message"
* When enabled (and when a full message is available from VCS log / file history selection), the patch Subject: [PATCH] … header uses the full multi-line commit message instead of only the subject/preset message.

### Validation
* Automated coverage updated for patch headers and commit message header behavior.
* Manually validated all scenarios (both options on/off, full-message present/absent, and patch creation flows), confirming output matches expectations.

I haven't pushed here in at least 6 years, don't remember what the flow is, but feel free to merge and edit if that's simpler than requesting changes.