### PR TITLE
Get Annotation Directly

### DIFF
--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/annotationValue.kt
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/annotationValue.kt
@@ -10,5 +10,5 @@ fun main(args: Array<String>) {
     val a = 5
 }
 
-// EXPRESSION: (SomeClass::class.java.annotations[0] as Anno).value
+// EXPRESSION: SomeClass::class.java.getAnnotation(Anno::class.java).value
 // RESULT: "abc": Ljava/lang/String;

--- a/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/annotationValue.out
+++ b/plugins/kotlin/jvm-debugger/test/testData/evaluation/singleBreakpoint/annotationValue.out
@@ -2,7 +2,7 @@ LineBreakpoint created at annotationValue.kt:10
 Run Java
 Connected to the target VM
 annotationValue.kt:10
-Compile bytecode for (SomeClass::class.java.annotations[0] as Anno).value
+Compile bytecode for SomeClass::class.java.getAnnotation(Anno::class.java).value
 Disconnected from the target VM
 
 Process finished with exit code 0


### PR DESCRIPTION
Do not depend on the order of `Class#getAnnotations()`

Fixes https://youtrack.jetbrains.com/issue/KTIJ-38949/Debugger-Test-testAnnotationValue-Assumes-Annotation-Order