### PR TITLE
[vcs-log] restore "All" action to clear the filters

### DIFF
--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/BranchFilterPopupComponent.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/BranchFilterPopupComponent.java
@@ -99,6 +99,7 @@ public final class BranchFilterPopupComponent extends MultipleValueFilterPopupCo
   protected @NotNull ActionGroup createActionGroup() {
     DefaultActionGroup actionGroup = new DefaultActionGroup();
 
+    actionGroup.add(createAllAction());
     actionGroup.add(createSelectMultipleValuesAction());
 
     VcsLogDataPack logData = myFilterModel.getDataPack();

--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/DateFilterPopupComponent.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/DateFilterPopupComponent.java
@@ -58,7 +58,8 @@ public class DateFilterPopupComponent extends FilterPopupComponent<VcsLogDateFil
     cal.add(Calendar.DAY_OF_YEAR, -6);
     Date oneWeekBefore = cal.getTime();
 
-    return new DefaultActionGroup(new SelectAction(),
+    return new DefaultActionGroup(createAllAction(),
+                                  new SelectAction(),
                                   new DateAction(oneDayBefore, VcsLogBundle.messagePointer("vcs.log.date.filter.action.last.day")),
                                   new DateAction(oneWeekBefore, VcsLogBundle.messagePointer("vcs.log.date.filter.action.last.week")));
   }

--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/FilterPopupComponent.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/FilterPopupComponent.java
@@ -1,6 +1,9 @@
 // Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.vcs.log.ui.filter;
 
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.vcs.log.VcsLogBundle;
 import com.intellij.vcs.log.statistics.VcsLogUsageTriggerCollector;
@@ -61,11 +64,38 @@ public abstract class FilterPopupComponent<Filter, Model extends FilterModel<Fil
     return filter == null ? null : getToolTip(filter);
   }
 
+  /**
+   * Returns the special action that indicates that no filtering is selected in this component.
+   */
+  @NotNull
+  protected AnAction createAllAction() {
+    return new AllAction();
+  }
+
   @Override
   protected Runnable createResetAction() {
     return () -> {
       myFilterModel.setFilter(null);
       VcsLogUsageTriggerCollector.triggerFilterReset(VcsLogUsageTriggerCollector.FilterResetType.CLOSE_BUTTON);
     };
+  }
+
+  private class AllAction extends DumbAwareAction {
+
+    AllAction() {
+      super(ALL_ACTION_TEXT);
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+      super.update(e);
+      e.getPresentation().setEnabledAndVisible(myFilterModel.getFilter() != null);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+      myFilterModel.setFilter(null);
+      VcsLogUsageTriggerCollector.triggerFilterReset(VcsLogUsageTriggerCollector.FilterResetType.ALL_OPTION);
+    }
   }
 }

--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/StructureFilterPopupComponent.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/StructureFilterPopupComponent.java
@@ -208,7 +208,8 @@ public class StructureFilterPopupComponent extends FilterPopupComponent<VcsLogFi
       structureActions.add(new SelectFromHistoryAction(filter));
     }
 
-    List<AnAction> actionsList = new ArrayList<>(Arrays.asList(new EditPathsAction(), new SelectPathsInTreeAction(),
+    List<AnAction> actionsList = new ArrayList<>(Arrays.asList(createAllAction(),
+                                                               new EditPathsAction(), new SelectPathsInTreeAction(),
                                                                new Separator(VcsLogBundle.messagePointer("vcs.log.filter.recent")),
                                                                new DefaultActionGroup(structureActions)));
 

--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/UserFilterPopupComponent.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/filter/UserFilterPopupComponent.java
@@ -47,6 +47,7 @@ public class UserFilterPopupComponent
   @Override
   protected @NotNull ActionGroup createActionGroup() {
     List<AnAction> group = new ArrayList<>();
+    group.add(createAllAction());
     group.add(createSelectMultipleValuesAction());
     if (!myLogData.getCurrentUser().isEmpty()) {
       group.add(new PredefinedValueAction(Collections.singletonList(VcsLogFilterObject.ME), () -> me(), true));


### PR DESCRIPTION
"All" action was removed in 3a774b5000532726e8ee9afbbfedf27c135cfce7, however it made it very inconvenient to use the filters from Quick Actions Popup. I don't see how having "All" action would interfere with anything, and it makes keyboard access significantly easier. So this PR restores the action.

[IJPL-89255](https://youtrack.jetbrains.com/issue/IJPL-89255)