### PR TITLE
Fix NullPointer in StatisticsEventLogProviders at startup

### DIFF
--- a/platform/statistics/src/com/intellij/internal/statistic/eventLog/StatisticsEventLogProvidersHolder.kt
+++ b/platform/statistics/src/com/intellij/internal/statistic/eventLog/StatisticsEventLogProvidersHolder.kt
@@ -18,15 +18,15 @@ import java.util.concurrent.atomic.AtomicReference
 
 @Service(Service.Level.APP)
 internal class StatisticsEventLogProvidersHolder(coroutineScope: CoroutineScope) {
+  // Cache for empty providers by [recorderId] to avoid creating new instances on every call
+  private val emptyProviders: MutableMap<String, StatisticsEventLoggerProvider> = ConcurrentHashMap()
+
   // Small temporary inconsistency between `eventLoggerProviders` and `eventLoggerProvidersExt` doesn't really matter,
   // and it will be smaller than other white noise in data.
   private val eventLoggerProviders: AtomicReference<Map<String, StatisticsEventLoggerProvider>> =
     AtomicReference(calculateEventLogProvider())
   private val eventLoggerProvidersExt: AtomicReference<Map<String, Collection<StatisticsEventLoggerProvider>>> =
     AtomicReference(calculateEventLogProviderExt())
-
-  // Cache for empty providers by [recorderId] to avoid creating new instances on every call
-  private val emptyProviders: MutableMap<String, StatisticsEventLoggerProvider> = ConcurrentHashMap()
 
   init {
     if (ApplicationManager.getApplication().extensionArea.hasExtensionPoint(EP_NAME)) {


### PR DESCRIPTION
This was introduced in IntelliJ commit: 7a6e6be7bd0 and causes an issue for Android Studio at startup due to property initialization order for non-JetBrains IDEs (calculateEventLogProvider behaves differently for Android Studio compared to IntelliJ).

Change-Id: Ibddd632793a86995c3f193c46f1cc1e3b23e098d