### PR TITLE
IJPL-245319 quote $new_name in fish shell integration

### DIFF
--- a/plugins/terminal/resources/shell-integrations/fish/fish-integration.fish
+++ b/plugins/terminal/resources/shell-integrations/fish/fish-integration.fish
@@ -13,8 +13,8 @@ function override_jb_variables
     set value $name_and_value[2]
     if string match -q -- "_INTELLIJ_FORCE_SET_*" $name
       set new_name (string sub -s 21 -- $name)
-      if [ $new_name ]
-        if [ $new_name = "PATH" ]; or [ $new_name = "CDPATH" ]; or [ $new_name = "MANPATH" ]
+      if test -n "$new_name"
+        if contains $new_name PATH CDPATH MANPATH
             set -x $new_name (string split ":" -- $value)
         else
             set -x $new_name $value
@@ -24,8 +24,8 @@ function override_jb_variables
 
     if string match -q -- "_INTELLIJ_FORCE_PREPEND_*" $name
       set new_name (string sub -s 25 -- $name)
-      if [ $new_name ]
-        if [ $new_name = "PATH" ]; or [ $new_name = "CDPATH" ]; or [ $new_name = "MANPATH" ]
+      if test -n "$new_name"
+        if contains $new_name PATH CDPATH MANPATH
             set -x $new_name (string split ":" -- "$value$$new_name")
         else
             set -x $new_name "$value$$new_name"


### PR DESCRIPTION
Fish's test-require-arg feature flag causes an error in `[ $new_name ]` when `$new_name` expands to nothing. Fixed by using `-n` and quoting the variable.

Also switched to `test -n` and `contains` as idiomatic equivalents.