### PR TITLE
[JEWEL-1244] Fix ListComboBox External SelectedIndex Changes Not Syncing To Internal State

### DIFF
--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/ListComboBoxUiTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/ListComboBoxUiTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
@@ -1175,6 +1176,212 @@ class ListComboBoxUiTest {
         composeRule.waitForIdle()
 
         assertTrue(selectedItemChangeTriggered, "Item click should be detected for faster taps")
+    }
+
+    @Test
+    fun `when ListComboBox selectedIndex is reset externally while popup is closed, selection updates correctly`() {
+        var selectedIndex by mutableIntStateOf(4) // Start at "Laughter"
+        val focusRequester = FocusRequester()
+
+        composeRule.setContent {
+            IntUiTheme {
+                ListComboBox(
+                    items = comboBoxItems,
+                    selectedIndex = selectedIndex,
+                    onSelectedItemChange = { index -> selectedIndex = index },
+                    modifier = Modifier.testTag("ComboBox").width(200.dp).focusRequester(focusRequester),
+                    itemKeys = { _, item -> item },
+                )
+            }
+        }
+
+        focusRequester.requestFocus()
+
+        comboBox.assertTextEquals("Laughter", includeEditableText = false)
+        assertEquals(4, selectedIndex)
+
+        // Reset selectedIndex externally while popup is closed
+        composeRule.runOnUiThread { selectedIndex = 0 }
+
+        // Verify combo box label updated
+        comboBox.assertTextEquals("Item 1", includeEditableText = false)
+
+        // Open popup and verify the correct item is selected
+        comboBox.performClick()
+        popupMenu.assertIsDisplayed()
+
+        comboBoxPopupList.performScrollToIndex(0)
+
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Item 1"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsSelected()
+
+        // Previously selected item should not be selected anymore
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Laughter"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsNotSelected()
+    }
+
+    @Test
+    fun `when ListComboBox selectedIndex is reset externally while popup is open, selection is not disrupted`() {
+        var selectedIndex by mutableIntStateOf(4) // Start at "Laughter"
+        val focusRequester = FocusRequester()
+
+        composeRule.setContent {
+            IntUiTheme {
+                ListComboBox(
+                    items = comboBoxItems,
+                    selectedIndex = selectedIndex,
+                    onSelectedItemChange = { index -> selectedIndex = index },
+                    modifier = Modifier.testTag("ComboBox").width(200.dp).focusRequester(focusRequester),
+                    itemKeys = { _, item -> item },
+                )
+            }
+        }
+
+        focusRequester.requestFocus()
+
+        // Verify initial state
+        comboBox.assertTextEquals("Laughter", includeEditableText = false)
+        assertEquals(4, selectedIndex)
+
+        // Open popup
+        comboBox.performClick()
+        popupMenu.assertIsDisplayed()
+
+        // Verify "Laughter" is selected in the popup
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Laughter"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsSelected()
+
+        // Reset selectedIndex externally while popup is open
+        composeRule.runOnUiThread { selectedIndex = 0 }
+
+        // Verify popup still shows "Laughter" as selected (not disrupted by external change)
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Laughter"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsSelected()
+
+        // Press Enter to commit current selection (should reconcile to internal listState)
+        comboBox.performKeyPress(Key.Enter, rule = composeRule)
+        popupMenu.assertDoesNotExist()
+
+        // After closing, selectedIndex should be reconciled back to "Laughter" (index 4)
+        assertEquals(4, selectedIndex)
+        comboBox.assertTextEquals("Laughter", includeEditableText = false)
+    }
+
+    @Test
+    fun `when EditableListComboBox selectedIndex is reset externally while popup is closed, selection updates correctly`() {
+        var selectedIndex by mutableIntStateOf(4) // Start at "Laughter"
+        val focusRequester = FocusRequester()
+
+        composeRule.setContent {
+            IntUiTheme {
+                EditableListComboBox(
+                    items = comboBoxItems,
+                    selectedIndex = selectedIndex,
+                    onSelectedItemChange = { index -> selectedIndex = index },
+                    modifier = Modifier.testTag("ComboBox").width(200.dp).focusRequester(focusRequester),
+                    itemKeys = { _, item -> item },
+                )
+            }
+        }
+
+        focusRequester.requestFocus()
+        composeRule.waitForIdle()
+
+        textField.assertTextEquals("Laughter")
+        assertEquals(4, selectedIndex)
+
+        // Reset selectedIndex externally while popup is closed
+        composeRule.runOnUiThread { selectedIndex = 0 }
+        composeRule.waitForIdle()
+
+        // Verify text field updated
+        textField.assertTextEquals("Item 1")
+
+        // Open popup and verify the correct item is selected
+        chevronContainer.performClick()
+        popupMenu.assertIsDisplayed()
+
+        comboBoxPopupList.performScrollToIndex(0)
+
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Item 1"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsSelected()
+
+        // Previously selected item should not be selected anymore
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Laughter"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsNotSelected()
+    }
+
+    @Test
+    fun `when EditableListComboBox selectedIndex is reset externally while popup is open, selection is not disrupted`() {
+        var selectedIndex by mutableIntStateOf(4) // Start at "Laughter"
+        val focusRequester = FocusRequester()
+
+        composeRule.setContent {
+            IntUiTheme {
+                EditableListComboBox(
+                    items = comboBoxItems,
+                    selectedIndex = selectedIndex,
+                    onSelectedItemChange = { index -> selectedIndex = index },
+                    modifier = Modifier.testTag("ComboBox").width(200.dp).focusRequester(focusRequester),
+                    itemKeys = { _, item -> item },
+                )
+            }
+        }
+
+        focusRequester.requestFocus()
+        composeRule.waitForIdle()
+
+        // Verify initial state
+        textField.assertTextEquals("Laughter")
+        assertEquals(4, selectedIndex)
+
+        // Open popup
+        chevronContainer.performClick()
+        popupMenu.assertIsDisplayed()
+
+        // Verify "Laughter" is selected in the popup
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Laughter"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsSelected()
+
+        // Reset selectedIndex externally while popup is open
+        composeRule.runOnUiThread { selectedIndex = 0 }
+        composeRule.waitForIdle()
+
+        // Verify popup still shows "Laughter" as selected (not disrupted by external change)
+        composeRule
+            .onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.Popup")) and hasText("Laughter"))
+            .assertExists()
+            .assertIsDisplayed()
+            .assertIsSelected()
+
+        // Press Enter to commit current selection (should reconcile to internal listState)
+        comboBox.performKeyPress(Key.Enter, rule = composeRule)
+        popupMenu.assertDoesNotExist()
+
+        // After closing, selectedIndex should be reconciled back to "Laughter" (index 4)
+        assertEquals(4, selectedIndex)
+        textField.assertTextEquals("Laughter")
     }
 
     private fun editableListComboBox(): SemanticsNodeInteraction {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
@@ -433,9 +433,22 @@ public fun EditableListComboBox(
     var hoveredItemIndex by remember { mutableIntStateOf(-1) }
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(itemKeys) {
-        // Select the first item in the list when creating
-        listState.selectedKeys = setOf(itemKeys(selectedIndex, items.getOrNull(selectedIndex).orEmpty()))
+    val popupManager = remember {
+        PopupManager(
+            onPopupVisibleChange = {
+                hoveredItemIndex = -1
+                onPopupVisibleChange(it)
+            },
+            name = "EditableListComboBoxPopup",
+        )
+    }
+
+    LaunchedEffect(itemKeys, selectedIndex, popupManager.isPopupVisible.value) {
+        if (!popupManager.isPopupVisible.value) {
+            val item = items.getOrNull(selectedIndex).orEmpty()
+            listState.selectedKeys = setOf(itemKeys(selectedIndex, item))
+            textFieldState.edit { replace(0, length, item) }
+        }
     }
 
     fun setSelectedItem(index: Int) {
@@ -506,16 +519,7 @@ public fun EditableListComboBox(
                 setSelectedItem(indexOfSelected)
             }
         },
-        popupManager =
-            remember {
-                PopupManager(
-                    onPopupVisibleChange = {
-                        hoveredItemIndex = -1
-                        onPopupVisibleChange(it)
-                    },
-                    name = "EditableListComboBoxPopup",
-                )
-            },
+        popupManager = popupManager,
         popupContent = {
             PopupContent(
                 items = items,
@@ -676,15 +680,6 @@ internal fun <T : Any> ListComboBoxImpl(
         ),
     itemContent: @Composable (index: Int, item: T, isSelected: Boolean, isActive: Boolean) -> Unit,
 ) {
-    LaunchedEffect(itemKeys) {
-        val item = items.getOrNull(selectedIndex)
-        if (item != null) {
-            listState.selectedKeys = setOf(itemKeys(selectedIndex, item))
-        } else {
-            listState.selectedKeys = emptySet()
-        }
-    }
-
     val density = LocalDensity.current
     var comboBoxSize by remember { mutableStateOf(DpSize.Zero) }
     var currentComboBoxSize by remember { mutableStateOf(DpSize.Zero) }
@@ -759,6 +754,19 @@ internal fun <T : Any> ListComboBoxImpl(
             },
             name = "ListComboBoxPopup",
         )
+    }
+
+    // Sync external selectedIndex changes to listState, but only when popup is closed
+    // to avoid disrupting the user's active browsing session when popup is open
+    LaunchedEffect(itemKeys, selectedIndex, popupManager.isPopupVisible.value) {
+        if (!popupManager.isPopupVisible.value) {
+            val item = items.getOrNull(selectedIndex)
+            if (item != null) {
+                listState.selectedKeys = setOf(itemKeys(selectedIndex, item))
+            } else {
+                listState.selectedKeys = emptySet()
+            }
+        }
     }
 
     fun commitSelectionFromHoverOrMapped() {


### PR DESCRIPTION
# Context

Currently, our Combo Box implementation only updates its selected index internally. This means that, if users want to programmatically change it, the change won't be respected by our Combo Box. If the user clicks on a ComboBox, it'll show the value of whatever the user chose previously as the current selected item, not the item that was set by the code.

# Changes

- Added `selectedIndex` to our `LaunchedEffect` in ComboBoxImpl, so that we can update the list state with the current selected index
- Added unit tests

If you'd like to test this yourself, apply the git patch below:

<details><summary>Details</summary>
<p>

```
Index: platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt	(revision db891e692f6611bc85709ecbe66a8b0fe87d226b)
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt	(date 1770752708307)
@@ -2,6 +2,7 @@
 // Apache 2.0 license.
 package org.jetbrains.jewel.samples.showcase.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -101,10 +102,8 @@
 private fun ListComboBoxes() {
     FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Column(Modifier.weight(1f).widthIn(min = 125.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("String-based API")
-            var selectedIndex by remember { mutableIntStateOf(2) }
-            val selectedItemText = if (selectedIndex >= 0) stringItems[selectedIndex] else "[none]"
-            InfoText(text = "Selected item: $selectedItemText")
+            var selectedIndex by remember { mutableIntStateOf(0) }
+            Text("Reset", modifier = Modifier.clickable(onClick = { selectedIndex = 0 }))
 
             ListComboBox(
                 items = stringItems,
@@ -203,8 +202,8 @@
 private fun EditableListComboBoxes() {
     FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Column(Modifier.weight(1f).widthIn(min = 125.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("String-based API, enabled")
-            var selectedIndex by remember { mutableIntStateOf(2) }
+            var selectedIndex by remember { mutableIntStateOf(0) }
+            Text("Reset", modifier = Modifier.clickable(onClick = { selectedIndex = 0 }))
             val selectedItemText = if (selectedIndex >= 0) stringItems[selectedIndex] else "[none]"
             InfoText(text = "Selected item: $selectedItemText")
 

```

</p>
</details>

# Evidences

|  | Before | After |
|--------|--------|--------|
| ListComboBox | <video src="https://github.com/user-attachments/assets/9ae5ef06-ce44-4424-8d72-035a2d8317d8" /> | <video src="https://github.com/user-attachments/assets/b985cc49-6be9-48ed-828c-6c50e1b0da87" /> |
| EditableComboBox | <video src="https://github.com/user-attachments/assets/67e9e1ee-946a-4337-8980-d04eefd12166" /> | <video src="https://github.com/user-attachments/assets/6469e239-81a4-42c7-8aae-6d3a44d76623" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes selection synchronization and popup-visible behavior in core UI components, which could subtly affect keyboard/mouse selection and commit-on-close flows, but is covered by new UI tests.
> 
> **Overview**
> Ensures `ListComboBox` and `EditableListComboBox` correctly reflect programmatic (`selectedIndex`) changes by syncing `selectedIndex` into the internal `SelectableLazyListState` **only when the popup is closed**, avoiding selection jumps while users are navigating an open popup.
> 
> Adds regression UI tests covering external `selectedIndex` resets for both combo box variants, validating correct selection highlighting and non-disruption while the popup is visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f5a58dd072bb3f5273338b9f6ff86349b272f1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->