### PR TITLE
[JEWEL-1228] Add CornerSize and Padding to BannerMetrics

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeBanner.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeBanner.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.jewel.bridge.theme
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.ui.unit.dp
 import com.intellij.util.ui.JBUI
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.ui.component.styling.BannerColors
@@ -18,7 +21,7 @@ internal fun readDefaultBannerStyle(): DefaultBannerStyles =
                         background = JBUI.CurrentTheme.Banner.INFO_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.INFO_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
         success =
             DefaultBannerStyle(
@@ -27,7 +30,7 @@ internal fun readDefaultBannerStyle(): DefaultBannerStyles =
                         background = JBUI.CurrentTheme.Banner.SUCCESS_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.SUCCESS_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
         warning =
             DefaultBannerStyle(
@@ -36,7 +39,7 @@ internal fun readDefaultBannerStyle(): DefaultBannerStyles =
                         background = JBUI.CurrentTheme.Banner.WARNING_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.WARNING_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
         error =
             DefaultBannerStyle(
@@ -45,7 +48,7 @@ internal fun readDefaultBannerStyle(): DefaultBannerStyles =
                         background = JBUI.CurrentTheme.Banner.ERROR_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.ERROR_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
     )
 
@@ -58,7 +61,7 @@ internal fun readInlineBannerStyle(): InlineBannerStyles =
                         background = JBUI.CurrentTheme.Banner.INFO_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.INFO_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
         success =
             InlineBannerStyle(
@@ -67,7 +70,7 @@ internal fun readInlineBannerStyle(): InlineBannerStyles =
                         background = JBUI.CurrentTheme.Banner.SUCCESS_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.SUCCESS_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
         warning =
             InlineBannerStyle(
@@ -76,7 +79,7 @@ internal fun readInlineBannerStyle(): InlineBannerStyles =
                         background = JBUI.CurrentTheme.Banner.WARNING_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.WARNING_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
         error =
             InlineBannerStyle(
@@ -85,6 +88,13 @@ internal fun readInlineBannerStyle(): InlineBannerStyles =
                         background = JBUI.CurrentTheme.Banner.ERROR_BACKGROUND.toComposeColor(),
                         border = JBUI.CurrentTheme.Banner.ERROR_BORDER_COLOR.toComposeColor(),
                     ),
-                metrics = BannerMetrics(borderWidth = borderWidth),
+                metrics = BannerMetrics.defaultBannerMetrics(),
             ),
+    )
+
+private fun BannerMetrics.Companion.defaultBannerMetrics() =
+    BannerMetrics(
+        borderWidth,
+        CornerSize(8.dp), // Swing uses arc diameter of 16, which is radius of 8
+        PaddingValues(vertical = 12.dp, horizontal = 12.dp), // Swing uses JBUI.Borders.empty(12)
     )

--- a/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
@@ -46,6 +46,8 @@ f:org.jetbrains.jewel.intui.standalone.StandalonePainterHintsProvider$Companion
 f:org.jetbrains.jewel.intui.standalone.styling.IntUIBannerStylingKt
 - sf:default-3ABfNKs(org.jetbrains.jewel.ui.component.styling.BannerMetrics$Companion,F):org.jetbrains.jewel.ui.component.styling.BannerMetrics
 - bs:default-3ABfNKs$default(org.jetbrains.jewel.ui.component.styling.BannerMetrics$Companion,F,I,java.lang.Object):org.jetbrains.jewel.ui.component.styling.BannerMetrics
+- sf:default-ziNgDLE(org.jetbrains.jewel.ui.component.styling.BannerMetrics$Companion,F,androidx.compose.foundation.shape.CornerSize,androidx.compose.foundation.layout.PaddingValues):org.jetbrains.jewel.ui.component.styling.BannerMetrics
+- bs:default-ziNgDLE$default(org.jetbrains.jewel.ui.component.styling.BannerMetrics$Companion,F,androidx.compose.foundation.shape.CornerSize,androidx.compose.foundation.layout.PaddingValues,I,java.lang.Object):org.jetbrains.jewel.ui.component.styling.BannerMetrics
 - sf:getDefault(org.jetbrains.jewel.ui.component.styling.DefaultBannerStyles$Companion):org.jetbrains.jewel.intui.standalone.styling.IntUiDefaultBannerStylesFactory
 - sf:getDefault(org.jetbrains.jewel.ui.component.styling.InlineBannerStyles$Companion):org.jetbrains.jewel.intui.standalone.styling.IntUiInlineBannerStylesFactory
 - sf:getError(org.jetbrains.jewel.ui.component.styling.BannerColors$Companion):org.jetbrains.jewel.intui.standalone.styling.IntUiErrorBannerColorFactory

--- a/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-0.37.0.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-0.37.0.txt
@@ -110,7 +110,8 @@ package org.jetbrains.jewel.intui.standalone.bundle {
 package org.jetbrains.jewel.intui.standalone.styling {
 
   public final class IntUIBannerStylingKt {
-    method public static org.jetbrains.jewel.ui.component.styling.BannerMetrics default(org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion, optional float borderWidth);
+    method @Deprecated public static org.jetbrains.jewel.ui.component.styling.BannerMetrics default(org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion, optional float borderWidth);
+    method public static org.jetbrains.jewel.ui.component.styling.BannerMetrics default(org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion, optional float borderWidth, optional androidx.compose.foundation.shape.CornerSize cornerSize, optional androidx.compose.foundation.layout.PaddingValues paddingValues);
     method public static org.jetbrains.jewel.intui.standalone.styling.IntUiDefaultBannerStylesFactory getDefault(org.jetbrains.jewel.ui.component.styling.DefaultBannerStyles.Companion);
     method public static org.jetbrains.jewel.intui.standalone.styling.IntUiInlineBannerStylesFactory getDefault(org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.Companion);
     method public static org.jetbrains.jewel.intui.standalone.styling.IntUiErrorBannerColorFactory getError(org.jetbrains.jewel.ui.component.styling.BannerColors.Companion);

--- a/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-stable-0.37.0.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-stable-0.37.0.txt
@@ -92,7 +92,8 @@ package org.jetbrains.jewel.intui.standalone {
 package org.jetbrains.jewel.intui.standalone.styling {
 
   public final class IntUIBannerStylingKt {
-    method public static org.jetbrains.jewel.ui.component.styling.BannerMetrics default(org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion, optional float borderWidth);
+    method @Deprecated public static org.jetbrains.jewel.ui.component.styling.BannerMetrics default(org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion, optional float borderWidth);
+    method public static org.jetbrains.jewel.ui.component.styling.BannerMetrics default(org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion, optional float borderWidth, optional androidx.compose.foundation.shape.CornerSize cornerSize, optional androidx.compose.foundation.layout.PaddingValues paddingValues);
     method public static org.jetbrains.jewel.intui.standalone.styling.IntUiDefaultBannerStylesFactory getDefault(org.jetbrains.jewel.ui.component.styling.DefaultBannerStyles.Companion);
     method public static org.jetbrains.jewel.intui.standalone.styling.IntUiInlineBannerStylesFactory getDefault(org.jetbrains.jewel.ui.component.styling.InlineBannerStyles.Companion);
     method public static org.jetbrains.jewel.intui.standalone.styling.IntUiErrorBannerColorFactory getError(org.jetbrains.jewel.ui.component.styling.BannerColors.Companion);

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUIBannerStyling.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUIBannerStyling.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.jewel.intui.standalone.styling
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -183,7 +185,18 @@ public object IntUiInlineBannerStylesFactory {
         InlineBannerStyles(information = information, success = success, warning = warning, error = error)
 }
 
-public fun BannerMetrics.Companion.default(borderWidth: Dp = 1.dp): BannerMetrics = BannerMetrics(borderWidth)
+@Deprecated(
+    "Use the `default()` function with `cornerSize` and `paddingValues`",
+    replaceWith = ReplaceWith("default(borderWidth, cornerSize = TODO(), paddingValues = TODO())"),
+)
+public fun BannerMetrics.Companion.default(borderWidth: Dp = 1.dp): BannerMetrics =
+    BannerMetrics(borderWidth, CornerSize(8.dp), PaddingValues(12.dp))
+
+public fun BannerMetrics.Companion.default(
+    borderWidth: Dp = 1.dp,
+    cornerSize: CornerSize = CornerSize(8.dp),
+    paddingValues: PaddingValues = PaddingValues(12.dp),
+): BannerMetrics = BannerMetrics(borderWidth, cornerSize, paddingValues)
 
 // region Inline Information Banner
 public val InlineBannerStyle.Companion.Information: IntUiInlineInformationBannerStyleFactory

--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
@@ -166,6 +166,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 }
 
                 InlineInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     title = optionalTitle,
                     icon = null,
@@ -173,6 +174,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 )
 
                 InlineInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     title = optionalTitle,
                     icon = null,
                     iconActions = {
@@ -202,6 +204,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 }
 
                 InlineInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     title = optionalTitle,
                     icon = null,
                     iconActions = { iconAction(AllIconsKeys.General.Refresh, "Restart", onClick = { restart += 1 }) },
@@ -210,6 +213,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 )
 
                 InlineInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     icon = null,
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
@@ -236,6 +240,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 )
 
                 InlineInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     title = optionalTitle,
                     icon = null,
@@ -254,12 +259,14 @@ public fun Banners(modifier: Modifier = Modifier) {
                 )
 
                 InlineInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     title = optionalTitle,
                     linkActions = null,
                     style = JewelTheme.inlineBannerStyle.information,
                 )
                 InlineErrorBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.inlineBannerStyle.error,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     title = optionalTitle,
@@ -272,6 +279,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                     },
                 )
                 InlineInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.inlineBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     title = optionalTitle,
@@ -281,6 +289,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                     },
                 )
                 InlineSuccessBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.inlineBannerStyle.success,
                     text = LONG_IPSUM,
                     title = optionalTitle,
@@ -312,6 +321,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                     },
                 )
                 InlineWarningBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.inlineBannerStyle.warning,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     title = optionalTitle,

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -988,6 +988,8 @@ f:org.jetbrains.jewel.ui.component.styling.BannerMetrics
 - sf:Companion:org.jetbrains.jewel.ui.component.styling.BannerMetrics$Companion
 - equals(java.lang.Object):Z
 - f:getBorderWidth-D9Ej5fM():F
+- f:getCornerSize():androidx.compose.foundation.shape.CornerSize
+- f:getPadding():androidx.compose.foundation.layout.PaddingValues
 - hashCode():I
 f:org.jetbrains.jewel.ui.component.styling.BannerMetrics$Companion
 f:org.jetbrains.jewel.ui.component.styling.BannerStylingKt

--- a/platform/jewel/ui/metalava/ui-api-0.37.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-0.37.0.txt
@@ -1079,8 +1079,13 @@ package org.jetbrains.jewel.ui.component.styling {
   }
 
   @androidx.compose.runtime.Stable @org.jetbrains.jewel.foundation.GenerateDataFunctions public final class BannerMetrics {
-    ctor @KotlinOnly public BannerMetrics(androidx.compose.ui.unit.Dp borderWidth);
+    ctor @KotlinOnly @Deprecated public BannerMetrics(androidx.compose.ui.unit.Dp borderWidth);
+    ctor @KotlinOnly public BannerMetrics(androidx.compose.ui.unit.Dp borderWidth, androidx.compose.foundation.shape.CornerSize cornerSize, androidx.compose.foundation.layout.PaddingValues padding);
+    method public androidx.compose.foundation.shape.CornerSize getCornerSize();
+    method public androidx.compose.foundation.layout.PaddingValues getPadding();
     property public androidx.compose.ui.unit.Dp borderWidth;
+    property public androidx.compose.foundation.shape.CornerSize cornerSize;
+    property public androidx.compose.foundation.layout.PaddingValues padding;
     field public static final org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion Companion;
   }
 

--- a/platform/jewel/ui/metalava/ui-api-stable-0.37.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-stable-0.37.0.txt
@@ -963,8 +963,13 @@ package org.jetbrains.jewel.ui.component.styling {
   }
 
   @androidx.compose.runtime.Stable @org.jetbrains.jewel.foundation.GenerateDataFunctions public final class BannerMetrics {
-    ctor @KotlinOnly public BannerMetrics(androidx.compose.ui.unit.Dp borderWidth);
+    ctor @KotlinOnly @Deprecated public BannerMetrics(androidx.compose.ui.unit.Dp borderWidth);
+    ctor @KotlinOnly public BannerMetrics(androidx.compose.ui.unit.Dp borderWidth, androidx.compose.foundation.shape.CornerSize cornerSize, androidx.compose.foundation.layout.PaddingValues padding);
+    method public androidx.compose.foundation.shape.CornerSize getCornerSize();
+    method public androidx.compose.foundation.layout.PaddingValues getPadding();
     property public androidx.compose.ui.unit.Dp borderWidth;
+    property public androidx.compose.foundation.shape.CornerSize cornerSize;
+    property public androidx.compose.foundation.layout.PaddingValues padding;
     field public static final org.jetbrains.jewel.ui.component.styling.BannerMetrics.Companion Companion;
   }
 

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
@@ -16,25 +16,26 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.annotations.Nls
-import org.jetbrains.jewel.foundation.modifier.thenIf
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.ui.component.banner.BannerActionsRow
@@ -44,6 +45,9 @@ import org.jetbrains.jewel.ui.component.banner.BannerLinkActionScope
 import org.jetbrains.jewel.ui.component.styling.InlineBannerStyle
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.theme.inlineBannerStyle
+
+private const val BANNER_ICON_SIZE = 16
+private const val BANNER_CONTENT_SPACING = 8
 
 /**
  * Displays an informational inline banner providing subtle, non-intrusive context or feedback.
@@ -1222,46 +1226,121 @@ private fun InlineBannerImpl(
     content: @Composable (() -> Unit),
 ) {
     val borderColor = style.colors.border
+    val layoutDirection = LocalLayoutDirection.current
+    val originalPadding = style.metrics.padding
+
+    val endPadding = if (actionIcons != null) 0.dp else originalPadding.calculateEndPadding(layoutDirection)
+    val adjustedPadding =
+        PaddingValues(
+            start = originalPadding.calculateStartPadding(layoutDirection),
+            top = originalPadding.calculateTopPadding(),
+            bottom = originalPadding.calculateBottomPadding(),
+            end = endPadding,
+        )
+
     RoundedCornerBox(
         modifier = modifier.testTag("InlineBanner"),
         borderColor = borderColor,
         backgroundColor = style.colors.background,
         contentColor = JewelTheme.contentColor,
-        borderWidth = 1.dp,
-        cornerSize = CornerSize(8.dp),
-        padding = PaddingValues(),
+        borderWidth = style.metrics.borderWidth,
+        cornerSize = style.metrics.cornerSize,
+        padding = adjustedPadding,
     ) {
-        Row(modifier = Modifier.padding(start = 12.dp)) {
-            if (icon != null) {
-                Box(modifier = Modifier.padding(top = 12.dp, bottom = 12.dp).size(16.dp)) { icon() }
-                Spacer(Modifier.width(8.dp))
-            }
+        SubcomposeLayout { constraints ->
+            val spacingPx = BANNER_CONTENT_SPACING.dp.roundToPx()
 
-            Column(
-                modifier =
-                    Modifier.weight(1f)
-                        .padding(top = 12.dp, bottom = 12.dp) // kftmt plz behave
-                        .thenIf(actionIcons == null) { padding(end = 12.dp) }
-            ) {
-                if (title != null) {
-                    Text(text = title, style = textStyle, fontWeight = Bold)
-                    Spacer(Modifier.height(8.dp))
-                }
-                content()
+            val unconstrained = constraints.copy(minWidth = 0)
+            val actionIconsPlaceables =
+                subcompose("actionIcons") {
+                        if (actionIcons != null) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) { actionIcons() }
+                        }
+                    }
+                    .map { it.measure(unconstrained) }
+            val actionIconsWidth = actionIconsPlaceables.maxOfOrNull { it.width } ?: 0
 
-                if (actions != null) {
-                    Spacer(Modifier.height(8.dp))
-                    FlowRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) { actions() }
-                }
-            }
+            val iconPlaceables =
+                subcompose("icon") {
+                        if (icon != null) {
+                            Box(modifier = Modifier.size(BANNER_ICON_SIZE.dp)) { icon() }
+                        }
+                    }
+                    .map { it.measure(unconstrained) }
+            val iconWidth = iconPlaceables.firstOrNull()?.width ?: 0
+            val iconHeight = iconPlaceables.firstOrNull()?.height ?: 0
 
-            if (actionIcons != null) {
-                Spacer(Modifier.width(8.dp))
-                Row(
-                    modifier = Modifier.align(Alignment.Top).padding(top = 8.dp, end = 8.dp, bottom = 8.dp),
-                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                ) {
-                    actionIcons()
+            // Calculate width available for the main content column
+            // Total - Icon - Spacing
+            val startOffset = if (iconWidth > 0) iconWidth + spacingPx else 0
+            val contentAvailableWidth = (constraints.maxWidth - startOffset).coerceAtLeast(0)
+
+            // Text MUST respect Action Icons (i.e, subtract their width)
+            val textConstraints =
+                constraints.copy(minWidth = 0, maxWidth = (contentAvailableWidth - actionIconsWidth).coerceAtLeast(0))
+            val textPlaceables =
+                subcompose("text") {
+                        Column {
+                            if (title != null) {
+                                Text(text = title, style = textStyle, fontWeight = Bold)
+                                Spacer(Modifier.height(BANNER_CONTENT_SPACING.dp))
+                            }
+                            content()
+                        }
+                    }
+                    .map { it.measure(textConstraints) }
+            val textHeight = textPlaceables.maxOfOrNull { it.height } ?: 0
+            val textWidth = textPlaceables.maxOfOrNull { it.width } ?: 0
+
+            // Link Actions must IGNORE Action Icons (use full available width)
+            // This allows buttons to render underneath the top-right icons
+            val linkConstraints = constraints.copy(minWidth = 0, maxWidth = contentAvailableWidth)
+            val linkPlaceables =
+                subcompose("links") {
+                        if (actions != null) {
+                            FlowRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) { actions() }
+                        }
+                    }
+                    .map { it.measure(linkConstraints) }
+            val linksHeight = linkPlaceables.maxOfOrNull { it.height } ?: 0
+            val linksWidth = linkPlaceables.maxOfOrNull { it.width } ?: 0
+
+            val contentHeight = textHeight + (if (linksHeight > 0) spacingPx else 0) + linksHeight
+            val totalHeight = maxOf(iconHeight, contentHeight)
+            val layoutHeight = totalHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
+            // calculating the width the banner actually wants to occupy, coerced to
+            // fit within the incoming minWidth/maxWidth constraints
+            val naturalWidth =
+                (startOffset + maxOf(textWidth + actionIconsWidth, linksWidth)).coerceIn(
+                    constraints.minWidth,
+                    constraints.maxWidth,
+                )
+
+            layout(naturalWidth, layoutHeight) {
+                iconPlaceables.forEach { it.placeRelative(0, 0) }
+
+                // Starts after icon
+                textPlaceables.forEach { it.placeRelative(startOffset, 0) }
+
+                // Starts after icon, below text
+                val linkY = textHeight + (if (linksHeight > 0) spacingPx else 0)
+                linkPlaceables.forEach { it.placeRelative(startOffset, linkY) }
+
+                if (actionIconsPlaceables.isNotEmpty()) {
+                    // We always offset the action icon to half the padding
+                    val topPaddingPx = adjustedPadding.calculateTopPadding().roundToPx()
+                    val halfPaddingTop = (originalPadding.calculateTopPadding().toPx() / 2).toInt()
+                    val halfPaddingEnd = (originalPadding.calculateEndPadding(layoutDirection).toPx() / 2).toInt()
+
+                    // Offset Logic:
+                    val yPos = halfPaddingTop - topPaddingPx
+
+                    actionIconsPlaceables.forEach { placeable ->
+                        // For the X calculation, naturalWidth is the edge (since we killed end padding)
+                        // Move left by icon width + half original padding
+                        val xPos = naturalWidth - placeable.width - halfPaddingEnd
+                        placeable.placeRelative(x = xPos, y = yPos)
+                    }
                 }
             }
         }
@@ -1286,7 +1365,8 @@ private fun RoundedCornerBox(
                 .border(borderWidth, borderColor, shape)
                 .background(backgroundColor, shape)
                 .clip(shape)
-                .padding(padding)
+                .padding(padding),
+        propagateMinConstraints = true,
     ) {
         CompositionLocalProvider(LocalContentColor provides contentColor) { content() }
     }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/BannerStyling.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/BannerStyling.kt
@@ -1,11 +1,14 @@
 package org.jetbrains.jewel.ui.component.styling
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 
 @Stable
@@ -170,21 +173,48 @@ public class BannerColors(public val background: Color, public val border: Color
     public companion object
 }
 
+/**
+ * Defines the geometric and spacing properties for a banner component.
+ *
+ * @param borderWidth The width of the banner's border stroke.
+ * @param cornerSize The corner radius applied to the banner's shape.
+ * @param padding The internal padding applied to the banner's content area.
+ */
 @Stable
 @GenerateDataFunctions
-public class BannerMetrics(public val borderWidth: Dp) {
+public class BannerMetrics(
+    public val borderWidth: Dp,
+    public val cornerSize: CornerSize,
+    public val padding: PaddingValues,
+) {
+    @Deprecated(
+        "Use the constructor with `cornerSize`  and `padding` parameters",
+        replaceWith = ReplaceWith("BannerMetrics(borderWidth, cornerSize = TODO(), padding = TODO())"),
+    )
+    public constructor(borderWidth: Dp) : this(borderWidth, CornerSize(8.dp), PaddingValues(12.dp))
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as BannerMetrics
 
-        return borderWidth == other.borderWidth
+        if (borderWidth != other.borderWidth) return false
+        if (cornerSize != other.cornerSize) return false
+        if (padding != other.padding) return false
+
+        return true
     }
 
-    override fun hashCode(): Int = borderWidth.hashCode()
+    override fun hashCode(): Int {
+        var result = borderWidth.hashCode()
+        result = 31 * result + cornerSize.hashCode()
+        result = 31 * result + padding.hashCode()
+        return result
+    }
 
-    override fun toString(): String = "BannerMetrics(borderWidth=$borderWidth)"
+    override fun toString(): String =
+        "BannerMetrics(" + "borderWidth=$borderWidth, " + "cornerSize=$cornerSize, " + "padding=$padding" + ")"
 
     public companion object
 }

--- a/plugins/devkit/intellij.devkit.compose/resources/messages/DevkitComposeBundle.properties
+++ b/plugins/devkit/intellij.devkit.compose/resources/messages/DevkitComposeBundle.properties
@@ -58,6 +58,16 @@ jewel.swing.editable.disabled=Editable + Disabled
 jewel.swing.text.areas=Text areas:
 jewel.swing.label=Swing
 jewel.compose.label=Compose
+jewel.inline.banners.label=Inline Banners
+jewel.swing.inline.banners=Swing inline banner
+jewel.compose.inline.banners=Compose inline banner
+jewel.banners.label=Banners
+jewel.swing.banners=Swing default banner
+jewel.compose.banners=Compose default banner
+jewel.swing.inline.banner.action.a="Action A
+jewel.swing.inline.banner.action.b="Action A
+jewel.swing.inline.banner.action.c="Action A
+jewel.swing.inline.banner.action.d="Action A
 
 compose.sandbox=Compose Sandbox
 compose.sandbox.show.automatically.on.project.open=Show automatically on project open

--- a/plugins/devkit/intellij.devkit.compose/src/demo/SwingComparisonTabPanel.kt
+++ b/plugins/devkit/intellij.devkit.compose/src/demo/SwingComparisonTabPanel.kt
@@ -31,6 +31,8 @@ import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
 import com.intellij.openapi.editor.colors.EditorFontType
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.util.IconLoader
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.InlineBanner
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.BrowserLink
 import com.intellij.ui.components.JBLabel
@@ -48,9 +50,12 @@ import org.jetbrains.jewel.bridge.JewelComposePanel
 import org.jetbrains.jewel.bridge.retrieveEditorColorScheme
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.DefaultInformationBanner
 import org.jetbrains.jewel.ui.component.EditableListComboBox
 import org.jetbrains.jewel.ui.component.ExternalLink
 import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.InformationDefaultBanner
+import org.jetbrains.jewel.ui.component.InlineInformationBanner
 import org.jetbrains.jewel.ui.component.ListComboBox
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.Text
@@ -60,6 +65,7 @@ import org.jetbrains.jewel.ui.disabledAppearance
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.theme.textAreaStyle
 import org.jetbrains.jewel.ui.typography
+import java.awt.Dimension
 import javax.swing.BoxLayout
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JLabel
@@ -76,6 +82,10 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
       iconsRow()
       separator()
       linksRow()
+      separator()
+      inlineBannersRow()
+      separator()
+      bannersRow()
       separator()
       textFieldsRow()
       separator()
@@ -119,6 +129,80 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
         .applyToComponent { autoHideOnDisable = false }
 
       compose { ExternalLink(text = "Disabled link", uri = "", enabled = false) }
+    }
+      .layout(RowLayout.PARENT_GRID)
+  }
+
+  private fun Panel.inlineBannersRow() {
+    row(DevkitComposeBundle.message("jewel.inline.banners.label")) {
+      val inlineBanner = InlineBanner(
+        messageText = DevkitComposeBundle.message("jewel.swing.inline.banners"),
+        status = EditorNotificationPanel.Status.Info,
+      )
+      inlineBanner.setGearAction("", {})
+      inlineBanner.addAction(DevkitComposeBundle.message("jewel.swing.inline.banner.action.a")) {}
+      inlineBanner.addAction(DevkitComposeBundle.message("jewel.swing.inline.banner.action.b")) {}
+      inlineBanner.addAction(DevkitComposeBundle.message("jewel.swing.inline.banner.action.c")) {}
+      inlineBanner.addAction(DevkitComposeBundle.message("jewel.swing.inline.banner.action.d")) {}
+
+      cell(
+        component = inlineBanner
+      )
+        .align(AlignY.CENTER)
+
+      compose {
+        Box {
+          InlineInformationBanner(
+            text = DevkitComposeBundle.message("jewel.compose.inline.banners"),
+            iconActions = {
+              iconAction(
+                AllIconsKeys.General.GearPlain,
+                "Close",
+                onClick = {},
+              )
+              iconAction(
+                AllIconsKeys.General.Close,
+                "Close",
+                onClick = {},
+              )
+            },
+            linkActions = {
+              action("Action A", onClick = {})
+              action("Action B", onClick = {})
+              action("Action C", onClick = {})
+              action("Action D", onClick = {})
+            }
+          )
+        }
+      }
+    }
+      .layout(RowLayout.PARENT_GRID)
+  }
+
+  private fun Panel.bannersRow() {
+    row(DevkitComposeBundle.message("jewel.banners.label")) {
+      val defaultBanner =
+        EditorNotificationPanel(EditorNotificationPanel.Status.Info).text(DevkitComposeBundle.message("jewel.swing.banners"))
+      defaultBanner.setCloseAction { }
+      cell(
+        component = defaultBanner
+      )
+        .align(AlignY.CENTER)
+
+      compose {
+        Box(Modifier.width(400.dp)) {
+          DefaultInformationBanner(
+            text = DevkitComposeBundle.message("jewel.compose.banners"),
+            iconActions = {
+              iconAction(
+                AllIconsKeys.General.Close,
+                "Close",
+                onClick = {},
+              )
+            },
+          )
+        }
+      }
     }
       .layout(RowLayout.PARENT_GRID)
   }
@@ -214,7 +298,8 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
     }
 
     row(DevkitComposeBundle.message("jewel.swing.titles.swing")) {
-      text(DevkitComposeBundle.message("jewel.swing.label.this.will.wrap.over.couple.rows"), maxLineLength = 30).component.font = JBFont.h1()
+      text(DevkitComposeBundle.message("jewel.swing.label.this.will.wrap.over.couple.rows"), maxLineLength = 30).component.font =
+        JBFont.h1()
     }
     row(DevkitComposeBundle.message("jewel.swing.titles.compose")) {
       compose {


### PR DESCRIPTION
# Context
Our current `InnerBannerImpl` code has some hardcoded values for both `cornerSize` and `padding`.

This PR adds both to `BannerMetrics` so users can freely set whatever value they want to, as is the case with all other Jewel components 😄

# Changes
- Added `InlineBanner` and `Banner` comparisons in `SwingComparisonTabPanel`
- Created the new parameters with their default values
   - CornerSize with `8.dp` radius
      - In the IJP's implementation, they actually set the diameter of the arc instead of just the radius. As can be seen in com.intellij.ui.InlineBannerBase:
        ```
        val cornerRadius = JBUI.scale(16)
        ```
        Luckily for us the radius of a diameter is basically D/2, so `8.dp`! :)
   - 12.dp padding
      - Still in com.intellij.ui.InlineBannerBase, the border is declared as:
         ```
         border = JBUI.Borders.empty(12)
         ```
         I.e, an empty view with borders and a content offset of `12 pixels`. We can directly translate this to Compose as `12.dp` 🕺🏻 (there's more to this than just this one line of code, but let's keep it simple for now, ok?) 
- Created a `defaultBannerMetrics()` function  in Bridge that applies the default values for all parameters in `BannerMetrics`
- Added some code to properly align the banner's icon and content with `iconActions` (oh boy.... You'll know what I mean by this soon enough)

<details><summary>First approach (calculating padding based on IconButton minSize patch)</summary>
<p>

If you want to compare the Subcomposlayout approach with my first one, that calculated the action icon padding based on IconButton's minSize, just apply the patch below:

[0001-JEWEL-1228-Add-CornerSize-and-Padding-to-BannerMetrics.patch](https://github.com/user-attachments/files/25097608/0001-JEWEL-1228-Add-CornerSize-and-Padding-to-BannerMetri.patch)


</p>
</details> 

# Screenshots

## `InlineBanner` Variants
| Variant | Before | After (Subcomposelayout) |
|---------|--------|--------|
| No icon  | <img width="728" height="87" alt="image" src="https://github.com/user-attachments/assets/51adec9d-7db1-4057-9c53-97a74429a3e2" /> | <img width="724" height="76" alt="image" src="https://github.com/user-attachments/assets/bb10f724-ccc3-421d-81ce-e2268084205f" /> |
| Simple | <img width="726" height="86" alt="image" src="https://github.com/user-attachments/assets/717708ce-fbf7-491e-a598-2d3c918158a9" /> | <img width="738" height="86" alt="image" src="https://github.com/user-attachments/assets/1514a2f0-6bfd-40b9-a574-5a22d836dbdb" /> |
| One Action Icon | <img width="727" height="87" alt="image" src="https://github.com/user-attachments/assets/9b1a1502-5d91-4444-b40b-e2f8aef561de" /> | <img width="721" height="79" alt="image" src="https://github.com/user-attachments/assets/6548a00c-bab1-4bc3-bda1-fb387d4eca03" /> |
| Two Action Icons | <img width="727" height="83" alt="image" src="https://github.com/user-attachments/assets/68452ad0-e08f-48de-9225-e76381efc986" /> | <img width="719" height="82" alt="image" src="https://github.com/user-attachments/assets/f0fb2eb8-68a3-411b-ad0c-a573a606fec9" /> |
| Three Action Icon (Jewel only)¹ | <img width="750" height="79" alt="image" src="https://github.com/user-attachments/assets/e50538c8-db24-45a3-abcd-f0094da645c8" /> | <img width="739" height="82" alt="image" src="https://github.com/user-attachments/assets/761b015a-39af-4f9c-a1bb-e17395f4238d" /> |
| One Link Action | <img width="734" height="106" alt="image" src="https://github.com/user-attachments/assets/71b3b200-8ea4-4138-8dee-9d651a3dd946" /> | <img width="723" height="104" alt="image" src="https://github.com/user-attachments/assets/54e9456a-97d2-4c75-8bbe-e96f6c69e189" /> |
| Two Link Actions | <img width="725" height="107" alt="image" src="https://github.com/user-attachments/assets/f93e37ab-e645-430e-b90e-1f0200ad782d" /> | <img width="719" height="103" alt="image" src="https://github.com/user-attachments/assets/aa4dcf2d-b442-4e27-8855-b0087ffb241a" /> |
| Three Link Actions | <img width="729" height="107" alt="image" src="https://github.com/user-attachments/assets/14b8702f-8fee-4bd7-8928-6e4f6f99ddc5" /> | <img width="720" height="105" alt="image" src="https://github.com/user-attachments/assets/9a22b3e1-1bf1-424d-8f65-969b249cdea7" /> |
| For or More Link Actions | <img width="726" height="109" alt="image" src="https://github.com/user-attachments/assets/e8f5250d-3898-4efc-966a-2c3f7dadb7e3" /> | <img width="736" height="92" alt="image" src="https://github.com/user-attachments/assets/f8eb03e9-80d3-45c0-b714-bf372542e4fc" /> |
| "More" Link Actions Submenu | <video src="https://github.com/user-attachments/assets/739dc2df-65b5-4671-9a43-2211141f8ff2" /> | <video src="https://github.com/user-attachments/assets/ce7be4a9-9f9c-42c5-9c92-dfb2161d856d" /> |
| Title (Jewel only) | <img width="732" height="107" alt="image" src="https://github.com/user-attachments/assets/911659f1-0f12-4180-8be7-031b6c8cf294" /> | <img width="731" height="106" alt="image" src="https://github.com/user-attachments/assets/fcb249ed-9b47-43de-a646-d73ac61492e9" /> |
| Complete | <img width="735" height="107" alt="image" src="https://github.com/user-attachments/assets/bfb9aaab-fa7a-4443-8330-912502648ebd" /> | <img width="727" height="105" alt="image" src="https://github.com/user-attachments/assets/d9da81cf-d915-42fc-b8de-65c85b1a0f01" /> |
| Complete (w/ Title) | <img width="730" height="136" alt="image" src="https://github.com/user-attachments/assets/311475f2-3a5d-40c5-abf1-4b49600c7936" /> | <img width="730" height="123" alt="image" src="https://github.com/user-attachments/assets/86e5a5d7-3262-4be0-8bf8-194b1485042e" /> |

¹ While messing around with all the variations, I found out that the text content in IJP's  `InlineBanner` doesn't respect the left most icon padding. This is what I mean:

<img width="739" height="105" alt="image" src="https://github.com/user-attachments/assets/f8c8005f-384e-4785-bef7-1cee6dae5161" />

The Figma spec doesn't explicitly defines a padding between the text and the icon too, but if it were to have a padding, it'd be `12.dp` it seems. We could easily add this padding into our calculations BUT my idea is to be as faithful as possible to IJP's implementation.

## Standalone Component Showcase
| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/7fa0fbbf-935a-48ec-a10f-f1739269c775" /> | <video src="https://github.com/user-attachments/assets/a416271c-72f0-468e-bdfb-b3cbf5224a19" />  | 

## Jewel Tool Window Components Tab
| Before | After |
|--------|--------|
| <img width="1640" height="970" alt="image" src="https://github.com/user-attachments/assets/87717e34-9e71-444f-b053-0b299cc4f39e" /> | <img width="1638" height="967" alt="image" src="https://github.com/user-attachments/assets/2e0eedae-3e05-4f32-9029-e740a633d324" /> | 

## New Demos
| Wrapping Content Size | RTL |
|---|---|
| <img width="900" height="734" alt="image" src="https://github.com/user-attachments/assets/416b4dfe-1375-4f0d-94e5-25a1e5b805ec" /> | <img width="729" height="744" alt="image" src="https://github.com/user-attachments/assets/26d971fe-e47c-4971-a6a9-2446f1307fdd" /> |

For other less important notes, check the section below

<details><summary>Details</summary>

1. You can see that our `InlineBanner` is slightly smaller than Swing. At first I thought that discrepancy was because `IconActionButton` has a default of `minSize: DpSize = DpSize(24.dp, 24.dp),` while the default icon size for Swing is `26px`, but setting a `minSize` of 26.dp in our `IconButton` does not match Swing's height still. I went over the Swing code again and again and so far I'm unable to tell exactly what's the culprit here... Ours perfectly match the specs from Figma, though.
2. Also, our `DefaultBanner` is the inverse: it's slightly bigger than Swing, but this PR (for now) is focused solely on `InlineBanner`.

</details> 

## Release notes

### ⚠️ Important Changes
 * `InlineBanner` no longer fills the available width by default; it now wraps its content instead. If you want banners to span the full width, be sure to add `modifier = Modifier.fillMaxWidth()`.

### Bug fixes
 * Now it's possible to customize the corner size and the padding of the `InlineBanner` components

### Deprecated API
* `BannerMetrics` constructor has been deprecated in favor of the new constructor that takes `borderWidth`, `cornerSize` and `paddingValues`
 * `BannerMetrics.Companion.default(borderWidth: Dp)` has been deprecated in favor of `BannerMetrics.Companion.default(borderWidth: Dp, cornerSize: CornerSize, paddingValues: PaddingValues)`