### PR TITLE
Fix: disallow single underscore as Kotlin class or package name (KTIJ-38655)

### DIFF
--- a/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
@@ -412,6 +412,7 @@ action.new.file.dialog.enum.title=Enum class
 action.new.file.dialog.object.title=Object
 action.new.file.error.empty.name=Name can't be empty
 action.new.file.error.empty.name.part=Name can't have empty parts
+action.new.file.error.underscore=Name can't be a single underscore
 
 action.new.script.name=Kotlin script
 

--- a/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
@@ -412,7 +412,7 @@ action.new.file.dialog.enum.title=Enum class
 action.new.file.dialog.object.title=Object
 action.new.file.error.empty.name=Name can't be empty
 action.new.file.error.empty.name.part=Name can't have empty parts
-action.new.file.error.underscore=Name can't be a single underscore
+action.new.file.error.underscore=Name can't consist only of underscores
 
 action.new.script.name=Kotlin script
 

--- a/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/actions/NewKotlinFileNameValidatorTest.kt
+++ b/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/actions/NewKotlinFileNameValidatorTest.kt
@@ -15,6 +15,7 @@ class NewKotlinFileNameValidatorTest : LightJavaCodeInsightFixtureTestCase(), Ex
     companion object {
         private const val EMPTY_PARTS_ERROR = "Name can't have empty parts"
         private const val EMPTY_ERROR = "Name can't be empty"
+        private const val UNDERSCORE_ERROR = "Name can't be a single underscore"
     }
 
     override fun setUp() {
@@ -57,6 +58,14 @@ class NewKotlinFileNameValidatorTest : LightJavaCodeInsightFixtureTestCase(), Ex
 
     fun testSimpleFileWithPath() {
         validateName("a/bb\\some", null)
+    }
+
+    fun testUnderscore() {
+        validateName("_", UNDERSCORE_ERROR)
+    }
+
+    fun testUnderscoreInQualified() {
+        validateName("a._.b", UNDERSCORE_ERROR)
     }
 
     private fun validateName(name: String, errorMessage: String?) {

--- a/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/actions/NewKotlinFileNameValidatorTest.kt
+++ b/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/actions/NewKotlinFileNameValidatorTest.kt
@@ -15,7 +15,7 @@ class NewKotlinFileNameValidatorTest : LightJavaCodeInsightFixtureTestCase(), Ex
     companion object {
         private const val EMPTY_PARTS_ERROR = "Name can't have empty parts"
         private const val EMPTY_ERROR = "Name can't be empty"
-        private const val UNDERSCORE_ERROR = "Name can't be a single underscore"
+        private const val UNDERSCORE_ERROR = "Name can't consist only of underscores"
     }
 
     override fun setUp() {
@@ -62,10 +62,21 @@ class NewKotlinFileNameValidatorTest : LightJavaCodeInsightFixtureTestCase(), Ex
 
     fun testUnderscore() {
         validateName("_", UNDERSCORE_ERROR)
+        validateName("__", UNDERSCORE_ERROR)
+        validateName("___", UNDERSCORE_ERROR)
     }
 
     fun testUnderscoreInQualified() {
         validateName("a._.b", UNDERSCORE_ERROR)
+        validateName("a.__.b", UNDERSCORE_ERROR)
+        validateName("a.___.b", UNDERSCORE_ERROR)
+    }
+
+    fun testValidNamesWithUnderscores() {
+        validateName("_a", null)
+        validateName("a_", null)
+        validateName("a_b", null)
+        validateName("a._b.c", null)
     }
 
     private fun validateName(name: String, errorMessage: String?) {

--- a/plugins/kotlin/kotlin.ide/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
+++ b/plugins/kotlin/kotlin.ide/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
@@ -155,6 +155,10 @@ object NewKotlinFileNameValidator : InputValidatorEx {
             return KotlinBundle.message("action.new.file.error.empty.name.part")
         }
 
+        if (parts.any { it.trim() == "_" }) {
+            return KotlinBundle.message("action.new.file.error.underscore")
+        }
+
         return null
     }
 

--- a/plugins/kotlin/kotlin.ide/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
+++ b/plugins/kotlin/kotlin.ide/src/org/jetbrains/kotlin/idea/actions/NewKotlinFileAction.kt
@@ -155,7 +155,7 @@ object NewKotlinFileNameValidator : InputValidatorEx {
             return KotlinBundle.message("action.new.file.error.empty.name.part")
         }
 
-        if (parts.any { it.trim() == "_" }) {
+        if (parts.any { part -> part.trim().all { it == '_' } }) {
             return KotlinBundle.message("action.new.file.error.underscore")
         }
 


### PR DESCRIPTION
Disallow single underscore as Kotlin class/package name

In Kotlin, a single underscore `_` is a reserved identifier and cannot be
used as a class or package name component.

Currently, the "New Kotlin Class/File" dialog does not prevent using `_` as
a name, allowing users to enter invalid names. This can lead to the
creation of incorrect code (e.g., `package _` or `class _`) which results
in compilation errors.

This change updates the validator for new Kotlin file names to specifically
check for and disallow any segment of the qualified name (class or package
part) from being a single underscore. A new, specific error message "Name
can't be a single underscore" is shown to the user if this validation fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to input validation for new Kotlin file/class/package names and adds corresponding test coverage and localized error text.
> 
> **Overview**
> Prevents creating Kotlin files/classes with *qualified name segments made only of underscores* (e.g. `_`, `__`, `a._.b`) via the "New Kotlin Class/File" dialog by extending `NewKotlinFileNameValidator` to reject such parts.
> 
> Adds a new user-facing validation message (`action.new.file.error.underscore`) and updates FIR tests to cover invalid underscore-only cases while still allowing normal underscore usage (e.g. `a_b`, `_a`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b36e2af8bec92b39ca9738eedfee9ee89984ea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->