### PR TITLE
Cleanup for Bazel attribute 'inc_threshold'

### DIFF
--- a/build/jvm-rules/.bazelrc
+++ b/build/jvm-rules/.bazelrc
@@ -10,7 +10,7 @@ build --tool_java_language_version=25
 # Java runtime the tools should use
 build --tool_java_runtime_version=remotejdk_25
 
-common --@rules_jvm//:koltin_inc_threshold=0 --@rules_jvm//:java_inc_threshold=0
+common --@rules_jvm//:kotlin_inc_threshold=0 --@rules_jvm//:java_inc_threshold=0
 
 # make sure you don't need to open file to read compilation errors
 common --experimental_ui_max_stdouterr_bytes=-1

--- a/build/jvm-rules/BUILD.bazel
+++ b/build/jvm-rules/BUILD.bazel
@@ -57,9 +57,9 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
-# --@rules_jvm//:koltin_inc_threshold=100
+# --@rules_jvm//:kotlin_inc_threshold=100
 int_flag(
-    name = "koltin_inc_threshold",
+    name = "kotlin_inc_threshold",
     build_setting_default = -1,
 )
 

--- a/build/jvm-rules/jvm-inc-builder-tests/testData/.bazelrc
+++ b/build/jvm-rules/jvm-inc-builder-tests/testData/.bazelrc
@@ -13,7 +13,7 @@ build --tool_java_language_version=25
 # Java runtime the tools should use
 build --tool_java_runtime_version=remotejdk_25
 
-common --@rules_jvm//:koltin_inc_threshold=0 --@rules_jvm//:java_inc_threshold=0
+common --@rules_jvm//:kotlin_inc_threshold=0 --@rules_jvm//:java_inc_threshold=0
 
 # make sure you don't need to open file to read compilation errors
 common --experimental_ui_max_stdouterr_bytes=-1

--- a/build/jvm-rules/rules/common-attrs.bzl
+++ b/build/jvm-rules/rules/common-attrs.bzl
@@ -120,7 +120,7 @@ common_attr = add_dicts(
         ),
         "_reduced_classpath": attr.bool(default = False),
         "_trace": attr.label(default = "//:trace"),
-        "_kotlin_inc_threshold": attr.label(default = "//:koltin_inc_threshold"),
+        "_kotlin_inc_threshold": attr.label(default = "//:kotlin_inc_threshold"),
         "_java_inc_threshold": attr.label(default = "//:java_inc_threshold"),
     },
 )

--- a/build/jvm-rules/rules/impl/compile.bzl
+++ b/build/jvm-rules/rules/impl/compile.bzl
@@ -26,7 +26,6 @@ load("//:rules/common-attrs.bzl", "add_dicts")
 load("//:rules/impl/associates.bzl", "get_associates")
 load("//:rules/impl/builder-args.bzl", "init_builder_args")
 load("//:rules/impl/compiler-plugins.bzl", "collect_compiler_plugins_for_export", "compiler_plugins_from", "exported_compiler_plugins_from")
-load("//:rules/impl/kotlinc-options.bzl", "KotlincOptions")
 load("//:rules/resource.bzl", "ResourceGroupInfo")
 
 visibility("private")
@@ -194,9 +193,6 @@ def _run_jvm_builder(
     kotlin_cri_storage_file = None
 
     kotlin_inc_threshold = ctx.attr._kotlin_inc_threshold[BuildSettingInfo].value
-    if kotlin_inc_threshold == -1:
-        kotlinc_options = ctx.attr.kotlinc_opts[KotlincOptions]
-        kotlin_inc_threshold = kotlinc_options.inc_threshold
     java_inc_threshold = ctx.attr._java_inc_threshold[BuildSettingInfo].value
 
     args = init_builder_args(ctx, srcs, resources, associates, transitiveInputs, plugins = plugins, compile_deps = compile_deps)

--- a/common.bazelrc
+++ b/common.bazelrc
@@ -58,7 +58,7 @@ common:windows --disk_cache=~/AppData/Local/Temp/JetBrains/monorepo-bazel-cache
 
 common --@rules_jvm//:default-javac-opts=@community//:default-javac-opts
 common --@rules_jvm//:default-kotlinc-opts=@community//:k25
-common --@rules_jvm//:koltin_inc_threshold=0 --@rules_jvm//:java_inc_threshold=0
+common --@rules_jvm//:kotlin_inc_threshold=0 --@rules_jvm//:java_inc_threshold=0
 
 # configure resources
 common --local_resources=memory=HOST_RAM*.77 --local_resources=cpu=HOST_CPUS*2


### PR DESCRIPTION
1. Fix typo in `kotlin_inc_threshold`
2. Remove dead codepath reading nonexistent field `KotlincOptions.inc_threshold`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-configuration cleanup: fixes a misspelled Bazel build setting name and deletes an unused fallback code path, with impact limited to incremental compilation toggling.
> 
> **Overview**
> Fixes a typo in the Bazel build setting for Kotlin incremental compilation by renaming `koltin_inc_threshold` to `kotlin_inc_threshold` and updating all `.bazelrc`/rule attribute references accordingly.
> 
> Removes the dead fallback that attempted to read `KotlincOptions.inc_threshold` in `compile.bzl`, making incremental/non-incremental selection depend solely on the `@rules_jvm` build settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3fa999d196f55b7b69d8095b5522c3f224f428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->