### PR TITLE
Make getMethodHandlesImplLookup Handle Exceptions

### DIFF
--- a/java/debugger/impl/src/com/intellij/debugger/engine/MethodInvokeUtils.kt
+++ b/java/debugger/impl/src/com/intellij/debugger/engine/MethodInvokeUtils.kt
@@ -76,12 +76,12 @@ object MethodInvokeUtils {
   }
 
   fun getMethodHandlesImplLookup(evaluationContext: EvaluationContextImpl): ObjectReference? {
-    val theClass = evaluationContext.debugProcess.findClass(evaluationContext,
-                                                            "java.lang.invoke.MethodHandles\$Lookup",
-                                                            null)
-    val theField = DebuggerUtils.findField(theClass,
-                                           "IMPL_LOOKUP")
-    return theClass?.getValue(theField) as? ObjectReference
+    val theClass = runCatching {
+      // On Android API < 26, this will throw
+      evaluationContext.debugProcess.findClass(evaluationContext, "java.lang.invoke.MethodHandles\$Lookup", null)
+    }.getOrNull() ?: return null
+    val theField = DebuggerUtils.findField(theClass, "IMPL_LOOKUP")
+    return theClass.getValue(theField) as? ObjectReference
   }
 }
 


### PR DESCRIPTION
On Android API < 26,:
```
debugProcess.findClass(evaluationContext, "java.lang.invoke.MethodHandles\$Lookup", null)
```

Will throw and this will make Evaluate Expression fail.

https://youtrack.jetbrains.com/issue/IDEA-388179/Evaluate-Expression-Throws-on-Android-API-25

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is localized to debugger evaluation utility code and only adds exception handling/fallback behavior; low risk aside from potentially masking unexpected class-loading errors.
> 
> **Overview**
> Prevents Evaluate Expression failures on older Android runtimes by making `getMethodHandlesImplLookup` tolerate `findClass` throwing (e.g., API < 26) and return `null` instead.
> 
> Callers already treat a `null` lookup as a helper-invocation failure, so evaluation now cleanly falls back instead of crashing when `MethodHandles$Lookup` is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2b1596e4171febbd682313c0683e5a0db1242c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->