### PR TITLE
misc [proxy]: proxy settings support plain url like "google.com" treated as https.

### DIFF
--- a/platform/platform-api/src/com/intellij/util/net/PlatformHttpClient.java
+++ b/platform/platform-api/src/com/intellij/util/net/PlatformHttpClient.java
@@ -103,7 +103,7 @@ public final class PlatformHttpClient {
 
   /// Uses the given URI to construct a preconfigured [HttpRequest.Builder].
   public static HttpRequest.@NotNull Builder requestBuilder(@NotNull URI uri) {
-    return (uri.getScheme().equals("file") ? new FileRequestBuilder().uri(uri) : HttpRequest.newBuilder(uri))
+    return ("file".equals(uri.getScheme()) ? new FileRequestBuilder().uri(uri) : HttpRequest.newBuilder(uri))
       .timeout(Duration.ofMillis(HttpRequests.READ_TIMEOUT))
       .header("User-Agent", userAgent());
   }

--- a/platform/platform-impl/src/com/intellij/util/net/ProxySettingsUi.kt
+++ b/platform/platform-impl/src/com/intellij/util/net/ProxySettingsUi.kt
@@ -242,7 +242,8 @@ internal class ProxySettingsUi(
       withContext(Dispatchers.IO) {
         try {
           val client = PlatformHttpClient.client()
-          val request = PlatformHttpClient.requestBuilder(URI(url)).timeout(Duration.ofSeconds(3)).build()
+          val uri = URI(url).takeIf { it.scheme != null } ?: URI("https://$url")
+          val request = PlatformHttpClient.requestBuilder(uri).timeout(Duration.ofSeconds(3)).build()
           JdkProxyProvider.toggleProxyAuthNotification(suppress = true)
           PlatformHttpClient.send(client, request, HttpResponse.BodyHandlers.discarding())
         }


### PR DESCRIPTION
also fix npe in PlatformHttpClient when uri param don't have schema; it shall fall into a special error handling we made in HttpRequestBuilderImpl means newIAE("URI with undefined scheme") , not a common pure strange NPE.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/0232dbf0-0ad5-4dcd-93e8-dc15c4de46e8" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/20d41392-2502-4e72-9df7-58b704c4aee7" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/adf261ea-65a0-459e-8ce0-beceedf5a4f2" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized changes to proxy connection test URL handling and a defensive null-safe scheme comparison in `PlatformHttpClient`.
> 
> **Overview**
> Proxy connection testing in `ProxySettingsUi` now accepts host-only inputs (e.g. `google.com`) by defaulting missing schemes to `https://` before building the request.
> 
> `PlatformHttpClient.requestBuilder` switches to a null-safe `"file".equals(uri.getScheme())` check to avoid unexpected NPEs when given a URI without a scheme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6da63ac6cd2fb027e668b591d46fdb98233e574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->