### PR TITLE
[JEWEL-1307] Circumvent crash when selecting Tooltip (and Text) inside a SelectionContainer

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Popup.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Popup.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.ui.component
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
@@ -72,25 +73,27 @@ public fun Popup(
     onKeyEvent: ((KeyEvent) -> Boolean)? = null,
     content: @Composable () -> Unit,
 ) {
-    if (JewelFlags.useCustomPopupRenderer) {
-        LocalPopupRenderer.current.Popup(
-            popupPositionProvider = popupPositionProvider,
-            properties = properties,
-            onDismissRequest = onDismissRequest,
-            onPreviewKeyEvent = onPreviewKeyEvent,
-            onKeyEvent = onKeyEvent,
-            cornerSize = cornerSize,
-            content = content,
-        )
-    } else {
-        ComposePopup(
-            popupPositionProvider = popupPositionProvider,
-            onDismissRequest = onDismissRequest,
-            properties = properties,
-            onPreviewKeyEvent = onPreviewKeyEvent,
-            onKeyEvent = onKeyEvent,
-            content = content,
-        )
+    DisableSelection {
+        if (JewelFlags.useCustomPopupRenderer) {
+            LocalPopupRenderer.current.Popup(
+                popupPositionProvider = popupPositionProvider,
+                properties = properties,
+                onDismissRequest = onDismissRequest,
+                onPreviewKeyEvent = onPreviewKeyEvent,
+                onKeyEvent = onKeyEvent,
+                cornerSize = cornerSize,
+                content = content,
+            )
+        } else {
+            ComposePopup(
+                popupPositionProvider = popupPositionProvider,
+                onDismissRequest = onDismissRequest,
+                properties = properties,
+                onPreviewKeyEvent = onPreviewKeyEvent,
+                onKeyEvent = onKeyEvent,
+                content = content,
+            )
+        }
     }
 }
 

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
@@ -74,7 +74,7 @@ public fun Tooltip(
     autoHideBehavior: AutoHideBehavior = AutoHideBehavior.Normal,
     content: @Composable () -> Unit,
 ) {
-    FlagAwareTooltipArea(
+    JewelTooltipArea(
         tooltip = {
             TooltipImpl(
                 enabled = enabled,
@@ -128,7 +128,7 @@ public fun Tooltip(
     tooltipPlacement: TooltipPlacement = style.metrics.placement,
     content: @Composable () -> Unit,
 ) {
-    FlagAwareTooltipArea(
+    JewelTooltipArea(
         tooltip = { TooltipImpl(enabled, style, tooltip = tooltip) },
         modifier = modifier,
         delayMillis = style.metrics.showDelay.inWholeMilliseconds.toInt(),

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TooltipArea.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TooltipArea.kt
@@ -2,7 +2,6 @@
 package org.jetbrains.jewel.ui.component
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.TooltipArea as ComposeTooltipArea
 import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.shape.CornerSize
@@ -29,55 +28,10 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.jetbrains.jewel.foundation.JewelFlags
-
-/**
- * A composable function that provides a tooltip area to display additional information associated with a UI element.
- * The tooltip appears when the user hovers over the content with their cursor, after an optional delay.
- *
- * This function behavior is influenced by the [JewelFlags.useCustomPopupRenderer]. If set to true, it will use the
- * custom popup implementation. Otherwise, it will use the default Compose tooltip implementation.
- *
- * @param tooltip Composable content of the tooltip.
- * @param modifier The modifier to be applied to the layout.
- * @param delayMillis Delay in milliseconds.
- * @param tooltipPlacement Defines the position of the tooltip.
- * @param content Composable content that the current tooltip is set to.
- * @see org.jetbrains.jewel.ui.component.Popup
- * @see androidx.compose.ui.window.Popup
- */
-@Composable
-internal fun FlagAwareTooltipArea(
-    tooltip: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    delayMillis: Int = 500,
-    tooltipPlacement: TooltipPlacement = TooltipPlacement.CursorPoint(offset = DpOffset(0.dp, 16.dp)),
-    cornerSize: CornerSize = ZeroCornerSize,
-    content: @Composable () -> Unit,
-) {
-    if (JewelFlags.useCustomPopupRenderer) {
-        JewelTooltipArea(
-            tooltip = tooltip,
-            modifier = modifier,
-            delayMillis = delayMillis,
-            tooltipPlacement = tooltipPlacement,
-            cornerSize = cornerSize,
-            content = content,
-        )
-    } else {
-        ComposeTooltipArea(
-            tooltip = tooltip,
-            modifier = modifier,
-            delayMillis = delayMillis,
-            tooltipPlacement = tooltipPlacement,
-            content = content,
-        )
-    }
-}
 
 /** Copy of the [androidx.compose.foundation.TooltipArea], but using our implementation of [Popup]. */
 @Composable
-private fun JewelTooltipArea(
+internal fun JewelTooltipArea(
     tooltip: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     delayMillis: Int = 500,


### PR DESCRIPTION
# Context
There's a crash in Jetpack Compose that happens where gesture being translated from text coordinates to the selection container coordinates don't share the same root node, which is the case for our tooltip and popups in general.

Filed issues about this bug:

https://youtrack.jetbrains.com/projects/CMP/issues/CMP-9161
https://issuetracker.google.com/issues/300781578

# Fix
- Wrap the tooltip in a `DisabledSelection` as a workaround.
- Also removed the internal `FlagAwareTooltipArea` in favor of using `JewelTooltipArea` directly.

# Screenshots/Screen Recordings

## Tooltip
| Scenario | Screen Recording |
|--------|--------|
| Crash | <video src="https://github.com/user-attachments/assets/4a57510f-2076-4b09-9725-f5dcdd183b0f" /> |
| Compose Popup | <video src="https://github.com/user-attachments/assets/bd622015-75a0-4c79-a74f-cf9eb0fff362" /> |
| Jewel Popup | <video src="https://github.com/user-attachments/assets/67232132-6cea-4745-9d96-60c2dc1ac4b1" /> |

The main use case where the crash can most commonly happen is this one, using tooltips. However, it is technically viable to have a `SelectionContainer` wrapping other components that do open a popup, like ComboBoxes and Menus. Why would you ever do such thing I've no idea, but here's proof that they are not crashing:

---

## Menu
| Scenario | Screen Recording |
|--------|--------|
| Crash | <video src="https://github.com/user-attachments/assets/77b329e9-cb34-4217-8a11-5364d012f335" /> |
| Compose Popup | <video src="https://github.com/user-attachments/assets/3f5e83dc-4d6e-4635-9975-ac0c44e82fe8" /> |
| Jewel Popup | <video src="https://github.com/user-attachments/assets/624f45a1-75d0-4466-83c4-fe3e36c89c8f" /> |


## ComboBox
| Scenario | Screen Recording |
|--------|--------|
| Crash | <video src="https://github.com/user-attachments/assets/2fbda99a-c104-45e9-8abb-410d2f29d264" /> |
| Compose Popup | <video src="https://github.com/user-attachments/assets/168ff99b-c730-43e1-be3e-a242ab02aaae" /> |
| Jewel Popup | <video src="https://github.com/user-attachments/assets/9a973ebd-2f5a-4133-b826-74c2f18f8695" /> |


## SpeedSearch
Funnily enough I wasn't able to reproduce the crash in SpeedSearch. Tried with both our native popup and Compose's but no luck.

There seems to be a bug with the selection though, it stops working after the speed search popup is rendered for the first time.

Anywho, have fun watching be try to force the crash using our native popup for 37 seconds:

https://github.com/user-attachments/assets/1dea946e-5e74-4b97-8d5b-6e27cd159184