### PR TITLE
KTIJ-38704 propagate JVM dependencies for shared MPP source sets

### DIFF
--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/build.gradle.kts
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    alias(libs.plugins.android.kotlin.multiplatform.library)
+    kotlin("multiplatform")
+    alias(libs.plugins.compose.compiler)
+    id("test.convention")
+}
+
+repositories {
+    {{ kts_kotlin_plugin_repositories }}
+    google()
+    mavenCentral()
+}
+
+kotlin {
+    jvm()
+
+    androidLibrary {
+        namespace = "test.compose.mpp"
+        compileSdk = 36
+        minSdk = 30
+    }
+
+    sourceSets {
+        val commonMain by getting
+        val jvmAndroidMain by creating {
+            dependsOn(commonMain)
+        }
+        val androidMain by getting {
+            dependsOn(jvmAndroidMain)
+            dependencies {
+                api(libs.androidx.compose.runtime)
+                implementation(libs.androidx.compose.material3)
+            }
+        }
+        val jvmMain by getting {
+            dependsOn(jvmAndroidMain)
+            dependencies {
+                api(libs.androidx.compose.runtime.desktop)
+                implementation(libs.compose.material3.desktop)
+                implementation(libs.compose.runtime.desktop)
+            }
+        }
+    }
+}

--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/buildSrc/build.gradle.kts
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/buildSrc/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+    {{ kts_kotlin_plugin_repositories }}
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:{{kgp_version}}")
+}

--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/buildSrc/settings.gradle.kts
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/buildSrc/settings.gradle.kts
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        {{ kts_kotlin_plugin_repositories }}
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+    plugins {
+        id("com.android.library") version "8.7.3"
+        id("org.jetbrains.compose") version "1.9.0"
+        kotlin("multiplatform") version "{{kgp_version}}"
+    }
+}

--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/buildSrc/src/main/kotlin/test.convention.gradle.kts
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/buildSrc/src/main/kotlin/test.convention.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+        }
+    }
+}

--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/gradle.properties
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.mpp.applyDefaultHierarchyTemplate=false

--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/gradle/libs.versions.toml
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+android-gradle-plugin = "{{agp_version}}"
+kotlin = "{{kgp_version}}"
+androidx-compose = "1.11.1"
+androidx-compose-material3 = "1.4.0"
+compose-plugin = "1.11.0"
+compose-material3-desktop = "1.9.0"
+
+[libraries]
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
+androidx-compose-runtime-desktop = { module = "androidx.compose.runtime:runtime-desktop", version.ref = "androidx-compose" }
+compose-material3-desktop = { module = "org.jetbrains.compose.material3:material3-desktop", version.ref = "compose-material3-desktop" }
+compose-runtime-desktop = { module = "org.jetbrains.compose.runtime:runtime-desktop", version.ref = "compose-plugin" }
+
+[plugins]
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-gradle-plugin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/settings.gradle.kts
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/settings.gradle.kts
@@ -1,0 +1,18 @@
+rootProject.name = "testConventionPluginAddsComposeMaterial3Dependency"
+
+pluginManagement {
+    repositories {
+        {{ kts_kotlin_plugin_repositories }}
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        {{ kts_kotlin_plugin_repositories }}
+        google()
+        mavenCentral()
+    }
+}

--- a/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/src/commonMain/kotlin/pkg/common.kt
+++ b/community/plugins/kotlin/idea/tests/testData/gradle/multiplatform/k2/highlighting/conventionPluginAddsComposeMaterial3Dependency/src/commonMain/kotlin/pkg/common.kt
@@ -1,0 +1,22 @@
+//region Test configuration
+// - hidden: line markers
+//endregion
+package pkg
+
+import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+
+@Composable
+fun usesMaterial3() {
+    AlertDialog(
+        onDismissRequest = {},
+        confirmButton = {
+            TextButton(onClick = {}) {
+                Text("OK")
+            }
+        },
+        text = {
+            Text("Body")
+        },
+    )
+}

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/mpp/populateModuleDependencies.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/configuration/mpp/populateModuleDependencies.kt
@@ -2,11 +2,16 @@
 
 package org.jetbrains.kotlin.idea.gradleJava.configuration.mpp
 
+import org.jetbrains.kotlin.gradle.idea.tcs.IdeaKotlinBinaryDependency
 import org.jetbrains.kotlin.gradle.idea.tcs.IdeaKotlinProjectArtifactDependency
 import org.jetbrains.kotlin.gradle.idea.tcs.IdeaKotlinUnresolvedBinaryDependency
 import org.jetbrains.kotlin.idea.gradleJava.configuration.KotlinMppGradleProjectResolver
 import org.jetbrains.kotlin.idea.gradleTooling.IdeaKotlinDependenciesContainer
+import org.jetbrains.kotlin.idea.gradleTooling.getCompilations
 import org.jetbrains.kotlin.idea.projectModel.KotlinGradlePluginVersionDependentApi
+import org.jetbrains.kotlin.idea.projectModel.KotlinPlatform.ANDROID
+import org.jetbrains.kotlin.idea.projectModel.KotlinPlatform.JVM
+import org.jetbrains.kotlin.idea.projectModel.KotlinSourceSet
 
 @OptIn(KotlinGradlePluginVersionDependentApi::class)
 internal fun KotlinMppGradleProjectResolver.Context.populateModuleDependencies() {
@@ -69,6 +74,63 @@ internal fun KotlinMppGradleProjectResolver.Context.populateModuleDependenciesWi
             this, sourceSetDataNode, sourceSet, substitutedSourceSetDependencies, createdDependencyNodes
         )
     }
+
+    populatePlatformPropagationDependenciesWithDependenciesContainer(dependencies)
+}
+
+private fun KotlinMppGradleProjectResolver.Context.populatePlatformPropagationDependenciesWithDependenciesContainer(
+    dependencies: IdeaKotlinDependenciesContainer
+) {
+    mppModel.sourceSetsByName.values
+        .filter { sourceSet -> isDependencyContainerPlatformPropagationAllowed(sourceSet) }
+        .forEach { sourceSet ->
+            val sourceSetModuleId = KotlinSourceSetModuleId(resolverCtx, gradleModule, sourceSet)
+            val sourceSetDataNode = projectDataNode.findSourceSetDataNode(sourceSetModuleId) ?: return@forEach
+            val propagatedDependencies = findDependencyContainerCompilationsToPropagateFrom(sourceSet)
+                .map { compilation ->
+                    compilation.declaredSourceSets
+                        .flatMap { declaredSourceSet -> dependencies[declaredSourceSet.name] }
+                        .filterIsInstance<IdeaKotlinBinaryDependency>()
+                        .toSet()
+                }
+                .dependencyContainerIntersection()
+
+            propagatedDependencies.forEachIndexed { index, dependency ->
+                sourceSetDataNode.addDependency(dependency)?.data?.setOrder(index)
+            }
+        }
+}
+
+private fun KotlinMppGradleProjectResolver.Context.isDependencyContainerPlatformPropagationAllowed(sourceSet: KotlinSourceSet): Boolean {
+    if (dependencyContainerPropagationPlatforms(sourceSet) == setOf(JVM, ANDROID)) {
+        return true
+    }
+
+    if (mppModel.sourceSetsByName.values.any { otherSourceSet -> sourceSet.name in otherSourceSet.declaredDependsOnSourceSets } &&
+        (sourceSet.actualPlatforms.platforms.singleOrNull() == JVM ||
+                sourceSet.actualPlatforms.platforms.singleOrNull() == ANDROID)
+    ) return true
+
+    return false
+}
+
+private fun KotlinMppGradleProjectResolver.Context.findDependencyContainerCompilationsToPropagateFrom(sourceSet: KotlinSourceSet) =
+    when (dependencyContainerPropagationPlatforms(sourceSet)) {
+        setOf(JVM, ANDROID) -> mppModel.getCompilations(sourceSet).filter { compilation -> compilation.platform == JVM }
+        else -> mppModel.getCompilations(sourceSet)
+    }.toSet()
+
+private fun KotlinMppGradleProjectResolver.Context.dependencyContainerPropagationPlatforms(sourceSet: KotlinSourceSet) =
+    mppModel.getCompilations(sourceSet).mapTo(mutableSetOf()) { compilation -> compilation.platform }
+
+private fun List<Set<IdeaKotlinBinaryDependency>>.dependencyContainerIntersection(): Set<IdeaKotlinBinaryDependency> {
+    if (isEmpty()) return emptySet()
+    if (size == 1) return first()
+
+    val coordinatesIntersection = map { dependencies -> dependencies.mapNotNull { it.coordinates }.toSet() }
+        .reduce { acc, coordinates -> acc intersect coordinates }
+
+    return first().filter { dependency -> dependency.coordinates in coordinatesIntersection }.toSet()
 }
 
 /**

--- a/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/gradle/multiplatformTests/testProperties/AndroidTestsProperties.kt
+++ b/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/gradle/multiplatformTests/testProperties/AndroidTestsProperties.kt
@@ -11,7 +11,8 @@ object AndroidGradlePluginVersionTestsProperty : KotlinTestsResolvableProperty<A
         MinSupported("MIN", "7.4.2"),
         LatestStable("STABLE", "8.5.2"),
         Beta("BETA", "8.5.2"),
-        Alpha("ALPHA", "8.6.0-alpha03");
+        Alpha("ALPHA", "8.6.0-alpha03"),
+        Agp92("AGP_9_2", "9.2.1");
     }
 
     override val versionByAlias: Map<Value, String> = Value.entries.associate { it to it.version }

--- a/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/gradle/multiplatformTests/testProperties/GradleVersionTestsProperty.kt
+++ b/plugins/kotlin/gradle/gradle-java/tests.shared/test/org/jetbrains/kotlin/gradle/multiplatformTests/testProperties/GradleVersionTestsProperty.kt
@@ -10,7 +10,8 @@ object GradleVersionTestsProperty : org.jetbrains.kotlin.gradle.multiplatformTes
         ForMinAgp("REQUIRED_FOR_MIN_AGP", "7.5.1"),
         ForStableAgp("REQUIRED_FOR_STABLE_AGP", "8.10.2"),
         ForBetaAgp("REQUIRED_FOR_BETA_AGP", "8.7"),
-        ForAlphaAgp("REQUIRED_FOR_ALPHA_AGP", "8.7")
+        ForAlphaAgp("REQUIRED_FOR_ALPHA_AGP", "8.7"),
+        ForAgp92("REQUIRED_FOR_AGP_9_2", "9.4.1")
     }
 
     override val versionByAlias: Map<Value, String> = Value.entries.associateWith { it.version }

--- a/plugins/kotlin/gradle/multiplatform-tests-k2/test/org/jetbrains/kotlin/gradle/idea/importing/multiplatformTests/k2/K2MppHighlightingIntegrationTest.kt
+++ b/plugins/kotlin/gradle/multiplatform-tests-k2/test/org/jetbrains/kotlin/gradle/idea/importing/multiplatformTests/k2/K2MppHighlightingIntegrationTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 class K2MppHighlightingIntegrationTest : AbstractKotlinMppGradleImportingTest() {
 
     override val allowOnNonMac: Boolean
-        get() = true
+        get() = false
 
     override fun TestConfigurationDslScope.defaultTestConfiguration() {
         hideHighlightsBelow = HighlightSeverity.ERROR

--- a/plugins/kotlin/gradle/multiplatform-tests-k2/test/org/jetbrains/kotlin/gradle/idea/importing/multiplatformTests/k2/K2MppHighlightingIntegrationTest.kt
+++ b/plugins/kotlin/gradle/multiplatform-tests-k2/test/org/jetbrains/kotlin/gradle/idea/importing/multiplatformTests/k2/K2MppHighlightingIntegrationTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 class K2MppHighlightingIntegrationTest : AbstractKotlinMppGradleImportingTest() {
 
     override val allowOnNonMac: Boolean
-        get() = false
+        get() = true
 
     override fun TestConfigurationDslScope.defaultTestConfiguration() {
         hideHighlightsBelow = HighlightSeverity.ERROR
@@ -84,5 +84,11 @@ class K2MppHighlightingIntegrationTest : AbstractKotlinMppGradleImportingTest() 
         doTest {
             publish("lib")
         }
+    }
+
+    @Test
+    @PluginTargetVersions(pluginVersion = "2.0.0+", gradleVersion = "9.4.1+")
+    fun testConventionPluginAddsComposeMaterial3Dependency() {
+        doTest()
     }
 }


### PR DESCRIPTION
## Summary

Fixes KTIJ-38704 by restoring IDE-side platform dependency propagation for Kotlin MPP imports that use the KGP dependency-container model.

The affected path skipped the older IDE-only propagation logic. As a result, shared JVM/Android source sets could miss binary dependencies declared by platform source sets, leaving common code without Compose Material3 on the analysis classpath after Gradle import.

## Changes

- Propagate binary dependencies from dependency-container compilations to shared JVM/Android source sets.
- Preserve the existing JVM-over-Android heuristic for JVM+Android shared source sets.
- Add AGP 9.2 / Gradle 9.4.1 test aliases.
- Add a highlighting regression fixture matching a convention-plugin setup with Compose Material3 used from `commonMain`.

## Verification

- `GRADLE_VERSION=REQUIRED_FOR_AGP_9_2 AGP_VERSION=AGP_9_2 JDK_17=/usr/lib/jvm/java-21-openjdk ANDROID_SDK_ROOT=/home/nikolaym/Android/Sdk ANDROID_HOME=/home/nikolaym/Android/Sdk JAVA_TOOL_OPTIONS=-Dandroid.sdk=/home/nikolaym/Android/Sdk ./tests.cmd --module intellij.kotlin.gradle.multiplatform.tests --test org.jetbrains.kotlin.gradle.idea.importing.multiplatformTests.k2.K2MppHighlightingIntegrationTest#testConventionPluginAddsComposeMaterial3Dependency`
- Result: `1 test, 1 passed, 0 failed, 0 skipped`
- Default local Gradle 8.10.2 run exits cleanly as skipped due to the `9.4.1+` version gate.
- `git diff --check`
