### PR TITLE
IJPL-244177 git4idea: do not block in GitRepositoryImpl.<init> on workingTreeHolder.updateState()

### DIFF
--- a/plugins/git4idea/src/git4idea/repo/GitRepositoryImpl.kt
+++ b/plugins/git4idea/src/git4idea/repo/GitRepositoryImpl.kt
@@ -78,9 +78,13 @@ class GitRepositoryImpl private constructor(
 
     workingTreeHolder = GitWorkingTreeHolderImpl(this)
     repoInfo = readRepoInfo()
-    runBlockingMaybeCancellable {
-      workingTreeHolder.updateState()
-    }
+    // IJPL-244177: do not block on workingTreeHolder.updateState() here.
+    // VcsRepositoryManager.checkAndUpdateRepositoryCollection constructs
+    // this class while holding MODIFY_LOCK; a synchronous wait turns
+    // O(N) repo construction into N x blocking-IO under the lock and
+    // deadlocks Dispatchers.IO once the pool is queued on that lock.
+    // Initial state is populated asynchronously via GitRepository.update()
+    // and the existing alarm-driven refresh, which run outside the lock.
   }
 
   @Deprecated("Deprecated in Java")


### PR DESCRIPTION
## Summary

Fix [IJPL-244177](https://youtrack.jetbrains.com/issue/IJPL-244177) — Git4Idea deadlock with many repositories.

`GitRepositoryImpl.<init>` synchronously bridges into a suspend function via `runBlockingMaybeCancellable { workingTreeHolder.updateState() }`. `VcsRepositoryManager.checkAndUpdateRepositoryCollection` constructs this class N times while holding the global `MODIFY_LOCK` write lock, turning O(N) repository discovery into N × blocking-IO inside the lock.

Once N grows large enough that every `Dispatchers.IO` worker is queued on the lock, the coroutine the lock-holder is waiting on can never be scheduled, and `Dispatchers.IO` deadlocks. `PerformanceWatcher` emits `Thread pool exhaustion: Dispatchers.IO is not responding for 5000 ms` continuously and the IDE freezes for the rest of the session.

## Change

Remove the synchronous `runBlockingMaybeCancellable { workingTreeHolder.updateState() }` from the `init` block of `GitRepositoryImpl`. The initial `workingTreeHolder.state` population then happens lazily via the existing asynchronous refresh paths — `GitRepository.update()` and the alarm-driven refresh — which run **outside** `MODIFY_LOCK` on their own dispatcher.

State consumers (gutter, annotations, log, branch UI) subscribe to the state-flow and update reactively, so the transient empty state at end-of-ctor is handled the same way it is handled after any subsequent refresh.

The unrelated `runBlockingMaybeCancellable` call in `update()` (line 191) is kept: it runs outside the global lock and its synchronous behaviour is desired by callers.

## Evidence

- Thread dumps from a reproducer (~167 nested `.git` directories) show one `DefaultDispatcher-worker-N` parked in `LockSupport.parkNanos` → `joinBlocking` → `runBlockingMaybeCancellable` → `GitRepositoryImpl.<init>:81`, holding `VcsRepositoryManager.MODIFY_LOCK`. 70+ other dispatcher workers are queued on the same lock inside `VcsRepositoryManager.checkAndUpdateRepositoryCollection` (`VcsRepositoryManager.kt:354`).
- A userland Java agent that performs **exactly** this change at JVM class-load time (ASM rewrite of one `INVOKESTATIC` to `POP; ACONST_NULL;`) has been running on the same reproducer for weeks: indexing completes in ~5 s, dumb mode exits in ~3 s, zero perfwatcher freezes, no lock waiters, all VCS features continue to work. Source: <https://github.com/bitranox/pycharm-vcs-deadlock-fix>.
- The reporter on IJPL-244177 independently worked around the deadlock with `-Dkotlinx.coroutines.io.parallelism=256`, which only enlarges the pool — this PR removes the cycle itself.

## Compatibility

- Anything that synchronously reads `workingTreeHolder.state` immediately after `<init>` (without subscribing to its flow) will observe an empty value briefly. No such caller has been observed in measurement; the IDE already handles transient empty state after a refresh.
- Affected versions per YouTrack: 2025.3, 2025.3 (253.28294.334), 2026.1.1 (261.23567.138).

## CLA

JetBrains CLA signed under GitHub username `bitranox`.

## Related

- [IJPL-244177](https://youtrack.jetbrains.com/issue/IJPL-244177) — Git4Idea deadlock with 80+ repos (this PR).
- [IJPL-244426](https://youtrack.jetbrains.com/issue/IJPL-244426) — Editor freeze on AsyncCompletion semaphore, attributed by reporter to the same `VcsRepositoryManager` thread starvation; plausibly a downstream symptom of the same deadlock.
