### PR TITLE
[JEWEL-1293] use IntUiDarkTheme colors for dark SimpleListItem

### DIFF
--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiSimpleListItemStyling.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiSimpleListItemStyling.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.ui.component.styling.SimpleListItemColors
 import org.jetbrains.jewel.ui.component.styling.SimpleListItemMetrics
@@ -35,7 +36,7 @@ public fun SimpleListItemStyle.Companion.lightFullWidth(
 ): SimpleListItemStyle = SimpleListItemStyle(colors, metrics)
 
 public fun SimpleListItemStyle.Companion.darkFullWidth(
-    colors: SimpleListItemColors = SimpleListItemColors.light(),
+    colors: SimpleListItemColors = SimpleListItemColors.dark(),
     metrics: SimpleListItemMetrics = SimpleListItemMetrics.fullWidth(),
 ): SimpleListItemStyle = SimpleListItemStyle(colors, metrics)
 
@@ -63,8 +64,8 @@ public fun SimpleListItemColors.Companion.light(
 public fun SimpleListItemColors.Companion.dark(
     background: Color = Color.Unspecified,
     backgroundActive: Color = background,
-    backgroundSelected: Color = IntUiLightTheme.colors.gray(2),
-    backgroundSelectedActive: Color = IntUiLightTheme.colors.blue(2),
+    backgroundSelected: Color = IntUiDarkTheme.colors.gray(2),
+    backgroundSelectedActive: Color = IntUiDarkTheme.colors.blue(2),
     content: Color = Color.Unspecified,
     contentActive: Color = Color.Unspecified,
     contentSelected: Color = Color.Unspecified,


### PR DESCRIPTION
Supersedes #3430 because the original author is unavailable and I cannot push to their fork.

This carries over the original fix and addresses the review feedback:
- use IntUiDarkTheme for dark SimpleListItem selected backgrounds
- make darkFullWidth() default to SimpleListItemColors.dark()
- use the requested JEWEL-1293 commit/title format

Verification:
- git diff --check
- ./bazel.cmd build //platform/jewel/int-ui/int-ui-standalone:jewel-intUi-standalone (blocked locally by sandbox permission while extracting Bazel Python toolchain cache: certifi/cacert.pem Operation not permitted)

## Release notes

### Bug fixes
 * Fixed `SimpleListItem` colors in dark mode to use the dark IntelliJ UI palette.
