### PR TITLE
IJPL-218807 Made the terminal support `OSC 9;4` progress indicator

### DIFF
--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalDisplayImpl.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalDisplayImpl.kt
@@ -12,6 +12,7 @@ import com.jediterm.terminal.ui.AwtTransformers
 import com.jediterm.terminal.ui.settings.DefaultSettingsProvider
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.plugins.terminal.block.ui.TerminalUi
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
 
 /**
  * Headless [TerminalDisplay] implementation which serves the following purpose:
@@ -35,6 +36,8 @@ class TerminalDisplayImpl(private val settings: DefaultSettingsProvider) : Termi
   var isBracketedPasteMode: Boolean = false
     private set
   var windowTitleText: String = ""
+    private set
+  var terminalProgressState: TerminalProgressState = TerminalProgressState.NONE
     private set
 
   private val dispatcher = EventDispatcher.create(TerminalDisplayListener::class.java)
@@ -79,6 +82,13 @@ class TerminalDisplayImpl(private val settings: DefaultSettingsProvider) : Termi
     if (this.windowTitleText != windowTitle) {
       this.windowTitleText = windowTitle
       dispatcher.multicaster.windowTitleChanged(windowTitle)
+    }
+  }
+
+  fun setTerminalProgressState(terminalProgressState: TerminalProgressState) {
+    if (this.terminalProgressState != terminalProgressState) {
+      this.terminalProgressState = terminalProgressState
+      dispatcher.multicaster.terminalProgressChanged(terminalProgressState)
     }
   }
 

--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalDisplayListener.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalDisplayListener.kt
@@ -5,6 +5,7 @@ import com.jediterm.terminal.CursorShape
 import com.jediterm.terminal.emulator.mouse.MouseFormat
 import com.jediterm.terminal.emulator.mouse.MouseMode
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
 import java.util.EventListener
 
 @ApiStatus.Internal
@@ -22,6 +23,8 @@ interface TerminalDisplayListener : EventListener {
   fun bracketedPasteModeChanged(isEnabled: Boolean) {}
 
   fun windowTitleChanged(title: String) {}
+
+  fun terminalProgressChanged(terminalProgressState: TerminalProgressState) {}
 
   fun beep() {}
 }

--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalOutput.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalOutput.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import org.jetbrains.plugins.terminal.LocalTerminalTtyConnector
 import org.jetbrains.plugins.terminal.block.reworked.TerminalShellIntegrationEventsListener
 import org.jetbrains.plugins.terminal.block.ui.withLock
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
 import org.jetbrains.plugins.terminal.session.impl.TerminalAliasesReceivedEvent
 import org.jetbrains.plugins.terminal.session.impl.TerminalBeepEvent
 import org.jetbrains.plugins.terminal.session.impl.TerminalCommandFinishedEvent
@@ -73,6 +74,7 @@ internal fun createTerminalOutputFlow(
     isAltSendsEscape = controller.altSendsEscape,
     isBracketedPasteMode = terminalDisplay.isBracketedPasteMode,
     windowTitle = terminalDisplay.windowTitleText,
+    terminalProgressState = terminalDisplay.terminalProgressState,
     isShellIntegrationEnabled = false,
     currentDirectory = getInitialWorkingDirectory(services),
   ))
@@ -216,6 +218,12 @@ internal fun createTerminalOutputFlow(
     override fun windowTitleChanged(title: String) {
       textBuffer.withLock {
         stateChangesTracker.updateState { it.copy(windowTitle = title) }
+      }
+    }
+
+    override fun terminalProgressChanged(terminalProgressState: TerminalProgressState) {
+      textBuffer.withLock {
+        stateChangesTracker.updateState { it.copy(terminalProgressState = terminalProgressState) }
       }
     }
   })

--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalSessionStart.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/session/TerminalSessionStart.kt
@@ -8,6 +8,7 @@ import com.intellij.platform.util.coroutines.childScope
 import com.intellij.terminal.JBTerminalSystemSettingsProviderBase
 import com.intellij.terminal.TerminalExecutorServiceManagerImpl
 import com.intellij.util.AwaitCancellationAndInvoke
+import com.intellij.util.asDisposable
 import com.intellij.util.awaitCancellationAndInvoke
 import com.jediterm.core.typeahead.TerminalTypeAheadManager
 import com.jediterm.terminal.TerminalExecutorServiceManager
@@ -27,6 +28,7 @@ import org.jetbrains.plugins.terminal.ShellStartupOptions
 import org.jetbrains.plugins.terminal.original
 import org.jetbrains.plugins.terminal.session.impl.TerminalSession
 import org.jetbrains.plugins.terminal.session.impl.TerminalSessionTerminatedEvent
+import org.jetbrains.plugins.terminal.progress.TerminalProgressParser
 import org.jetbrains.plugins.terminal.util.closeConnectorAndStopEmulation
 
 @ApiStatus.Internal
@@ -60,6 +62,7 @@ fun createTerminalSession(
 
   val maxHistoryLinesCount = AdvancedSettings.getInt("terminal.buffer.max.lines.count")
   val services: JediTermServices = createJediTermServices(observableTtyConnector, options, maxHistoryLinesCount, settings)
+  installTerminalProgressListener(observableTtyConnector, services.terminalDisplay, coroutineScope)
 
   val outputScope = coroutineScope.childScope("Terminal output forwarding")
   val shellIntegrationController = TerminalShellIntegrationController(services.controller)
@@ -100,6 +103,19 @@ fun createTerminalSession(
     coroutineScope = coroutineScope,
     ttyConnector = ttyConnector.original as LocalTerminalTtyConnector,
   )
+}
+
+private fun installTerminalProgressListener(
+  connector: ObservableTtyConnector,
+  terminalDisplay: TerminalDisplayImpl,
+  coroutineScope: CoroutineScope,
+) {
+  val parser = TerminalProgressParser(terminalDisplay::setTerminalProgressState)
+  connector.addListener(coroutineScope.asDisposable(), object : TtyConnectorListener {
+    override fun charsRead(buf: CharArray, offset: Int, length: Int) {
+      parser.process(buf, offset, length)
+    }
+  })
 }
 
 private fun createJediTermServices(

--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/view/impl/TerminalViewImpl.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/view/impl/TerminalViewImpl.kt
@@ -88,6 +88,8 @@ import org.jetbrains.plugins.terminal.fus.TerminalStartupFusInfo
 import org.jetbrains.plugins.terminal.hyperlinks.TerminalHyperlinkId
 import org.jetbrains.plugins.terminal.hyperlinks.TerminalSourceNavigationInfo
 import org.jetbrains.plugins.terminal.hyperlinks.session.TerminalHyperlinksSessionId
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
+import org.jetbrains.plugins.terminal.progress.TerminalProgressStripe
 import org.jetbrains.plugins.terminal.session.TerminalGridSize
 import org.jetbrains.plugins.terminal.session.TerminalStartupOptions
 import org.jetbrains.plugins.terminal.session.impl.TerminalSession
@@ -150,6 +152,7 @@ class TerminalViewImpl(
   private var isAlternateScreenBuffer = false
 
   private val terminalPanel: TerminalPanel
+  private val progressStripe: TerminalProgressStripe
 
   @VisibleForTesting
   val outputEditorKeyEventsHandler: TerminalKeyEventsHandler
@@ -158,7 +161,7 @@ class TerminalViewImpl(
   val shellIntegrationFeaturesInitJob: Job
 
   override val component: JComponent
-    get() = terminalPanel
+    get() = progressStripe
   override val preferredFocusableComponent: JComponent
     get() = terminalPanel.preferredFocusableComponent
   override val gridSize: TerminalGridSize?
@@ -334,15 +337,17 @@ class TerminalViewImpl(
       mutableSessionState.value = TerminalViewSessionState.Terminated
       // Hide the cursor on process termination
       val currentState = sessionModel.terminalState.value
-      sessionModel.updateTerminalState(currentState.copy(isCursorVisible = false))
+      sessionModel.updateTerminalState(currentState.copy(isCursorVisible = false, terminalProgressState = TerminalProgressState.NONE))
     }
 
     terminalPanel = TerminalPanel(initialContent = outputEditor)
+    progressStripe = TerminalProgressStripe(terminalPanel, coroutineScope.asDisposable())
 
     listenSearchController()
     listenPanelSizeChanges()
     listenAlternateBufferSwitch()
     listenApplicationTitleChanges()
+    listenTerminalProgressChanges()
     listenKeyEvents()
 
     refreshVfsOnFocusChange(
@@ -521,6 +526,14 @@ class TerminalViewImpl(
           @Suppress("HardCodedStringLiteral")
           applicationTitle = state.windowTitle
         }
+      }
+    }
+  }
+
+  private fun listenTerminalProgressChanges() {
+    coroutineScope.launch(Dispatchers.EDT + ModalityState.any().asContextElement() + CoroutineName("Terminal progress listener")) {
+      sessionModel.terminalState.collect { state ->
+        progressStripe.progressChanged(state.terminalProgressState)
       }
     }
   }

--- a/plugins/terminal/resources/messages/TerminalBundle.properties
+++ b/plugins/terminal/resources/messages/TerminalBundle.properties
@@ -198,6 +198,7 @@ exit.code.label=Exit code {0}
 terminal.prompt.lang.description=Terminal Prompt (internal)
 doc.popup.alias.text=Alias for "{0}"
 terminal.output.editor.title=Terminal Output
+terminal.progress.accessible.name=Terminal progress
 
 feedback.notification.title=Share feedback about Terminal
 feedback.notification.text=Please answer a few questions about your experience with Terminal.

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/AbstractTerminalRunner.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/AbstractTerminalRunner.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.terminal.block.TerminalWidgetImpl;
 import org.jetbrains.plugins.terminal.block.ui.TerminalUiUtils;
+import org.jetbrains.plugins.terminal.progress.TerminalProgressManager;
 
 import java.awt.Component;
 import java.time.Duration;
@@ -240,9 +241,10 @@ public abstract class AbstractTerminalRunner<T extends Process> {
             if (myProject.isDisposed() || widgetDisposable.isDisposed()) return;
             try {
               ShellStartupOptions optionsWithTermSize = configuredOptions.builder().initialTermSize(resultInitialTermSize).build();
-              TtyConnector connector = createTtyConnector(optionsWithTermSize);
+              TtyConnector connector = TerminalProgressManager.wrapConnector(terminalWidget, createTtyConnector(optionsWithTermSize));
               Duration durationBetweenStartupAndConnectorCreated = startupMoment.elapsedNow();
-              if (connector instanceof ProcessTtyConnector processTtyConnector) {
+              ProcessTtyConnector processTtyConnector = ShellTerminalWidget.getProcessTtyConnector(connector);
+              if (processTtyConnector != null) {
                 logCommonStartupInfo(
                   connector,
                   processTtyConnector.getProcess(),

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/block/reworked/TerminalSessionModelImpl.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/block/reworked/TerminalSessionModelImpl.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
 import org.jetbrains.plugins.terminal.session.impl.TerminalState
 
 @ApiStatus.Internal
@@ -32,6 +33,7 @@ class TerminalSessionModelImpl : TerminalSessionModel {
         isAltSendsEscape = true,
         isBracketedPasteMode = false,
         windowTitle = "",
+        terminalProgressState = TerminalProgressState.NONE,
         isShellIntegrationEnabled = false,
         currentDirectory = null,
       )

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressManager.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressManager.kt
@@ -1,0 +1,37 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.terminal.progress
+
+import com.intellij.terminal.ui.TerminalWidget
+import com.jediterm.terminal.TtyConnector
+import org.jetbrains.annotations.ApiStatus
+import javax.swing.JComponent
+
+@ApiStatus.Internal
+object TerminalProgressManager {
+  private const val PROGRESS_LISTENER_CLIENT_PROPERTY: String = "TerminalProgressListener"
+
+  @JvmStatic
+  fun install(component: JComponent, listener: TerminalProgressListener) {
+    component.putClientProperty(PROGRESS_LISTENER_CLIENT_PROPERTY, listener)
+  }
+
+  @JvmStatic
+  fun wrapConnector(terminalWidget: TerminalWidget, connector: TtyConnector): TtyConnector {
+    val listener = getListener(terminalWidget) ?: return connector
+    return TerminalProgressTtyConnector(connector, listener::progressChanged)
+  }
+
+  @JvmStatic
+  fun clear(terminalWidget: TerminalWidget) {
+    getListener(terminalWidget)?.progressChanged(TerminalProgressState.NONE)
+  }
+
+  private fun getListener(terminalWidget: TerminalWidget): TerminalProgressListener? {
+    return terminalWidget.component.getClientProperty(PROGRESS_LISTENER_CLIENT_PROPERTY) as? TerminalProgressListener
+  }
+}
+
+@ApiStatus.Internal
+fun interface TerminalProgressListener {
+  fun progressChanged(progressState: TerminalProgressState)
+}

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressParser.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressParser.kt
@@ -1,0 +1,118 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.terminal.progress
+
+import org.jetbrains.annotations.ApiStatus
+
+@ApiStatus.Internal
+class TerminalProgressParser(private val progressHandler: (TerminalProgressState) -> Unit) {
+  private var previousWasEscape = false
+  private var oscBuffer: StringBuilder? = null
+  private var escapeInOsc = false
+
+  fun process(buf: CharArray, offset: Int, length: Int) {
+    for (i in offset until offset + length) {
+      processChar(buf[i])
+    }
+  }
+
+  fun process(text: CharSequence) {
+    for (c in text) {
+      processChar(c)
+    }
+  }
+
+  private fun processChar(c: Char) {
+    val buffer = oscBuffer
+    if (buffer == null) {
+      processCharOutsideOsc(c)
+      return
+    }
+
+    previousWasEscape = false
+    if (c == STRING_TERMINATOR) {
+      finishOsc(buffer)
+      return
+    }
+    if (escapeInOsc) {
+      if (c == ST_ESCAPE_END) {
+        finishOsc(buffer)
+        return
+      }
+      buffer.append(ESCAPE)
+      escapeInOsc = false
+    }
+
+    when (c) {
+      BEL -> finishOsc(buffer)
+      ESCAPE -> escapeInOsc = true
+      else -> {
+        buffer.append(c)
+        if (buffer.length > MAX_OSC_LENGTH) {
+          resetOsc()
+        }
+      }
+    }
+  }
+
+  private fun processCharOutsideOsc(c: Char) {
+    if (c == OSC) {
+      oscBuffer = StringBuilder()
+      previousWasEscape = false
+      return
+    }
+
+    if (previousWasEscape) {
+      if (c == OSC_ESCAPE_START) {
+        oscBuffer = StringBuilder()
+        previousWasEscape = false
+      }
+      else {
+        previousWasEscape = c == ESCAPE
+      }
+    }
+    else {
+      previousWasEscape = c == ESCAPE
+    }
+  }
+
+  private fun finishOsc(buffer: StringBuilder) {
+    val text = buffer.toString()
+    resetOsc()
+    parseProgressState(text)?.let(progressHandler)
+  }
+
+  private fun resetOsc() {
+    oscBuffer = null
+    escapeInOsc = false
+    previousWasEscape = false
+  }
+
+  private fun parseProgressState(text: String): TerminalProgressState? {
+    val parts = text.split(';')
+    if (parts.size < 3 || parts[0] != "9" || parts[1] != "4") return null
+
+    return when (parts[2].toIntOrNull()) {
+      0 -> TerminalProgressState.NONE
+      1 -> parseDeterminateProgress(parts, TerminalProgressState::normal)
+      2 -> parseDeterminateProgress(parts, TerminalProgressState::error)
+      3 -> TerminalProgressState.indeterminate()
+      4 -> parseDeterminateProgress(parts, TerminalProgressState::warning)
+      else -> null
+    }
+  }
+
+  private fun parseDeterminateProgress(parts: List<String>, factory: (Int) -> TerminalProgressState): TerminalProgressState? {
+    val percent = parts.getOrNull(3)?.toIntOrNull()?.takeIf { it in 0..100 } ?: return null
+    return factory(percent)
+  }
+
+  private companion object {
+    const val ESCAPE: Char = '\u001B'
+    const val BEL: Char = '\u0007'
+    const val OSC_ESCAPE_START: Char = ']'
+    const val ST_ESCAPE_END: Char = '\\'
+    const val OSC: Char = '\u009D'
+    const val STRING_TERMINATOR: Char = '\u009C'
+    const val MAX_OSC_LENGTH: Int = 1024
+  }
+}

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressState.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressState.kt
@@ -1,0 +1,41 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.terminal.progress
+
+import org.jetbrains.annotations.ApiStatus
+
+@ApiStatus.Internal
+data class TerminalProgressState(
+  val status: TerminalProgressStatus,
+  val percent: Int,
+) {
+  val isVisible: Boolean
+    get() = status != TerminalProgressStatus.NONE
+
+  val isIndeterminate: Boolean
+    get() = status == TerminalProgressStatus.INDETERMINATE
+
+  companion object {
+    val NONE: TerminalProgressState = TerminalProgressState(TerminalProgressStatus.NONE, 0)
+
+    fun normal(percent: Int): TerminalProgressState = determinate(TerminalProgressStatus.NORMAL, percent)
+
+    fun error(percent: Int): TerminalProgressState = determinate(TerminalProgressStatus.ERROR, percent)
+
+    fun warning(percent: Int): TerminalProgressState = determinate(TerminalProgressStatus.WARNING, percent)
+
+    fun indeterminate(): TerminalProgressState = TerminalProgressState(TerminalProgressStatus.INDETERMINATE, 0)
+
+    private fun determinate(status: TerminalProgressStatus, percent: Int): TerminalProgressState {
+      return TerminalProgressState(status, percent.coerceIn(0, 100))
+    }
+  }
+}
+
+@ApiStatus.Internal
+enum class TerminalProgressStatus {
+  NONE,
+  NORMAL,
+  ERROR,
+  INDETERMINATE,
+  WARNING,
+}

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressStripe.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressStripe.kt
@@ -1,0 +1,85 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.terminal.progress
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.util.ProgressBarUtil
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.ProgressBarLoadingDecorator
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.plugins.terminal.TerminalBundle
+import java.awt.BorderLayout
+import javax.swing.JComponent
+import javax.swing.JProgressBar
+
+@ApiStatus.Internal
+class TerminalProgressStripe(
+  targetComponent: JComponent,
+  private val parentDisposable: Disposable,
+) : JBPanel<TerminalProgressStripe>(BorderLayout()), TerminalProgressListener {
+  private val contentPanel = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+    isOpaque = false
+    add(targetComponent, BorderLayout.CENTER)
+  }
+  private val decorator = ProgressBarLoadingDecorator(contentPanel, parentDisposable, 0)
+
+  init {
+    isOpaque = false
+    decorator.loadingText = ""
+    add(decorator.component, BorderLayout.CENTER)
+    configureProgressBar()
+    progressChanged(TerminalProgressState.NONE)
+  }
+
+  override fun progressChanged(progressState: TerminalProgressState) {
+    val application = ApplicationManager.getApplication()
+    if (application.isDispatchThread) {
+      applyProgressState(progressState)
+    }
+    else {
+      application.invokeLater {
+        if (!Disposer.isDisposed(parentDisposable)) {
+          applyProgressState(progressState)
+        }
+      }
+    }
+  }
+
+  private fun applyProgressState(progressState: TerminalProgressState) {
+    val progressBar = progressBar
+    progressBar.putClientProperty(ProgressBarUtil.STATUS_KEY, progressState.progressBarStatus)
+    progressBar.isIndeterminate = progressState.isIndeterminate
+    if (!progressState.isIndeterminate) {
+      progressBar.value = progressState.percent.coerceIn(0, 100)
+    }
+
+    if (progressState.isVisible) {
+      decorator.startLoading()
+    }
+    else {
+      progressBar.isIndeterminate = false
+      progressBar.value = 100
+      decorator.stopLoading()
+    }
+  }
+
+  private fun configureProgressBar() {
+    val progressBar = progressBar
+    progressBar.minimum = 0
+    progressBar.maximum = 100
+    progressBar.isStringPainted = false
+    progressBar.accessibleContext.accessibleName = TerminalBundle.message("terminal.progress.accessible.name")
+  }
+
+  private val progressBar: JProgressBar
+    get() = decorator.progressBar
+}
+
+val TerminalProgressState.progressBarStatus: String?
+  @ApiStatus.Internal
+  get() = when (status) {
+    TerminalProgressStatus.ERROR -> ProgressBarUtil.FAILED_VALUE
+    TerminalProgressStatus.WARNING -> ProgressBarUtil.WARNING_VALUE
+    else -> null
+  }

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressTtyConnector.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/progress/TerminalProgressTtyConnector.kt
@@ -1,0 +1,55 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.terminal.progress
+
+import com.jediterm.core.util.TermSize
+import com.jediterm.terminal.TtyConnector
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.plugins.terminal.ProxyTtyConnector
+
+@ApiStatus.Internal
+class TerminalProgressTtyConnector(
+  override val connector: TtyConnector,
+  progressHandler: (TerminalProgressState) -> Unit,
+) : ProxyTtyConnector {
+  private val progressParser = TerminalProgressParser(progressHandler)
+
+  override fun read(buf: CharArray, offset: Int, length: Int): Int {
+    val charsReadCount = connector.read(buf, offset, length)
+    if (charsReadCount > 0) {
+      progressParser.process(buf, offset, charsReadCount)
+    }
+    return charsReadCount
+  }
+
+  override fun write(bytes: ByteArray) {
+    connector.write(bytes)
+  }
+
+  override fun write(string: String?) {
+    connector.write(string)
+  }
+
+  override fun isConnected(): Boolean {
+    return connector.isConnected
+  }
+
+  override fun resize(termSize: TermSize) {
+    connector.resize(termSize)
+  }
+
+  override fun waitFor(): Int {
+    return connector.waitFor()
+  }
+
+  override fun ready(): Boolean {
+    return connector.ready()
+  }
+
+  override fun getName(): String? {
+    return connector.name
+  }
+
+  override fun close() {
+    connector.close()
+  }
+}

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/session/impl/TerminalState.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/session/impl/TerminalState.kt
@@ -5,6 +5,7 @@ import com.jediterm.terminal.CursorShape
 import com.jediterm.terminal.emulator.mouse.MouseFormat
 import com.jediterm.terminal.emulator.mouse.MouseMode
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
 
 @ApiStatus.Internal
 data class TerminalState(
@@ -20,6 +21,7 @@ data class TerminalState(
   val isAltSendsEscape: Boolean,
   val isBracketedPasteMode: Boolean,
   val windowTitle: String,
+  val terminalProgressState: TerminalProgressState,
   /** Whether such events as command started/finished are supported by the shell integration */
   val isShellIntegrationEnabled: Boolean,
   /**

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/session/impl/dto/TerminalProgressStateDto.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/session/impl/dto/TerminalProgressStateDto.kt
@@ -1,0 +1,51 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.terminal.session.impl.dto
+
+import kotlinx.serialization.Serializable
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
+import org.jetbrains.plugins.terminal.progress.TerminalProgressStatus
+
+@ApiStatus.Internal
+@Serializable
+data class TerminalProgressStateDto(
+  val status: TerminalProgressStatusDto = TerminalProgressStatusDto.NONE,
+  val percent: Int = 0,
+)
+
+@ApiStatus.Internal
+@Serializable
+enum class TerminalProgressStatusDto {
+  NONE,
+  NORMAL,
+  ERROR,
+  INDETERMINATE,
+  WARNING,
+}
+
+@ApiStatus.Internal
+fun TerminalProgressState.toDto(): TerminalProgressStateDto {
+  return TerminalProgressStateDto(status.toDto(), percent)
+}
+
+@ApiStatus.Internal
+fun TerminalProgressStateDto.toTerminalProgressState(): TerminalProgressState {
+  val coercedPercent = percent.coerceIn(0, 100)
+  return when (status) {
+    TerminalProgressStatusDto.NONE -> TerminalProgressState.NONE
+    TerminalProgressStatusDto.NORMAL -> TerminalProgressState.normal(coercedPercent)
+    TerminalProgressStatusDto.ERROR -> TerminalProgressState.error(coercedPercent)
+    TerminalProgressStatusDto.INDETERMINATE -> TerminalProgressState.indeterminate()
+    TerminalProgressStatusDto.WARNING -> TerminalProgressState.warning(coercedPercent)
+  }
+}
+
+private fun TerminalProgressStatus.toDto(): TerminalProgressStatusDto {
+  return when (this) {
+    TerminalProgressStatus.NONE -> TerminalProgressStatusDto.NONE
+    TerminalProgressStatus.NORMAL -> TerminalProgressStatusDto.NORMAL
+    TerminalProgressStatus.ERROR -> TerminalProgressStatusDto.ERROR
+    TerminalProgressStatus.INDETERMINATE -> TerminalProgressStatusDto.INDETERMINATE
+    TerminalProgressStatus.WARNING -> TerminalProgressStatusDto.WARNING
+  }
+}

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/session/impl/dto/TerminalStateDto.kt
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/session/impl/dto/TerminalStateDto.kt
@@ -19,6 +19,7 @@ data class TerminalStateDto(
   val isAltSendsEscape: Boolean,
   val isBracketedPasteMode: Boolean,
   val windowTitle: String,
+  val terminalProgressState: TerminalProgressStateDto = TerminalProgressStateDto(),
   val isShellIntegrationEnabled: Boolean,
   val currentDirectory: String?,
 )
@@ -37,6 +38,7 @@ fun TerminalState.toDto(): TerminalStateDto {
     isAltSendsEscape = isAltSendsEscape,
     isBracketedPasteMode = isBracketedPasteMode,
     windowTitle = windowTitle,
+    terminalProgressState = terminalProgressState.toDto(),
     isShellIntegrationEnabled = isShellIntegrationEnabled,
     currentDirectory = currentDirectory,
   )
@@ -56,6 +58,7 @@ fun TerminalStateDto.toTerminalState(): TerminalState {
     isAltSendsEscape = isAltSendsEscape,
     isBracketedPasteMode = isBracketedPasteMode,
     windowTitle = windowTitle,
+    terminalProgressState = terminalProgressState.toTerminalProgressState(),
     isShellIntegrationEnabled = isShellIntegrationEnabled,
     currentDirectory = currentDirectory,
   )

--- a/plugins/terminal/src/org/jetbrains/plugins/terminal/ui/TerminalContainer.java
+++ b/plugins/terminal/src/org/jetbrains/plugins/terminal/ui/TerminalContainer.java
@@ -20,10 +20,12 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 import org.jetbrains.plugins.terminal.TerminalBundle;
 import org.jetbrains.plugins.terminal.TerminalOptionsProvider;
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
+import org.jetbrains.plugins.terminal.progress.TerminalProgressManager;
+import org.jetbrains.plugins.terminal.progress.TerminalProgressStripe;
 
+import javax.swing.JComponent;
 import javax.swing.JPanel;
 import java.awt.BorderLayout;
-import java.awt.Component;
 import java.awt.Container;
 
 public final class TerminalContainer {
@@ -80,6 +82,7 @@ public final class TerminalContainer {
   }
 
   private void processSessionCompleted() {
+    TerminalProgressManager.clear(myTerminalWidget);
     if (myForceHideUiWhenSessionEnds || TerminalOptionsProvider.getInstance().getCloseSessionOnLogout()) {
       myTerminalToolWindowManager.closeTab(myContent);
     }
@@ -131,13 +134,15 @@ public final class TerminalContainer {
       setChildComponent(terminal.myTerminalWidget.getComponent());
     }
 
-    private void setChildComponent(@NotNull Component childComponent) {
+    private void setChildComponent(@NotNull JComponent childComponent) {
       Container parent = childComponent.getParent();
       if (parent != null) {
         parent.remove(childComponent);
       }
+      TerminalProgressStripe progressStripe = new TerminalProgressStripe(childComponent, myTerminal.myContent);
+      TerminalProgressManager.install(childComponent, progressStripe);
       removeAll();
-      add(childComponent, BorderLayout.CENTER);
+      add(progressStripe, BorderLayout.CENTER);
       revalidate();
     }
   }

--- a/plugins/terminal/tests/src/com/intellij/terminal/tests/progress/TerminalProgressParserTest.kt
+++ b/plugins/terminal/tests/src/com/intellij/terminal/tests/progress/TerminalProgressParserTest.kt
@@ -1,0 +1,82 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.terminal.tests.progress
+
+import com.intellij.openapi.progress.util.ProgressBarUtil
+import org.jetbrains.plugins.terminal.progress.TerminalProgressParser
+import org.jetbrains.plugins.terminal.progress.TerminalProgressState
+import org.jetbrains.plugins.terminal.progress.TerminalProgressStatus
+import org.jetbrains.plugins.terminal.progress.progressBarStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TerminalProgressParserTest {
+  @Test
+  fun `parses determinate progress terminated by BEL`() {
+    val events = parse("$ESC]9;4;1;42$BEL")
+
+    assertEquals(listOf(TerminalProgressState.normal(42)), events)
+  }
+
+  @Test
+  fun `parses indeterminate progress terminated by ST`() {
+    val events = parse("$ESC]9;4;3;0$ESC\\")
+
+    assertEquals(listOf(TerminalProgressState.indeterminate()), events)
+  }
+
+  @Test
+  fun `parses clear progress without percent`() {
+    val events = parse("$ESC]9;4;0$BEL")
+
+    assertEquals(listOf(TerminalProgressState.NONE), events)
+  }
+
+  @Test
+  fun `parses split sequence`() {
+    val events = mutableListOf<TerminalProgressState>()
+    val parser = TerminalProgressParser(events::add)
+
+    parser.process("${ESC}]9;")
+    parser.process("4;4;7")
+    parser.process("5$BEL")
+
+    assertEquals(listOf(TerminalProgressState.warning(75)), events)
+  }
+
+  @Test
+  fun `parses error state`() {
+    val events = parse("$ESC]9;4;2;13$BEL")
+
+    assertEquals(TerminalProgressStatus.ERROR, events.single().status)
+    assertEquals(13, events.single().percent)
+  }
+
+  @Test
+  fun `maps terminal progress states to progress bar statuses`() {
+    assertEquals(ProgressBarUtil.FAILED_VALUE, TerminalProgressState.error(15).progressBarStatus)
+    assertEquals(ProgressBarUtil.WARNING_VALUE, TerminalProgressState.warning(15).progressBarStatus)
+    assertNull(TerminalProgressState.normal(15).progressBarStatus)
+    assertNull(TerminalProgressState.indeterminate().progressBarStatus)
+    assertNull(TerminalProgressState.NONE.progressBarStatus)
+  }
+
+  @Test
+  fun `ignores unsupported and malformed sequences`() {
+    val events = parse("plain text$ESC]0;title$BEL$ESC]9;4;1;101$BEL$ESC]9;4;x;1$BEL")
+
+    assertTrue(events.isEmpty())
+  }
+
+  private fun parse(text: String): List<TerminalProgressState> {
+    val events = mutableListOf<TerminalProgressState>()
+    TerminalProgressParser(events::add).process(text)
+    return events
+  }
+
+  private companion object {
+    const val ESC: Char = '\u001B'
+    const val BEL: Char = '\u0007'
+  }
+}


### PR DESCRIPTION
With this PR Terminal programs can now report tab progress with `OSC 9;4`. The parser reads these sequences from process output to handle the progress state.

Classic Terminal and Reworked Terminal use the same progress stripe. The classic path wraps the terminal component directly. Reworked Terminal stores progress in session state, the data is shared with frontend and remote clients.

Parser tests cover BEL and ST terminators, split reads, clear, error, warning, indeterminate, and malformed sequences.
Based on https://github.com/MicrosoftDocs/terminal/blob/main/TerminalDocs/tutorials/progress-bar-sequences.md

This should fix https://youtrack.jetbrains.com/issue/IJPL-218807/Terminal-progress-bar-OSC-94-sequence

Screenshots:
<img width="1343" height="465" alt="Screenshot 2026-06-04 at 11 57 56" src="https://github.com/user-attachments/assets/f4cdb5f7-092a-4b07-8263-f22e350a6121" />
<img width="1355" height="445" alt="Screenshot 2026-06-04 at 12 03 45" src="https://github.com/user-attachments/assets/fd96d5fc-ce76-4cb5-bd8e-fe270a0805d9" />

https://github.com/user-attachments/assets/f28768ab-5fcb-4049-8193-d5c1214c504c

