### PR TITLE
[JEWEL-1276] Fix popup focus-stealing in JDialogRenderer

### DIFF
--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/popup/JDialogRenderer.kt
@@ -318,7 +318,7 @@ private fun JPopupImpl(
                     }
                 }
                 is AWTKeyEvent -> {
-                    if (!dialog.isActive) return@AWTEventListener
+                    if (!dialog.isVisible) return@AWTEventListener
 
                     val composeEvent = event.toComposeKeyEvent()
 
@@ -344,9 +344,15 @@ private fun JPopupImpl(
     DisposableEffect(dialog) {
         dialog.contentPane = composePanel
 
-        dialog.isAutoRequestFocus = currentProperties.focusable
+        // JEWEL-1276 this weird code duplicates the JBPopup/AbstractPopup logic to avoid focus stealing on macOS.
+        // The actual hack is implemented in LocalPopupComponentFactory and uses the fact that macOS only sets the
+        // "key window" when a new window/popup is created. We don't want our popups to do it by default, so we
+        // start them as non-focusable, and then make them focusable a short while later.
+        dialog.focusableWindowState = false
+        dialog.isAutoRequestFocus = false
         dialog.isVisible = true
         dialog.size = composePanel.preferredSize
+        SwingUtilities.invokeLater { dialog.focusableWindowState = true }
 
         onDispose {
             dialog.isVisible = false


### PR DESCRIPTION
Focusable popups rendered via `JDialogRenderer` steal key-window status on macOS, causing the parent window's title bar and traffic-light buttons to grey out as if the window were inactive. This happens because `focusableWindowState` is `true` when `setVisible(true)` is called, making the `JDialog` the macOS key window and deactivating the parent.

Notice how with this PR the semaphore icons remain active:

<img width="638" height="328" alt="image" src="https://github.com/user-attachments/assets/d5dec3bb-fe10-4995-a9de-1d6588df1f12" />

## Changes

* Apply the same `focusableWindowState` toggle technique used in IntelliJ's `AbstractPopup`/`DialogPopupWrapper`: set `focusableWindowState = false` and `isAutoRequestFocus = false` synchronously before `isVisible = true`, then restore `focusableWindowState = true` via `SwingUtilities.invokeLater`. The popup shows without becoming the key window, but can still accept focus on explicit interaction.
* Change the `AWTEventListener` keyboard gate from `dialog.isActive` to `dialog.isVisible`, so `onKeyEvent`/`onPreviewKeyEvent` callbacks fire without requiring the dialog to hold key-window status.

## Release notes

### Bug fixes

* Fixed focusable popups stealing key-window status on macOS, which caused the parent window title bar to appear inactive when a popup was shown via `JDialogRenderer`.
