### PR TITLE
[JEWEL-1303] Cache instances to avoid repeated allocations

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeTypography.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeTypography.kt
@@ -2,6 +2,8 @@
 package org.jetbrains.jewel.bridge
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
@@ -13,8 +15,10 @@ import com.intellij.ide.ui.UISettingsUtils
 import com.intellij.util.ui.JBFont
 import java.awt.Font
 import org.jetbrains.jewel.bridge.theme.computeBaseLineHeightFor
+import org.jetbrains.jewel.bridge.theme.retrieveConsoleTextStyle
 import org.jetbrains.jewel.bridge.theme.retrieveDefaultTextStyle
 import org.jetbrains.jewel.bridge.theme.retrieveEditorTextStyle
+import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.Typography
 
 /**
@@ -24,39 +28,57 @@ import org.jetbrains.jewel.ui.Typography
 public object BridgeTypography : Typography {
     @get:Composable
     override val labelTextStyle: TextStyle
-        get() = retrieveDefaultTextStyle()
+        get() = remember(JewelTheme.instanceUuid) { retrieveDefaultTextStyle() }
 
     @get:Composable
     override val labelTextSize: TextUnit
-        get() = labelTextStyle.fontSize
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.fontSize) }.value
+        }
 
     @get:Composable
     override val h0TextStyle: TextStyle
-        get() = labelTextStyle.applyFrom(JBFont.h0())
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.applyFrom(JBFont.h0())) }.value
+        }
 
     @get:Composable
     override val h1TextStyle: TextStyle
-        get() = labelTextStyle.applyFrom(JBFont.h1())
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.applyFrom(JBFont.h1())) }.value
+        }
 
     @get:Composable
     override val h2TextStyle: TextStyle
-        get() = labelTextStyle.applyFrom(JBFont.h2())
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.applyFrom(JBFont.h2())) }.value
+        }
 
     @get:Composable
     override val h3TextStyle: TextStyle
-        get() = labelTextStyle.applyFrom(JBFont.h3())
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.applyFrom(JBFont.h3())) }.value
+        }
 
     @get:Composable
     override val h4TextStyle: TextStyle
-        get() = labelTextStyle.applyFrom(JBFont.h4())
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.applyFrom(JBFont.h4())) }.value
+        }
 
     @get:Composable
     override val editorTextStyle: TextStyle
-        get() = retrieveEditorTextStyle()
+        get() = remember(JewelTheme.instanceUuid) { retrieveEditorTextStyle() }
 
     @get:Composable
     override val consoleTextStyle: TextStyle
-        get() = retrieveEditorTextStyle()
+        get() = remember(JewelTheme.instanceUuid) { retrieveConsoleTextStyle() }
 
     @get:Composable
     override val regular: TextStyle
@@ -64,11 +86,17 @@ public object BridgeTypography : Typography {
 
     @get:Composable
     override val medium: TextStyle
-        get() = labelTextStyle.applyFrom(JBFont.medium())
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.applyFrom(JBFont.medium())) }.value
+        }
 
     @get:Composable
     override val small: TextStyle
-        get() = labelTextStyle.applyFrom(JBFont.small())
+        get() {
+            val baseStyle = labelTextStyle
+            return remember(baseStyle) { mutableStateOf(baseStyle.applyFrom(JBFont.small())) }.value
+        }
 }
 
 // Do NOT use for editor and console fonts! They are already unscaled.

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
@@ -45,7 +45,10 @@ public fun SwingBridgeTheme(content: @Composable () -> Unit) {
         swingCompatMode = true,
     ) {
         CompositionLocalProvider(
-            LocalPainterHintsProvider provides BridgePainterHintsProvider(themeData.themeDefinition.isDark),
+            LocalPainterHintsProvider provides
+                remember(themeData.themeDefinition.isDark) {
+                    BridgePainterHintsProvider(themeData.themeDefinition.isDark)
+                },
             LocalNewUiChecker provides BridgeNewUiChecker,
             LocalDensity provides scaleDensityWithIdeScale(LocalDensity.current),
             LocalClipboard provides remember { JewelBridgeClipboard() },
@@ -53,7 +56,7 @@ public fun SwingBridgeTheme(content: @Composable () -> Unit) {
             LocalMenuItemShortcutHintProvider provides BridgeMenuItemShortcutHintProvider,
             LocalTypography provides BridgeTypography,
             LocalUriHandler provides BridgeUriHandler,
-            LocalMessageResourceResolverProvider provides BridgeMessageResourceResolver(),
+            LocalMessageResourceResolverProvider provides remember { BridgeMessageResourceResolver() },
             LocalPlatformCursorController provides BridgePlatformCursorController,
         ) {
             content()

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/IntUiTypography.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/IntUiTypography.kt
@@ -2,6 +2,7 @@
 package org.jetbrains.jewel.intui.standalone
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
@@ -18,7 +19,7 @@ import org.jetbrains.jewel.ui.component.plus
 public object IntUiTypography : Typography {
     @get:Composable
     override val labelTextStyle: TextStyle
-        get() = JewelTheme.createDefaultTextStyle()
+        get() = remember { JewelTheme.createDefaultTextStyle() }
 
     @get:Composable
     override val labelTextSize: TextUnit
@@ -26,27 +27,33 @@ public object IntUiTypography : Typography {
 
     @get:Composable
     override val h0TextStyle: TextStyle
-        get() = JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 12.sp, fontWeight = FontWeight.Bold)
+        get() = remember {
+            JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 12.sp, fontWeight = FontWeight.Bold)
+        }
 
     @get:Composable
     override val h1TextStyle: TextStyle
-        get() = JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 9.sp, fontWeight = FontWeight.Bold)
+        get() = remember {
+            JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 9.sp, fontWeight = FontWeight.Bold)
+        }
 
     @get:Composable
     override val h2TextStyle: TextStyle
-        get() = JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 5.sp)
+        get() = remember { JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 5.sp) }
 
     @get:Composable
     override val h3TextStyle: TextStyle
-        get() = JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 3.sp)
+        get() = remember { JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 3.sp) }
 
     @get:Composable
     override val h4TextStyle: TextStyle
-        get() = JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 1.sp, fontWeight = FontWeight.Bold)
+        get() = remember {
+            JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize + 1.sp, fontWeight = FontWeight.Bold)
+        }
 
     @get:Composable
     override val editorTextStyle: TextStyle
-        get() = JewelTheme.createEditorTextStyle()
+        get() = remember { JewelTheme.createEditorTextStyle() }
 
     @get:Composable
     override val consoleTextStyle: TextStyle
@@ -58,9 +65,9 @@ public object IntUiTypography : Typography {
 
     @get:Composable
     override val medium: TextStyle
-        get() = JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize - 1.sp)
+        get() = remember { JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize - 1.sp) }
 
     @get:Composable
     override val small: TextStyle
-        get() = JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize - 2.sp)
+        get() = remember { JewelTheme.createDefaultTextStyle(fontSize = DefaultFontSize - 2.sp) }
 }

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
@@ -1077,7 +1077,7 @@ public fun IntUiTheme(
 ) {
     BaseJewelTheme(theme, ComponentStyling.default().with(styling), swingCompatMode) {
         CompositionLocalProvider(
-            LocalPainterHintsProvider provides StandalonePainterHintsProvider(theme),
+            LocalPainterHintsProvider provides remember(theme) { StandalonePainterHintsProvider(theme) },
             LocalNewUiChecker provides StandaloneNewUiChecker,
             LocalMenuItemShortcutProvider provides StandaloneShortcutProvider,
             LocalMenuItemShortcutHintProvider provides StandaloneMenuItemShortcutHintProvider,


### PR DESCRIPTION
# Context

We are allocating some instances with each recomposition. This PR fixes the ones reported + some others that I could find :) (just 2)

For more information on how to run/verify this, check the [YT issue](https://youtrack.jetbrains.com/issue/JEWEL-1303/Cache-TextStyle-instances-in-IntUiTypography-to-avoid-repeated-allocations).

It's a small fix but it prevents pressuring GC, so a valid fix anyways

# Screenshots

|  | Screenshot |
|--------|--------|
| Before | <img width="3226" height="598" alt="image" src="https://github.com/user-attachments/assets/75aaa55d-df80-4a21-ad8f-b7ccff2e6da3" /> |
| After | <img width="1621" height="267" alt="image" src="https://github.com/user-attachments/assets/817774e3-bdb1-440a-9119-4124c39ed25b" /> |

## Release notes

### Bug fixes
 * Fixed `TextStyle` instances in `IntUiTypography` being re-allocated on every recomposition instead of being cached
 * Fixed `StandalonePainterHintsProvider` and `BridgePainterHintsProvider`/`BridgeMessageResourceResolver` being re-allocated on every recomposition of `IntUiTheme` and `SwingBridgeTheme`