### PR TITLE
Fix 'occured' -> 'occurred' typos in EelReceiveChannel, Python debugger, Devkit

### DIFF
--- a/platform/eel/src/com/intellij/platform/eel/channels/EelReceiveChannel.kt
+++ b/platform/eel/src/com/intellij/platform/eel/channels/EelReceiveChannel.kt
@@ -16,7 +16,7 @@ interface EelReceiveChannel {
    * To read to the end, read until result is [ReadResult.EOF].
    *
    * @return [ReadResult] (see its doc for usage instructions)
-   * @throws EelReceiveChannelException if some I/O error occured that certainly can be treated just as [ReadResult.EOF].
+   * @throws EelReceiveChannelException if some I/O error occurred that certainly can be treated just as [ReadResult.EOF].
    *   The channel is unusable after receiving the error. No methods except [closeForReceive] may be called.
    */
   @Throws(EelReceiveChannelException::class)
@@ -30,7 +30,7 @@ interface EelReceiveChannel {
    * I.e., it is possible that [available] returns 0 even though it's possible to read something immediately.
    * Moreover, implementations may return 0 every time.
    *
-   * @throws EelReceiveChannelException if some I/O error occured that certainly can be treated just as [ReadResult.EOF].
+   * @throws EelReceiveChannelException if some I/O error occurred that certainly can be treated just as [ReadResult.EOF].
    *   The channel is unusable after receiving the error. No methods except [closeForReceive] may be called.
    */
   @Throws(EelReceiveChannelException::class)

--- a/plugins/devkit/devkit-core/src/actions/NewRemoteDevModuleAction.kt
+++ b/plugins/devkit/devkit-core/src/actions/NewRemoteDevModuleAction.kt
@@ -86,7 +86,7 @@ internal class NewRemoteDevModuleAction : DumbAwareAction() {
       catch (e: Exception) {
         LOG.warn("Couldn't create Remote Dev Module", e)
         withContext(Dispatchers.EDT) {
-          Messages.showErrorDialog(project, "Remote Dev Module created only partially. An exception occured during the process: ${e.message}.", "Remote Dev Module Creation Failed")
+          Messages.showErrorDialog(project, "Remote Dev Module created only partially. An exception occurred during the process: ${e.message}.", "Remote Dev Module Creation Failed")
         }
       }
     }

--- a/python/src/com/jetbrains/python/debugger/PyUnitTestsDebuggingService.java
+++ b/python/src/com/jetbrains/python/debugger/PyUnitTestsDebuggingService.java
@@ -138,7 +138,7 @@ final class PyUnitTestsDebuggingService {
   /**
    * Check if the error has happened while set up or tear down.
    *
-   * @param frames of the thread where an exception has occured
+   * @param frames of the thread where an exception has occurred
    */
   public static boolean isErrorInTestSetUpOrTearDown(@NotNull List<PyStackFrameInfo> frames) {
     for (PyStackFrameInfo frameInfo : frames) {


### PR DESCRIPTION
Fix 4 instances of \`occured\` → \`occurred\` across 3 files in the IntelliJ codebase.

## Files

| File | Context |
|------|---------|
| \`platform/eel/src/com/intellij/platform/eel/channels/EelReceiveChannel.kt\` (×2) | KDoc on \`receive\`/\`receiveFully\` \`@throws\` |
| \`python/src/com/jetbrains/python/debugger/PyUnitTestsDebuggingService.java\` | Javadoc on frames param |
| \`plugins/devkit/devkit-core/src/actions/NewRemoteDevModuleAction.kt\` | User-facing dialog text ("An exception occured during the process") |

The dialog text fix is user-visible in the Remote Dev Module Creation Failed error dialog.

## Testing

Comment/string-literal-only change; no tests impacted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely text-only typo fixes in comments and a user-facing error message; no behavioral or API changes.
> 
> **Overview**
> Fixes the misspelling *"occured" → "occurred"* in `EelReceiveChannel` KDoc, `PyUnitTestsDebuggingService` Javadoc, and the Remote Dev Module creation failure dialog text in `NewRemoteDevModuleAction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b81c0879467d811e531d67586e570d89059da20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->