### PR TITLE
[JEWEL-1290] DefaultBanner Should not Hardcode Padding

### DIFF
--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Banners.kt
@@ -65,6 +65,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 GroupHeader("Default banner (aka editor banners)")
 
                 DefaultInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.defaultBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     linkActions = {
@@ -74,6 +75,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 )
 
                 DefaultInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.defaultBannerStyle.information,
                     iconActions = {
                         iconAction(
@@ -91,6 +93,7 @@ public fun Banners(modifier: Modifier = Modifier) {
                 )
 
                 DefaultInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.defaultBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     icon = null,
@@ -100,32 +103,40 @@ public fun Banners(modifier: Modifier = Modifier) {
                     },
                 )
 
-                DefaultInformationBanner(style = JewelTheme.defaultBannerStyle.information, text = LONG_IPSUM)
+                DefaultInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
+                    style = JewelTheme.defaultBannerStyle.information,
+                    text = LONG_IPSUM,
+                )
 
                 DefaultInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.defaultBannerStyle.information,
                     text = LONG_IPSUM,
                     icon = null,
                 )
 
                 DefaultInformationBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     style = JewelTheme.defaultBannerStyle.information,
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                 )
 
                 DefaultSuccessBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     style = JewelTheme.defaultBannerStyle.success,
                 )
 
                 DefaultWarningBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
                     style = JewelTheme.defaultBannerStyle.warning,
                 )
 
                 DefaultErrorBanner(
+                    modifier = Modifier.fillMaxWidth(),
                     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
-                    modifier = Modifier,
                     icon = { Icon(AllIconsKeys.General.BalloonError, null) },
                     linkActions = {
                         action("Action A", onClick = { clickLabel = "Error default Action A clicked" })

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/DefaultBanner.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/DefaultBanner.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -185,6 +186,10 @@ public fun DefaultInformationBanner(
  * @param content The primary content of the banner, briefly describing the information it conveys.
  *
  * This banner is primarily used to display persistent messages without interrupting the workflow.
+ *
+ * **Note:** The [content] slot does not support subcomposition-based composables (e.g., `BoxWithConstraints`, lazy
+ * layouts), because the banner uses `Modifier.width(IntrinsicSize.Max)` internally. Subcomposition-based layouts cannot
+ * report intrinsic measurements and will throw at runtime.
  *
  * **Guidelines:** [on IJP SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html)
  *
@@ -376,6 +381,10 @@ public fun DefaultSuccessBanner(
  *
  * Use this banner to provide clear, visual feedback of a completed or successful action.
  *
+ * **Note:** The [content] slot does not support subcomposition-based composables (e.g., `BoxWithConstraints`, lazy
+ * layouts), because the banner uses `Modifier.width(IntrinsicSize.Max)` internally. Subcomposition-based layouts cannot
+ * report intrinsic measurements and will throw at runtime.
+ *
  * **Guidelines:** [on IJP SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html)
  *
  * **Swing equivalent:**
@@ -563,6 +572,10 @@ public fun DefaultWarningBanner(
  *
  * Use this banner to make users aware of potential issues without stopping their flow.
  *
+ * **Note:** The [content] slot does not support subcomposition-based composables (e.g., `BoxWithConstraints`, lazy
+ * layouts), because the banner uses `Modifier.width(IntrinsicSize.Max)` internally. Subcomposition-based layouts cannot
+ * report intrinsic measurements and will throw at runtime.
+ *
  * **Guidelines:** [on IJP SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html)
  *
  * **Swing equivalent:**
@@ -747,6 +760,10 @@ public fun DefaultErrorBanner(
  *
  * Use this banner to provide high-visibility error messages requiring immediate user attention.
  *
+ * **Note:** The [content] slot does not support subcomposition-based composables (e.g., `BoxWithConstraints`, lazy
+ * layouts), because the banner uses `Modifier.width(IntrinsicSize.Max)` internally. Subcomposition-based layouts cannot
+ * report intrinsic measurements and will throw at runtime.
+ *
  * **Guidelines:** [on IJP SDK webhelp](https://plugins.jetbrains.com/docs/intellij/banner.html)
  *
  * **Swing equivalent:**
@@ -850,10 +867,10 @@ private fun DefaultBannerImpl(
     modifier: Modifier = Modifier,
     content: @Composable (() -> Unit),
 ) {
-    Column(modifier = modifier) {
+    Column(modifier = modifier.width(IntrinsicSize.Max)) {
         Divider(orientation = Orientation.Horizontal, color = style.colors.border, modifier = Modifier.fillMaxWidth())
         Row(
-            modifier = Modifier.background(style.colors.background).padding(10.dp),
+            modifier = Modifier.background(style.colors.background).padding(style.metrics.padding),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (icon != null) {

--- a/plugins/devkit/intellij.devkit.compose/src/demo/SwingComparisonTabPanel.kt
+++ b/plugins/devkit/intellij.devkit.compose/src/demo/SwingComparisonTabPanel.kt
@@ -205,7 +205,7 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
         .align(AlignY.CENTER)
 
       compose {
-        Box(Modifier.width(400.dp)) {
+        Box {
           DefaultInformationBanner(
             text = DevkitComposeBundle.message("jewel.compose.banners"),
             iconActions = {


### PR DESCRIPTION
# Context

`DefaultBanner` has a default padding value of `10.dp`. This PR changes it to use whatever is set in `style.metrics.padding` instead. It also stops filling the entire available width and instead just wraps its content.

# Changes

- Changed `.padding(10.dp)` to `.padding(style.metrics.padding)` in the Row that wraps the banner content.
- Add `.width(IntrinsicSize.Max)` to the `Column` that wraps the banner content.

## Release notes

### ⚠️ Important Changes
 * `*DefaultBanner` no longer fills the available width by default; it now wraps its content instead. If you want banners to span the full width, be sure to add `modifier = Modifier.fillMaxWidth()`.

### Bug fixes
 * Paddings for `*DefaultBanner` components are now customizable

# Screenshots

| Before | After |
|--------|--------|
| <img width="723" height="569" alt="image" src="https://github.com/user-attachments/assets/99714781-92a6-4485-939d-54df307330a2" /> | <img width="723" height="573" alt="image" src="https://github.com/user-attachments/assets/eda292d2-0b60-444d-96ed-3d35dcace94f" /> |