### PR TITLE
Added delay in startup.kt to account for restart time, if existing IDE process is exiting

### DIFF
--- a/platform/platform-impl/bootstrap/src/com/intellij/platform/ide/bootstrap/startup.kt
+++ b/platform/platform-impl/bootstrap/src/com/intellij/platform/ide/bootstrap/startup.kt
@@ -117,6 +117,10 @@ fun startApplication(
   val isHeadless = AppMode.isHeadless()
 
   val lockSystemDirsJob = scope.launch {
+    // Adding startup delay to account for restart process, if existing IDE instance is exiting 
+    // Ref: https://youtrack.jetbrains.com/issue/IJPL-179219, https://youtrack.jetbrains.com/issue/IJPL-185318 
+    delay(2000)
+    
     // the "import-needed" check must be performed strictly before IDE directories are locked
     configImportNeededDeferred.join()
     span("system dirs locking") {


### PR DESCRIPTION
IJPL-179219, IJPL-185318: Start failed issues