### PR TITLE
Restore IJ/AS-DEPENDENCY-PLACEHOLDER

### DIFF
--- a/plugins/kotlin/plugin/resources/META-INF/plugin.xml
+++ b/plugins/kotlin/plugin/resources/META-INF/plugin.xml
@@ -16,6 +16,7 @@
   <vendor url="https://www.jetbrains.com">JetBrains</vendor>
 
   <dependencies>
+    <!-- IJ/AS-DEPENDENCY-PLACEHOLDER -->
     <module name="intellij.java.backend"/>
     <module name="intellij.platform.collaborationTools"/>
     <module name="intellij.platform.scriptDebugger.ui"/>


### PR DESCRIPTION
This is used in KotlinPluginBuilder when targeting Android Studio. It appears to have been removed accidentally in IntelliJ commit https://github.com/JetBrains/intellij-community/commit/9200c626a7.