### PR TITLE
IDEA-387204 bookmarks: sync line numbers after document reload

### DIFF
--- a/platform/bookmarks/src/com/intellij/ide/bookmark/providers/LineBookmarkProvider.kt
+++ b/platform/bookmarks/src/com/intellij/ide/bookmark/providers/LineBookmarkProvider.kt
@@ -221,6 +221,7 @@ class LineBookmarkProvider(private val project: Project, coroutineScope: Corouti
         }
         override fun fileContentReloaded(file: VirtualFile, document: Document) {
           reloadingDocs.remove(document)
+          afterDocumentChange(document)
         }
       })
     }


### PR DESCRIPTION
When a file is reloaded from disk, `beforeFileContentReload` adds the document to `reloadingDocs`, causing `afterDocumentChange` to skip all intermediate notifications during the reload — which is intentional (IJPL-62074). However, once `fileContentReloaded` fires and the document is removed from the set, `afterDocumentChange` was never called to reconcile the final state.

During reload the platform updates RangeMarkers to reflect new line positions, so the editor gutter shows bookmark icons at the correct (shifted) lines. But `LineBookmarkImpl.line` was never updated, leaving the stored line number stale. This caused the Bookmarks tool window to display the old line number while the gutter marker appeared at the new one.

Fix: call `afterDocumentChange(document)` at the end of `fileContentReloaded`, after removing the document from `reloadingDocs`, so the guard no longer blocks it and bookmark line numbers are resynced with the post-reload RangeMarker positions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to bookmark synchronization that runs only after `fileContentReloaded`, with minimal surface area outside the bookmarks subsystem.
> 
> **Overview**
> Fixes stale line numbers for line bookmarks after a document is reloaded from disk.
> 
> `LineBookmarkProvider` now calls `afterDocumentChange(document)` at the end of `FileDocumentManagerListener.fileContentReloaded`, ensuring stored `LineBookmarkImpl.line` values are reconciled with the post-reload `RangeMarker` positions (so the Bookmarks tool window matches gutter markers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d2f5bb7c422f67a9de74330c792a12d00fa612. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->