### PR TITLE
IJPL-245390: Fix Find Usages on @Data fields missing calls through interface references

### DIFF
--- a/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/extension/LombokFieldFindUsagesHandlerFactory.java
+++ b/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/extension/LombokFieldFindUsagesHandlerFactory.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMember;
+import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiRecordComponent;
 import com.intellij.psi.util.PsiUtilCore;
 import com.intellij.usageView.UsageInfo;
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * It should find calls to getters/setters of some field changed by lombok accessors
@@ -88,7 +90,20 @@ public final class LombokFieldFindUsagesHandlerFactory extends FindUsagesHandler
         Arrays.stream(containingClass.getMethods())
           .filter(LombokLightMethodBuilder.class::isInstance)
           .filter(psiMethod -> psiMethod.getNavigationElement() == refPsiField)
-          .forEach(collector::add);
+          .forEach(lombokMethod -> {
+            // Mirror JavaFindUsagesHandler behaviour for physical methods with isSearchForBaseMethod:
+            // search for the deepest super/interface method so that calls through an interface
+            // reference (e.g. interf.getString()) are also reported as usages.
+            // Direct calls on the concrete type (impl.getString()) are still found via
+            // processInexactReference in MethodTextOccurrenceProcessor.
+            PsiMethod[] superMethods = lombokMethod.findDeepestSuperMethods();
+            if (superMethods.length > 0) {
+              Collections.addAll(collector, superMethods);
+            }
+            else {
+              collector.add(lombokMethod);
+            }
+          });
       }
     };
   }

--- a/plugins/lombok/src/test/java/de/plushnikov/intellij/plugin/usage/LombokUsageTest.java
+++ b/plugins/lombok/src/test/java/de/plushnikov/intellij/plugin/usage/LombokUsageTest.java
@@ -26,6 +26,15 @@ public class LombokUsageTest extends AbstractLombokLightCodeInsightTestCase {
     assertUsages(usages, "findUsageGetterSetter.setBar", "findUsageGetterSetter.getBar");
   }
 
+  public void testFindUsageGetterSetterWithInterface() {
+    final Collection<UsageInfo> usages = loadTestClass();
+    assertUsages(usages,
+                 "service.setBar",
+                 "service.getBar",
+                 "impl.setBar",
+                 "impl.getBar");
+  }
+
   public void testFindUsageAccessors() {
     final Collection<UsageInfo> usages = loadTestClass();
     assertUsages(usages, "findUsageAccessors.setBar", "findUsageAccessors.getBar");

--- a/plugins/lombok/testData/usage/FindUsageGetterSetterWithInterface.java
+++ b/plugins/lombok/testData/usage/FindUsageGetterSetterWithInterface.java
@@ -1,0 +1,22 @@
+import lombok.Data;
+
+interface FindUsageGetterSetterWithInterfaceService {
+  String getBar();
+  void setBar(String bar);
+}
+
+@Data
+class FindUsageGetterSetterWithInterfaceImpl implements FindUsageGetterSetterWithInterfaceService {
+  private String b<caret>ar;
+}
+
+class FindUsageGetterSetterWithInterfaceUser {
+  public static void main(String[] args) {
+    FindUsageGetterSetterWithInterfaceService service = new FindUsageGetterSetterWithInterfaceImpl();
+    service.setBar("myBar");
+    System.out.println("Bar is: " + service.getBar());
+    FindUsageGetterSetterWithInterfaceImpl impl = new FindUsageGetterSetterWithInterfaceImpl();
+    impl.setBar("directBar");
+    System.out.println("Bar is: " + impl.getBar());
+  }
+}


### PR DESCRIPTION
Fix Find Usages on @Data fields missing calls through interface references

When a @Data-annotated class implements an interface, Find Usages on a
field previously missed call sites that invoked the getter/setter through
an interface-typed reference (e.g. `interf.getString()`).

The root cause was that LombokFieldFindUsagesHandlerFactory added the
LombokLightMethodBuilder as the secondary search element. When
MethodTextOccurrenceProcessor.processInexactReference ran for it, calls
resolved to the interface method were not matched because the class
substitutor lookup was done in the wrong direction.

Fix: replace the lombok method with its findDeepestSuperMethods() results
as the secondary element, mirroring the isSearchForBaseMethod behaviour
of JavaFindUsagesHandler for physical methods. When no super methods
exist (plain @Data class, no interface), fall back to the lombok method
itself so existing behaviour is preserved.