### PR TITLE
[JEWEL-1256] Fix incremental Markdown parsing for table rows

### DIFF
--- a/platform/jewel/markdown/core/api-dump-experimental.txt
+++ b/platform/jewel/markdown/core/api-dump-experimental.txt
@@ -230,6 +230,7 @@ f:org.jetbrains.jewel.markdown.SemanticsKt
 - a:renderImageContent(org.jetbrains.jewel.markdown.InlineMarkdown$Image,androidx.compose.runtime.Composer,I):androidx.compose.foundation.text.InlineTextContent
 *:org.jetbrains.jewel.markdown.extensions.MarkdownBlockProcessorExtension
 - a:canProcess(org.commonmark.node.CustomBlock):Z
+- getAllowsMergingWithNextBlock():Z
 - a:processMarkdownBlock(org.commonmark.node.CustomBlock,org.jetbrains.jewel.markdown.processing.MarkdownProcessor):org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock
 *:org.jetbrains.jewel.markdown.extensions.MarkdownBlockRendererExtension
 - a:RenderCustomBlock(org.jetbrains.jewel.markdown.MarkdownBlock$CustomBlock,org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer,org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer,Z,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function1,androidx.compose.runtime.Composer,I):V

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension.kt
@@ -28,4 +28,32 @@ public interface MarkdownBlockProcessorExtension {
      * @return null if the processing fails, otherwise the processed [MarkdownBlock.CustomBlock].
      */
     public fun processMarkdownBlock(block: CustomBlock, processor: MarkdownProcessor): MarkdownBlock.CustomBlock?
+
+    /**
+     * Whether this extension allows the next block to be merged into the custom block handled by this extension.
+     *
+     * When `true`, incremental parsing in editor mode will include this block in re-parsing when the following block
+     * changes, allowing proper merging behavior. This is needed for blocks like tables, where a paragraph immediately
+     * after a table header can become part of the table body.
+     *
+     * Example:
+     * ```
+     * |  |  |
+     * |--|--|
+     * |
+     * ```
+     *
+     * is a table with a header only and a paragraph consisting of one symbol `|`, but:
+     * ```
+     * |  |  |
+     * |--|--|
+     * | A
+     * ```
+     *
+     * is already a table with a header and one incomplete row.
+     *
+     * Defaults to `false`.
+     */
+    public val allowsMergingWithNextBlock: Boolean
+        get() = false
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
@@ -239,8 +239,7 @@ public class MarkdownProcessor(
                 .subSequence(prefixPos, fullUpdatedText.length - commonSuffix.length)
                 .lineSequence()
                 .count() - previousText.subSequence(prefixPos, suffixPos).lineSequence().count()
-        // if modification starts at the edge, include the previous block by using less instead of less equal
-        val firstBlock = previousStartIndexes.indexOfLast { it < prefixPos }
+        val firstBlock = findFirstBlockToReparse(previousStartIndexes, prefixPos, previousBlocks)
         val blockAfterLast =
             previousEndIndexes.indexOfFirst { suffixPos <= it }.let { if (it == -1) previousBlocks.size else it + 1 }
         val changedText =
@@ -261,6 +260,35 @@ public class MarkdownProcessor(
         val updatedText: String,
         val nLinesDelta: Int,
     )
+
+    /**
+     * Finds the index of the first block that needs to be re-parsed after a text change.
+     *
+     * This function determines which block starts the range that needs re-parsing. It also considers whether the
+     * preceding block (if any) should be included, based on whether that block's extension allows merging with the next
+     * block.
+     */
+    private fun findFirstBlockToReparse(
+        previousStartIndexes: List<Int>,
+        prefixPos: Int,
+        previousBlocks: List<Block>,
+    ): Int {
+        // if modification starts at the edge, include the previous block by using less instead of less equal
+        val fb = previousStartIndexes.indexOfLast { it < prefixPos }
+        if (fb <= 0) return fb
+        val precedingBlock = previousBlocks[fb - 1]
+        // There are certain blocks (like tables) that can "absorb" the current block
+        // after the block is edited enough to be accounted as part of the preceding block.
+        // In case of tables, the current block can be a new table row.
+        return if (precedingBlock is CustomBlock && allowsMergingWithNextBlock(precedingBlock)) {
+            fb - 1
+        } else {
+            fb
+        }
+    }
+
+    private fun allowsMergingWithNextBlock(block: CustomBlock): Boolean =
+        blockExtensions.find { it.canProcess(block) }?.allowsMergingWithNextBlock == true
 
     private fun parseRawMarkdown(@Language("Markdown") rawMarkdown: String): List<Block> {
         val document =

--- a/platform/jewel/markdown/extensions/gfm-tables/BUILD.bazel
+++ b/platform/jewel/markdown/extensions/gfm-tables/BUILD.bazel
@@ -56,6 +56,10 @@ jvm_library(
     "//platform/jewel/foundation:foundation_test_lib",
     "//libraries/compose-foundation-desktop:compose-foundation-desktop_test_lib",
     "//libraries/compose-runtime-desktop:compose-runtime-desktop_test_lib",
+    "//libraries/compose-foundation-desktop-junit",
+    "//libraries/compose-foundation-desktop-junit:compose-foundation-desktop-junit_test_lib",
+    "//libraries/junit4",
+    "//libraries/junit4:junit4_test_lib",
   ],
   plugins = ["@lib//:compose-plugin"]
 )

--- a/platform/jewel/markdown/extensions/gfm-tables/intellij.platform.jewel.markdown.extensions.gfmTables.iml
+++ b/platform/jewel/markdown/extensions/gfm-tables/intellij.platform.jewel.markdown.extensions.gfmTables.iml
@@ -39,6 +39,8 @@
     <orderEntry type="module" module-name="intellij.platform.jewel.foundation" />
     <orderEntry type="module" module-name="intellij.libraries.compose.foundation.desktop" />
     <orderEntry type="module" module-name="intellij.libraries.compose.runtime.desktop" />
+    <orderEntry type="module" module-name="intellij.libraries.compose.foundation.desktop.junit" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.libraries.junit4" scope="TEST" />
     <orderEntry type="module-library">
       <library name="commonmark.ext.gfm.tables" type="repository">
         <properties include-transitive-deps="false" maven-id="org.commonmark:commonmark-ext-gfm-tables:0.24.0">

--- a/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableProcessorExtension.kt
@@ -45,6 +45,8 @@ public object GitHubTableProcessorExtension : MarkdownProcessorExtension {
     override val htmlConverterExtension: MarkdownHtmlConverterExtension = GitHubTablesHtmlConverterExtension
 
     private object GitHubTablesProcessorExtension : MarkdownBlockProcessorExtension {
+        override val allowsMergingWithNextBlock: Boolean = true
+
         override fun canProcess(block: CustomBlock): Boolean = block is CommonMarkTableBlock
 
         override fun processMarkdownBlock(

--- a/platform/jewel/markdown/extensions/gfm-tables/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableIncrementalParsingTest.kt
+++ b/platform/jewel/markdown/extensions/gfm-tables/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/github/tables/GitHubTableIncrementalParsingTest.kt
@@ -1,0 +1,125 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.markdown.extensions.github.tables
+
+import org.jetbrains.jewel.markdown.MarkdownBlock
+import org.jetbrains.jewel.markdown.MarkdownMode
+import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+public class GitHubTableIncrementalParsingTest {
+    @Test
+    public fun `paragraph after table header becomes table row when edited`() {
+        val processor = MarkdownProcessor(listOf(GitHubTableProcessorExtension), MarkdownMode.EditorPreview(null))
+
+        val initialMarkdown =
+            """
+            | A | B |
+            |---|---|
+            |
+            """
+                .trimIndent()
+
+        val initialBlocks = processor.processMarkdownDocument(initialMarkdown)
+
+        assertEquals("Initial state should have 2 blocks", 2, initialBlocks.size)
+        assertTrue("First block should be a table", initialBlocks[0] is TableBlock)
+        assertTrue("Second block should be a paragraph", initialBlocks[1] is MarkdownBlock.Paragraph)
+
+        val initialTable = initialBlocks[0] as TableBlock
+        assertEquals("Initial table should have no body rows", 0, initialTable.rows.size)
+
+        val updatedMarkdown =
+            """
+            | A | B |
+            |---|---|
+            | X | Y |
+            """
+                .trimIndent()
+
+        val updatedBlocks = processor.processMarkdownDocument(updatedMarkdown)
+
+        assertEquals("Updated state should have 1 block", 1, updatedBlocks.size)
+        assertTrue("Block should be a table", updatedBlocks[0] is TableBlock)
+
+        val updatedTable = updatedBlocks[0] as TableBlock
+        assertEquals("Updated table should have 1 body row", 1, updatedTable.rows.size)
+    }
+
+    @Test
+    public fun `typing after pipe character completes table row`() {
+        val processor = MarkdownProcessor(listOf(GitHubTableProcessorExtension), MarkdownMode.EditorPreview(null))
+
+        val step1 =
+            """
+            | Col1 | Col2 |
+            |------|------|
+            |
+            """
+                .trimIndent()
+
+        processor.processMarkdownDocument(step1)
+
+        val step2 =
+            """
+            | Col1 | Col2 |
+            |------|------|
+            | A
+            """
+                .trimIndent()
+
+        val step2Blocks = processor.processMarkdownDocument(step2)
+        assertEquals("After typing 'A', should have 1 block (table)", 1, step2Blocks.size)
+        assertTrue("Block should be a table", step2Blocks[0] is TableBlock)
+
+        val step3 =
+            """
+            | Col1 | Col2 |
+            |------|------|
+            | A | B |
+            """
+                .trimIndent()
+
+        val step3Blocks = processor.processMarkdownDocument(step3)
+        assertEquals("After completing row, should have 1 block (table)", 1, step3Blocks.size)
+
+        val table = step3Blocks[0] as TableBlock
+        assertEquals("Table should have 1 body row", 1, table.rows.size)
+    }
+
+    @Test
+    public fun `editing paragraph after complete table does not break parsing`() {
+        val processor = MarkdownProcessor(listOf(GitHubTableProcessorExtension), MarkdownMode.EditorPreview(null))
+
+        val initialMarkdown =
+            """
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+            
+            Some paragraph text
+            """
+                .trimIndent()
+
+        val initialBlocks = processor.processMarkdownDocument(initialMarkdown)
+        assertEquals("Should have 2 blocks", 2, initialBlocks.size)
+        assertTrue("First block should be a table", initialBlocks[0] is TableBlock)
+        assertTrue("Second block should be a paragraph", initialBlocks[1] is MarkdownBlock.Paragraph)
+
+        val updatedMarkdown =
+            """
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+            
+            Some edited paragraph text
+            """
+                .trimIndent()
+
+        val updatedBlocks = processor.processMarkdownDocument(updatedMarkdown)
+        assertEquals("Should still have 2 blocks", 2, updatedBlocks.size)
+        assertTrue("First block should still be a table", updatedBlocks[0] is TableBlock)
+        assertTrue("Second block should still be a paragraph", updatedBlocks[1] is MarkdownBlock.Paragraph)
+    }
+}


### PR DESCRIPTION
## Description

When typing in the Markdown editor, a line starting with `|` immediately after a table header was initially parsed as a paragraph. As the user continued typing (e.g., `| A | B |`), the line should become a table row, but incremental parsing didn't re-evaluate the preceding table block, causing the row to remain a separate paragraph.

This change introduces `allowsMergingWithNextBlock` property to `MarkdownBlockProcessorExtension`, allowing extensions to indicate that they can absorb subsequent blocks during re-parsing. The `MarkdownProcessor` now checks this property and includes the preceding block in the re-parse range when appropriate.


## Examples 

### Before

https://github.com/user-attachments/assets/4f0b5c6d-2c30-447a-86c0-0fcfb2b34eef

### After

https://github.com/user-attachments/assets/3949dce8-c920-48f4-8998-3e825d45b9d1

## Release notes

### Bug fixes
 * **JEWEL-1256** Fix incremental parsing for manually typed table rows in editor mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes incremental parsing boundaries in `MarkdownProcessor` and extends the experimental `MarkdownBlockProcessorExtension` API, which could affect editor-preview parsing behavior for other custom blocks if misconfigured.
> 
> **Overview**
> Fixes editor-mode incremental Markdown parsing so blocks like GFM tables can *absorb* a following paragraph when edits turn it into a table row.
> 
> This introduces `MarkdownBlockProcessorExtension.allowsMergingWithNextBlock` (default `false`) and updates `MarkdownProcessor` to include the preceding custom block in the reparse range when that flag is enabled.
> 
> Enables the flag for the GFM tables processor and adds a dedicated `gfmTables.tests` module plus JUnit tests covering the table-header-to-row incremental typing scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d86eb4c4787de2779512b442a9ddf0bc13ae1b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->