### PR TITLE
PY-81983 python: fix inlining optional argument when it is reassigned

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/refactoring/inline/PyInlineFunctionProcessor.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/refactoring/inline/PyInlineFunctionProcessor.kt
@@ -180,13 +180,22 @@ class PyInlineFunctionProcessor(
     val functionScope = ControlFlowCache.getScope(myFunction)
     PyClassRefactoringUtil.rememberNamedReferences(myFunction)
 
+    val reassignedParams = mutableSetOf<String>()
+    myFunction.statementList.accept(object : PyRecursiveElementVisitor() {
+      override fun visitPyTargetExpression(node: PyTargetExpression) {
+        if (!node.isQualified) {
+          node.name?.let { reassignedParams.add(it) }
+        }
+        super.visitPyTargetExpression(node)
+      }
+    })
+
     references.forEach { usage ->
       val reference = usage.element as PyReferenceExpression
       val languageLevel = LanguageLevel.forElement(reference)
       val refScopeOwner = ScopeUtil.getScopeOwner(reference) ?: error("Unable to find scope owner for ${reference.name}")
       val declarations = mutableListOf<PyAssignmentStatement>()
       val generatedNames = mutableSetOf<String>()
-
 
       val callSite = PsiTreeUtil.getParentOfType(reference, PyCallExpression::class.java)
                      ?: error("Unable to find call expression for ${reference.name}")
@@ -210,7 +219,7 @@ class PyInlineFunctionProcessor(
       val returnStatements = mutableListOf<PyReturnStatement>()
 
       val mappedArguments =
-        prepareArguments(callSite, declarations, generatedNames, scopeAnchor, reference, languageLevel, resolveContext, selfUsed)
+        prepareArguments(callSite, declarations, generatedNames, scopeAnchor, reference, languageLevel, resolveContext, selfUsed, reassignedParams)
 
       myFunction.statementList.accept(object : PyRecursiveElementVisitor() {
         override fun visitPyReferenceExpression(node: PyReferenceExpression) {
@@ -421,6 +430,7 @@ class PyInlineFunctionProcessor(
     languageLevel: LanguageLevel,
     context: PyResolveContext,
     selfUsed: Boolean,
+    reassignedParams: Set<String>,
   ): Map<String, PyExpression> {
     val mapping = callSite.mapArguments(context).firstOrNull() ?: error("Can't map arguments for ${reference.name}")
     val mappedParams = mapping.mappedParameters
@@ -439,14 +449,14 @@ class PyInlineFunctionProcessor(
     val passedArguments = mappedParams.asSequence()
       .map { (arg, param) ->
         val argValue = if (arg is PyKeywordArgument) arg.valueExpression!! else arg
-        tryExtractDeclaration(param.name!!, argValue, declarations, generatedNames, scopeAnchor, languageLevel)
+        tryExtractDeclaration(param.name!!, argValue, declarations, generatedNames, scopeAnchor, languageLevel, reassignedParams)
       }
       .toMap()
 
     val defaultValues = myFunction.parameterList.parameters.asSequence()
       .filter { it.name !in passedArguments }
       .filter { it.hasDefaultValue() }
-      .map { tryExtractDeclaration(it.name!!, it.defaultValue!!, declarations, generatedNames, scopeAnchor, languageLevel) }
+      .map { tryExtractDeclaration(it.name!!, it.defaultValue!!, declarations, generatedNames, scopeAnchor, languageLevel, reassignedParams) }
       .toMap()
 
     return self + passedArguments + defaultValues
@@ -454,9 +464,9 @@ class PyInlineFunctionProcessor(
 
   private fun tryExtractDeclaration(
     paramName: String, arg: PyExpression, declarations: MutableList<PyAssignmentStatement>, generatedNames: MutableSet<String>,
-    scopeAnchor: PsiElement, languageLevel: LanguageLevel,
+    scopeAnchor: PsiElement, languageLevel: LanguageLevel, reassignedParams: Set<String>,
   ): Pair<String, PyExpression> {
-    if (arg !is PyReferenceExpression && arg !is PyLiteralExpression) {
+    if (paramName in reassignedParams || (arg !is PyReferenceExpression && arg !is PyLiteralExpression)) {
       return extractDeclaration(paramName, arg, declarations, generatedNames, scopeAnchor, languageLevel)
     }
     return paramName to arg

--- a/python/python-psi-impl/src/com/jetbrains/python/refactoring/inline/PyInlineFunctionProcessor.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/refactoring/inline/PyInlineFunctionProcessor.kt
@@ -27,6 +27,7 @@ import com.jetbrains.python.codeInsight.dataflow.scope.ScopeUtil
 import com.jetbrains.python.psi.LanguageLevel
 import com.jetbrains.python.psi.PyAssignmentStatement
 import com.jetbrains.python.psi.PyCallExpression
+import com.jetbrains.python.psi.PyClass
 import com.jetbrains.python.psi.PyDecorator
 import com.jetbrains.python.psi.PyElementGenerator
 import com.jetbrains.python.psi.PyExpression
@@ -182,6 +183,14 @@ class PyInlineFunctionProcessor(
 
     val reassignedParams = mutableSetOf<String>()
     myFunction.statementList.accept(object : PyRecursiveElementVisitor() {
+      override fun visitPyFunction(node: PyFunction) {
+        // Do not recurse into nested functions — their locals are in a different scope
+      }
+
+      override fun visitPyClass(node: PyClass) {
+        // Do not recurse into nested classes — their locals are in a different scope
+      }
+
       override fun visitPyTargetExpression(node: PyTargetExpression) {
         if (!node.isQualified) {
           node.name?.let { reassignedParams.add(it) }

--- a/python/testData/refactoring/inlineFunction/parameterReassigned/main.after.py
+++ b/python/testData/refactoring/inlineFunction/parameterReassigned/main.after.py
@@ -1,0 +1,10 @@
+def function1(a, b, argument=None):
+    if argument is None:
+        argument = a + b
+    print(argument)
+
+def function2():
+    argument = None
+    if argument is None:
+        argument = 1 + 2
+    print(argument)

--- a/python/testData/refactoring/inlineFunction/parameterReassigned/main.py
+++ b/python/testData/refactoring/inlineFunction/parameterReassigned/main.py
@@ -1,0 +1,7 @@
+def function1(a, b, argument=None):
+    if argument is None:
+        argument = a + b
+    print(argument)
+
+def function2():
+    function1<caret>(1, 2)

--- a/python/testData/refactoring/inlineFunction/parameterReassignedInNestedScope/main.after.py
+++ b/python/testData/refactoring/inlineFunction/parameterReassignedInNestedScope/main.after.py
@@ -1,0 +1,10 @@
+def foo(x):
+    def bar():
+        x = 10
+    print(x)
+
+def baz():
+    def bar():
+        x = 10
+
+    print(1)

--- a/python/testData/refactoring/inlineFunction/parameterReassignedInNestedScope/main.py
+++ b/python/testData/refactoring/inlineFunction/parameterReassignedInNestedScope/main.py
@@ -1,0 +1,7 @@
+def foo(x):
+    def bar():
+        x = 10
+    print(x)
+
+def baz():
+    foo<caret>(1)

--- a/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
@@ -133,4 +133,5 @@ class PyInlineFunctionTest : PyTestCase() {
   fun testUsedAsReference() = doTestError("The function foo is used as a reference and cannot be inlined. The function definition will not be removed", isReferenceError = true)
   fun testUsesArgumentUnpacking() = doTestError("The function foo uses argument unpacking and cannot be inlined. The function definition will not be removed", isReferenceError = true)
   fun testNestedIfElseIndentation() = doTest()
+  fun testParameterReassigned() = doTest()
 }

--- a/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
@@ -134,4 +134,5 @@ class PyInlineFunctionTest : PyTestCase() {
   fun testUsesArgumentUnpacking() = doTestError("The function foo uses argument unpacking and cannot be inlined. The function definition will not be removed", isReferenceError = true)
   fun testNestedIfElseIndentation() = doTest()
   fun testParameterReassigned() = doTest()
+  fun testParameterReassignedInNestedScope() = doTest()
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/PY-81983/Inlining-a-function-replaces-usages-of-the-optional-argument-with-None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inline-refactoring substitution logic, so regressions could affect other inlining scenarios (argument mapping/defaults/name generation), though the change is localized and covered by new tests.
> 
> **Overview**
> Fixes `PyInlineFunctionProcessor` argument substitution so **parameters that are reassigned inside the inlined function** (commonly optional args like `argument=None` later reassigned) are no longer replaced inline with the original expression (e.g., `None`), but are instead extracted into a generated assignment at the call site.
> 
> Adds scope-aware detection of reassigned names in the function body (skipping nested `PyFunction`/`PyClass` scopes) and threads this into argument/default-value mapping; includes new inline-refactoring test cases covering reassignment and nested-scope reassignment behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54c69c6bdb6a20f8981a13b002033a6ccda4cb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->