### PR TITLE
[maven] IDEA-388560 workspace map fallback for pom-defined ${revision}

### DIFF
--- a/plugins/maven-server-api/src/main/java/org/jetbrains/idea/maven/model/MavenWorkspaceMapWrapper.java
+++ b/plugins/maven-server-api/src/main/java/org/jetbrains/idea/maven/model/MavenWorkspaceMapWrapper.java
@@ -2,8 +2,11 @@
 package org.jetbrains.idea.maven.model;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -11,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,6 +23,7 @@ public class MavenWorkspaceMapWrapper {
   private final Properties mySystemProperties;
 
   private final Map<String, Set<MavenId>> myArtifactToIdToMavenIdMapping = new HashMap<>();
+  private final Map<File, Properties> myPomPropertiesCache = new ConcurrentHashMap<>();
 
   public MavenWorkspaceMapWrapper(MavenWorkspaceMap workspaceMap, Properties systemProperties) {
     myWorkspaceMap = workspaceMap;
@@ -46,6 +51,53 @@ public class MavenWorkspaceMapWrapper {
 
   public MavenWorkspaceMap.Data findFileAndOriginalId(MavenId mavenId) {
     return myWorkspaceMap.findFileAndOriginalId(mavenId);
+  }
+
+  /**
+   * Same as {@link #findFileAndOriginalId(MavenId)}, but on miss looks for a same
+   * {@code groupId+artifactId} workspace entry whose version is an unresolved
+   * CI-friendly placeholder (e.g. {@code ${revision}}), and accepts it if and only
+   * if the placeholder, resolved against the candidate workspace pom's effective
+   * {@code <properties>}, equals the requested concrete version (or vice versa).
+   * <p>
+   * Required when the {@code <revision>} property is defined in a pom
+   * {@code <properties>} block rather than passed via {@code -Drevision=...}
+   * — {@link #interpolate(MavenId)} only consults system properties and can
+   * leave workspace map keys as literal {@code ${revision}}, causing concrete-version
+   * lookups from dependency resolution to miss (IDEA-388560).
+   */
+  public @Nullable MavenWorkspaceMap.Data findFileAndOriginalIdWithRevisionFallback(@NotNull MavenId requested) {
+    MavenWorkspaceMap.Data direct = myWorkspaceMap.findFileAndOriginalId(requested);
+    if (direct != null) return direct;
+
+    String requestedVersion = requested.getVersion();
+    if (requestedVersion == null) return null;
+    boolean requestIsPlaceholder = isPlaceholder(requestedVersion);
+
+    for (MavenId candidate : getAvailableIdsForArtifactId(requested.getArtifactId())) {
+      if (!Objects.equals(candidate.getGroupId(), requested.getGroupId())) continue;
+      String candidateVersion = candidate.getVersion();
+      boolean candidateIsPlaceholder = isPlaceholder(candidateVersion);
+      if (!candidateIsPlaceholder && !requestIsPlaceholder) continue;
+      if (isVersionMarker(candidateVersion)) continue;
+
+      MavenWorkspaceMap.Data data = myWorkspaceMap.findFileAndOriginalId(candidate);
+      if (data == null) continue;
+      File pomFile = data.getFile(MavenConstants.POM_EXTENSION);
+      if (pomFile == null || !pomFile.isFile()) continue;
+
+      if (candidateIsPlaceholder && !requestIsPlaceholder) {
+        if (!requestedVersion.equals(expandPlaceholder(candidateVersion, pomFile))) continue;
+      }
+      else if (requestIsPlaceholder && !candidateIsPlaceholder) {
+        if (!candidateVersion.equals(expandPlaceholder(requestedVersion, pomFile))) continue;
+      }
+      else if (!Objects.equals(candidateVersion, requestedVersion)) {
+        continue;
+      }
+      return data;
+    }
+    return null;
   }
 
   public @NotNull Set<MavenId> getAvailableIdsForArtifactId(String artifactId) {
@@ -94,4 +146,79 @@ public class MavenWorkspaceMapWrapper {
       mavenIds.add(id);
     }
   }
+
+  private static boolean isPlaceholder(@Nullable String s) {
+    return s != null && s.length() > 3 && s.startsWith("${") && s.endsWith("}");
+  }
+
+  private static boolean isVersionMarker(@Nullable String version) {
+    return version == null || version.isEmpty()
+           || "LATEST".equals(version) || "RELEASE".equals(version);
+  }
+
+  private @Nullable String expandPlaceholder(@NotNull String placeholder, @NotNull File pomFile) {
+    if (!isPlaceholder(placeholder)) return placeholder;
+    String key = placeholder.substring(2, placeholder.length() - 1).trim();
+    Properties props = myPomPropertiesCache.computeIfAbsent(pomFile, MavenWorkspaceMapWrapper::collectPropertiesChain);
+    String value = props.getProperty(key);
+    if (value == null) return null;
+    return isPlaceholder(value) ? expandPlaceholder(value, pomFile) : value;
+  }
+
+  /**
+   * Reads {@code <properties>} entries from {@code startPom} and best-effort walks the
+   * {@code <parent>/<relativePath>} chain (capped at {@link #PARENT_WALK_LIMIT} levels).
+   * Used solely by {@link #expandPlaceholder} to resolve {@code ${revision}}-like
+   * CI-friendly placeholders. Intentionally regex-based to avoid pulling an XML parser
+   * into the maven-server-api module.
+   */
+  private static @NotNull Properties collectPropertiesChain(@NotNull File startPom) {
+    Properties result = new Properties();
+    File current = startPom;
+    for (int depth = 0; current != null && current.isFile() && depth < PARENT_WALK_LIMIT; depth++) {
+      String xml;
+      try {
+        xml = Files.readString(current.toPath());
+      }
+      catch (IOException e) {
+        break;
+      }
+      Matcher propsMatcher = PROPS_BLOCK.matcher(xml);
+      if (propsMatcher.find()) {
+        Matcher entryMatcher = PROP_ENTRY.matcher(propsMatcher.group(1));
+        while (entryMatcher.find()) {
+          result.putIfAbsent(entryMatcher.group(1), entryMatcher.group(2).trim());
+        }
+      }
+      current = locateParentPom(current, xml);
+    }
+    return result;
+  }
+
+  private static @Nullable File locateParentPom(@NotNull File pomFile, @NotNull String xml) {
+    Matcher parentMatcher = PARENT_BLOCK.matcher(xml);
+    if (!parentMatcher.find()) return null;
+    File dir = pomFile.getParentFile();
+    if (dir == null) return null;
+    Matcher relPath = RELATIVE_PATH.matcher(parentMatcher.group(1));
+    File next;
+    if (relPath.find()) {
+      String relative = relPath.group(1).trim();
+      if (relative.isEmpty()) return null;
+      File candidate = new File(dir, relative);
+      next = candidate.isDirectory() ? new File(candidate, MavenConstants.POM_XML) : candidate;
+    }
+    else {
+      File grand = dir.getParentFile();
+      if (grand == null) return null;
+      next = new File(grand, MavenConstants.POM_XML);
+    }
+    return (next.equals(pomFile) || !next.isFile()) ? null : next;
+  }
+
+  private static final Pattern PROPS_BLOCK = Pattern.compile("<properties>(.*?)</properties>", Pattern.DOTALL);
+  private static final Pattern PROP_ENTRY = Pattern.compile("<([A-Za-z0-9_.\\-]+)>([^<]+)</\\1>");
+  private static final Pattern PARENT_BLOCK = Pattern.compile("<parent>(.*?)</parent>", Pattern.DOTALL);
+  private static final Pattern RELATIVE_PATH = Pattern.compile("<relativePath>([^<]*)</relativePath>");
+  private static final int PARENT_WALK_LIMIT = 10;
 }

--- a/plugins/maven-server-api/test/java/org/jetbrains/idea/maven/model/MavenWorkspaceMapWrapperTest.kt
+++ b/plugins/maven-server-api/test/java/org/jetbrains/idea/maven/model/MavenWorkspaceMapWrapperTest.kt
@@ -1,0 +1,148 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.idea.maven.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.Properties
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeText
+
+class MavenWorkspaceMapWrapperTest {
+
+  /**
+   * IDEA-388560: when a workspace artifact's version is the unresolved literal `${revision}`
+   * (because the property lives in pom `<properties>` rather than `-Drevision=...`),
+   * the existing exact-key lookup misses for concrete-version requests like `5.0.1-SNAPSHOT`.
+   * The fallback must accept the literal entry iff the pom's effective `<revision>` matches.
+   */
+  @Test
+  fun `falls back to placeholder entry when its resolved revision matches concrete request`() {
+    val tmp = createTempDirectory()
+    val pom = tmp.resolve("pom.xml")
+    pom.writeText(
+      """
+      <project>
+        <groupId>com.example</groupId>
+        <artifactId>module</artifactId>
+        <version>${"$"}{revision}</version>
+        <properties>
+          <revision>5.0.1-SNAPSHOT</revision>
+        </properties>
+      </project>
+      """.trimIndent()
+    )
+
+    val rawMap = MavenWorkspaceMap()
+    rawMap.register(MavenId("com.example", "module", "\${revision}"), pom.toFile())
+    val wrapper = MavenWorkspaceMapWrapper(rawMap, Properties())
+
+    val data = wrapper.findFileAndOriginalIdWithRevisionFallback(
+      MavenId("com.example", "module", "5.0.1-SNAPSHOT")
+    )
+
+    assertThat(data).isNotNull
+    assertThat(data!!.getFile(MavenConstants.POM_EXTENSION)).isEqualTo(pom.toFile())
+  }
+
+  /**
+   * The fallback must NOT short-circuit when the requested concrete version differs from
+   * what the placeholder would resolve to (e.g. a sibling module declares parent at a
+   * frozen dated release like `2026.05.22T09.56` while the workspace runs at
+   * `${revision}=5.0.1-SNAPSHOT`). Returning the workspace data here would bind the
+   * dependency to the wrong artifact version.
+   */
+  @Test
+  fun `does not match when placeholder resolves to a different version`() {
+    val tmp = createTempDirectory()
+    val pom = tmp.resolve("pom.xml")
+    pom.writeText(
+      """
+      <project>
+        <groupId>com.example</groupId>
+        <artifactId>module</artifactId>
+        <version>${"$"}{revision}</version>
+        <properties>
+          <revision>5.0.1-SNAPSHOT</revision>
+        </properties>
+      </project>
+      """.trimIndent()
+    )
+
+    val rawMap = MavenWorkspaceMap()
+    rawMap.register(MavenId("com.example", "module", "\${revision}"), pom.toFile())
+    val wrapper = MavenWorkspaceMapWrapper(rawMap, Properties())
+
+    val data = wrapper.findFileAndOriginalIdWithRevisionFallback(
+      MavenId("com.example", "module", "2026.05.22T09.56")
+    )
+
+    assertThat(data).isNull()
+  }
+
+  /**
+   * Exact-version lookups must still work unchanged.
+   */
+  @Test
+  fun `exact match returns directly without fallback`() {
+    val tmp = createTempDirectory()
+    val pom = tmp.resolve("pom.xml")
+    pom.writeText("<project/>")
+
+    val rawMap = MavenWorkspaceMap()
+    rawMap.register(MavenId("com.example", "module", "5.0.1-SNAPSHOT"), pom.toFile())
+    val wrapper = MavenWorkspaceMapWrapper(rawMap, Properties())
+
+    val data = wrapper.findFileAndOriginalIdWithRevisionFallback(
+      MavenId("com.example", "module", "5.0.1-SNAPSHOT")
+    )
+
+    assertThat(data).isNotNull
+  }
+
+  /**
+   * Fallback walks the `<parent><relativePath>` chain so the placeholder can be defined
+   * in an aggregator pom (typical for boot-parent style hierarchies).
+   */
+  @Test
+  fun `placeholder resolves via parent pom relative path`() {
+    val tmp = createTempDirectory()
+    val parent = tmp.resolve("pom.xml")
+    parent.writeText(
+      """
+      <project>
+        <groupId>com.example</groupId>
+        <artifactId>parent</artifactId>
+        <version>${"$"}{revision}</version>
+        <properties>
+          <revision>5.0.1-SNAPSHOT</revision>
+        </properties>
+      </project>
+      """.trimIndent()
+    )
+    val moduleDir = tmp.resolve("child").also { java.nio.file.Files.createDirectories(it) }
+    val childPom = moduleDir.resolve("pom.xml")
+    childPom.writeText(
+      """
+      <project>
+        <parent>
+          <groupId>com.example</groupId>
+          <artifactId>parent</artifactId>
+          <version>${"$"}{revision}</version>
+          <relativePath>../pom.xml</relativePath>
+        </parent>
+        <artifactId>child</artifactId>
+      </project>
+      """.trimIndent()
+    )
+
+    val rawMap = MavenWorkspaceMap()
+    rawMap.register(MavenId("com.example", "child", "\${revision}"), childPom.toFile())
+    val wrapper = MavenWorkspaceMapWrapper(rawMap, Properties())
+
+    val data = wrapper.findFileAndOriginalIdWithRevisionFallback(
+      MavenId("com.example", "child", "5.0.1-SNAPSHOT")
+    )
+
+    assertThat(data).isNotNull
+  }
+}

--- a/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3WorkspaceMapReader.java
+++ b/plugins/maven/maven3-server-impl/src/org/jetbrains/idea/maven/server/Maven3WorkspaceMapReader.java
@@ -51,7 +51,8 @@ public class Maven3WorkspaceMapReader implements MavenWorkspaceReader {
 
   @Override
   public File findArtifact(Artifact artifact) {
-    MavenWorkspaceMap.Data resolved = myWorkspaceMap.findFileAndOriginalId(new MavenId(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion()));
+    MavenId id = new MavenId(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+    MavenWorkspaceMap.Data resolved = myWorkspaceMap.findFileAndOriginalIdWithRevisionFallback(id);
     if (resolved == null) return null;
 
     return resolved.getFile(artifact.getExtension());

--- a/plugins/maven/maven40-server-impl/src/com/intellij/maven/server/m40/utils/Maven40WorkspaceMapReader.java
+++ b/plugins/maven/maven40-server-impl/src/com/intellij/maven/server/m40/utils/Maven40WorkspaceMapReader.java
@@ -38,8 +38,8 @@ public class Maven40WorkspaceMapReader implements WorkspaceReader, MavenWorkspac
 
   @Override
   public File findArtifact(Artifact artifact) {
-    MavenWorkspaceMap.Data resolved =
-      myWorkspaceMap.findFileAndOriginalId(new MavenId(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion()));
+    MavenId id = new MavenId(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+    MavenWorkspaceMap.Data resolved = myWorkspaceMap.findFileAndOriginalIdWithRevisionFallback(id);
     if (resolved == null) return null;
 
     return resolved.getFile(artifact.getExtension());


### PR DESCRIPTION
## Summary

Workspace map short-circuit misses for CI-friendly versioned projects (Maven `${revision}` placeholder) when the property is defined in pom `<properties>` rather than passed via `-Drevision=...`. Fixes [IDEA-388560](https://youtrack.jetbrains.com/issue/IDEA-388560).

## Regression

Commit c5d43b12c857 ("[maven] IDEA-368906 interpolate workspace map", 2025-03-21) added `MavenWorkspaceMapWrapper#interpolate(...)`, which expands `${...}` placeholders against `Properties.getProperty(key, "")` — i.e. **JVM system properties only**.

Most CI-friendly users define `<revision>` in pom `<properties>`:

```xml
<properties>
    <revision>5.0.1-SNAPSHOT</revision>
</properties>
```

The Maven embedder's JVM doesn't see this (it's a Maven model property, not a system property). `getProperty("revision", "")` returns `""`, so every workspace `MavenId` whose version is `${revision}` gets registered under the literal placeholder key plus an empty-string alias. Dependency resolution later asks for the resolved concrete version (`5.0.1-SNAPSHOT`) and misses → falls through to remote repositories → writes `.lastUpdated` tombstones for workspace artifacts → red squiggles across the project ("Project Structure handles module as external").

## Fix

New additive `MavenWorkspaceMapWrapper#findFileAndOriginalIdWithRevisionFallback`:

1. Exact-key lookup first — behaviour unchanged when `-Drevision=...` is set.
2. On miss, scans same `groupId+artifactId` workspace entries.
3. If either side has a `${...}` placeholder, the placeholder is resolved against the candidate workspace pom's effective `<properties>`, walking the `<parent><relativePath>` chain (capped at 10 levels).
4. Match returned **only when** the placeholder resolves to the concrete side. Prevents over-matching when a sibling module references its parent at an unrelated frozen dated release.

`Maven3WorkspaceMapReader#findArtifact` and `Maven40WorkspaceMapReader#findArtifact` route their Aether lookup through the new method. Other callers of the existing `findFileAndOriginalId` are untouched.

Pom parsing is intentionally regex-based on `<properties>` + `<parent><relativePath>` so `maven-server-api` stays free of XML-parser dependencies.

## Test plan

New unit test `MavenWorkspaceMapWrapperTest.kt` covers:
- [x] Fallback matches placeholder entry when its resolved revision equals concrete request
- [x] Fallback rejects placeholder entry when revision resolves to a different version (frozen-version sibling case)
- [x] Exact-version lookups bypass fallback
- [x] Placeholder resolution via `<parent><relativePath>` chain

Minimal 5-pom reproducer attached to the YouTrack ticket emits the expected `WARN o.j.i.maven - Cannot resolve property ${revision}` + `.lastUpdated` tombstones on `master`, succeeds with this patch.

## YouTrack

https://youtrack.jetbrains.com/issue/IDEA-388560