### PR TITLE
[vcs-log] consider other branch-like filters when checking if the log is filtered by a single branch

### DIFF
--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/util/VcsLogUtil.java
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/util/VcsLogUtil.java
@@ -29,6 +29,7 @@ import com.intellij.vcs.log.VcsFullCommitDetails;
 import com.intellij.vcs.log.VcsLogAggregatedStoredRefs;
 import com.intellij.vcs.log.VcsLogAggregatedStoredRefsKt;
 import com.intellij.vcs.log.VcsLogBranchFilter;
+import com.intellij.vcs.log.VcsLogBranchLikeFilter;
 import com.intellij.vcs.log.VcsLogBundle;
 import com.intellij.vcs.log.VcsLogDataKeys;
 import com.intellij.vcs.log.VcsLogDataPack;
@@ -190,7 +191,9 @@ public final class VcsLogUtil {
 
   public static @Nullable @NlsSafe String getSingleFilteredBranch(@NotNull VcsLogFilterCollection filters,
                                                                   @NotNull VcsLogAggregatedStoredRefs refs) {
-    VcsLogBranchFilter filter = filters.get(VcsLogFilterCollection.BRANCH_FILTER);
+    List<VcsLogBranchLikeFilter> branchLikeFilters = ContainerUtil.filterIsInstance(filters.getFilters(), VcsLogBranchLikeFilter.class);
+    if (branchLikeFilters.size() != 1) return null;
+    VcsLogBranchFilter filter = ContainerUtil.getOnlyItem(ContainerUtil.filterIsInstance(branchLikeFilters, VcsLogBranchFilter.class));
     if (filter == null) return null;
 
     String branchName = null;


### PR DESCRIPTION
This is a fix for [IJPL-245209](https://youtrack.jetbrains.com/issue/IJPL-245209) issue that ensures that current branch highlighting in Git Log is visible when single branch filter is accompanied by a revision filter.