### PR TITLE
[JEWEL-1286] Use correct colors for MarkdownStyling

### DIFF
--- a/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
+++ b/platform/jewel/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
@@ -51,7 +51,7 @@ public fun MarkdownStyling.Companion.light(
     blockVerticalSpacing: Dp = 16.dp,
     paragraph: Paragraph = Paragraph.light(inlinesStyling),
     heading: Heading = Heading.light(baseTextStyle),
-    blockQuote: BlockQuote = BlockQuote.light(textColor = baseTextStyle.color),
+    blockQuote: BlockQuote = BlockQuote.light(),
     code: Code = Code.light(editorTextStyle),
     list: List = List.light(baseTextStyle),
     image: Image = Image.default(),
@@ -65,16 +65,16 @@ public fun MarkdownStyling.Companion.light(
 public fun MarkdownStyling.Companion.dark(
     baseTextStyle: TextStyle = defaultTextStyle,
     editorTextStyle: TextStyle = defaultEditorTextStyle,
-    inlinesStyling: InlinesStyling = InlinesStyling.dark(defaultTextStyle, editorTextStyle),
+    inlinesStyling: InlinesStyling = InlinesStyling.dark(baseTextStyle, editorTextStyle),
     blockVerticalSpacing: Dp = 16.dp,
     paragraph: Paragraph = Paragraph.dark(inlinesStyling),
     heading: Heading = Heading.dark(baseTextStyle),
-    blockQuote: BlockQuote = BlockQuote.dark(textColor = baseTextStyle.color),
+    blockQuote: BlockQuote = BlockQuote.dark(),
     code: Code = Code.dark(editorTextStyle),
     list: List = List.dark(baseTextStyle),
     image: Image = Image.default(),
     thematicBreak: ThematicBreak = ThematicBreak.dark(),
-    htmlBlock: HtmlBlock = HtmlBlock.dark(editorTextStyle.copy(color = blockContentColorLight)),
+    htmlBlock: HtmlBlock = HtmlBlock.dark(editorTextStyle.copy(color = blockContentColorDark)),
 ): MarkdownStyling =
     MarkdownStyling(blockVerticalSpacing, paragraph, heading, blockQuote, code, list, image, thematicBreak, htmlBlock)
 


### PR DESCRIPTION
# Context

We are overriding the expected code for quote blocks in Markdown when on dark mode, resulting in a text that's barely visible. This PR fixes this, and also takes this opportunity to use the default text style declared by the user in some other blocks.

# Fix

Use correct colors quote blocks in `MarkdownStyling.dark`

## Release notes

### Bug fixes
 * `MarkdownStyling.dark` now uses the correct color for `BlockQuote` and `HtmlBlock`
 * `MarkdownStyling.dark` now correctly uses the `TextStyle` declared in `baseTextStyle` to stylize its own `inlinesStyling`.


## Screenshots / Screen Recordings

| Before | After|
|---|---|
| <video src="https://github.com/user-attachments/assets/f48d0664-84f7-431e-bf90-e97ad20a5ec9" /> | <video src="https://github.com/user-attachments/assets/70342d21-b455-49e9-9ce3-a8350abcce70" /> |

(yes this reproducer was created by AI)
