### PR TITLE
Write Shard Status File Early

### DIFF
--- a/platform/testFramework/bootstrap/src/com/intellij/tests/JUnit5BazelRunner.java
+++ b/platform/testFramework/bootstrap/src/com/intellij/tests/JUnit5BazelRunner.java
@@ -197,6 +197,8 @@ public final class JUnit5BazelRunner {
       Path ideaHome;
       Path tempDir = getBazelTempDir();
 
+      ShardFilter.writeShardStatus();
+
       String jbEnvSandboxValue = System.getenv(jbEnvSandbox);
       if (jbEnvSandboxValue == null) {
         throw new RuntimeException("Missing " + jbEnvSandbox + " env variable in bazel test environment");
@@ -270,7 +272,6 @@ public final class JUnit5BazelRunner {
         Stream<InterceptingTestExecutionListener> listeners =
           testExecutionListeners.stream().map(it -> new InterceptingTestExecutionListener(it, interceptor));
 
-        ShardFilter.writeShardStatus();
         launcher.registerTestExecutionListeners(listeners.toArray(TestExecutionListener[]::new));
         launcher.execute(testPlan);
       }


### PR DESCRIPTION
Shard status must be written even if no tests are actually executed so write it early.

[Bug BAZEL-3206](https://youtrack.jetbrains.com/issue/BAZEL-3206/JUnit5BazelRunner-Doesnt-Write-Shard-Status-File-if-No-Tests-Are-Executed)