### PR TITLE
[JEWEL-1138] Scale images to fit available width

### DIFF
--- a/platform/jewel/markdown/core/BUILD.bazel
+++ b/platform/jewel/markdown/core/BUILD.bazel
@@ -105,7 +105,7 @@ jvm_library(
   name = "jewel-markdown-core-tests_test_lib",
   testonly = True,
   visibility = ["//visibility:public"],
-  srcs = glob(["src/test/kotlin/**/*.kt", "src/test/kotlin/**/*.java", "src/test/kotlin/**/*.form"], allow_empty = True),
+  srcs = glob(["src/test/kotlin/**/*.kt", "src/test/kotlin/**/*.java", "src/test/kotlin/**/*.form", "src/testFixtures/kotlin/**/*.kt", "src/testFixtures/kotlin/**/*.java", "src/testFixtures/kotlin/**/*.form"], allow_empty = True),
   resources = [":jewel-markdown-core-tests_test_resources"],
   kotlinc_opts = ":custom_jewel-markdown-core-tests",
   associates = [

--- a/platform/jewel/markdown/core/build.gradle.kts
+++ b/platform/jewel/markdown/core/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jewel
     `jewel-check-public-api`
+    `java-test-fixtures`
     alias(libs.plugins.composeDesktop)
     alias(libs.plugins.compose.compiler)
 }
@@ -10,6 +11,9 @@ dependencies {
     api(libs.commonmark.core)
     api(libs.jsoup)
 
+    testFixturesImplementation(projects.foundation)
+
+    testImplementation(testFixtures(project))
     testImplementation(compose.desktop.uiTestJUnit4)
     testImplementation(projects.ui)
     testImplementation(projects.markdown.testing)

--- a/platform/jewel/markdown/core/intellij.platform.jewel.markdown.core.tests.iml
+++ b/platform/jewel/markdown/core/intellij.platform.jewel.markdown.core.tests.iml
@@ -26,6 +26,9 @@
     <content url="file://$MODULE_DIR$/src/test/kotlin">
       <sourceFolder url="file://$MODULE_DIR$/src/test/kotlin" isTestSource="true" />
     </content>
+    <content url="file://$MODULE_DIR$/src/testFixtures/kotlin">
+      <sourceFolder url="file://$MODULE_DIR$/src/testFixtures/kotlin" isTestSource="true" />
+    </content>
     <content url="file://$MODULE_DIR$/src/test/resources">
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
     </content>

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -5,13 +5,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.text.InlineTextContent
@@ -36,15 +34,36 @@ import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.onFirstVisible
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphIntrinsics
+import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.resolveDefaults
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.LayoutDirection.Ltr
 import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.code.MimeType
@@ -78,6 +97,7 @@ import org.jetbrains.jewel.ui.component.HorizontallyScrollableContainer
 import org.jetbrains.jewel.ui.component.Text
 
 private const val DISABLED_CODE_ALPHA = .5f
+private const val COMPOSE_INLINE_CONTENT_ANNOTATION_TAG = "androidx.compose.foundation.text.inlineContent"
 private val MIME_TYPE_REGEX = "^\\w+/.+$".toRegex()
 
 /**
@@ -145,6 +165,7 @@ public open class DefaultMarkdownBlockRenderer(
             ThematicBreak -> RenderThematicBreak(rootStyling.thematicBreak, enabled, modifier)
             is MarkdownBlock.HtmlBlockWithAttributes ->
                 RenderHtmlBlockWithAttributes(block, enabled, onUrlClick, modifier)
+
             is CustomBlock -> {
                 rendererExtensions
                     .find { it.blockRenderer?.canRender(block) == true }
@@ -206,31 +227,50 @@ public open class DefaultMarkdownBlockRenderer(
         softWrap: Boolean,
         maxLines: Int,
     ) {
-        val onlyImages = remember(block) { block.inlineContent.all { it is InlineMarkdown.Image } }
-        val images = renderedImages(block)
+        RenderBlockWithInlines(
+            block,
+            styling.inlinesStyling,
+            enabled,
+            onUrlClick,
+            onTextLayout,
+            modifier,
+            overflow,
+            softWrap,
+            maxLines,
+        )
+    }
 
-        if (onlyImages) {
-            RenderImages(images, modifier)
-        } else {
-            val renderedContent = rememberRenderedContent(block, styling.inlinesStyling, enabled, onUrlClick)
-            val textColor =
-                styling.inlinesStyling.textStyle.color
-                    .takeOrElse { LocalContentColor.current }
-                    .takeOrElse { styling.inlinesStyling.textStyle.color }
-            val mergedStyle = styling.inlinesStyling.textStyle.merge(TextStyle(color = textColor))
+    @Composable
+    private fun RenderBlockWithInlines(
+        block: WithInlineMarkdown,
+        inlinesStyling: InlinesStyling,
+        enabled: Boolean,
+        onUrlClick: (String) -> Unit,
+        onTextLayout: (TextLayoutResult) -> Unit,
+        modifier: Modifier = Modifier,
+        overflow: TextOverflow = TextOverflow.Clip,
+        softWrap: Boolean = true,
+        maxLines: Int = Int.MAX_VALUE,
+    ) {
+        val originalImages = renderedImages(block)
 
-            Text(
-                modifier = modifier,
-                text = renderedContent,
-                overflow = overflow,
-                softWrap = softWrap,
-                maxLines = maxLines,
-                onTextLayout = onTextLayout,
-                inlineContent = images,
-                style = mergedStyle,
-                textAlign = LocalTextAlignment.current,
-            )
-        }
+        val renderedContent = rememberRenderedContent(block, inlinesStyling, enabled, onUrlClick)
+        val textColor = inlinesStyling.textStyle.color.takeOrElse { LocalContentColor.current }
+        val mergedStyle = inlinesStyling.textStyle.merge(TextStyle(color = textColor))
+        val density = LocalDensity.current
+
+        TextWithScalableInlineContent(
+            text = renderedContent,
+            inlineContent = originalImages,
+            density = density,
+            modifier = modifier,
+            overflow = overflow,
+            softWrap = softWrap,
+            maxLines = maxLines,
+            onTextLayout = onTextLayout,
+            style = mergedStyle,
+            textAlign = LocalTextAlignment.current,
+        )
     }
 
     @Composable
@@ -284,30 +324,15 @@ public open class DefaultMarkdownBlockRenderer(
         onUrlClick: (String) -> Unit,
         modifier: Modifier,
     ) {
-        val onlyImages = remember(block) { block.inlineContent.all { it is InlineMarkdown.Image } }
-        val images = renderedImages(block)
-
-        if (onlyImages && images.isEmpty()) return
-
         Column(modifier = modifier.padding(styling.padding)) {
-            if (onlyImages) {
-                RenderImages(images)
-            } else {
-                val renderedContent = rememberRenderedContent(block, styling.inlinesStyling, enabled, onUrlClick)
-
-                val textColor =
-                    styling.inlinesStyling.textStyle.color.takeOrElse {
-                        LocalContentColor.current.takeOrElse { styling.inlinesStyling.textStyle.color }
-                    }
-                val mergedStyle = styling.inlinesStyling.textStyle.merge(TextStyle(color = textColor))
-                Text(
-                    text = renderedContent,
-                    style = mergedStyle,
-                    modifier = Modifier.focusProperties { this.canFocus = false },
-                    inlineContent = images,
-                    textAlign = LocalTextAlignment.current,
-                )
-            }
+            RenderBlockWithInlines(
+                block,
+                styling.inlinesStyling,
+                enabled,
+                onUrlClick,
+                {},
+                Modifier.focusProperties { this.canFocus = false },
+            )
 
             if (styling.underlineWidth > 0.dp && styling.underlineColor.isSpecified) {
                 Spacer(Modifier.height(styling.underlineGap))
@@ -820,21 +845,290 @@ public open class DefaultMarkdownBlockRenderer(
         }
     }
 
+    /**
+     * A Text composable that automatically scales inline content when there's insufficient horizontal space.
+     *
+     * Uses [SubcomposeLayout] to defer composition until constraints are known, allowing placeholder sizes to be
+     * computed based on actual available width without triggering recomposition. The outer [Layout] wrapper provides
+     * custom [MeasurePolicy.maxIntrinsicWidth] using [rememberTextMeasurer] for proper intrinsic measurements, which is
+     * crucial for grid-based containers like tables to preserve proportions.
+     */
     @Composable
-    private fun RenderImages(images: Map<String, InlineTextContent>, modifier: Modifier = Modifier) {
-        if (images.isEmpty()) return
+    private fun TextWithScalableInlineContent(
+        text: AnnotatedString,
+        inlineContent: Map<String, InlineTextContent>,
+        density: Density,
+        modifier: Modifier = Modifier,
+        overflow: TextOverflow = TextOverflow.Clip,
+        softWrap: Boolean = true,
+        maxLines: Int = Int.MAX_VALUE,
+        onTextLayout: (TextLayoutResult) -> Unit = {},
+        style: TextStyle = TextStyle.Default,
+        textAlign: TextAlign = LocalTextAlignment.current,
+    ) {
+        val inlineContentLayoutState = inlineContent.toLayoutState()
+        val inlineContentIds = inlineContentLayoutState.map { it.id }.toSet()
+        val placeholderWidths = inlineContentLayoutState.map { it.placeholder.width.value }
 
-        val density = LocalDensity.current
-        FlowRow(modifier) {
-            images.map { (text, inlineBlock) ->
-                Box(
-                    modifier =
-                        with(density) {
-                            Modifier.size(inlineBlock.placeholder.width.toDp(), inlineBlock.placeholder.height.toDp())
+        // Fast path: no images or only zero-width images - just render regular Text
+        if (placeholderWidths.sum() <= 0.01f) {
+            Text(
+                modifier = modifier,
+                text = text,
+                overflow = overflow,
+                softWrap = softWrap,
+                maxLines = maxLines,
+                onTextLayout = onTextLayout,
+                inlineContent = inlineContent,
+                style = style,
+                textAlign = textAlign,
+            )
+            return
+        }
+
+        // Pre-measure text with unscaled inline content to get intrinsic width.
+        // This is used for grid-based containers to preserve proportions, i.e., tables.
+        val textMeasurer = rememberTextMeasurer()
+        val fontFamilyResolver = LocalFontFamilyResolver.current
+        val layoutDirection = LocalLayoutDirection.current
+        val mergedStyle = remember(style, textAlign) { style.merge(TextStyle(textAlign = textAlign)) }
+        val textWithoutInlineContent = remember(text, inlineContentIds) { text.withoutInlineContent(inlineContentIds) }
+
+        val maxIntrinsicWidth =
+            remember(text, placeholderWidths, mergedStyle, textMeasurer) {
+                val placeholders = getPlaceholders(text, inlineContent)
+
+                // Measure with unconstrained width
+                val measured =
+                    textMeasurer.measure(
+                        text = text,
+                        style = mergedStyle,
+                        softWrap = false,
+                        maxLines = 1,
+                        placeholders = placeholders,
+                    )
+
+                measured.size.width
+            }
+
+        val minIntrinsicWidth =
+            remember(textWithoutInlineContent, mergedStyle, density, fontFamilyResolver, layoutDirection) {
+                textWithoutInlineContent.minParagraphIntrinsicWidth(
+                    style = mergedStyle,
+                    density = density,
+                    fontFamilyResolver = fontFamilyResolver,
+                    layoutDirection = layoutDirection,
+                )
+            }
+
+        // Outer `Layout` provides custom intrinsics (`SubcomposeLayout` doesn't support intrinsics).
+        // Inner `SubcomposeLayout` defers `Text` composition until constraints are known,
+        // so we can compute scaled placeholders based on actual available width.
+        val measurePolicy =
+            remember(
+                maxIntrinsicWidth,
+                minIntrinsicWidth,
+                text,
+                inlineContentLayoutState,
+                mergedStyle,
+                overflow,
+                softWrap,
+                maxLines,
+                textMeasurer,
+                density,
+            ) {
+                object : MeasurePolicy {
+                    override fun MeasureScope.measure(
+                        measurables: List<Measurable>,
+                        constraints: Constraints,
+                    ): MeasureResult {
+                        val placeable = measurables.firstOrNull()?.measure(constraints)
+
+                        return layout(
+                            width = placeable?.width ?: constraints.minWidth,
+                            height = placeable?.height ?: constraints.minHeight,
+                        ) {
+                            placeable?.place(0, 0)
                         }
-                ) {
-                    inlineBlock.children(text)
+                    }
+
+                    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+                        measurables: List<IntrinsicMeasurable>,
+                        height: Int,
+                    ): Int = maxIntrinsicWidth
+
+                    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+                        measurables: List<IntrinsicMeasurable>,
+                        height: Int,
+                    ): Int = minIntrinsicWidth
+
+                    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+                        measurables: List<IntrinsicMeasurable>,
+                        width: Int,
+                    ): Int = computeHeightForWidth(width)
+
+                    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+                        measurables: List<IntrinsicMeasurable>,
+                        width: Int,
+                    ): Int = computeHeightForWidth(width)
+
+                    private fun computeHeightForWidth(width: Int): Int {
+                        val availableWidth = if (width == Constraints.Infinity) Int.MAX_VALUE else width
+                        val scaledContent = scaleInlineContent(inlineContent, availableWidth, density)
+
+                        val placeholders = getPlaceholders(text, scaledContent)
+
+                        val constraints =
+                            if (width == Constraints.Infinity) {
+                                Constraints()
+                            } else {
+                                Constraints(maxWidth = width)
+                            }
+
+                        val measuredText =
+                            textMeasurer.measure(
+                                text = text,
+                                style = mergedStyle,
+                                placeholders = placeholders,
+                                constraints = constraints,
+                                overflow = overflow,
+                                softWrap = softWrap,
+                                maxLines = maxLines,
+                            )
+
+                        return measuredText.size.height
+                    }
                 }
+            }
+
+        Layout(
+            modifier = modifier.testTag(DOWNSCALED_INLINE_CONTENT_TAG),
+            measurePolicy = measurePolicy,
+            content = {
+                SubcomposeLayout { constraints ->
+                    val availableWidth =
+                        if (constraints.maxWidth == Constraints.Infinity) {
+                            Int.MAX_VALUE
+                        } else {
+                            constraints.maxWidth
+                        }
+
+                    val scaledContent = scaleInlineContent(inlineContent, availableWidth, density)
+
+                    val measurables =
+                        subcompose(Unit) {
+                            Text(
+                                text = text,
+                                overflow = overflow,
+                                softWrap = softWrap,
+                                maxLines = maxLines,
+                                onTextLayout = onTextLayout,
+                                inlineContent = scaledContent,
+                                style = style,
+                                textAlign = textAlign,
+                            )
+                        }
+
+                    val placeable = measurables.firstOrNull()?.measure(constraints)
+
+                    layout(
+                        width = placeable?.width ?: constraints.minWidth,
+                        height = placeable?.height ?: constraints.minHeight,
+                    ) {
+                        placeable?.place(0, 0)
+                    }
+                }
+            },
+        )
+    }
+
+    private fun getPlaceholders(
+        text: AnnotatedString,
+        inlineContent: Map<String, InlineTextContent>,
+    ): List<AnnotatedString.Range<Placeholder>> =
+        text.getInlineContentAnnotations().mapNotNull { annotation ->
+            inlineContent[annotation.item]?.let { content ->
+                AnnotatedString.Range(content.placeholder, annotation.start, annotation.end)
+            }
+        }
+
+    private fun AnnotatedString.withoutInlineContent(inlineContentIds: Set<String>): AnnotatedString {
+        if (inlineContentIds.isEmpty()) return this
+
+        val inlineRanges = getInlineContentAnnotations().filter { it.item in inlineContentIds }
+        if (inlineRanges.isEmpty()) return this
+
+        return buildAnnotatedString {
+            var currentIndex = 0
+            for (range in inlineRanges) {
+                if (currentIndex < range.start) {
+                    append(text, currentIndex, range.start)
+                }
+
+                append(' ')
+                currentIndex = range.end
+            }
+
+            if (currentIndex < text.length) {
+                append(text, currentIndex, text.length)
+            }
+        }
+    }
+
+    private fun AnnotatedString.getInlineContentAnnotations(): List<AnnotatedString.Range<String>> =
+        getStringAnnotations(COMPOSE_INLINE_CONTENT_ANNOTATION_TAG, 0, text.length)
+
+    private fun Map<String, InlineTextContent>.toLayoutState(): Set<InlineContentLayoutState> =
+        entries
+            .map { (id, content) -> InlineContentLayoutState(id = id, placeholder = content.placeholder) }
+            .toSortedSet(compareBy(InlineContentLayoutState::id))
+
+    private fun AnnotatedString.minParagraphIntrinsicWidth(
+        style: TextStyle,
+        density: Density,
+        fontFamilyResolver: FontFamily.Resolver,
+        layoutDirection: LayoutDirection,
+    ): Int {
+        val segments = text.split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
+        if (segments.isEmpty()) return 0
+        val resolvedStyle = resolveDefaults(style, layoutDirection)
+
+        return segments.maxOf { segment ->
+            ceil(
+                    ParagraphIntrinsics(
+                            text = segment,
+                            style = resolvedStyle,
+                            annotations = emptyList(),
+                            density = density,
+                            fontFamilyResolver = fontFamilyResolver,
+                        )
+                        .minIntrinsicWidth
+                )
+                .toInt()
+        }
+    }
+
+    /** Scales the inline content placeholders by the given scale factor. */
+    private fun scaleInlineContent(
+        content: Map<String, InlineTextContent>,
+        availableWidth: Int,
+        density: Density,
+    ): Map<String, InlineTextContent> {
+        return content.mapValues { (_, inlineContent) ->
+            val width = with(density) { inlineContent.placeholder.width.roundToPx() }
+            if (width == 0 || availableWidth >= width) {
+                inlineContent
+            } else {
+                val scale = availableWidth.toFloat() / width
+                InlineTextContent(
+                    placeholder =
+                        Placeholder(
+                            width = inlineContent.placeholder.width * scale,
+                            height = inlineContent.placeholder.height * scale,
+                            placeholderVerticalAlign = inlineContent.placeholder.placeholderVerticalAlign,
+                        ),
+                    children = inlineContent.children,
+                )
             }
         }
     }
@@ -860,6 +1154,8 @@ public open class DefaultMarkdownBlockRenderer(
         private val LocalTextAlignment: ProvidableCompositionLocal<TextAlign> = staticCompositionLocalOf {
             TextAlign.Start
         }
+
+        private val WHITESPACE_REGEX = "\\s+".toRegex()
     }
 }
 
@@ -935,3 +1231,8 @@ private fun MimeType.Known.fromMimeTypeString(mimeType: String): MimeType =
 
         else -> UNKNOWN
     }
+
+/** Test tag applied to the scalable inline content layout when SubcomposeLayout path is used. */
+public const val DOWNSCALED_INLINE_CONTENT_TAG: String = "ScalableInlineContent"
+
+private data class InlineContentLayoutState(val id: String, val placeholder: Placeholder)

--- a/platform/jewel/markdown/core/src/testFixtures/kotlin/org/jetbrains/jewel/markdown/TestTheme.kt
+++ b/platform/jewel/markdown/core/src/testFixtures/kotlin/org/jetbrains/jewel/markdown/TestTheme.kt
@@ -1,0 +1,183 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jetbrains.jewel.foundation.BorderColors
+import org.jetbrains.jewel.foundation.DisabledAppearanceValues
+import org.jetbrains.jewel.foundation.GlobalColors
+import org.jetbrains.jewel.foundation.GlobalMetrics
+import org.jetbrains.jewel.foundation.OutlineColors
+import org.jetbrains.jewel.foundation.TextColors
+import org.jetbrains.jewel.foundation.theme.ThemeColorPalette
+import org.jetbrains.jewel.foundation.theme.ThemeDefinition
+import org.jetbrains.jewel.foundation.theme.ThemeIconData
+import org.jetbrains.jewel.markdown.rendering.InlinesStyling
+import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
+import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.List.Ordered.NumberFormatStyles.NumberFormatStyle
+import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.List.Unordered.BulletCharStyles
+
+public fun createThemeDefinition(): ThemeDefinition =
+    ThemeDefinition(
+        name = "Test",
+        isDark = false,
+        globalColors =
+            GlobalColors(
+                borders = BorderColors(normal = Color.Black, focused = Color.Black, disabled = Color.Black),
+                outlines =
+                    OutlineColors(
+                        focused = Color.Black,
+                        focusedWarning = Color.Black,
+                        focusedError = Color.Black,
+                        warning = Color.Black,
+                        error = Color.Black,
+                    ),
+                text =
+                    TextColors(
+                        normal = Color.Black,
+                        selected = Color.Black,
+                        disabled = Color.Black,
+                        disabledSelected = Color.Black,
+                        info = Color.Black,
+                        error = Color.Black,
+                        warning = Color.Black,
+                    ),
+                panelBackground = Color.White,
+                toolwindowBackground = Color.White,
+            ),
+        globalMetrics = GlobalMetrics(outlineWidth = 10.dp, rowHeight = 24.dp),
+        defaultTextStyle = TextStyle.Default,
+        editorTextStyle = TextStyle.Default,
+        consoleTextStyle = TextStyle.Default,
+        contentColor = Color.Black,
+        colorPalette = ThemeColorPalette.Empty,
+        iconData = ThemeIconData.Empty,
+        disabledAppearanceValues = DisabledAppearanceValues(brightness = 33, contrast = -35, alpha = 100),
+    )
+
+public fun createMarkdownStyling(): MarkdownStyling {
+    val mockSpanStyle = SpanStyle(Color.Black)
+    val inlinesStyling =
+        InlinesStyling(
+            textStyle = TextStyle.Default,
+            inlineCode = mockSpanStyle,
+            link = mockSpanStyle,
+            linkDisabled = mockSpanStyle,
+            linkFocused = mockSpanStyle,
+            linkHovered = mockSpanStyle,
+            linkPressed = mockSpanStyle,
+            linkVisited = mockSpanStyle,
+            emphasis = mockSpanStyle,
+            strongEmphasis = mockSpanStyle,
+            inlineHtml = mockSpanStyle,
+        )
+    return MarkdownStyling(
+        blockVerticalSpacing = 8.dp,
+        paragraph = MarkdownStyling.Paragraph(inlinesStyling),
+        heading =
+            MarkdownStyling.Heading(
+                h1 = MarkdownStyling.Heading.H1(inlinesStyling, 1.dp, Color.Black, 2.dp, PaddingValues(4.dp)),
+                h2 = MarkdownStyling.Heading.H2(inlinesStyling, 1.dp, Color.Black, 2.dp, PaddingValues(4.dp)),
+                h3 = MarkdownStyling.Heading.H3(inlinesStyling, 1.dp, Color.Black, 2.dp, PaddingValues(4.dp)),
+                h4 = MarkdownStyling.Heading.H4(inlinesStyling, 1.dp, Color.Black, 2.dp, PaddingValues(4.dp)),
+                h5 = MarkdownStyling.Heading.H5(inlinesStyling, 1.dp, Color.Black, 2.dp, PaddingValues(4.dp)),
+                h6 = MarkdownStyling.Heading.H6(inlinesStyling, 1.dp, Color.Black, 2.dp, PaddingValues(4.dp)),
+            ),
+        blockQuote =
+            MarkdownStyling.BlockQuote(
+                padding = PaddingValues(4.dp),
+                lineWidth = 2.dp,
+                lineColor = Color.Gray,
+                pathEffect = null,
+                strokeCap = StrokeCap.Square,
+                textColor = Color.Black,
+            ),
+        code =
+            MarkdownStyling.Code(
+                indented =
+                    MarkdownStyling.Code.Indented(
+                        editorTextStyle = TextStyle.Default.copy(fontSize = CODE_TEXT_SIZE.sp),
+                        padding = PaddingValues(4.dp),
+                        shape = RectangleShape,
+                        background = Color.LightGray,
+                        borderWidth = 0.dp,
+                        borderColor = Color.DarkGray,
+                        fillWidth = true,
+                        scrollsHorizontally = true,
+                    ),
+                fenced =
+                    MarkdownStyling.Code.Fenced(
+                        editorTextStyle = TextStyle.Default.copy(fontSize = CODE_TEXT_SIZE.sp),
+                        padding = PaddingValues(4.dp),
+                        shape = RectangleShape,
+                        background = Color.LightGray,
+                        borderWidth = 0.dp,
+                        borderColor = Color.DarkGray,
+                        fillWidth = true,
+                        scrollsHorizontally = true,
+                        infoTextStyle = TextStyle.Default,
+                        infoPadding = PaddingValues(2.dp),
+                        infoPosition = MarkdownStyling.Code.Fenced.InfoPosition.TopStart,
+                    ),
+            ),
+        list =
+            MarkdownStyling.List(
+                ordered =
+                    MarkdownStyling.List.Ordered(
+                        numberStyle = TextStyle.Default,
+                        numberContentGap = 1.dp,
+                        numberMinWidth = 2.dp,
+                        numberTextAlign = TextAlign.Start,
+                        itemVerticalSpacing = 4.dp,
+                        itemVerticalSpacingTight = 2.dp,
+                        padding = PaddingValues(4.dp),
+                        numberFormatStyles =
+                            MarkdownStyling.List.Ordered.NumberFormatStyles(firstLevel = NumberFormatStyle.Decimal),
+                    ),
+                unordered =
+                    MarkdownStyling.List.Unordered(
+                        bullet = '.',
+                        bulletStyle = TextStyle.Default,
+                        bulletContentGap = 1.dp,
+                        itemVerticalSpacing = 4.dp,
+                        itemVerticalSpacingTight = 2.dp,
+                        padding = PaddingValues(4.dp),
+                        markerMinWidth = 16.dp,
+                        bulletCharStyles = BulletCharStyles(),
+                    ),
+            ),
+        image =
+            MarkdownStyling.Image(
+                alignment = Alignment.Center,
+                contentScale = ContentScale.Crop,
+                padding = PaddingValues(8.dp),
+                shape = RectangleShape,
+                background = Color.Transparent,
+                borderWidth = 1.dp,
+                borderColor = Color.LightGray,
+            ),
+        thematicBreak =
+            MarkdownStyling.ThematicBreak(padding = PaddingValues(4.dp), lineWidth = 2.dp, lineColor = Color.DarkGray),
+        htmlBlock =
+            MarkdownStyling.HtmlBlock(
+                textStyle = TextStyle.Default,
+                padding = PaddingValues(4.dp),
+                shape = RectangleShape,
+                background = Color.White,
+                borderWidth = 1.dp,
+                borderColor = Color.Gray,
+                fillWidth = true,
+            ),
+    )
+}
+
+public const val CODE_TEXT_SIZE: Int = 10

--- a/platform/jewel/markdown/extensions/images/BUILD.bazel
+++ b/platform/jewel/markdown/extensions/images/BUILD.bazel
@@ -114,6 +114,8 @@ jvm_library(
     "@lib//:jetbrains-annotations",
     "//platform/jewel/markdown/core",
     "//platform/jewel/markdown/core:core_test_lib",
+    "//platform/jewel/markdown/core:jewel-markdown-core-tests",
+    "//platform/jewel/markdown/core:jewel-markdown-core-tests_test_lib",
     "//platform/jewel/ui",
     "//platform/jewel/ui:ui_test_lib",
     "//platform/jewel/foundation",

--- a/platform/jewel/markdown/extensions/images/build.gradle.kts
+++ b/platform/jewel/markdown/extensions/images/build.gradle.kts
@@ -11,8 +11,10 @@ dependencies {
     api(libs.coil.svg)
 
     implementation(projects.markdown.core)
+    implementation(projects.ui)
     runtimeOnly(libs.ktor.client.java)
     testImplementation(libs.coil.test)
     testImplementation(compose.desktop.uiTestJUnit4)
     testImplementation(compose.desktop.currentOs) { exclude(group = "org.jetbrains.compose.material") }
+    testImplementation(testFixtures(projects.markdown.core))
 }

--- a/platform/jewel/markdown/extensions/images/intellij.platform.jewel.markdown.extensions.images.tests.iml
+++ b/platform/jewel/markdown/extensions/images/intellij.platform.jewel.markdown.extensions.images.tests.iml
@@ -32,6 +32,7 @@
     <orderEntry type="library" scope="TEST" name="jetbrains-annotations" level="project" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="intellij.platform.jewel.markdown.core" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.platform.jewel.markdown.core.tests" scope="TEST" />
     <orderEntry type="module" module-name="intellij.platform.jewel.ui" scope="TEST" />
     <orderEntry type="module" module-name="intellij.platform.jewel.foundation" scope="TEST" />
     <orderEntry type="module" module-name="intellij.libraries.coil" scope="TEST" />

--- a/platform/jewel/markdown/extensions/images/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImplTest.kt
+++ b/platform/jewel/markdown/extensions/images/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImplTest.kt
@@ -1,10 +1,16 @@
 // Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package org.jetbrains.jewel.markdown.extensions.images
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertWidthIsAtLeast
@@ -12,6 +18,7 @@ import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import coil3.ColorImage
@@ -22,19 +29,32 @@ import coil3.decode.DataSource
 import coil3.request.ErrorResult
 import coil3.request.SuccessResult
 import coil3.test.FakeImageLoaderEngine
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.markdown.InlineMarkdown
+import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
+import org.jetbrains.jewel.markdown.createMarkdownStyling
+import org.jetbrains.jewel.markdown.createThemeDefinition
+import org.jetbrains.jewel.markdown.rendering.DOWNSCALED_INLINE_CONTENT_TAG
+import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
+import org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
+import org.jetbrains.jewel.ui.component.Text as JewelText
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalCoilApi::class)
+@OptIn(ExperimentalCoilApi::class, ExperimentalJewelApi::class)
 public class Coil3ImageRendererExtensionImplTest {
     @get:Rule public val composeTestRule: ComposeContentTestRule = createComposeRule()
 
     private val platformContext: PlatformContext = PlatformContext.INSTANCE
     private val imageUrl = "https://example.com/image.png"
+    private val imageUrl2 = "https://example.com/image2.png"
 
     @Test
     public fun `image renders with correct size on success`() {
@@ -92,7 +112,7 @@ public class Coil3ImageRendererExtensionImplTest {
                 .intercept(
                     predicate = { it == imageUrl },
                     interceptor = {
-                        delay(500) // simulating network delay
+                        delay(500.milliseconds) // simulating network delay
 
                         SuccessResult(fakeImage, it.request, DataSource.MEMORY)
                     },
@@ -123,6 +143,365 @@ public class Coil3ImageRendererExtensionImplTest {
             .assertHeightIsAtLeast(fakeImageHeight.dp)
     }
 
+    @Test
+    public fun `single image wider than container is downscaled to fit available width`() {
+        val fakeImageWidth = 300
+        val fakeImageHeight = 200
+        val containerWidth = 100
+        val fakeImage = ColorImage(Color.Blue.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph = Paragraph(InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"))
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        // The image should be scaled down to fit the container width
+        // Scale factor = 100 / 300 = 0.333...
+        // Expected height = 200 * 0.333... = 66.67
+        val expectedHeight = (fakeImageHeight * containerWidth / fakeImageWidth)
+        composeTestRule
+            .onNodeWithContentDescription("HUGE image")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(expectedHeight.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
+    @Test
+    public fun `single image narrower than container is not upscaled`() {
+        val fakeImageWidth = 50
+        val fakeImageHeight = 30
+        val containerWidth = 200
+        val fakeImage = ColorImage(Color.Green.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph = Paragraph(InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "smol image"))
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        // The image should remain at its original size, not upscaled
+        composeTestRule
+            .onNodeWithContentDescription("smol image")
+            .assertExists()
+            .assertWidthIsEqualTo(fakeImageWidth.dp)
+            .assertHeightIsEqualTo(fakeImageHeight.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
+    @Test
+    public fun `text with leading image is downscaled when container is narrow`() {
+        val fakeImageWidth = 200
+        val fakeImageHeight = 100
+        val containerWidth = 100
+        val fakeImage = ColorImage(Color.Red.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"),
+                InlineMarkdown.Text(" and then some!"),
+            )
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        val expectedHeight = (fakeImageHeight * containerWidth / fakeImageWidth)
+        composeTestRule
+            .onNodeWithContentDescription("HUGE image")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(expectedHeight.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
+    @Test
+    public fun `text with trailing image is downscaled when container is narrow`() {
+        val fakeImageWidth = 200
+        val fakeImageHeight = 100
+        val containerWidth = 100
+        val fakeImage = ColorImage(Color.Blue.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Text("Behold the "),
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"),
+            )
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        val expectedHeight = (fakeImageHeight * containerWidth / fakeImageWidth)
+        composeTestRule
+            .onNodeWithContentDescription("HUGE image")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(expectedHeight.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
+    @Test
+    public fun `image between text is downscaled when container is narrow`() {
+        val fakeImageWidth = 200
+        val fakeImageHeight = 100
+        val containerWidth = 100
+        val fakeImage = ColorImage(Color.Green.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Text("Behold, the "),
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"),
+                InlineMarkdown.Text("!!!"),
+            )
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        val expectedHeight = (fakeImageHeight * containerWidth / fakeImageWidth)
+        composeTestRule
+            .onNodeWithContentDescription("HUGE image")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(expectedHeight.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
+    @Test
+    public fun `images don't affect the min intrinsic width of paragraph`() {
+        val fakeImageWidth = 200
+        val fakeImageHeight = 100
+        val fakeImage = ColorImage(Color.Yellow.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Text("Prefix "),
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Intrinsic image"),
+                InlineMarkdown.Text("followedbyanincrediblelonguninterrupredsequenceofwords"),
+            )
+
+        var paragraphMinWidth = -1
+        var textMinWidth = -1
+
+        composeTestRule.setContent {
+            JewelTheme(createThemeDefinition()) {
+                val imageExtension = Coil3ImageRendererExtension(imageLoader)
+                val markdownStyling = createMarkdownStyling()
+                val blockRenderer =
+                    DefaultMarkdownBlockRenderer(
+                        rootStyling = markdownStyling,
+                        rendererExtensions = listOf(imageExtension),
+                        inlineRenderer = DefaultInlineMarkdownRenderer(listOf(imageExtension)),
+                    )
+
+                Column {
+                    Box(
+                        modifier =
+                            Modifier.width(IntrinsicSize.Min).onGloballyPositioned { paragraphMinWidth = it.size.width }
+                    ) {
+                        blockRenderer.RenderParagraph(
+                            block = paragraph,
+                            styling = markdownStyling.paragraph,
+                            enabled = true,
+                            onUrlClick = {},
+                            modifier = Modifier,
+                        )
+                    }
+
+                    Box(
+                        modifier =
+                            Modifier.width(IntrinsicSize.Min).onGloballyPositioned { textMinWidth = it.size.width }
+                    ) {
+                        JewelText(
+                            text =
+                                buildAnnotatedString {
+                                    append("Prefix followedbyanincrediblelonguninterrupredsequenceofwords")
+                                },
+                            style = markdownStyling.paragraph.inlinesStyling.textStyle,
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertTrue("Expected the paragraph min intrinsic width to be positive.", paragraphMinWidth > 0)
+            assertEquals(textMinWidth, paragraphMinWidth)
+        }
+    }
+
+    @Test
+    public fun `two images in paragraph are both downscaled when container is narrow`() {
+        val fakeImage1Width = 200
+        val fakeImage1Height = 100
+        val fakeImage2Width = 300
+        val fakeImage2Height = 150
+        val containerWidth = 100
+
+        val fakeImage1 = ColorImage(Color.Red.toArgb(), width = fakeImage1Width, height = fakeImage1Height)
+        val fakeImage2 = ColorImage(Color.Blue.toArgb(), width = fakeImage2Width, height = fakeImage2Height)
+
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept({ it == imageUrl }, fakeImage1)
+                .intercept({ it == imageUrl2 }, fakeImage2)
+                .build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text 1", title = "First image"),
+                InlineMarkdown.Text(" text between "),
+                InlineMarkdown.Image(source = imageUrl2, alt = "Alt text 2", title = "Second image"),
+            )
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        val expectedHeight1 = (fakeImage1Height * containerWidth / fakeImage1Width)
+        val expectedHeight2 = (fakeImage2Height * containerWidth / fakeImage2Width)
+
+        composeTestRule
+            .onNodeWithContentDescription("First image")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(expectedHeight1.dp)
+
+        composeTestRule
+            .onNodeWithContentDescription("Second image")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(expectedHeight2.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
+    @Test
+    public fun `text only paragraph uses fast path without scaling logic`() {
+        val containerWidth = 100
+
+        // Create an empty engine since we don't expect any image loading
+        val engine = FakeImageLoaderEngine.Builder().build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph = Paragraph(InlineMarkdown.Text("Just plain text without any images"))
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    public fun `zero width image does not render and composition goes fast path`() {
+        // Tests that zero-width images trigger the fast path: placeholderWidths.sum() <= 0.01f
+        val fakeImageWidth = 0
+        val fakeImageHeight = 100
+        val containerWidth = 50
+        val fakeImage = ColorImage(Color.Cyan.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Text("Zero width: "),
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Zero width image"),
+            )
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        // Fast path: SubcomposeLayout is NOT used for zero-width images
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    public fun `first image fits but second image needs downscaling`() {
+        val fakeImage1Width = 80 // Fits in container
+        val fakeImage1Height = 60
+        val fakeImage2Width = 200 // Needs downscaling
+        val fakeImage2Height = 100
+        val containerWidth = 100
+
+        val fakeImage1 = ColorImage(Color.Green.toArgb(), width = fakeImage1Width, height = fakeImage1Height)
+        val fakeImage2 = ColorImage(Color.Red.toArgb(), width = fakeImage2Width, height = fakeImage2Height)
+
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept({ it == imageUrl }, fakeImage1)
+                .intercept({ it == imageUrl2 }, fakeImage2)
+                .build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text 1", title = "smol image"),
+                InlineMarkdown.Text(" and "),
+                InlineMarkdown.Image(source = imageUrl2, alt = "Alt text 2", title = "beeg image"),
+            )
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        // First image should keep original size (fits in container)
+        composeTestRule
+            .onNodeWithContentDescription("smol image")
+            .assertExists()
+            .assertWidthIsEqualTo(fakeImage1Width.dp)
+            .assertHeightIsEqualTo(fakeImage1Height.dp)
+
+        // Second image should be downscaled
+        val downscaledImage2Height = (fakeImage2Height * containerWidth / fakeImage2Width)
+        composeTestRule
+            .onNodeWithContentDescription("beeg image")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(downscaledImage2Height.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
+    @Test
+    public fun `image barely exceeding container width is scaled without rounding errors`() {
+        val fakeImageWidth = 101
+        val fakeImageHeight = 100
+        val containerWidth = 100
+        val fakeImage = ColorImage(Color.Magenta.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
+
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Text("Edge case: "),
+                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Barely oversized"),
+            )
+
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
+
+        // Scale factor = 100 / 101 ≈ 0.99
+        // Expected height = 100 * (100 / 101) ≈ 99
+        val expectedHeightRounded = 99
+        composeTestRule
+            .onNodeWithContentDescription("Barely oversized")
+            .assertExists()
+            .assertWidthIsEqualTo(containerWidth.dp)
+            .assertHeightIsEqualTo(expectedHeightRounded.dp)
+
+        composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
+    }
+
     private fun setContent(extension: Coil3ImageRendererExtensionImpl, image: InlineMarkdown.Image) {
         composeTestRule.setContent {
             val inlineContent = buildMap { extension.renderImageContent(image)?.let { put("inlineTextContent", it) } }
@@ -131,6 +510,34 @@ public class Coil3ImageRendererExtensionImplTest {
                 appendInlineContent("inlineTextContent", "[rendered image]")
             }
             BasicText(text = annotatedString, inlineContent = inlineContent)
+        }
+    }
+
+    private fun setConstrainedContentWithParagraph(
+        imageLoader: ImageLoader,
+        paragraph: Paragraph,
+        containerWidthDp: Int,
+    ) {
+        composeTestRule.setContent {
+            JewelTheme(createThemeDefinition()) {
+                val imageExtension = Coil3ImageRendererExtension(imageLoader)
+                val markdownStyling = createMarkdownStyling()
+                val blockRenderer =
+                    DefaultMarkdownBlockRenderer(
+                        rootStyling = markdownStyling,
+                        rendererExtensions = listOf(imageExtension),
+                        inlineRenderer = DefaultInlineMarkdownRenderer(listOf(imageExtension)),
+                    )
+                Box(modifier = Modifier.width(containerWidthDp.dp)) {
+                    blockRenderer.RenderParagraph(
+                        block = paragraph,
+                        styling = markdownStyling.paragraph,
+                        enabled = true,
+                        onUrlClick = {},
+                        modifier = Modifier,
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This is achieved by splitting paragraphs and headings by images and rendering them in a FlowRow as separate composables. Paragraphs and headings without images are rendered as a single Text composable, like before.

There are two notable changes:
  - `ScalableImage` is introduced. This is an `Image` composed in a custom `Layout` that takes care of adjusting height according to the current downscaling factor.
  - Text with images is split into separate composables (see above).

Pros:
  - It doesn't increase complexity and doesn't affect performance for previously supported cases: text without images, images without text.
  - It doesn't add additional subcompositions.

Cons:
  - If text surrounds an image from both sides, this text will be copied with a line break in place of the image. It can break

Possible alternatives:
  - Wrap an image in a `BoxWithConstraints`. It would limit Markdown extensions rendering a lot, as it prohibits possible containers to measure themselves by using children's intrinsics. Note that `FlowRow` doesn't cause such a problem because it defines custom intrinsic measurement (see `FlowMeasurePolicy`).
  - Custom `SubcomposeLayout` with a custom intrinsic measurement instead of a `FlowRow`. `FlowRow` downscales an image properly, but it keeps the reserved vertical space, so other content is rendered far enough as if the image were unscaled. While theoretically possible, that would be too challenging to implement, and maybe not immensely required for our case -- images right in-between text shouldn't be a common practice.

## Examples


https://github.com/user-attachments/assets/c8fff00c-2f9b-4e9d-b746-81e2309ade26



https://github.com/user-attachments/assets/a398c508-e8a8-453b-8044-fa59e84ddc49

https://github.com/user-attachments/assets/d35ff9d1-efd0-4cf0-8256-082bcc615cfa


## Release notes

### Bug fixes
 * **JEWEL-1138** Scale images to fit available width and adjust vertical space

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Compose text/layout measurement to dynamically scale inline image placeholders, which can affect rendering and intrinsic sizing in tables and other constrained containers. Adds/rewires test infrastructure and new UI tests to validate sizing behavior across many edge cases.
> 
> **Overview**
> Adds automatic *downscaling* for inline markdown images when the available width is smaller than the image placeholder, so images fit their container and vertical space matches the scaled size.
> 
> `DefaultMarkdownBlockRenderer` now routes paragraph/heading inline rendering through a new `TextWithScalableInlineContent` path that uses `SubcomposeLayout` plus custom intrinsics (with a fast path for no/zero-width images), and exposes `DOWNSCALED_INLINE_CONTENT_TAG` for testing.
> 
> Build/test wiring is updated to introduce `core` test fixtures (`java-test-fixtures`, Bazel/IML src roots) and share a common `TestTheme`; the images extension adds a dependency on these fixtures and expands its Coil tests to cover downscaling, non-upscaling, intrinsic-width behavior, and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8e21f24730fd1549e1bd937aed02741fce99e21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->