### PR TITLE
[JEWEL-1287] LazyTree multi-selection highlight never merges due to conflicting outerPadding and corner-merging logic

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeLazyTree.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeLazyTree.kt
@@ -45,7 +45,7 @@ internal fun readLazyTreeStyle(): LazyTreeStyle {
                 simpleListItemMetrics =
                     SimpleListItemMetrics(
                         innerPadding = PaddingValues(horizontal = 12.dp),
-                        outerPadding = PaddingValues(4.dp),
+                        outerPadding = PaddingValues(horizontal = 4.dp),
                         selectionBackgroundCornerSize = CornerSize(JBUI.CurrentTheme.Tree.ARC.dp / 2),
                         iconTextGap = 2.dp,
                     ),


### PR DESCRIPTION
BasicLazyTree has corner-merging logic that squares off touching edges
between adjacent selected items, intending to produce a continuous
selection block. However, outerPadding = PaddingValues(4.dp) adds 4dp
vertical padding outside the selection background on every row, creating
an 8dp gap between adjacent backgrounds and making the corner-merging
logic permanently ineffective.

Fix by removing the vertical component of outerPadding so adjacent
selection backgrounds can touch and merge as intended.

issue:

https://youtrack.jetbrains.com/issue/JEWEL-1287/LazyTree-multi-selection-highlight-never-merges-due-to-conflicting-outerPadding-and-corner-merging-logic

## Release notes

### Bug fixes
 * Fixed LazyTree multi-selection highlights so adjacent selected rows merge into a continuous selection block.