### PR TITLE
PY-89262 Prevent inline refactoring from suggesting to modify library…

### DIFF
--- a/python/python-psi-impl/src/com/jetbrains/python/refactoring/inline/PyInlineFunctionProcessor.kt
+++ b/python/python-psi-impl/src/com/jetbrains/python/refactoring/inline/PyInlineFunctionProcessor.kt
@@ -488,6 +488,12 @@ class PyInlineFunctionProcessor(
   override fun getCommandName() = PyPsiBundle.message("refactoring.inline.function.command.name", myFunction.name)
   override fun getRefactoringId() = PyInlineFunctionHandler.Helper.REFACTORING_ID
 
+  override fun getElementsToWrite(descriptor: UsageViewDescriptor): Collection<PsiElement> {
+    // If we are not going to remove the declaration, do not require the declaration's file to be writable.
+    // Otherwise, inlining a function from a library/read-only file would trigger a "non-project file" warning.
+    return if (myRemoveDeclaration) super.getElementsToWrite(descriptor) else emptyList()
+  }
+
   override fun createUsageViewDescriptor(usages: Array<out UsageInfo>) = object : UsageViewDescriptor {
     override fun getElements(): Array<PsiElement> = arrayOf(myFunction)
     override fun getProcessedElementsHeader(): String = PyPsiBundle.message("refactoring.inline.function.function.to.inline")

--- a/python/testData/refactoring/inlineFunction/readOnlyLibraryFunction/lib.py
+++ b/python/testData/refactoring/inlineFunction/readOnlyLibraryFunction/lib.py
@@ -1,0 +1,3 @@
+def foo(arg):
+    local = arg + arg
+    return local

--- a/python/testData/refactoring/inlineFunction/readOnlyLibraryFunction/main.after.py
+++ b/python/testData/refactoring/inlineFunction/readOnlyLibraryFunction/main.after.py
@@ -1,0 +1,2 @@
+local = 42 + 42
+x = local

--- a/python/testData/refactoring/inlineFunction/readOnlyLibraryFunction/main.py
+++ b/python/testData/refactoring/inlineFunction/readOnlyLibraryFunction/main.py
@@ -1,0 +1,3 @@
+from lib import foo
+
+x = fo<caret>o(42)

--- a/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
+++ b/python/testSrc/com/jetbrains/python/refactoring/PyInlineFunctionTest.kt
@@ -2,6 +2,7 @@
 package com.jetbrains.python.refactoring
 
 import com.intellij.codeInsight.TargetElementUtil
+import com.intellij.openapi.application.WriteAction
 import com.intellij.refactoring.util.CommonRefactoringUtil
 import com.jetbrains.python.fixtures.PyTestCase
 import com.jetbrains.python.psi.LanguageLevel
@@ -133,4 +134,28 @@ class PyInlineFunctionTest : PyTestCase() {
   fun testUsedAsReference() = doTestError("The function foo is used as a reference and cannot be inlined. The function definition will not be removed", isReferenceError = true)
   fun testUsesArgumentUnpacking() = doTestError("The function foo uses argument unpacking and cannot be inlined. The function definition will not be removed", isReferenceError = true)
   fun testNestedIfElseIndentation() = doTest()
+
+  // PY-89262
+  fun testReadOnlyLibraryFunction() {
+    val testName = getTestName(true)
+    myFixture.copyDirectoryToProject(testName, "")
+    myFixture.configureByFile("main.py")
+    val libVFile = myFixture.findFileInTempDir("lib.py")
+    assertNotNull(libVFile)
+    WriteAction.runAndWait<RuntimeException> { libVFile!!.isWritable = false }
+    try {
+      var element = TargetElementUtil.findTargetElement(myFixture.editor, TargetElementUtil.getInstance().referenceSearchFlags)
+      if (element!!.containingFile is PyiFile) element = PyiUtil.getOriginalElement(element as PyElement)
+      val reference = TargetElementUtil.findReference(myFixture.editor)
+      assertTrue(element is PyFunction)
+      assertFalse("Precondition: the library file should be non-writable", element!!.containingFile.virtualFile.isWritable)
+      // Must not throw due to a read-only check on the library file, since we don't remove the declaration.
+      PyInlineFunctionProcessor(myFixture.project, myFixture.editor, element as PyFunction, reference,
+                                myInlineThisOnly = false, removeDeclaration = false).run()
+      myFixture.checkResultByFile("$testName/main.after.py")
+    }
+    finally {
+      WriteAction.runAndWait<RuntimeException> { libVFile!!.isWritable = true }
+    }
+  }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/PY-89262/Inlining-library-function-suggests-modifying-library-file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to inline-refactoring dialog text/option selection and add a targeted UI-level test for read-only functions.
> 
> **Overview**
> Prevents **Inline Function** refactoring from implying it will delete/modify a library (read-only) function declaration.
> 
> `PyInlineFunctionDialog` now detects non-writable targets and (1) disables the *keep declaration* option, (2) relabels *Inline all* to *Inline all invocations in project*, and (3) forces `removeDeclaration=false` when inlining read-only functions. Adds a bundle message for the new label and a regression test covering the dialog behavior for a non-writable `lib.py` function.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d3c8a66c6d29165b4830219f15c7e90de437c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->