### PR TITLE
Allow DexBytecodeInspector to Accept Dex Files as User Data

### DIFF
--- a/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/DexBytecodeInspector.kt
+++ b/plugins/kotlin/jvm-debugger/core/src/org/jetbrains/kotlin/idea/debugger/core/DexBytecodeInspector.kt
@@ -2,9 +2,11 @@
 package org.jetbrains.kotlin.idea.debugger.core
 
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.util.Key
 import com.sun.jdi.Method
 import org.jetbrains.kotlin.idea.debugger.stepping.smartStepInto.KotlinMethodSmartStepTarget
 import org.jetbrains.kotlin.idea.debugger.stepping.smartStepInto.SmartStepIntoContext
+import java.nio.file.Path
 
 /**
  * A debugger extension that allows to implement dex specific
@@ -25,5 +27,7 @@ interface DexBytecodeInspector {
     companion object {
         internal val EP: ExtensionPointName<DexBytecodeInspector> =
             ExtensionPointName.create("com.intellij.debugger.dexBytecodeInspector")
+
+        val DEX_FILES_KEY: Key<List<Path>> = Key("DEX_FILES_KEY")
     }
 }

--- a/plugins/kotlin/jvm-debugger/testFramework/testSrc/org/jetbrains/kotlin/idea/debugger/test/ArtAttacher.kt
+++ b/plugins/kotlin/jvm-debugger/testFramework/testSrc/org/jetbrains/kotlin/idea/debugger/test/ArtAttacher.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.observable.util.whenDisposed
 import com.intellij.ui.classFilter.ClassFilter
 import com.intellij.util.io.Compressor
 import com.intellij.util.io.delete
+import org.jetbrains.kotlin.idea.debugger.core.DexBytecodeInspector
 import java.lang.ProcessBuilder.Redirect.PIPE
 import java.nio.file.Files
 import java.nio.file.Path
@@ -70,6 +71,7 @@ internal class ArtAttacher : VmAttacher {
         testCase.setTimeout(getTestTimeoutMillis())
         val mainClass = javaParameters.mainClass
         val dexFile = buildDexFile(javaParameters.classPath.pathList)
+        testCase.project.putUserData(DexBytecodeInspector.DEX_FILES_KEY, listOf(dexFile))
         val command = buildCommandLine(dexFile.pathString, mainClass)
         testCase.testRootDisposable.whenDisposed {
             dexFile.delete()


### PR DESCRIPTION
* Add cache for dexed classes to reduce test run time.
* Register some extensions that allow more tests to pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ART-based debugger test launcher to build and cache per-classpath DEX artifacts and to register Android-specific debugger extensions; this can affect test correctness and stability due to caching, reflection-based D8 invocation, and new extension point wiring.
> 
> **Overview**
> Speeds up ART VM debugger tests by switching from a single temp DEX build to **per-dependency DEX generation with an optional on-disk cache** (controlled by `INTELLIJ_DEBUGGER_TESTS_DEX_CACHE` / `intellij.debugger.tests.dex.cache`), using a hash-based filename and atomic moves.
> 
> The ART attacher now **registers Android-specific extensions** (`AndroidDexer` and `FieldVisibilityProvider`) for the test session and stores the produced DEX paths in project user data via `DexBytecodeInspector.DEX_FILES_KEY` to enable dex-aware inspections during debugging.
> 
> Build/test module metadata is updated to include required Android and JDOM test dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c3632c7842e6ccffd591b4e55e219e457d79ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->