### PR TITLE
Skip excluded roots from IndexableSetContributor scanning

### DIFF
--- a/platform/lang-impl/src/com/intellij/util/indexing/roots/IndexableSetContributorFilesIterator.kt
+++ b/platform/lang-impl/src/com/intellij/util/indexing/roots/IndexableSetContributorFilesIterator.kt
@@ -53,7 +53,7 @@ class IndexableSetContributorFilesIterator(private val name: String?,
     fileIterator: ContentIterator,
     fileFilter: VirtualFileFilter
   ): Boolean {
-    return IndexableFilesIterationMethods.iterateRoots(project, roots, fileIterator, fileFilter, excludeNonProjectRoots = false)
+    return IndexableFilesIterationMethods.iterateRoots(project, roots, fileIterator, fileFilter, excludeNonProjectRoots = true)
   }
 
   override fun getRootUrls(project: Project): Set<String> {

--- a/platform/platform-tests/testSrc/com/intellij/openapi/roots/impl/indexing/IndexableFilesBeneathExcludedDirectoryTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/roots/impl/indexing/IndexableFilesBeneathExcludedDirectoryTest.kt
@@ -171,7 +171,8 @@ class IndexableFilesBeneathExcludedDirectoryTest : IndexableFilesBaseTest() {
         setOf(additionalRootsFile)
     }
     maskIndexableSetContributors(contributor)
-    assertIndexableFiles(projectFile.file, appFile.file)
+    assertIndexableFiles()
+    assertHasNoIndexes(projectFile.file, appFile.file)
   }
 
   @Test


### PR DESCRIPTION
Ref:
+ Agent-Logs-Url: https://github.com/DevDengChao/intellij-community/sessions/9155bf3e-0cd5-45b8-b886-e567f2363851
+ https://youtrack.jetbrains.com/issue/IJPL-243399/Webstorm-spend-a-lot-of-time-Analyzing-project-on-.worktrees-dir