### PR TITLE
IDEA-384446 Allow executing different Gradle test tasks on a module

### DIFF
--- a/platform/execution-impl/src/com/intellij/execution/actions/BaseRunConfigurationAction.java
+++ b/platform/execution-impl/src/com/intellij/execution/actions/BaseRunConfigurationAction.java
@@ -26,9 +26,10 @@ package com.intellij.execution.actions;
  import com.intellij.openapi.util.registry.Registry;
  import com.intellij.openapi.util.text.StringUtil;
  import com.intellij.openapi.vfs.VirtualFile;
- import org.jetbrains.annotations.Nls;
- import org.jetbrains.annotations.NotNull;
- import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
  import javax.swing.Icon;
  import java.util.ArrayList;
@@ -163,15 +164,18 @@ package com.intellij.execution.actions;
     return producers.get(0);
   }
 
-  private void perform(@NotNull ConfigurationFromContext configurationFromContext, @NotNull ConfigurationContext context) {
+  @VisibleForTesting
+  void perform(@NotNull ConfigurationFromContext configurationFromContext, @NotNull ConfigurationContext context) {
     int eventCount = IdeEventQueue.getInstance().getEventCount();
-    RunnerAndConfigurationSettings configurationSettings = configurationFromContext.getConfigurationSettings();
-    context.setConfiguration(configurationSettings);
+    context.setConfiguration(configurationFromContext.getConfigurationSettings());
     configurationFromContext.onFirstRun(context, () -> {
+      // A producer may replace the generated settings after showing additional UI, for example when a test task is selected.
+      RunnerAndConfigurationSettings configurationSettings = configurationFromContext.getConfigurationSettings();
+      // Updates the context again with the settings that will actually run.
+      context.setConfiguration(configurationSettings);
       if (LOG.isDebugEnabled()) {
-        RunnerAndConfigurationSettings settings = context.getConfiguration();
-        RunConfiguration configuration = settings == null ? null : settings.getConfiguration();
-        String configurationClass = configuration == null ? null : configuration.getClass().getName();
+        RunConfiguration configuration = configurationSettings.getConfiguration();
+        String configurationClass = configuration.getClass().getName();
         LOG.debug(String.format("Create run configuration: %s", configurationClass));
       }
       // Reset event counter if some UI was shown as

--- a/platform/execution-impl/src/com/intellij/execution/actions/RunContextAction.java
+++ b/platform/execution-impl/src/com/intellij/execution/actions/RunContextAction.java
@@ -30,6 +30,7 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,16 +55,22 @@ public class RunContextAction extends BaseRunConfigurationAction {
     ReadAction
       .nonBlocking(() -> findExisting(context))
       .finishOnUiThread(ModalityState.nonModal(), existingConfiguration -> {
-        if (configuration != existingConfiguration) {
+        if (shouldAddNewConfiguration(runManager, configuration, existingConfiguration)) {
           RunConfigurationOptionUsagesCollector.logAddNew(context.getProject(), configuration.getType().getId(), context.getPlace());
           runManager.setTemporaryConfiguration(configuration);
-          perform(runManager, configuration, dataContext);
         }
-        else {
-          perform(runManager, configuration, dataContext);
-        }
+        perform(runManager, configuration, dataContext);
       })
       .submit(AppExecutorUtil.getAppExecutorService());
+  }
+
+  @VisibleForTesting
+  static boolean shouldAddNewConfiguration(@NotNull RunManagerEx runManager,
+                                           @NotNull RunnerAndConfigurationSettings configuration,
+                                           @Nullable RunnerAndConfigurationSettings existingConfiguration) {
+    // onFirstRun may replace generated settings with a stored configuration after findExisting() cached a miss.
+    // Do not add those stored settings again as a temporary configuration.
+    return configuration != existingConfiguration && !runManager.hasSettings(configuration);
   }
 
   private void perform(RunManagerEx runManager,

--- a/platform/lang-impl/testSources/com/intellij/execution/actions/ConfigurationContextTest.java
+++ b/platform/lang-impl/testSources/com/intellij/execution/actions/ConfigurationContextTest.java
@@ -4,6 +4,7 @@ package com.intellij.execution.actions;
 import com.intellij.execution.Location;
 import com.intellij.execution.PsiLocation;
 import com.intellij.execution.RunManager;
+import com.intellij.execution.RunManagerEx;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.executors.DefaultRunExecutor;
@@ -14,6 +15,7 @@ import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.extensions.ExtensionPoint;
 import com.intellij.openapi.fileTypes.FileTypes;
 import com.intellij.openapi.util.Disposer;
@@ -28,6 +30,7 @@ import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 
+import javax.swing.Icon;
 import java.util.List;
 import java.util.Objects;
 
@@ -173,6 +176,68 @@ public class ConfigurationContextTest extends BasePlatformTestCase {
     new RunContextAction(DefaultRunExecutor.getRunExecutorInstance()).update(event1);
     assertTrue(event1.getPresentation().isEnabledAndVisible());
     assertEquals("Run 'world_'", event1.getPresentation().getText());
+  }
+
+  public void testRunActionUsesConfigurationSelectedOnFirstRun() {
+    myFixture.configureByText(FileTypes.PLAIN_TEXT, "qq<caret>q");
+    ConfigurationContext context = ConfigurationContext.getFromContext(createDataContext(), ActionPlaces.UNKNOWN);
+    RunManager runManager = RunManager.getInstance(getProject());
+    RunnerAndConfigurationSettings initial = runManager.createConfiguration("initial", FakeConfigurationFactory.INSTANCE);
+    RunnerAndConfigurationSettings selected = runManager.createConfiguration("selected", FakeConfigurationFactory.INSTANCE);
+    Ref<RunnerAndConfigurationSettings> performed = Ref.create();
+    ConfigurationFromContext configurationFromContext = new ConfigurationFromContext() {
+      private RunnerAndConfigurationSettings mySettings = initial;
+
+      @Override
+      public @NotNull RunnerAndConfigurationSettings getConfigurationSettings() {
+        return mySettings;
+      }
+
+      @Override
+      public void setConfigurationSettings(RunnerAndConfigurationSettings configurationSettings) {
+        mySettings = configurationSettings;
+      }
+
+      @Override
+      public @NotNull PsiElement getSourceElement() {
+        return myFixture.getFile();
+      }
+
+      @Override
+      public void onFirstRun(ConfigurationContext configurationContext, Runnable startRunnable) {
+        setConfigurationSettings(selected);
+        startRunnable.run();
+      }
+    };
+    BaseRunConfigurationAction action = new BaseRunConfigurationAction(() -> "", () -> "", (Icon)null) {
+      @Override
+      protected void perform(@NotNull RunnerAndConfigurationSettings configurationSettings,
+                             @NotNull ConfigurationContext configurationContext) {
+        performed.set(configurationSettings);
+      }
+
+      @Override
+      protected void updatePresentation(@NotNull Presentation presentation,
+                                        @NotNull String actionText,
+                                        ConfigurationContext configurationContext) {
+      }
+    };
+
+    action.perform(configurationFromContext, context);
+
+    assertSame(selected, performed.get());
+    assertSame(selected, context.getConfiguration());
+  }
+
+  public void testManagedConfigurationIsNotAddedAgain() {
+    RunManager runManager = RunManager.getInstance(getProject());
+    RunnerAndConfigurationSettings managed = runManager.createConfiguration("managed", FakeConfigurationFactory.INSTANCE);
+    RunnerAndConfigurationSettings unmanaged = runManager.createConfiguration("unmanaged", FakeConfigurationFactory.INSTANCE);
+    addConfiguration(managed);
+
+    assertFalse(RunContextAction.shouldAddNewConfiguration((RunManagerEx)runManager, managed, null));
+    assertTrue(RunContextAction.shouldAddNewConfiguration((RunManagerEx)runManager, unmanaged, null));
+    assertFalse(RunContextAction.shouldAddNewConfiguration((RunManagerEx)runManager, unmanaged, unmanaged));
   }
 
   private @NotNull DataContext createDataContext() {

--- a/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
+++ b/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
@@ -2,6 +2,7 @@
 package org.jetbrains.plugins.gradle.execution.test.runner
 
 import com.intellij.execution.JavaRunConfigurationExtensionManager
+import com.intellij.execution.RunManager
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.ConfigurationFromContext
 import com.intellij.openapi.util.Ref
@@ -16,6 +17,8 @@ import org.jetbrains.plugins.gradle.util.cmd.node.GradleCommandLineTasks
 import org.jetbrains.plugins.gradle.util.createTestWildcardFilter
 import java.util.StringJoiner
 import java.util.function.Consumer
+
+private const val DEFAULT_TEST_TASK_NAME = "test"
 
 abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : PsiElement> : GradleTestRunConfigurationProducer() {
 
@@ -33,9 +36,23 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
 
   protected abstract fun getAllTestsTaskToRun(context: ConfigurationContext, element: E, chosenElements: List<Ex>): List<TestTasksToRun>
 
+  override fun findOrCreateConfigurationFromContext(context: ConfigurationContext): ConfigurationFromContext? {
+    val configurationFromContext = super.findOrCreateConfigurationFromContext(context) ?: return null
+    val element = getElement(context) ?: return configurationFromContext
+    if (allTestsTaskToRun(context, element).map { it.tasksToRun.testName }.toSet().size > 1) {
+      (configurationFromContext.configuration as GradleRunConfiguration).name =
+        suggestConfigurationName(context, element, emptyList())
+    }
+    return configurationFromContext
+  }
+
   private fun getAllTasksAndArguments(context: ConfigurationContext, element: E, chosenElements: List<Ex>): List<GradleCommandLineTasks> {
     return getAllTestsTaskToRun(context, element, chosenElements)
       .map { it.toTasksAndArguments() }
+  }
+
+  private fun allTestsTaskToRun(context: ConfigurationContext, element: E): List<TestTasksToRun> {
+    return getAllTestsTaskToRun(context, element, emptyList())
   }
 
   override fun doSetupConfigurationFromContext(
@@ -69,7 +86,11 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
     val module = context.module ?: return false
     val externalProjectPath = resolveProjectPath(module) ?: return false
     val element = getElement(context) ?: return false
-    val allTasksAndArguments = getAllTasksAndArguments(context, element, emptyList())
+    val allTestsTaskToRun = allTestsTaskToRun(context, element)
+    if (allTestsTaskToRun.map { it.tasksToRun.testName }.toSet().size > 1) {
+      return false
+    }
+    val allTasksAndArguments = allTestsTaskToRun.map { it.toTasksAndArguments() }
     val tasksAndArguments = configuration.commandLine.tasks.tokens
     return externalProjectPath == configuration.settings.externalProjectPath &&
            tasksAndArguments.isNotEmpty() && allTasksAndArguments.isNotEmpty() &&
@@ -96,14 +117,44 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
           .mapValues { it.value.map(TestTasksToRun::testFilter).toSet() }
           .map { createTasksAndArguments(it.key, it.value) }
 
-        runConfiguration.name = suggestConfigurationName(context, element, elements)
-        setUniqueNameIfNeeded(project, runConfiguration)
         runConfiguration.settings.taskNames = chosenTasksAndArguments.flatMap { it.tokens }
         runConfiguration.settings.scriptParameters = if (chosenTasksAndArguments.size > 1) "--continue" else ""
+        runConfiguration.name = suggestConfigurationName(context, element, elements)
+          .withGradleTestTaskName(chosenTestsToRun)
+        if (!hasSameExistingConfiguration(runConfiguration)) {
+          setUniqueNameIfNeeded(project, runConfiguration)
+        }
 
         super.onFirstRun(configuration, context, startRunnable)
       }
     }
+  }
+
+  private fun String.withGradleTestTaskName(chosenTestsToRun: List<List<TestTasksToRun>>): String {
+    val testTaskName = chosenTestsToRun.flatten().map { it.tasksToRun.testName }.distinct().singleOrNull()
+    if (testTaskName == null || testTaskName == DEFAULT_TEST_TASK_NAME) return this
+    if (endsWith(".$DEFAULT_TEST_TASK_NAME'")) {
+      return removeSuffix(".$DEFAULT_TEST_TASK_NAME'") + ".$testTaskName'"
+    }
+    if (endsWith("'")) {
+      return dropLast(1) + ".$testTaskName'"
+    }
+    return "$this.$testTaskName"
+  }
+
+  private fun hasSameExistingConfiguration(configuration: GradleRunConfiguration): Boolean {
+    val taskNames = configuration.commandLine.tasks.tokens
+    val scriptParameters = configuration.settings.scriptParameters
+    return RunManager.getInstance(configuration.project)
+      .getConfigurationSettingsList(configurationFactory.type)
+      .any { settings ->
+        val existingConfiguration = settings.configuration as? GradleRunConfiguration ?: return@any false
+        existingConfiguration !== configuration &&
+        existingConfiguration.name == configuration.name &&
+        existingConfiguration.settings.externalProjectPath == configuration.settings.externalProjectPath &&
+        existingConfiguration.commandLine.tasks.tokens == taskNames &&
+        existingConfiguration.settings.scriptParameters == scriptParameters
+      }
   }
 
   /**

--- a/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
+++ b/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
@@ -19,8 +19,6 @@ import org.jetbrains.plugins.gradle.util.createTestWildcardFilter
 import java.util.StringJoiner
 import java.util.function.Consumer
 
-private const val DEFAULT_TEST_TASK_NAME = "test"
-
 abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : PsiElement> : GradleTestRunConfigurationProducer() {
 
   protected abstract fun getElement(context: ConfigurationContext): E?
@@ -31,6 +29,19 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
   protected abstract fun getLocationName(context: ConfigurationContext, element: E): String
 
   protected abstract fun suggestConfigurationName(context: ConfigurationContext, element: E, chosenElements: List<Ex>): String
+
+  protected open fun getTaskTargetNames(
+    context: ConfigurationContext,
+    element: E,
+    chosenElements: List<Ex>,
+  ): List<String> = listOf(suggestConfigurationName(context, element, chosenElements))
+
+  protected open fun suggestTaskFirstConfigurationName(
+    context: ConfigurationContext,
+    element: E,
+    chosenElements: List<Ex>,
+    selectedTestTaskNames: List<String>,
+  ): String = createTaskFirstConfigurationNameFor(selectedTestTaskNames, getTaskTargetNames(context, element, chosenElements))
 
   protected abstract fun chooseSourceElements(context: ConfigurationContext, element: E, onElementsChosen: Consumer<List<Ex>>)
 
@@ -127,6 +138,7 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
       val allTestsToRun = getAllTestsTaskToRun(context, element, elements)
         .groupBy { it.tasksToRun.testName }
         .mapValues { it.value }
+      val hasMultipleTestTasks = allTestsToRun.size > 1
       testTasksChooser.chooseTestTasks(project, dataContext, allTestsToRun) { chosenTestsToRun ->
         val chosenTasksAndArguments = chosenTestsToRun.flatten()
           .groupBy { it.tasksToRun }
@@ -140,26 +152,22 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
         else {
           runConfiguration.settings.taskNames = chosenTasksAndArguments.flatMap { it.tokens }
           runConfiguration.settings.scriptParameters = if (chosenTasksAndArguments.size > 1) "--continue" else ""
-          runConfiguration.name = suggestConfigurationName(context, element, elements)
-            .withGradleTestTaskName(chosenTestsToRun)
+
+          val selectedTestTaskNames = chosenTestsToRun.flatten()
+            .map { it.tasksToRun.testName }
+            .distinct()
+
+          runConfiguration.name = if (hasMultipleTestTasks) {
+            suggestTaskFirstConfigurationName(context, element, elements, selectedTestTaskNames)
+          } else {
+            suggestConfigurationName(context, element, elements)
+          }
           setUniqueNameIfNeeded(project, runConfiguration)
         }
 
         super.onFirstRun(configuration, context, startRunnable)
       }
     }
-  }
-
-  private fun String.withGradleTestTaskName(chosenTestsToRun: List<List<TestTasksToRun>>): String {
-    val testTaskName = chosenTestsToRun.flatten().map { it.tasksToRun.testName }.distinct().singleOrNull()
-    if (testTaskName == null || testTaskName == DEFAULT_TEST_TASK_NAME) return this
-    if (endsWith(".$DEFAULT_TEST_TASK_NAME'")) {
-      return removeSuffix(".$DEFAULT_TEST_TASK_NAME'") + ".$testTaskName'"
-    }
-    if (endsWith("'")) {
-      return dropLast(1) + ".$testTaskName'"
-    }
-    return "$this.$testTaskName"
   }
 
   private fun findExistingConfigurationSettings(

--- a/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
+++ b/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
@@ -3,6 +3,7 @@ package org.jetbrains.plugins.gradle.execution.test.runner
 
 import com.intellij.execution.JavaRunConfigurationExtensionManager
 import com.intellij.execution.RunManager
+import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.ConfigurationFromContext
 import com.intellij.openapi.util.Ref
@@ -58,7 +59,7 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
   override fun doSetupConfigurationFromContext(
     configuration: GradleRunConfiguration,
     context: ConfigurationContext,
-    sourceElement: Ref<PsiElement>
+    sourceElement: Ref<PsiElement>,
   ): Boolean {
     val project = context.project ?: return false
     val module = context.module ?: return false
@@ -81,14 +82,18 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
 
   override fun doIsConfigurationFromContext(
     configuration: GradleRunConfiguration,
-    context: ConfigurationContext
+    context: ConfigurationContext,
   ): Boolean {
     val module = context.module ?: return false
     val externalProjectPath = resolveProjectPath(module) ?: return false
     val element = getElement(context) ?: return false
     val allTestsTaskToRun = allTestsTaskToRun(context, element)
     if (allTestsTaskToRun.map { it.tasksToRun.testName }.toSet().size > 1) {
-      return false
+      // Ignore, only if the configuration has been stored already, so the task chooser
+      // is shown again when `onFirstRun` executes. If the config new then it's accepted.
+      val runManager = RunManager.getInstance(configuration.project)
+      val stored = getConfigurationSettingsList(runManager).any { it.configuration === configuration }
+      if (stored) return false
     }
     val allTasksAndArguments = allTestsTaskToRun.map { it.toTasksAndArguments() }
     val tasksAndArguments = configuration.commandLine.tasks.tokens
@@ -99,12 +104,13 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
 
   override fun onFirstRun(configuration: ConfigurationFromContext, context: ConfigurationContext, startRunnable: Runnable) {
     val project = context.project
-    val element = getElement(context)
-    if (project == null || element == null) {
+    if (project == null) {
       LOG.warn("Cannot extract configuration data from context, uses raw run configuration")
       super.onFirstRun(configuration, context, startRunnable)
       return
     }
+    @Suppress("UNCHECKED_CAST")
+    val element = configuration.sourceElement as E
     val runConfiguration = configuration.configuration as GradleRunConfiguration
     val dataContext = contextWithLocationName(context.dataContext, getLocationName(context, element))
     chooseSourceElements(context, element) { elements ->
@@ -117,11 +123,15 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
           .mapValues { it.value.map(TestTasksToRun::testFilter).toSet() }
           .map { createTasksAndArguments(it.key, it.value) }
 
-        runConfiguration.settings.taskNames = chosenTasksAndArguments.flatMap { it.tokens }
-        runConfiguration.settings.scriptParameters = if (chosenTasksAndArguments.size > 1) "--continue" else ""
-        runConfiguration.name = suggestConfigurationName(context, element, elements)
-          .withGradleTestTaskName(chosenTestsToRun)
-        if (!hasSameExistingConfiguration(runConfiguration)) {
+        val existingConfiguration = findExistingConfigurationSettings(context, chosenTasksAndArguments)
+        if (existingConfiguration != null) {
+          configuration.configurationSettings = existingConfiguration
+        }
+        else {
+          runConfiguration.settings.taskNames = chosenTasksAndArguments.flatMap { it.tokens }
+          runConfiguration.settings.scriptParameters = if (chosenTasksAndArguments.size > 1) "--continue" else ""
+          runConfiguration.name = suggestConfigurationName(context, element, elements)
+            .withGradleTestTaskName(chosenTestsToRun)
           setUniqueNameIfNeeded(project, runConfiguration)
         }
 
@@ -142,18 +152,23 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
     return "$this.$testTaskName"
   }
 
-  private fun hasSameExistingConfiguration(configuration: GradleRunConfiguration): Boolean {
-    val taskNames = configuration.commandLine.tasks.tokens
-    val scriptParameters = configuration.settings.scriptParameters
-    return RunManager.getInstance(configuration.project)
-      .getConfigurationSettingsList(configurationFactory.type)
-      .any { settings ->
-        val existingConfiguration = settings.configuration as? GradleRunConfiguration ?: return@any false
-        existingConfiguration !== configuration &&
-        existingConfiguration.name == configuration.name &&
-        existingConfiguration.settings.externalProjectPath == configuration.settings.externalProjectPath &&
-        existingConfiguration.commandLine.tasks.tokens == taskNames &&
-        existingConfiguration.settings.scriptParameters == scriptParameters
+  private fun findExistingConfigurationSettings(
+    context: ConfigurationContext,
+    tasksAndArguments: List<GradleCommandLineTasks>,
+  ): RunnerAndConfigurationSettings? {
+    val project = context.project ?: return null
+    val module = context.module ?: return null
+    val externalProjectPath = resolveProjectPath(module) ?: return null
+    return getConfigurationSettingsList(RunManager.getInstance(project))
+      .firstOrNull { runnerAndConfigurationSettings ->
+        val existingConfiguration = runnerAndConfigurationSettings.configuration as? GradleRunConfiguration ?: return@firstOrNull false
+        (existingConfiguration.settings.externalProjectPath == externalProjectPath
+         && existingConfiguration.commandLine.tasks.tokens.isNotEmpty()
+         // Use task tokens rather than the rest of the configuration to discriminate the task to run
+         && isConsistedFrom(
+          existingConfiguration.commandLine.tasks.tokens,
+          tasksAndArguments.map { it.tokens })
+        )
       }
   }
 

--- a/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
+++ b/plugins/gradle/java/src/execution/test/runner/AbstractGradleTestRunConfigurationProducer.kt
@@ -25,6 +25,9 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
 
   protected abstract fun getElement(context: ConfigurationContext): E?
 
+  /** Resolves the element again when possible and validates any fallback supplied by the original configuration. */
+  protected abstract fun getElementForFirstRun(context: ConfigurationContext, sourceElement: PsiElement): E?
+
   protected abstract fun getLocationName(context: ConfigurationContext, element: E): String
 
   protected abstract fun suggestConfigurationName(context: ConfigurationContext, element: E, chosenElements: List<Ex>): String
@@ -36,6 +39,9 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
   }
 
   protected abstract fun getAllTestsTaskToRun(context: ConfigurationContext, element: E, chosenElements: List<Ex>): List<TestTasksToRun>
+
+  /** Whether [onFirstRun] uses [testTasksChooser] to select among the available test tasks. */
+  protected open fun usesBaseTestTasksChooser(): Boolean = true
 
   override fun findOrCreateConfigurationFromContext(context: ConfigurationContext): ConfigurationFromContext? {
     val configurationFromContext = super.findOrCreateConfigurationFromContext(context) ?: return null
@@ -54,6 +60,18 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
 
   private fun allTestsTaskToRun(context: ConfigurationContext, element: E): List<TestTasksToRun> {
     return getAllTestsTaskToRun(context, element, emptyList())
+  }
+
+  override fun findExistingConfiguration(context: ConfigurationContext): RunnerAndConfigurationSettings? {
+    val element = getElement(context) ?: return super.findExistingConfiguration(context)
+    val hasMultipleTestTasks = allTestsTaskToRun(context, element)
+                                 .map { it.tasksToRun.testName }
+                                 .toSet()
+                                 .size > 1
+    if (usesBaseTestTasksChooser() && hasMultipleTestTasks) {
+      return null
+    }
+    return super.findExistingConfiguration(context)
   }
 
   override fun doSetupConfigurationFromContext(
@@ -88,13 +106,6 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
     val externalProjectPath = resolveProjectPath(module) ?: return false
     val element = getElement(context) ?: return false
     val allTestsTaskToRun = allTestsTaskToRun(context, element)
-    if (allTestsTaskToRun.map { it.tasksToRun.testName }.toSet().size > 1) {
-      // Ignore, only if the configuration has been stored already, so the task chooser
-      // is shown again when `onFirstRun` executes. If the config new then it's accepted.
-      val runManager = RunManager.getInstance(configuration.project)
-      val stored = getConfigurationSettingsList(runManager).any { it.configuration === configuration }
-      if (stored) return false
-    }
     val allTasksAndArguments = allTestsTaskToRun.map { it.toTasksAndArguments() }
     val tasksAndArguments = configuration.commandLine.tasks.tokens
     return externalProjectPath == configuration.settings.externalProjectPath &&
@@ -104,13 +115,12 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
 
   override fun onFirstRun(configuration: ConfigurationFromContext, context: ConfigurationContext, startRunnable: Runnable) {
     val project = context.project
-    if (project == null) {
+    val element = getElementForFirstRun(context, configuration.sourceElement)
+    if (project == null || element == null) {
       LOG.warn("Cannot extract configuration data from context, uses raw run configuration")
       super.onFirstRun(configuration, context, startRunnable)
       return
     }
-    @Suppress("UNCHECKED_CAST")
-    val element = configuration.sourceElement as E
     val runConfiguration = configuration.configuration as GradleRunConfiguration
     val dataContext = contextWithLocationName(context.dataContext, getLocationName(context, element))
     chooseSourceElements(context, element) { elements ->
@@ -157,18 +167,16 @@ abstract class AbstractGradleTestRunConfigurationProducer<E : PsiElement, Ex : P
     tasksAndArguments: List<GradleCommandLineTasks>,
   ): RunnerAndConfigurationSettings? {
     val project = context.project ?: return null
-    val module = context.module ?: return null
-    val externalProjectPath = resolveProjectPath(module) ?: return null
+    if (tasksAndArguments.isEmpty()) return null
+    val selectedTaskTokens = tasksAndArguments.map { it.tokens }
     return getConfigurationSettingsList(RunManager.getInstance(project))
       .firstOrNull { runnerAndConfigurationSettings ->
         val existingConfiguration = runnerAndConfigurationSettings.configuration as? GradleRunConfiguration ?: return@firstOrNull false
-        (existingConfiguration.settings.externalProjectPath == externalProjectPath
-         && existingConfiguration.commandLine.tasks.tokens.isNotEmpty()
-         // Use task tokens rather than the rest of the configuration to discriminate the task to run
-         && isConsistedFrom(
-          existingConfiguration.commandLine.tasks.tokens,
-          tasksAndArguments.map { it.tokens })
-        )
+        val existingTaskTokens = existingConfiguration.commandLine.tasks.tokens
+
+        (isConfigurationCompatibleForSelectedTasks(existingConfiguration)
+         && existingTaskTokens.size == selectedTaskTokens.sumOf { it.size }
+         && isConsistedFrom(existingTaskTokens, selectedTaskTokens))
       }
   }
 

--- a/plugins/gradle/java/src/execution/test/runner/AllInDirectoryGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/AllInDirectoryGradleConfigurationProducer.java
@@ -52,6 +52,13 @@ public class AllInDirectoryGradleConfigurationProducer extends AbstractGradleTes
   }
 
   @Override
+  protected @Nullable PsiElement getElementForFirstRun(@NotNull ConfigurationContext context, @NotNull PsiElement sourceElement) {
+    PsiElement element = getElement(context);
+    if (element != null) return element;
+    return sourceElement instanceof PsiFileSystemItem item && item.isDirectory() ? item : null;
+  }
+
+  @Override
   protected @NotNull String getLocationName(@NotNull ConfigurationContext context, @NotNull PsiElement element) {
     Module module = Objects.requireNonNull(context.getModule());
     return String.format("'%s'", module.getName());

--- a/plugins/gradle/java/src/execution/test/runner/AllInDirectoryGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/AllInDirectoryGradleConfigurationProducer.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
@@ -72,6 +73,23 @@ public class AllInDirectoryGradleConfigurationProducer extends AbstractGradleTes
   ) {
     Module module = Objects.requireNonNull(context.getModule());
     return ExecutionBundle.message("test.in.scope.presentable.text", module.getName());
+  }
+
+  @Override
+  protected @NotNull List<String> getTaskTargetNames(@NotNull ConfigurationContext context,
+                                                      @NotNull PsiElement element,
+                                                      @NotNull List<? extends PsiElement> chosenElements) {
+    Module module = Objects.requireNonNull(context.getModule());
+    String gradleProjectPath = StringUtil.notNullize(resolveGradleIdentityPath(module), module.getName());
+    return List.of("[" + gradleProjectPath + "]");
+  }
+
+  @Override
+  protected @NotNull String suggestTaskFirstConfigurationName(@NotNull ConfigurationContext context,
+                                                               @NotNull PsiElement element,
+                                                               @NotNull List<? extends PsiElement> chosenElements,
+                                                               @NotNull List<String> selectedTestTaskNames) {
+    return createTaskFirstConfigurationNameIn(selectedTestTaskNames, getTaskTargetNames(context, element, chosenElements));
   }
 
   @Override

--- a/plugins/gradle/java/src/execution/test/runner/AllInPackageGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/AllInPackageGradleConfigurationProducer.java
@@ -52,6 +52,13 @@ public class AllInPackageGradleConfigurationProducer extends AbstractGradleTestR
   }
 
   @Override
+  protected @Nullable PsiPackage getElementForFirstRun(@NotNull ConfigurationContext context, @NotNull PsiElement sourceElement) {
+    PsiPackage element = getElement(context);
+    if (element != null) return element;
+    return sourceElement instanceof PsiPackage psiPackage ? psiPackage : null;
+  }
+
+  @Override
   protected @NotNull String getLocationName(@NotNull ConfigurationContext context, @NotNull PsiPackage element) {
     return String.format("'%s'", element.getName());
   }

--- a/plugins/gradle/java/src/execution/test/runner/AllInPackageGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/AllInPackageGradleConfigurationProducer.java
@@ -73,6 +73,21 @@ public class AllInPackageGradleConfigurationProducer extends AbstractGradleTestR
   }
 
   @Override
+  protected @NotNull List<String> getTaskTargetNames(@NotNull ConfigurationContext context,
+                                                      @NotNull PsiPackage element,
+                                                      @NotNull List<? extends PsiPackage> chosenElements) {
+    return List.of(element.getQualifiedName());
+  }
+
+  @Override
+  protected @NotNull String suggestTaskFirstConfigurationName(@NotNull ConfigurationContext context,
+                                                               @NotNull PsiPackage element,
+                                                               @NotNull List<? extends PsiPackage> chosenElements,
+                                                               @NotNull List<String> selectedTestTaskNames) {
+    return createTaskFirstConfigurationNameIn(selectedTestTaskNames, getTaskTargetNames(context, element, chosenElements));
+  }
+
+  @Override
   protected void chooseSourceElements(
     @NotNull ConfigurationContext context,
     @NotNull PsiPackage element,

--- a/plugins/gradle/java/src/execution/test/runner/GradleTestRunConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/GradleTestRunConfigurationProducer.java
@@ -24,6 +24,7 @@ import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.jetbrains.plugins.gradle.execution.GradleRunConfigurationProducer;
 import org.jetbrains.plugins.gradle.execution.GradleRunnerUtil;
 import org.jetbrains.plugins.gradle.execution.build.CachedModuleDataFinder;
@@ -134,6 +135,15 @@ public abstract class GradleTestRunConfigurationProducer extends GradleRunConfig
 
   protected TestTasksChooser getTestTasksChooser() {
     return testTasksChooser;
+  }
+
+  /**
+   * Checks producer-specific metadata without comparing editable configuration options.
+   * Specialized producers should override this when task tokens alone do not identify their configurations.
+   */
+  @VisibleForTesting
+  protected boolean isConfigurationCompatibleForSelectedTasks(@NotNull GradleRunConfiguration configuration) {
+    return true;
   }
 
   @TestOnly

--- a/plugins/gradle/java/src/execution/test/runner/GradleTestRunConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/GradleTestRunConfigurationProducer.java
@@ -31,6 +31,7 @@ import org.jetbrains.plugins.gradle.execution.build.CachedModuleDataFinder;
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
 import org.jetbrains.plugins.gradle.settings.TestRunner;
+import org.jetbrains.plugins.gradle.util.GradleBundle;
 import org.jetbrains.plugins.gradle.util.GradleModuleData;
 import org.jetbrains.plugins.gradle.util.TasksToRun;
 
@@ -135,6 +136,40 @@ public abstract class GradleTestRunConfigurationProducer extends GradleRunConfig
 
   protected TestTasksChooser getTestTasksChooser() {
     return testTasksChooser;
+  }
+
+  protected static @NotNull String createTaskFirstConfigurationNameFor(
+    @NotNull List<String> taskNames,
+    @NotNull List<String> targetNames
+  ) {
+    return GradleBundle.message(
+      "gradle.tests.task.first.configuration.name.for",
+      suggestSelectionName(taskNames),
+      suggestSelectionName(targetNames)
+    );
+  }
+
+  protected static @NotNull String createTaskFirstConfigurationNameIn(
+    @NotNull List<String> taskNames,
+    @NotNull List<String> targetNames
+  ) {
+    return GradleBundle.message(
+      "gradle.tests.task.first.configuration.name.in",
+      suggestSelectionName(taskNames),
+      suggestSelectionName(targetNames)
+    );
+  }
+
+  protected static @NotNull String suggestSelectionName(@NotNull List<String> names) {
+    List<String> distinctNames = names.stream().distinct().toList();
+    if (distinctNames.isEmpty()) return "";
+    if (distinctNames.size() == 1) return distinctNames.getFirst();
+    return GradleBundle.message("gradle.tests.pattern.producer.configuration.name", distinctNames.getFirst(), distinctNames.size() - 1);
+  }
+
+  protected static @Nullable String resolveGradleIdentityPath(@NotNull Module module) {
+    GradleModuleData gradleModuleData = CachedModuleDataFinder.getGradleModuleData(module);
+    return gradleModuleData == null ? null : gradleModuleData.getGradleIdentityPathOrNull();
   }
 
   /**

--- a/plugins/gradle/java/src/execution/test/runner/PatternGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/PatternGradleConfigurationProducer.java
@@ -25,6 +25,7 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.PsiElementProcessor;
+import com.intellij.util.containers.ContainerUtil;
 import kotlin.jvm.functions.Function1;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,6 +33,7 @@ import org.jetbrains.plugins.gradle.service.execution.GradleExternalTaskConfigur
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
 import org.jetbrains.plugins.gradle.util.GradleBundle;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
+import org.jetbrains.plugins.gradle.util.TasksToRun;
 import org.jetbrains.plugins.gradle.util.cmd.node.GradleCommandLine;
 
 import java.util.ArrayList;
@@ -39,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.jetbrains.plugins.gradle.execution.test.runner.TestGradleConfigurationProducerUtilKt.applyTestConfiguration;
 import static org.jetbrains.plugins.gradle.execution.test.runner.TestGradleConfigurationProducerUtilKt.getSourceFile;
@@ -122,6 +125,7 @@ public final class PatternGradleConfigurationProducer extends GradleTestRunConfi
       return;
     }
     TestMappings testMappings = getTestMappings(project, tests);
+    List<String> availableTestTaskNames = getAvailableTestTaskNames(project, testMappings);
     getTestTasksChooser().chooseTestTasks(project, context.getDataContext(), testMappings.getClasses().values(), tasks -> {
       ExternalSystemTaskExecutionSettings settings = runConfiguration.getSettings();
       Function1<String, VirtualFile> findTestSource = test -> getSourceFile(testMappings.getClasses().get(test));
@@ -137,7 +141,17 @@ public final class PatternGradleConfigurationProducer extends GradleTestRunConfi
         configuration.setConfigurationSettings(existingConfiguration);
       }
       else {
-        runConfiguration.setName(suggestConfigurationName(tests));
+        List<String> selectedTestTaskNames = tasks.stream()
+          .flatMap(sourceTasks -> sourceTasks.values().stream())
+          .map(TasksToRun::getTestName)
+          .distinct()
+          .toList();
+        if (availableTestTaskNames.size() > 1) {
+          runConfiguration.setName(createTaskFirstConfigurationNameFor(selectedTestTaskNames, getPresentableTestNames(tests, testMappings)));
+        }
+        else {
+          runConfiguration.setName(suggestConfigurationName(tests));
+        }
         setUniqueNameIfNeeded(project, runConfiguration);
       }
       super.onFirstRun(configuration, context, startRunnable);
@@ -173,6 +187,25 @@ public final class PatternGradleConfigurationProducer extends GradleTestRunConfi
     if (tests.isEmpty()) return "";
     if (tests.size() == 1) return tests.get(0);
     return GradleBundle.message("gradle.tests.pattern.producer.configuration.name", tests.get(0), tests.size() - 1);
+  }
+
+  private static @NotNull List<String> getAvailableTestTaskNames(@NotNull Project project, @NotNull TestMappings testMappings) {
+    return testMappings.getClasses().values().stream()
+      .map(TestGradleConfigurationProducerUtilKt::getSourceFile)
+      .filter(Objects::nonNull)
+      .flatMap(source -> findAllTestsTaskToRun(source, project).stream())
+      .map(TasksToRun::getTestName)
+      .distinct()
+      .toList();
+  }
+
+  private static @NotNull List<String> getPresentableTestNames(@NotNull List<String> tests, @NotNull TestMappings testMappings) {
+    return ContainerUtil.map(tests, test -> {
+      PsiClass psiClass = testMappings.getClasses().get(test);
+      String className = psiClass == null ? test : StringUtil.notNullize(psiClass.getName(), test);
+      String methodName = testMappings.getMethods().get(test);
+      return methodName == null ? className : className + "." + methodName;
+    });
   }
 
   private static @Nullable Module getModuleFromContext(ConfigurationContext context) {

--- a/plugins/gradle/java/src/execution/test/runner/PatternGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/PatternGradleConfigurationProducer.java
@@ -5,6 +5,8 @@ import com.intellij.codeInsight.TestFrameworks;
 import com.intellij.execution.JavaRunConfigurationExtensionManager;
 import com.intellij.execution.JavaTestConfigurationBase;
 import com.intellij.execution.Location;
+import com.intellij.execution.RunManager;
+import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.execution.actions.ConfigurationFromContext;
 import com.intellij.execution.configurations.ConfigurationFactory;
@@ -30,6 +32,7 @@ import org.jetbrains.plugins.gradle.service.execution.GradleExternalTaskConfigur
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
 import org.jetbrains.plugins.gradle.util.GradleBundle;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
+import org.jetbrains.plugins.gradle.util.cmd.node.GradleCommandLine;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -129,10 +132,41 @@ public final class PatternGradleConfigurationProducer extends GradleTestRunConfi
         super.onFirstRun(configuration, context, startRunnable);
         return;
       }
-      runConfiguration.setName(suggestConfigurationName(tests));
-      setUniqueNameIfNeeded(project, runConfiguration);
+      RunnerAndConfigurationSettings existingConfiguration = findExistingConfigurationSettings(context, runConfiguration);
+      if (existingConfiguration != null) {
+        configuration.setConfigurationSettings(existingConfiguration);
+      }
+      else {
+        runConfiguration.setName(suggestConfigurationName(tests));
+        setUniqueNameIfNeeded(project, runConfiguration);
+      }
       super.onFirstRun(configuration, context, startRunnable);
     });
+  }
+
+  private @Nullable RunnerAndConfigurationSettings findExistingConfigurationSettings(
+    @NotNull ConfigurationContext context,
+    @NotNull GradleRunConfiguration selectedConfiguration
+  ) {
+    String externalProjectPath = selectedConfiguration.getSettings().getExternalProjectPath();
+    List<String> selectedTaskTokens = getNormalizedTaskTokens(selectedConfiguration);
+    if (externalProjectPath == null || selectedTaskTokens.isEmpty()) return null;
+    for (RunnerAndConfigurationSettings settings : getConfigurationSettingsList(RunManager.getInstance(context.getProject()))) {
+      if (settings.getConfiguration() instanceof GradleRunConfiguration existingConfiguration
+          && existingConfiguration != selectedConfiguration
+          && isConfigurationCompatibleForSelectedTasks(existingConfiguration)
+          && externalProjectPath.equals(existingConfiguration.getSettings().getExternalProjectPath())
+          && selectedTaskTokens.equals(getNormalizedTaskTokens(existingConfiguration))
+      ) {
+        return settings;
+      }
+    }
+    return null;
+  }
+
+  private static @NotNull List<String> getNormalizedTaskTokens(@NotNull GradleRunConfiguration configuration) {
+    String commandLine = String.join(" ", configuration.getSettings().getTaskNames());
+    return GradleCommandLine.parse(commandLine).getTasks().getTokens();
   }
 
   private static @NotNull String suggestConfigurationName(List<String> tests) {

--- a/plugins/gradle/java/src/execution/test/runner/TestClassGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/TestClassGradleConfigurationProducer.java
@@ -97,6 +97,16 @@ public class TestClassGradleConfigurationProducer extends AbstractGradleTestRunC
   }
 
   @Override
+  protected @NotNull List<String> getTaskTargetNames(
+    @NotNull ConfigurationContext context,
+    @NotNull PsiClass element,
+    @NotNull List<? extends PsiClass> chosenElements
+  ) {
+    List<? extends PsiClass> elements = chosenElements.isEmpty() ? List.of(element) : chosenElements;
+    return ContainerUtil.map(elements, psiClass -> Objects.requireNonNull(psiClass.getName()));
+  }
+
+  @Override
   protected void chooseSourceElements(
     @NotNull ConfigurationContext context,
     @NotNull PsiClass element,

--- a/plugins/gradle/java/src/execution/test/runner/TestClassGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/TestClassGradleConfigurationProducer.java
@@ -75,6 +75,13 @@ public class TestClassGradleConfigurationProducer extends AbstractGradleTestRunC
   }
 
   @Override
+  protected @Nullable PsiClass getElementForFirstRun(@NotNull ConfigurationContext context, @NotNull PsiElement sourceElement) {
+    PsiClass element = getElement(context);
+    if (element != null) return element;
+    return sourceElement instanceof PsiClass psiClass ? psiClass : null;
+  }
+
+  @Override
   protected @NotNull String getLocationName(@NotNull ConfigurationContext context, @NotNull PsiClass element) {
     return Objects.requireNonNull(element.getName());
   }

--- a/plugins/gradle/java/src/execution/test/runner/TestMethodGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/TestMethodGradleConfigurationProducer.java
@@ -85,6 +85,17 @@ public class TestMethodGradleConfigurationProducer extends AbstractGradleTestRun
   }
 
   @Override
+  protected @NotNull List<String> getTaskTargetNames(
+    @NotNull ConfigurationContext context,
+    @NotNull PsiMethod element,
+    @NotNull List<? extends PsiClass> chosenElements
+  ) {
+    PsiClass psiClass = Objects.requireNonNull(getContainingClass(context.getLocation(), element));
+    List<? extends PsiClass> elements = chosenElements.isEmpty() ? List.of(psiClass) : chosenElements;
+    return ContainerUtil.map(elements, aClass -> aClass.getName() + "." + element.getName());
+  }
+
+  @Override
   protected void chooseSourceElements(
     @NotNull ConfigurationContext context,
     @NotNull PsiMethod element,

--- a/plugins/gradle/java/src/execution/test/runner/TestMethodGradleConfigurationProducer.java
+++ b/plugins/gradle/java/src/execution/test/runner/TestMethodGradleConfigurationProducer.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import com.intellij.util.containers.ContainerUtil;
@@ -58,6 +59,13 @@ public class TestMethodGradleConfigurationProducer extends AbstractGradleTestRun
     VirtualFile source = psiFile.getVirtualFile();
     if (source == null) return null;
     return psiMethod;
+  }
+
+  @Override
+  protected @Nullable PsiMethod getElementForFirstRun(@NotNull ConfigurationContext context, @NotNull PsiElement sourceElement) {
+    PsiMethod element = getElement(context);
+    if (element != null) return element;
+    return sourceElement instanceof PsiMethod psiMethod ? psiMethod : null;
   }
 
   @Override

--- a/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
+++ b/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
@@ -232,6 +232,30 @@ class GradleTestRunConfigurationProducerTest : GradleTestRunConfigurationProduce
   }
 
   @Test
+  fun `test configuration with one of multiple test tasks keeps chosen existing configuration name`() {
+    currentExternalProjectSettings.isResolveModulePerSourceSet = false
+    val projectData = generateAndImportTemplateProject()
+    val testClass = projectData["project"]["AutomationTestCase"].element
+    val existingTaskConfiguration = createAndAddRunConfiguration(""":automationTest --tests "AutomationTestCase"""")
+    existingTaskConfiguration.name = "AutomationTestCase.automationTest"
+    val runConfiguration = createAndAddRunConfiguration(""":test --tests "AutomationTestCase"""")
+    runConfiguration.name = "AutomationTestCase"
+
+    runReadActionAndWait {
+      val context = getContextByLocation(testClass)
+      val producer = getConfigurationProducer<TestClassGradleConfigurationProducer>()
+      assertFalse(producer.isConfigurationFromContext(runConfiguration, context))
+      producer.setTestTasksChooser { it == "automationTest" }
+
+      val configurationFromContext = getConfigurationFromContext(context)
+      val configuration = configurationFromContext.configuration as GradleRunConfiguration
+      assertEquals("AutomationTestCase", configuration.name)
+      producer.onFirstRun(configurationFromContext, context, Runnable {})
+      assertEquals("AutomationTestCase.automationTest", configuration.name)
+    }
+  }
+
+  @Test
   fun `test multiple selected abstract tests`() {
     val projectData = generateAndImportTemplateProject()
     runReadActionAndWait {

--- a/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
+++ b/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
@@ -244,6 +244,7 @@ class GradleTestRunConfigurationProducerTest : GradleTestRunConfigurationProduce
       val context = getContextByLocation(testClass)
       val producer = getConfigurationProducer<TestClassGradleConfigurationProducer>()
       producer.setTestTasksChooser { it == "automationTest" }
+      assertNull(producer.findExistingConfiguration(context))
 
       val configurationFromContext = getConfigurationFromContext(context)
       val configuration = configurationFromContext.configuration as GradleRunConfiguration
@@ -253,6 +254,73 @@ class GradleTestRunConfigurationProducerTest : GradleTestRunConfigurationProduce
       assertSame(existingTaskConfiguration, configurationFromContext.configuration)
       assertEquals("Custom automation tests", configurationFromContext.configuration.name)
       assertEquals("-Dfoo=bar", existingTaskConfiguration.settings.scriptParameters)
+    }
+  }
+
+  @Test
+  fun `test pattern configuration reuses edited configuration after task selection`() {
+    currentExternalProjectSettings.isResolveModulePerSourceSet = false
+    val projectData = generateAndImportTemplateProject()
+    val testClass = projectData["project"]["AutomationTestCase"]
+    val existingTaskConfiguration = createAndAddRunConfiguration(
+      """:automationTest --tests "AutomationTestCase.test1" --tests "AutomationTestCase.test2""""
+    )
+    existingTaskConfiguration.name = "Custom automation tests"
+    existingTaskConfiguration.settings.scriptParameters = "-Dfoo=bar"
+
+    runReadActionAndWait {
+      val context = getContextByLocation(testClass["test1"].element, testClass["test2"].element)
+      val producer = getConfigurationProducer<PatternGradleConfigurationProducer>()
+      producer.setTestTasksChooser { it == "automationTest" }
+
+      val configurationFromContext = getConfigurationFromContext(context)
+      assertNotSame(existingTaskConfiguration, configurationFromContext.configuration)
+      producer.onFirstRun(configurationFromContext, context) {}
+
+      assertSame(existingTaskConfiguration, configurationFromContext.configuration)
+      assertEquals("Custom automation tests", configurationFromContext.configuration.name)
+      assertEquals("-Dfoo=bar", existingTaskConfiguration.settings.scriptParameters)
+    }
+  }
+
+  @Test
+  fun `test configuration with multiple selected test tasks does not reuse a partial configuration`() {
+    currentExternalProjectSettings.isResolveModulePerSourceSet = false
+    val projectData = generateAndImportTemplateProject()
+    val testClass = projectData["project"]["AutomationTestCase"].element
+    val partialConfiguration = createAndAddRunConfiguration(""":automationTest --tests "AutomationTestCase"""")
+
+    runReadActionAndWait {
+      val context = getContextByLocation(testClass)
+      val producer = getConfigurationProducer<TestClassGradleConfigurationProducer>()
+      producer.setTestTasksChooser { true }
+
+      val configurationFromContext = getConfigurationFromContext(context)
+      producer.onFirstRun(configurationFromContext, context) {}
+
+      assertNotSame(partialConfiguration, configurationFromContext.configuration)
+      val configuration = configurationFromContext.configuration as GradleRunConfiguration
+      assertContainsElements(configuration.settings.taskNames, ":autoTest", ":automationTest")
+      assertEquals("--continue", configuration.settings.scriptParameters)
+    }
+  }
+
+  @Test
+  fun `test selected test task reuse respects producer compatibility`() {
+    currentExternalProjectSettings.isResolveModulePerSourceSet = false
+    val projectData = generateAndImportTemplateProject()
+    val testClass = projectData["project"]["AutomationTestCase"].element
+    val existingConfiguration = createAndAddRunConfiguration(""":automationTest --tests "AutomationTestCase"""")
+
+    runReadActionAndWait {
+      val context = getContextByLocation(testClass)
+      val producer = IncompatibleTestClassGradleConfigurationProducer()
+      producer.setTestTasksChooser { it == "automationTest" }
+      val configurationFromContext = requireNotNull(producer.createConfigurationFromContext(context))
+
+      producer.onFirstRun(configurationFromContext, context) {}
+
+      assertNotSame(existingConfiguration, configurationFromContext.configuration)
     }
   }
 
@@ -461,5 +529,11 @@ class GradleTestRunConfigurationProducerTest : GradleTestRunConfigurationProduce
       assertFalse(classConfigProducer.isConfigurationFromContext(classConfiguration, methodContext))
       assertFalse(methodConfigProducer.isConfigurationFromContext(methodConfiguration, classContext))
     }
+  }
+
+  private class IncompatibleTestClassGradleConfigurationProducer : TestClassGradleConfigurationProducer() {
+    override fun isConfigurationCompatibleForSelectedTasks(
+      configuration: GradleRunConfiguration,
+    ): Boolean = false
   }
 }

--- a/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
+++ b/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
@@ -232,26 +232,27 @@ class GradleTestRunConfigurationProducerTest : GradleTestRunConfigurationProduce
   }
 
   @Test
-  fun `test configuration with one of multiple test tasks keeps chosen existing configuration name`() {
+  fun `test configuration with one of multiple test tasks reuses edited configuration`() {
     currentExternalProjectSettings.isResolveModulePerSourceSet = false
     val projectData = generateAndImportTemplateProject()
     val testClass = projectData["project"]["AutomationTestCase"].element
     val existingTaskConfiguration = createAndAddRunConfiguration(""":automationTest --tests "AutomationTestCase"""")
-    existingTaskConfiguration.name = "AutomationTestCase.automationTest"
-    val runConfiguration = createAndAddRunConfiguration(""":test --tests "AutomationTestCase"""")
-    runConfiguration.name = "AutomationTestCase"
+    existingTaskConfiguration.name = "Custom automation tests"
+    existingTaskConfiguration.settings.scriptParameters = "-Dfoo=bar"
 
     runReadActionAndWait {
       val context = getContextByLocation(testClass)
       val producer = getConfigurationProducer<TestClassGradleConfigurationProducer>()
-      assertFalse(producer.isConfigurationFromContext(runConfiguration, context))
       producer.setTestTasksChooser { it == "automationTest" }
 
       val configurationFromContext = getConfigurationFromContext(context)
       val configuration = configurationFromContext.configuration as GradleRunConfiguration
+      assertNotSame(existingTaskConfiguration, configuration)
       assertEquals("AutomationTestCase", configuration.name)
-      producer.onFirstRun(configurationFromContext, context, Runnable {})
-      assertEquals("AutomationTestCase.automationTest", configuration.name)
+      producer.onFirstRun(configurationFromContext, context) {}
+      assertSame(existingTaskConfiguration, configurationFromContext.configuration)
+      assertEquals("Custom automation tests", configurationFromContext.configuration.name)
+      assertEquals("-Dfoo=bar", existingTaskConfiguration.settings.scriptParameters)
     }
   }
 

--- a/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
+++ b/plugins/gradle/java/testSources/execution/test/producer/GradleTestRunConfigurationProducerTest.kt
@@ -258,6 +258,51 @@ class GradleTestRunConfigurationProducerTest : GradleTestRunConfigurationProduce
   }
 
   @Test
+  fun `test configuration uses selected task first`() {
+    currentExternalProjectSettings.isResolveModulePerSourceSet = false
+    val projectData = generateAndImportTemplateProject()
+
+    runReadActionAndWait {
+      val nonDefaultContext = getContextByLocation(projectData["project"].root.subDirectory("automation"))
+      val nonDefaultConfiguration = getConfigurationFromContext(nonDefaultContext)
+      val producer = nonDefaultConfiguration.configurationProducer as AllInDirectoryGradleConfigurationProducer
+      assertEquals("Tests in 'project'", nonDefaultConfiguration.configuration.name)
+      producer.setTestTasksChooser { it == "automationTest" }
+      producer.onFirstRun(nonDefaultConfiguration, nonDefaultContext) {}
+      assertEquals("automationTest in [:]", nonDefaultConfiguration.configuration.name)
+
+      val testClass = projectData["project"]["AutomationTestCase"]
+      val classContext = getContextByLocation(testClass.element)
+      val classConfiguration = getConfigurationFromContext(classContext)
+      val classProducer = classConfiguration.configurationProducer as TestClassGradleConfigurationProducer
+      classProducer.setTestTasksChooser { it == "automationTest" }
+      classProducer.onFirstRun(classConfiguration, classContext) {}
+      assertEquals("automationTest for AutomationTestCase", classConfiguration.configuration.name)
+
+      val methodContext = getContextByLocation(testClass["test1"].element)
+      val methodConfiguration = getConfigurationFromContext(methodContext)
+      val methodProducer = methodConfiguration.configurationProducer as TestMethodGradleConfigurationProducer
+      methodProducer.setTestTasksChooser { it == "automationTest" }
+      methodProducer.onFirstRun(methodConfiguration, methodContext) {}
+      assertEquals("automationTest for AutomationTestCase.test1", methodConfiguration.configuration.name)
+
+      val patternContext = getContextByLocation(testClass["test1"].element, testClass["test2"].element)
+      val patternConfiguration = getConfigurationFromContext(patternContext)
+      val patternProducer = patternConfiguration.configurationProducer as PatternGradleConfigurationProducer
+      patternProducer.setTestTasksChooser { it == "automationTest" }
+      patternProducer.onFirstRun(patternConfiguration, patternContext) {}
+      assertEquals("automationTest for AutomationTestCase.test1 and 1 more", patternConfiguration.configuration.name)
+
+      val defaultContext = getContextByLocation(projectData["project"].root.subDirectory("src", "test"))
+      val defaultConfiguration = getConfigurationFromContext(defaultContext)
+      val defaultProducer = defaultConfiguration.configurationProducer as AllInDirectoryGradleConfigurationProducer
+      defaultProducer.setTestTasksChooser { it == "test" }
+      defaultProducer.onFirstRun(defaultConfiguration, defaultContext) {}
+      assertEquals("Tests in 'project'", defaultConfiguration.configuration.name)
+    }
+  }
+
+  @Test
   fun `test pattern configuration reuses edited configuration after task selection`() {
     currentExternalProjectSettings.isResolveModulePerSourceSet = false
     val projectData = generateAndImportTemplateProject()
@@ -302,6 +347,7 @@ class GradleTestRunConfigurationProducerTest : GradleTestRunConfigurationProduce
       val configuration = configurationFromContext.configuration as GradleRunConfiguration
       assertContainsElements(configuration.settings.taskNames, ":autoTest", ":automationTest")
       assertEquals("--continue", configuration.settings.scriptParameters)
+      assertEquals("autoTest and 1 more for AutomationTestCase", configuration.name)
     }
   }
 

--- a/plugins/gradle/resources/messages/GradleBundle.properties
+++ b/plugins/gradle/resources/messages/GradleBundle.properties
@@ -137,6 +137,8 @@ gradle.tests.tasks.choosing.popup.title=Run Tasks for {0}
 gradle.tests.tasks.choosing.popup.hint=Select several tasks to run them at once
 gradle.tests.tasks.choosing.warning.text=No tasks available
 gradle.tests.pattern.producer.configuration.name={0} and {1} more
+gradle.tests.task.first.configuration.name.for={0} for {1}
+gradle.tests.task.first.configuration.name.in={0} in {1}
 
 action.Gradle.ImportExternalProject.text=Link Gradle Project
 action.Gradle.ImportExternalProject.description=Link Gradle project described by this file

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestClassGradleConfigurationProducer.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestClassGradleConfigurationProducer.kt
@@ -89,6 +89,7 @@ abstract class AbstractKotlinMultiplatformTestClassGradleConfigurationProducer :
     ) {
         val locationName = classes.singleOrNull()?.name
         val dataContext = MultiplatformTestTasksChooser.createContext(context.dataContext, locationName)
+        val availableTestTaskNames = mppTestTasksChooser.listAvailableTasks(classes).map { it.testName }.distinct()
 
         mppTestTasksChooser.multiplatformChooseTasks(context.project, dataContext, classes) { tasks ->
             val configuration = fromContext.configuration as GradleRunConfiguration
@@ -101,7 +102,12 @@ abstract class AbstractKotlinMultiplatformTestClassGradleConfigurationProducer :
                 performRunnable.run()
             }
             settings.externalProjectPath = ExternalSystemApiUtil.getExternalProjectPath(module)
-            configuration.name = classes.joinToString("|") { it.name ?: "<error>" }
+            val selectedTestTaskNames = tasks.flatMap { it.values }.map { it.testName }.distinct()
+            configuration.name = if (availableTestTaskNames.size > 1) {
+                createTaskFirstConfigurationNameFor(selectedTestTaskNames, classes.map { it.name ?: "<error>" })
+            } else {
+                classes.joinToString("|") { it.name ?: "<error>" }
+            }
             performRunnable.run()
         }
     }

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestClassGradleConfigurationProducer.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestClassGradleConfigurationProducer.kt
@@ -29,6 +29,8 @@ abstract class AbstractKotlinMultiplatformTestClassGradleConfigurationProducer :
     override val forceGradleRunner: Boolean get() = true
     override val hasTestFramework: Boolean get() = true
 
+    override fun usesBaseTestTasksChooser(): Boolean = false
+
     private val mppTestTasksChooser = MultiplatformTestTasksChooser()
 
     abstract fun isApplicable(module: Module, platform: TargetPlatform): Boolean

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestMethodGradleConfigurationProducer.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestMethodGradleConfigurationProducer.kt
@@ -92,6 +92,7 @@ abstract class AbstractKotlinMultiplatformTestMethodGradleConfigurationProducer 
         vararg classes: PsiClass
     ) {
         val dataContext = MultiplatformTestTasksChooser.createContext(context.dataContext, psiMethod.name)
+        val availableTestTaskNames = mppTestTasksChooser.listAvailableTasks(classes.asList()).map { it.testName }.distinct()
 
         val contextualSuffix = when (context.location) {
             is PsiMemberParameterizedLocation -> (context.location as? PsiMemberParameterizedLocation)?.paramSetName?.trim('[', ']')
@@ -115,7 +116,12 @@ abstract class AbstractKotlinMultiplatformTestMethodGradleConfigurationProducer 
             settings.externalProjectPath = ExternalSystemApiUtil.getExternalProjectPath(module)
 
             if (result) {
-                configuration.name = (if (classes.size == 1) classes[0].name!! + "." else "") + psiMethod.name
+                val selectedTestTaskNames = tasks.flatMap { it.values }.map { it.testName }.distinct()
+                configuration.name = if (availableTestTaskNames.size > 1) {
+                    createTaskFirstConfigurationNameFor(selectedTestTaskNames, classes.map { "${it.name}.${psiMethod.name}" })
+                } else {
+                    (if (classes.size == 1) classes[0].name!! + "." else "") + psiMethod.name
+                }
                 performRunnable.run()
             } else {
                 LOG.warn("Cannot apply method test configuration, uses raw run configuration")

--- a/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestMethodGradleConfigurationProducer.kt
+++ b/plugins/kotlin/gradle/gradle-java/src/org/jetbrains/kotlin/idea/gradleJava/run/AbstractKotlinTestMethodGradleConfigurationProducer.kt
@@ -29,6 +29,8 @@ abstract class AbstractKotlinMultiplatformTestMethodGradleConfigurationProducer 
     override val forceGradleRunner: Boolean get() = true
     override val hasTestFramework: Boolean get() = true
 
+    override fun usesBaseTestTasksChooser(): Boolean = false
+
     private val mppTestTasksChooser = MultiplatformTestTasksChooser()
 
     abstract fun isApplicable(module: Module, platform: TargetPlatform): Boolean


### PR DESCRIPTION
### Summary

This pull request ensures users can execute different Gradle test tasks on the same module from the context menu without having to clear the existing run configuration. Precisely, always shows the task chooser (if multiple test tasks are available). 

Also, this change adjusts the naming conventions for the run configurations with the test task name to improve usability.

<img width="557" height="465" alt="Screenshot 2026-06-04 at 16 06 39" src="https://github.com/user-attachments/assets/59501883-6a4a-40d3-9021-1caebb77e56c" />
<img width="455" height="199" alt="Screenshot 2026-06-04 at 16 07 20" src="https://github.com/user-attachments/assets/3ab37339-1b93-4f83-b190-de27de140e04" />

Should fix https://youtrack.jetbrains.com/issue/IDEA-384446/Gradle-Cannot-Execute-different-test-task-on-a-module-after-running-one

### Important Changes

- Prevent reusing existing context configurations before showing the task chooser when multiple Gradle test tasks are available.
- Maintain naming consistency: the chooser action retains the name of the default test task, and the selected task determines the new configuration name.
- Avoid appending a unique suffix if an equivalent configuration for the selected test task already exists.
