### PR TITLE
IDEA-354352 preserve JUnit XML report details

### DIFF
--- a/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
+++ b/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
@@ -25,6 +25,7 @@ import org.xml.sax.helpers.DefaultHandler;
 import java.io.Reader;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 
 public class AntTestContentHandler extends DefaultHandler {
@@ -79,7 +80,7 @@ public class AntTestContentHandler extends DefaultHandler {
   private final List<TestProblem> myProblems = new ArrayList<>();
   private TestIgnoredEvent myIgnoredEvent;
   private int myPropertiesLevel;
-  private final ArrayDeque<TextElement> myTextElements = new ArrayDeque<>();
+  private final Deque<TextElement> myTextElements = new ArrayDeque<>();
 
   public AntTestContentHandler(GeneralTestEventsProcessor processor) {
     myProcessor = processor;

--- a/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
+++ b/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
@@ -23,6 +23,9 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.Reader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AntTestContentHandler extends DefaultHandler {
   public static final class AntTestOutputExtension implements ImportTestOutputExtension {
@@ -38,11 +41,11 @@ public class AntTestContentHandler extends DefaultHandler {
 
         @Override
         public void startElement(String name, String nsPrefix, String nsURI, String systemID, int lineNr) {
-          rooName[0] = name;
+          rooName[0] = getElementName(name);
         }
       });
-      return TESTSUITES.equals(rooName[0]) ? new AntTestContentHandler(processor)
-                                           : null;
+      return TESTSUITES.equals(rooName[0]) || TESTSUITE.equals(rooName[0]) ? new AntTestContentHandler(processor)
+                                                                            : null;
     }
   }
 
@@ -55,18 +58,28 @@ public class AntTestContentHandler extends DefaultHandler {
   private static final String DURATION = "time";
   private static final String ERROR = "error";
   private static final String FAILURE = "failure";
+  private static final String RERUN_ERROR = "rerunError";
+  private static final String RERUN_FAILURE = "rerunFailure";
+  private static final String FLAKY_ERROR = "flakyError";
+  private static final String FLAKY_FAILURE = "flakyFailure";
   private static final String SKIPPED = "skipped";
   private static final String IGNORED = "ignored";
   private static final String OUT = "system-out";
   private static final String ERR = "system-err";
+  private static final String PROPERTIES = "properties";
+  private static final String PROPERTY = "property";
+  private static final String MESSAGE = "message";
+  private static final String TYPE = "type";
+  private static final String VALUE = "value";
 
   private final GeneralTestEventsProcessor myProcessor;
   private final Stack<String> mySuites = new Stack<>();
   private String myCurrentTest;
   private String myDuration;
-  private String myStatus;
-  private final StringBuilder currentValue = new StringBuilder();
-  private boolean myErrorOutput = false;
+  private final List<TestProblem> myProblems = new ArrayList<>();
+  private TestIgnoredEvent myIgnoredEvent;
+  private int myPropertiesLevel;
+  private final ArrayDeque<TextElement> myTextElements = new ArrayDeque<>();
 
   public AntTestContentHandler(GeneralTestEventsProcessor processor) {
     myProcessor = processor;
@@ -74,7 +87,8 @@ public class AntTestContentHandler extends DefaultHandler {
 
   @Override
   public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-    if (TESTSUITE.equals(qName)) {
+    String name = getElementName(qName);
+    if (TESTSUITE.equals(name)) {
       String nameValue = attributes.getValue(NAME);
       final String suiteName = nameValue == null ? "" : StringUtil.unescapeXmlEntities(nameValue);
       String packageValue = attributes.getValue(PACKAGE);
@@ -84,77 +98,281 @@ public class AntTestContentHandler extends DefaultHandler {
                                                                                                            StringUtil.notNullize(suiteName))));
       mySuites.push(suiteName);
     }
-    else if (TESTCASE.equals(qName)) {
+    else if (TESTCASE.equals(name)) {
       String nameValue = attributes.getValue(NAME);
-      final String name = nameValue == null ? "" : StringUtil.unescapeXmlEntities(nameValue);
-      myCurrentTest = name;
-      myStatus = null;
+      final String testName = nameValue == null ? "" : StringUtil.unescapeXmlEntities(nameValue);
+      myCurrentTest = testName;
+      myProblems.clear();
+      myIgnoredEvent = null;
       myDuration = attributes.getValue(DURATION);
       String classNameValue = attributes.getValue(CLASSNAME);
       String classname = classNameValue == null ? null : StringUtil.unescapeXmlEntities(classNameValue);
-      String location = StringUtil.isEmpty(classname) ? name : classname + "/" + name;
-      final TestStartedEvent startedEvent = new TestStartedEvent(name, "java:test://" + location);
+      String location = StringUtil.isEmpty(classname) ? testName : classname + "/" + testName;
+      final TestStartedEvent startedEvent = new TestStartedEvent(testName, "java:test://" + location);
       myProcessor.onTestStarted(startedEvent);
     }
-    else if (ERR.equals(qName)) {
-      myErrorOutput = true;
+    else if (OUT.equals(name) || ERR.equals(name)) {
+      myTextElements.push(new TextElement(name, OUT.equals(name) ? TextElementKind.OUTPUT : TextElementKind.ERROR_OUTPUT));
     }
-    else if (SKIPPED.equals(qName)) {
-      myStatus = TestResultsXmlFormatter.STATUS_SKIPPED;
+    else if (PROPERTIES.equals(name)) {
+      myPropertiesLevel++;
     }
-    else if (IGNORED.equals(qName)) {
-      myStatus = TestResultsXmlFormatter.STATUS_IGNORED;
+    else if (PROPERTY.equals(name) && myPropertiesLevel > 0) {
+      String propertyName = attributes.getValue(NAME);
+      String propertyValue = attributes.getValue(VALUE);
+      myTextElements.push(new TextElement(name, TextElementKind.PROPERTY,
+                                          propertyName == null ? "" : StringUtil.unescapeXmlEntities(propertyName),
+                                          propertyValue == null ? null : StringUtil.unescapeXmlEntities(propertyValue)));
     }
-    else if (FAILURE.equals(qName)) {
-      myStatus = TestResultsXmlFormatter.STATUS_FAILED;
+    else if (SKIPPED.equals(name) || IGNORED.equals(name)) {
+      myTextElements.push(new TextElement(name, TextElementKind.IGNORED,
+                                          StringUtil.unescapeXmlEntities(StringUtil.notNullize(attributes.getValue(MESSAGE))),
+                                          null));
     }
-    else if (ERROR.equals(qName)) {
-      myStatus = TestResultsXmlFormatter.STATUS_ERROR;
+    else if (isProblemElement(name)) {
+      boolean error = ERROR.equals(name) || RERUN_ERROR.equals(name) || FLAKY_ERROR.equals(name);
+      boolean primary = ERROR.equals(name) || FAILURE.equals(name);
+      myTextElements.push(new TextElement(name,
+                                          error ? TextElementKind.ERROR : TextElementKind.FAILURE,
+                                          StringUtil.unescapeXmlEntities(StringUtil.notNullize(attributes.getValue(MESSAGE))),
+                                          StringUtil.unescapeXmlEntities(StringUtil.notNullize(attributes.getValue(TYPE))),
+                                          primary,
+                                          getProblemLabel(name)));
     }
-    currentValue.setLength(0);
   }
 
   @Override
   public void characters(char[] ch, int start, int length) {
-    currentValue.append(ch, start, length);
+    for (TextElement element : myTextElements) {
+      element.text.append(ch, start, length);
+    }
   }
 
   @Override
   public void endElement(String uri, String localName, String qName) {
-    final String currentText = StringUtil.unescapeXmlEntities(currentValue.toString());
-    currentValue.setLength(0);
-    if (TESTSUITE.equals(qName)) {
+    String name = getElementName(qName);
+    TextElement textElement = pollTextElement(name);
+    if (textElement != null) {
+      handleTextElement(textElement);
+    }
+
+    if (TESTSUITE.equals(name)) {
       myProcessor.onSuiteFinished(new TestSuiteFinishedEvent(mySuites.pop()));
     }
-    else if (TESTCASE.equals(qName)) {
-      if (myStatus != null) {
-        if (myStatus.equals(TestResultsXmlFormatter.STATUS_ERROR) || myStatus.equals(TestResultsXmlFormatter.STATUS_FAILED)) {
-          myProcessor.onTestFailure(
-            new TestFailedEvent(myCurrentTest, "", currentText, myStatus.equals(TestResultsXmlFormatter.STATUS_ERROR), null, null));
-        }
-        else if (myStatus.equals(TestResultsXmlFormatter.STATUS_IGNORED) || myStatus.equals(TestResultsXmlFormatter.STATUS_SKIPPED)) {
-          myProcessor.onTestIgnored(new TestIgnoredEvent(myCurrentTest, "", currentText));
-        } else {
-          throw new IllegalStateException("Unknown status: " + myStatus);
+    else if (TESTCASE.equals(name)) {
+      TestFailedEvent failedEvent = createTestFailedEvent();
+      if (failedEvent != null) {
+        myProcessor.onTestFailure(failedEvent);
+      }
+      else {
+        emitNonPrimaryProblems();
+        if (myIgnoredEvent != null) {
+          myProcessor.onTestIgnored(myIgnoredEvent);
         }
       }
       long time;
       try {
-        time = (long)(1000 * Float.parseFloat(myDuration));
+        time = myDuration != null ? (long)(1000 * Float.parseFloat(myDuration)) : -1;
       }
       catch (NumberFormatException e) {
         time = -1;
       }
       myProcessor.onTestFinished(new TestFinishedEvent(myCurrentTest, time));
       myCurrentTest = null;
+      myDuration = null;
+      myProblems.clear();
+      myIgnoredEvent = null;
     }
-    else if ((ERR.equals(qName) || OUT.equals(qName)) && !StringUtil.isEmpty(currentText)) {
-      if (myCurrentTest != null) {
-        myProcessor.onTestOutput(new TestOutputEvent(myCurrentTest, currentText, !myErrorOutput));
+    else if (PROPERTIES.equals(name) && myPropertiesLevel > 0) {
+      myPropertiesLevel--;
+    }
+  }
+
+  private void handleTextElement(@NotNull TextElement element) {
+    String text = StringUtil.unescapeXmlEntities(element.text.toString());
+    switch (element.kind) {
+      case OUTPUT -> emitOutput(text, false);
+      case ERROR_OUTPUT -> emitOutput(text, true);
+      case PROPERTY -> emitProperty(element.message, element.type != null ? element.type : text);
+      case IGNORED -> myIgnoredEvent = new TestIgnoredEvent(myCurrentTest,
+                                                            StringUtil.notNullize(element.message),
+                                                            text);
+      case FAILURE, ERROR -> {
+        TestProblem problem = new TestProblem(element.kind == TextElementKind.ERROR,
+                                             element.primaryResult,
+                                             element.message,
+                                             element.type,
+                                             element.label,
+                                             text);
+        myProblems.add(problem);
       }
-      else {
-        myProcessor.onUncapturedOutput(currentText, myErrorOutput ? ProcessOutputTypes.STDERR : ProcessOutputTypes.STDOUT);
+    }
+  }
+
+  private void emitProperty(@Nullable String name, @Nullable String value) {
+    if (StringUtil.isEmpty(name) && StringUtil.isEmpty(value)) return;
+
+    StringBuilder text = new StringBuilder("Property");
+    if (!StringUtil.isEmpty(name)) {
+      text.append(' ').append(name);
+    }
+    if (!StringUtil.isEmpty(value)) {
+      text.append('=').append(value);
+    }
+    text.append('\n');
+    emitOutput(text.toString(), false);
+  }
+
+  private void emitOutput(@Nullable String text, boolean stderr) {
+    if (StringUtil.isEmpty(text)) return;
+
+    if (myCurrentTest != null) {
+      myProcessor.onTestOutput(new TestOutputEvent(myCurrentTest, text, !stderr));
+    }
+    else {
+      myProcessor.onUncapturedOutput(text, stderr ? ProcessOutputTypes.STDERR : ProcessOutputTypes.STDOUT);
+    }
+  }
+
+  private @Nullable TestFailedEvent createTestFailedEvent() {
+    int firstPrimaryIndex = -1;
+    for (int i = 0; i < myProblems.size(); i++) {
+      if (myProblems.get(i).primary) {
+        firstPrimaryIndex = i;
+        break;
       }
+    }
+    if (firstPrimaryIndex < 0) return null;
+
+    TestProblem first = myProblems.get(firstPrimaryIndex);
+    String message = first.getMessage();
+    StringBuilder stackTrace = new StringBuilder(first.text);
+    for (int i = 0; i < myProblems.size(); i++) {
+      if (i == firstPrimaryIndex) continue;
+      TestProblem problem = myProblems.get(i);
+      if (!stackTrace.isEmpty()) {
+        stackTrace.append('\n');
+      }
+      stackTrace.append(problem.formatForOutput());
+    }
+    return new TestFailedEvent(myCurrentTest, message, stackTrace.toString(), first.error, null, null);
+  }
+
+  private void emitNonPrimaryProblems() {
+    for (TestProblem problem : myProblems) {
+      if (!problem.primary) {
+        emitOutput(problem.formatForOutput(), true);
+      }
+    }
+  }
+
+  private @Nullable TextElement pollTextElement(@NotNull String name) {
+    if (myTextElements.isEmpty() || !name.equals(myTextElements.peek().name)) return null;
+    return myTextElements.pop();
+  }
+
+  private static boolean isProblemElement(@NotNull String name) {
+    return ERROR.equals(name) || FAILURE.equals(name) ||
+           RERUN_ERROR.equals(name) || RERUN_FAILURE.equals(name) ||
+           FLAKY_ERROR.equals(name) || FLAKY_FAILURE.equals(name);
+  }
+
+  private static @NotNull String getProblemLabel(@NotNull String name) {
+    return switch (name) {
+      case ERROR -> "Error";
+      case FAILURE -> "Failure";
+      case RERUN_ERROR -> "Rerun error";
+      case RERUN_FAILURE -> "Rerun failure";
+      case FLAKY_ERROR -> "Flaky error";
+      case FLAKY_FAILURE -> "Flaky failure";
+      default -> "Problem";
+    };
+  }
+
+  private static @NotNull String getElementName(@NotNull String qName) {
+    int index = qName.indexOf(':');
+    return index < 0 ? qName : qName.substring(index + 1);
+  }
+
+  private enum TextElementKind {
+    OUTPUT,
+    ERROR_OUTPUT,
+    PROPERTY,
+    IGNORED,
+    FAILURE,
+    ERROR
+  }
+
+  private static final class TextElement {
+    final @NotNull String name;
+    final @NotNull TextElementKind kind;
+    final @Nullable String message;
+    final @Nullable String type;
+    final boolean primaryResult;
+    final @NotNull String label;
+    final @NotNull StringBuilder text = new StringBuilder();
+
+    TextElement(@NotNull String name, @NotNull TextElementKind kind) {
+      this(name, kind, null, null, false, "");
+    }
+
+    TextElement(@NotNull String name, @NotNull TextElementKind kind, @Nullable String message, @Nullable String type) {
+      this(name, kind, message, type, false, "");
+    }
+
+    TextElement(@NotNull String name,
+                @NotNull TextElementKind kind,
+                @Nullable String message,
+                @Nullable String type,
+                boolean primaryResult,
+                @NotNull String label) {
+      this.name = name;
+      this.kind = kind;
+      this.message = message;
+      this.type = type;
+      this.primaryResult = primaryResult;
+      this.label = label;
+    }
+  }
+
+  private static final class TestProblem {
+    final boolean error;
+    final boolean primary;
+    final @NotNull String message;
+    final @NotNull String type;
+    final @NotNull String label;
+    final @NotNull String text;
+
+    TestProblem(boolean error,
+                boolean primary,
+                @Nullable String message,
+                @Nullable String type,
+                @NotNull String label,
+                @Nullable String text) {
+      this.error = error;
+      this.primary = primary;
+      this.message = StringUtil.notNullize(message);
+      this.type = StringUtil.notNullize(type);
+      this.label = label;
+      this.text = StringUtil.notNullize(text);
+    }
+
+    @NotNull String getMessage() {
+      if (!StringUtil.isEmpty(message)) return message;
+      if (!StringUtil.isEmpty(type)) return type;
+      return error ? TestResultsXmlFormatter.STATUS_ERROR : TestResultsXmlFormatter.STATUS_FAILED;
+    }
+
+    @NotNull String formatForOutput() {
+      StringBuilder builder = new StringBuilder(primary ? getMessage() : label);
+      if (!StringUtil.isEmpty(type)) {
+        builder.append(" (").append(type).append(')');
+      }
+      if (!StringUtil.isEmpty(text)) {
+        builder.append('\n').append(text);
+      }
+      builder.append('\n');
+      return builder.toString();
     }
   }
 }

--- a/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
+++ b/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
@@ -133,6 +133,10 @@ public class AntTestContentHandler extends DefaultHandler {
                                           null));
     }
     else if (isProblemElement(name)) {
+      // Text in those enclosed elements are collected as "raw" text.
+      // This allows to handle Surefire's way of nesting a <stackTrace> element inside
+      // flaky/rerun elements ; other junit report writers may also put diagnostic text
+      // in such element.
       boolean error = ERROR.equals(name) || RERUN_ERROR.equals(name) || FLAKY_ERROR.equals(name);
       boolean primary = ERROR.equals(name) || FAILURE.equals(name);
       myTextElements.push(new TextElement(name,
@@ -163,11 +167,15 @@ public class AntTestContentHandler extends DefaultHandler {
       myProcessor.onSuiteFinished(new TestSuiteFinishedEvent(mySuites.pop()));
     }
     else if (TESTCASE.equals(name)) {
+      // Note: TestFailedEvent does not model surefire diagnostic messages (earlier individual attempts).
+      // The failure/error elements define the final state, while Surefire injects retry/flaky elements as diagnostics.
+      // * re-ran tests are appended to the primary stack trace
       TestFailedEvent failedEvent = createTestFailedEvent();
       if (failedEvent != null) {
         myProcessor.onTestFailure(failedEvent);
       }
       else {
+        // * flakies, however, are appended to stderr (because there's no primary failures)
         emitNonPrimaryProblems();
         if (myIgnoredEvent != null) {
           myProcessor.onTestIgnored(myIgnoredEvent);
@@ -245,6 +253,7 @@ public class AntTestContentHandler extends DefaultHandler {
         break;
       }
     }
+    // test passed, but it may have flaked
     if (firstPrimaryIndex < 0) return null;
 
     TestProblem first = myProblems.get(firstPrimaryIndex);
@@ -287,6 +296,7 @@ public class AntTestContentHandler extends DefaultHandler {
     return switch (name) {
       case ERROR -> "Error";
       case FAILURE -> "Failure";
+      // Surefire problems
       case RERUN_ERROR -> "Rerun error";
       case RERUN_FAILURE -> "Rerun failure";
       case FLAKY_ERROR -> "Flaky error";

--- a/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
+++ b/java/execution/impl/src/com/intellij/execution/AntTestContentHandler.java
@@ -13,6 +13,8 @@ import com.intellij.execution.testframework.sm.runner.events.TestSuiteFinishedEv
 import com.intellij.execution.testframework.sm.runner.events.TestSuiteStartedEvent;
 import com.intellij.execution.testframework.sm.runner.history.ImportTestOutputExtension;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.rt.execution.junit.ComparisonFailureData;
+import com.intellij.rt.execution.testFrameworks.AbstractExpectedPatterns;
 import com.intellij.util.containers.Stack;
 import com.intellij.util.xml.NanoXmlBuilder;
 import com.intellij.util.xml.NanoXmlUtil;
@@ -256,7 +258,10 @@ public class AntTestContentHandler extends DefaultHandler {
       }
       stackTrace.append(problem.formatForOutput());
     }
-    return new TestFailedEvent(myCurrentTest, message, stackTrace.toString(), first.error, null, null);
+    ComparisonFailureData comparisonData = AbstractExpectedPatterns.parseComparisonFailure(message);
+    String actual = comparisonData != null ? comparisonData.getActual() : null;
+    String expected = comparisonData != null ? comparisonData.getExpected() : null;
+    return new TestFailedEvent(myCurrentTest, message, stackTrace.toString(), first.error, actual, expected);
   }
 
   private void emitNonPrimaryProblems() {

--- a/java/java-runtime/src/com/intellij/rt/execution/testFrameworks/AbstractExpectedPatterns.java
+++ b/java/java-runtime/src/com/intellij/rt/execution/testFrameworks/AbstractExpectedPatterns.java
@@ -3,6 +3,7 @@ package com.intellij.rt.execution.testFrameworks;
 
 import com.intellij.rt.execution.junit.ComparisonFailureData;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -11,6 +12,22 @@ public class AbstractExpectedPatterns {
 
   private static final Pattern ASSERT_EQUALS_PATTERN = Pattern.compile("expected:<(.*)> but was:<(.*)>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
   private static final Pattern ASSERT_EQUALS_CHAINED_PATTERN = Pattern.compile("but was:<(.*)>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+  private static final List<Pattern> PATTERNS = new ArrayList<>();
+
+  private static final String[] PATTERN_STRINGS = new String[]{
+    "\nexpected: is \"(.*)\"\n\\s*got: \"(.*)\"\n",
+    "\nexpected: is \"(.*)\"\n\\s*but:\\s+was \"(.*)\"",
+    "\nexpected: (.*)\n\\s*got: (.*)",
+    "expected same:<(.*)> was not:<(.*)>",
+    "\nexpected: \"(.*)\"\n\\s*but: was \"(.*)\"",
+    "expected: (.*)\n\\s*but: was (.*)",
+    "expected: (.*)\\s+but was: (.*)",
+    "expecting:\\s+<(.*)> to be equal to:\\s+<(.*)>\\s+but was not"
+  };
+
+  static {
+    registerPatterns(PATTERN_STRINGS, PATTERNS);
+  }
 
   /**
    * System property to specify the maximum threshold for expected patterns.
@@ -24,6 +41,10 @@ public class AbstractExpectedPatterns {
     for (String string : patternStrings) {
       patterns.add(Pattern.compile(string, Pattern.DOTALL | Pattern.CASE_INSENSITIVE));
     }
+  }
+
+  public static ComparisonFailureData parseComparisonFailure(String message) {
+    return createExceptionNotification(message, PATTERNS);
   }
 
   protected static ComparisonFailureData createExceptionNotification(String message, List<Pattern> patterns) {

--- a/java/java-tests/testData/execution/junitReports/common-junit-report.xml
+++ b/java/java-tests/testData/execution/junitReports/common-junit-report.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Test run" tests="5" failures="1" errors="1" skipped="1" time="10.0" timestamp="2026-06-05T10:00:00">
+  <testsuite name="Tests.Registration" tests="5" failures="1" errors="1" skipped="1" time="10.0" file="tests/registration.code">
+    <properties>
+      <property name="version" value="1.774"/>
+      <property name="commit" value="ef7bebf"/>
+    </properties>
+    <testcase name="testCase4" classname="Tests.Registration" time="0" file="tests/registration.code" line="164">
+      <skipped message="Test was skipped."/>
+    </testcase>
+    <testcase name="testCase5" classname="Tests.Registration" time="2.902412" file="tests/registration.code" line="202">
+      <failure message="Expected value did not match." type="AssertionError">
+        AssertionError: Expected value did not match.
+        at Tests.Registration.testCase5(RegistrationTest.java:202)
+      </failure>
+    </testcase>
+    <testcase name="testCase6" classname="Tests.Registration" time="3.819" file="tests/registration.code" line="235">
+      <error message="Division by zero." type="ArithmeticError">
+        ArithmeticError: Division by zero.
+        at Tests.Registration.testCase6(RegistrationTest.java:235)
+      </error>
+    </testcase>
+    <testcase name="testCase7" classname="Tests.Registration" time="2.944" file="tests/registration.code" line="287">
+      <system-out>Data written to standard out.
+[[ATTACHMENT|screenshots/dashboard.png]]
+</system-out>
+      <system-err>Data written to standard error.</system-err>
+    </testcase>
+    <testcase name="testCase8" classname="Tests.Registration" time="1.625275" file="tests/registration.code" line="302">
+      <properties>
+        <property name="priority" value="high"/>
+        <property name="attachment" value="screenshots/dashboard.png"/>
+        <property name="description">This text describes the purpose of this test case.</property>
+      </properties>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/java/java-tests/testData/execution/junitReports/maven-single-suite-failure.xml
+++ b/java/java-tests/testData/execution/junitReports/maven-single-suite-failure.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostic.compiler.based.DiagnosticCompilerTestFE10TestdataTestGenerated$Tests$Multiplatform" tests="1" skipped="0" failures="1" errors="0" timestamp="2024-05-31T14:31:45" hostname="NVC00775" time="1.583">
+  <properties/>
+  <testcase name="testPrivateExpectFakeOverride_incompatibleReturnType()" classname="org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostic.compiler.based.DiagnosticCompilerTestFE10TestdataTestGenerated$Tests$Multiplatform" time="1.583">
+    <failure message="com.intellij.rt.execution.junit.FileComparisonFailure: Actual data differs from file content: privateExpectFakeOverride_incompatibleReturnType.fir.kt expected:&lt;...ExpectClass(val [&lt;!ACTUAL_WITHOUT_EXPECT!&gt;x&lt;!&gt;]: Int)...&gt; but was:&lt;...ExpectClass(val [x]: Int)...&gt;" type="com.intellij.rt.execution.junit.FileComparisonFailure">com.intellij.rt.execution.junit.FileComparisonFailure: Actual data differs from file content: privateExpectFakeOverride_incompatibleReturnType.fir.kt expected:&lt;...ExpectClass(val [&lt;!ACTUAL_WITHOUT_EXPECT!&gt;x&lt;!&gt;]: Int)...&gt; but was:&lt;...ExpectClass(val [x]: Int)...&gt;
+      at org.jetbrains.kotlin.test.services.GlobalMetadataInfoHandler.compareAllMetaDataInfos(GlobalMetadataInfoHandler.kt:77)
+      at org.jetbrains.kotlin.test.TestRunner.runTestPipeline(TestRunner.kt:106)
+      at org.jetbrains.kotlin.test.TestRunner.runTestImpl(TestRunner.kt:69)
+    </failure>
+  </testcase>
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/java/java-tests/testData/execution/junitReports/nested-junit-report.xml
+++ b/java/java-tests/testData/execution/junitReports/nested-junit-report.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Hand-written report with one branch nested more deeply than its sibling. -->
+<testsuites>
+  <testsuite name="idea.import.AllChecks" tests="7" failures="1" errors="1" skipped="1" time="0.730">
+    <testsuite name="idea.import.FastChecks" tests="4" failures="1" errors="1" skipped="1" time="0.130">
+      <testsuite name="idea.import.ArithmeticChecks" tests="4" failures="1" errors="1" skipped="1" time="0.120">
+        <testcase name="addsTwoNumbers" classname="idea.import.ArithmeticChecks" time="0.010"/>
+        <testcase name="reportsUnexpectedProduct" classname="idea.import.ArithmeticChecks" time="0.020">
+          <failure message="Expected product 42 but was 41" type="java.lang.AssertionError">
+            at idea.import.ArithmeticChecks.reportsUnexpectedProduct(ArithmeticChecks.java:24)
+          </failure>
+        </testcase>
+        <testcase name="skipsDivisionByZero" classname="idea.import.ArithmeticChecks" time="0.000">
+          <skipped message="Zero divisor is covered elsewhere"/>
+        </testcase>
+        <testcase name="reportsMissingOperand" classname="idea.import.ArithmeticChecks" time="0.090">
+          <error message="Right operand was not initialized" type="java.lang.IllegalStateException">
+            at idea.import.ArithmeticChecks.reportsMissingOperand(ArithmeticChecks.java:41)
+          </error>
+        </testcase>
+        <system-out><![CDATA[Arithmetic checks produced diagnostic output]]></system-out>
+        <system-err><![CDATA[Arithmetic checks produced diagnostic warnings]]></system-err>
+      </testsuite>
+      <system-out><![CDATA[Fast checks finished]]></system-out>
+    </testsuite>
+    <testsuite name="idea.import.ServiceChecks" tests="3" failures="0" errors="0" skipped="0" time="0.600">
+      <testcase name="createsSession" classname="idea.import.ServiceChecks" time="0.200"/>
+      <testcase name="refreshesSession" classname="idea.import.ServiceChecks" time="0.180"/>
+      <testcase name="closesSession" classname="idea.import.ServiceChecks" time="0.220"/>
+      <system-out><![CDATA[Service checks completed]]></system-out>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/java/java-tests/testData/execution/junitReports/surefire-rerun-flaky-report.xml
+++ b/java/java-tests/testData/execution/junitReports/surefire-rerun-flaky-report.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="RetryingTest" tests="2" skipped="0" failures="1" errors="0" time="0.200">
+  <testcase name="flakyPassesOnRerun" classname="RetryingTest" time="0.100">
+    <flakyFailure message="first attempt failed" type="java.lang.AssertionError">
+      first attempt stack trace
+      at RetryingTest.flakyPassesOnRerun(RetryingTest.java:12)
+    </flakyFailure>
+  </testcase>
+  <testcase name="failsAfterRerun" classname="RetryingTest" time="0.100">
+    <rerunFailure message="rerun failed" type="java.lang.AssertionError">
+      rerun stack trace
+      at RetryingTest.failsAfterRerun(RetryingTest.java:25)
+    </rerunFailure>
+    <failure message="final failure" type="java.lang.AssertionError">
+      final stack trace
+      at RetryingTest.failsAfterRerun(RetryingTest.java:25)
+    </failure>
+  </testcase>
+</testsuite>

--- a/java/java-tests/testData/execution/junitReports/surefire-rerun-flaky-report.xml
+++ b/java/java-tests/testData/execution/junitReports/surefire-rerun-flaky-report.xml
@@ -1,19 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="RetryingTest" tests="2" skipped="0" failures="1" errors="0" time="0.200">
+<testsuite name="RetryingTest" time="0.200" tests="2" errors="0" skipped="0" failures="1">
   <testcase name="flakyPassesOnRerun" classname="RetryingTest" time="0.100">
+    <!-- A failed attempt is reported as flakyFailure when a later rerun passes. -->
     <flakyFailure message="first attempt failed" type="java.lang.AssertionError">
-      first attempt stack trace
-      at RetryingTest.flakyPassesOnRerun(RetryingTest.java:12)
+      <stackTrace><![CDATA[java.lang.AssertionError: first attempt failed
+]]></stackTrace>
     </flakyFailure>
+    <!-- An errored attempt is reported as flakyError when a later rerun passes. -->
+    <flakyError message="second attempt errored" type="java.lang.IllegalStateException">
+      <stackTrace><![CDATA[java.lang.IllegalStateException: second attempt errored
+]]></stackTrace>
+    </flakyError>
   </testcase>
   <testcase name="failsAfterRerun" classname="RetryingTest" time="0.100">
+    <!-- The first attempt remains the primary failure when all reruns are exhausted. -->
+    <failure message="initial failure" type="java.lang.AssertionError"><![CDATA[java.lang.AssertionError: initial failure
+]]></failure>
+    <!-- A failed retry after the primary attempt is represented as rerunFailure. -->
     <rerunFailure message="rerun failed" type="java.lang.AssertionError">
-      rerun stack trace
-      at RetryingTest.failsAfterRerun(RetryingTest.java:25)
+      <stackTrace><![CDATA[java.lang.AssertionError: rerun failed
+]]></stackTrace>
     </rerunFailure>
-    <failure message="final failure" type="java.lang.AssertionError">
-      final stack trace
-      at RetryingTest.failsAfterRerun(RetryingTest.java:25)
-    </failure>
+    <!-- An errored retry after the primary attempt is represented as rerunError. -->
+    <rerunError message="rerun errored" type="java.lang.IllegalStateException">
+      <stackTrace><![CDATA[java.lang.IllegalStateException: rerun errored
+]]></stackTrace>
+    </rerunError>
   </testcase>
 </testsuite>

--- a/java/java-tests/testData/execution/junitReports/unusual-strings-junit-report.xml
+++ b/java/java-tests/testData/execution/junitReports/unusual-strings-junit-report.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Unusual but valid XML string content:
+  - U+FEFF byte order marks at the start of failure message
+  - XML unicode entities
+  - Raw unicode supplementary symbol in a test name
+  - Trailing spaces in a test name and a whitespace-only failure message
+  - Terminal-style markers such as [31m as literal text, without an ESC character
+  - Raw Unicode U+FFFD replacement character in a test name
+  - An ordinary test after the unusual names, proving that parsing continues
+-->
+<testsuites>
+  <testsuite name="dev.acme.ReportTextChecks" tests="5" failures="1" errors="1" skipped="1" time="0.480">
+    <testcase name="keepsPlainText" classname="dev.acme.ReportTextChecks" time="0.010"/>
+    <testcase name="temporarilyDisabled" classname="dev.acme.ReportTextChecks" time="0.000">
+      <skipped message="Waiting for the replacement decoder"/>
+    </testcase>
+    <testcase name="rendersCafeComparison" classname="dev.acme.ReportTextChecks" time="0.030">
+      <failure message="﻿Expected &#8216;caf&#233;&#8217; but was &#8216;cafe&#8217;" type="org.opentest4j.AssertionFailedError"><![CDATA[org.opentest4j.AssertionFailedError: accents differ
+    at dev.acme.ReportTextChecks.rendersCafeComparison(ReportTextChecks.java:37)
+Terminal-style markers: [31mDIFFERENT[0m
+]]></failure>
+      <system-out><![CDATA[[32mencoded stdout[0m]]></system-out>
+      <system-err><![CDATA[decoder warning [33mCHECK INPUT[0m]]></system-err>
+    </testcase>
+    <testcase name="readsSymbol𝄞WithoutLoss" classname="dev.acme.ReportTextChecks" time="0.140">
+      <error message="java.nio.charset.MalformedInputException: Input length = 1" type="java.nio.charset.MalformedInputException"><![CDATA[java.nio.charset.MalformedInputException: Input length = 1
+    at dev.acme.ReportTextChecks.readsSymbolWithoutLoss(ReportTextChecks.java:52)
+]]></error>
+    </testcase>
+    <testcase name="recoversAfterRetry   " classname="dev.acme.ReportTextChecks" time="0.300">
+      <flakyFailure message="   " type="org.opentest4j.AssertionFailedError"><![CDATA[first attempt compared decomposed text]]></flakyFailure>
+      <flakyError message="﻿transient decoder failure" type="java.lang.IllegalArgumentException"><![CDATA[second attempt rejected the byte sequence]]></flakyError>
+      <system-out><![CDATA[retry output [32mRECOVERED[0m]]></system-out>
+    </testcase>
+  </testsuite>
+  <testsuite name="dev.acme.RetryTextChecks" tests="2" failures="0" errors="0" skipped="0" time="0.070">
+    <testcase name="continuesAfterReplacement�" classname="dev.acme.RetryTextChecks" time="0.050">
+      <rerunFailure message="﻿replacement mismatch" type="org.opentest4j.AssertionFailedError"><![CDATA[first run saw a replacement character]]></rerunFailure>
+      <rerunError message="﻿decoder state was stale" type="java.lang.IllegalStateException"><![CDATA[second run reset the decoder]]></rerunError>
+    </testcase>
+    <testcase name="stillRunsAfterOddName" classname="dev.acme.RetryTextChecks" time="0.020"/>
+  </testsuite>
+</testsuites>

--- a/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
@@ -15,16 +15,21 @@
  */
 package com.intellij.java.execution;
 
+import com.intellij.JavaTestUtil;
 import com.intellij.execution.testframework.sm.runner.BaseSMTRunnerTestCase;
 import com.intellij.execution.testframework.sm.runner.GeneralToSMTRunnerEventsConvertor;
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
 import com.intellij.execution.testframework.sm.runner.history.ImportedToGeneralTestEventsConverter;
+import com.intellij.execution.testframework.sm.runner.ui.MockPrinter;
 import com.intellij.openapi.util.Disposer;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 public class AntImportTest extends BaseSMTRunnerTestCase {
@@ -60,6 +65,10 @@ public class AntImportTest extends BaseSMTRunnerTestCase {
   private SMTestProxy.SMRootTestProxy parseTestResult(@Language("XML") @NotNull String text) throws IOException {
     ImportedToGeneralTestEventsConverter.parseTestResults(() -> new StringReader(text), myEventsProcessor);
     return myRootNode;
+  }
+
+  private SMTestProxy.SMRootTestProxy parseTestResultFixture(@NotNull String fileName) throws IOException {
+    return parseTestResult(Files.readString(Path.of(JavaTestUtil.getJavaTestDataPath(), "execution/junitReports", fileName)));
   }
 
   public void testAntFormatTest() throws Exception {
@@ -114,5 +123,69 @@ public class AntImportTest extends BaseSMTRunnerTestCase {
     SMTestProxy suite = rootNode.getChildren().get(0);
     SMTestProxy ignoredTest = suite.getChildren().get(0);
     assertTrue(ignoredTest.isIgnored());
+  }
+
+  public void testMavenSingleSuiteReportPreservesFailure() throws Exception {
+    SMTestProxy.SMRootTestProxy rootNode = parseTestResultFixture("maven-single-suite-failure.xml");
+
+    SMTestProxy test = findTest(rootNode, "testPrivateExpectFakeOverride_incompatibleReturnType()");
+    assertTrue(test.isDefect());
+    assertContains(test.getErrorMessage(), "Actual data differs from file content");
+    assertContains(test.getStacktrace(), "GlobalMetadataInfoHandler.compareAllMetaDataInfos");
+  }
+
+  public void testCommonJUnitReportPreservesOutputAndProperties() throws Exception {
+    SMTestProxy.SMRootTestProxy rootNode = parseTestResultFixture("common-junit-report.xml");
+
+    SMTestProxy failure = findTest(rootNode, "testCase5");
+    assertTrue(failure.isDefect());
+    assertEquals("Expected value did not match.", failure.getErrorMessage());
+    assertContains(failure.getStacktrace(), "Tests.Registration.testCase5");
+
+    SMTestProxy error = findTest(rootNode, "testCase6");
+    assertTrue(error.isDefect());
+    assertEquals("Division by zero.", error.getErrorMessage());
+
+    SMTestProxy skipped = findTest(rootNode, "testCase4");
+    assertTrue(skipped.isIgnored());
+
+    SMTestProxy output = findTest(rootNode, "testCase7");
+    MockPrinter outputPrinter = MockPrinter.fillPrinter(output);
+    assertContains(outputPrinter.getStdOut(), "Data written to standard out.");
+    assertContains(outputPrinter.getStdErr(), "Data written to standard error.");
+
+    SMTestProxy properties = findTest(rootNode, "testCase8");
+    MockPrinter propertiesPrinter = MockPrinter.fillPrinter(properties);
+    assertContains(propertiesPrinter.getStdOut(), "Property priority=high");
+    assertContains(propertiesPrinter.getStdOut(), "Property attachment=screenshots/dashboard.png");
+    assertContains(propertiesPrinter.getStdOut(), "This text describes the purpose of this test case");
+  }
+
+  public void testSurefireRerunAndFlakyDetailsAreVisibleWithoutChangingFinalStatus() throws Exception {
+    SMTestProxy.SMRootTestProxy rootNode = parseTestResultFixture("surefire-rerun-flaky-report.xml");
+
+    SMTestProxy flaky = findTest(rootNode, "flakyPassesOnRerun");
+    assertTrue(flaky.isPassed());
+    MockPrinter flakyPrinter = MockPrinter.fillPrinter(flaky);
+    assertContains(flakyPrinter.getStdErr(), "Flaky failure");
+    assertContains(flakyPrinter.getStdErr(), "first attempt stack trace");
+
+    SMTestProxy failed = findTest(rootNode, "failsAfterRerun");
+    assertTrue(failed.isDefect());
+    assertEquals("final failure", failed.getErrorMessage());
+    assertContains(failed.getStacktrace(), "final stack trace");
+    assertContains(failed.getStacktrace(), "Rerun failure");
+    assertContains(failed.getStacktrace(), "rerun stack trace");
+  }
+
+  private static @NotNull SMTestProxy findTest(@NotNull SMTestProxy.SMRootTestProxy rootNode, @NotNull String testName) {
+    SMTestProxy test = (SMTestProxy)findTestByName(testName, rootNode);
+    assertNotNull(test);
+    return test;
+  }
+
+  private static void assertContains(@Nullable String actual, @NotNull String expected) {
+    assertNotNull(actual);
+    assertTrue(actual, actual.contains(expected));
   }
 }

--- a/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
@@ -166,21 +166,29 @@ public class AntImportTest extends BaseSMTRunnerTestCase {
     assertContains(propertiesPrinter.getStdOut(), "This text describes the purpose of this test case");
   }
 
-  public void testSurefireRerunAndFlakyDetailsAreVisibleWithoutChangingFinalStatus() throws Exception {
+  public void testSurefireRerunAndFlakyDetailsAreExposedAreFlattened() throws Exception {
     SMTestProxy.SMRootTestProxy rootNode = parseTestResultFixture("surefire-rerun-flaky-report.xml");
 
+    // Note: SMTestProxy does not model individual Surefire attempts:
+
+    // * flaky tests are emitted as stderr, because these test eventually passed
     SMTestProxy flaky = findTest(rootNode, "flakyPassesOnRerun");
     assertTrue(flaky.isPassed());
     MockPrinter flakyPrinter = MockPrinter.fillPrinter(flaky);
     assertContains(flakyPrinter.getStdErr(), "Flaky failure");
-    assertContains(flakyPrinter.getStdErr(), "first attempt stack trace");
+    assertContains(flakyPrinter.getStdErr(), "java.lang.AssertionError: first attempt failed");
+    assertContains(flakyPrinter.getStdErr(), "Flaky error");
+    assertContains(flakyPrinter.getStdErr(), "java.lang.IllegalStateException: second attempt errored");
 
+    // * re-ran tests are appended to the primary failure's stack trace.
     SMTestProxy failed = findTest(rootNode, "failsAfterRerun");
     assertTrue(failed.isDefect());
-    assertEquals("final failure", failed.getErrorMessage());
-    assertContains(failed.getStacktrace(), "final stack trace");
+    assertEquals("initial failure", failed.getErrorMessage());
+    assertContains(failed.getStacktrace(), "java.lang.AssertionError: initial failure");
     assertContains(failed.getStacktrace(), "Rerun failure");
-    assertContains(failed.getStacktrace(), "rerun stack trace");
+    assertContains(failed.getStacktrace(), "java.lang.AssertionError: rerun failed");
+    assertContains(failed.getStacktrace(), "Rerun error");
+    assertContains(failed.getStacktrace(), "java.lang.IllegalStateException: rerun errored");
   }
 
   private static @NotNull SMTestProxy findTest(@NotNull SMTestProxy.SMRootTestProxy rootNode, @NotNull String testName) {

--- a/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
@@ -21,6 +21,7 @@ import com.intellij.execution.testframework.sm.runner.GeneralToSMTRunnerEventsCo
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
 import com.intellij.execution.testframework.sm.runner.history.ImportedToGeneralTestEventsConverter;
 import com.intellij.execution.testframework.sm.runner.ui.MockPrinter;
+import com.intellij.execution.testframework.stacktrace.DiffHyperlink;
 import com.intellij.openapi.util.Disposer;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
@@ -132,6 +133,10 @@ public class AntImportTest extends BaseSMTRunnerTestCase {
     assertTrue(test.isDefect());
     assertContains(test.getErrorMessage(), "Actual data differs from file content");
     assertContains(test.getStacktrace(), "GlobalMetadataInfoHandler.compareAllMetaDataInfos");
+    DiffHyperlink diffHyperlink = test.getDiffViewerProvider();
+    assertNotNull(diffHyperlink);
+    assertEquals("...ExpectClass(val [<!ACTUAL_WITHOUT_EXPECT!>x<!>]: Int)...", diffHyperlink.getLeft());
+    assertEquals("...ExpectClass(val [x]: Int)...", diffHyperlink.getRight());
   }
 
   public void testCommonJUnitReportPreservesOutputAndProperties() throws Exception {

--- a/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/execution/AntImportTest.java
@@ -191,6 +191,65 @@ public class AntImportTest extends BaseSMTRunnerTestCase {
     assertContains(failed.getStacktrace(), "java.lang.IllegalStateException: rerun errored");
   }
 
+  public void testNestedSuitesPreserveHierarchyAndResults() throws Exception {
+    SMTestProxy.SMRootTestProxy rootNode = parseTestResultFixture("nested-junit-report.xml");
+
+    assertEquals(1, rootNode.getChildren().size());
+    SMTestProxy allTests = rootNode.getChildren().getFirst();
+    assertEquals("idea.import.AllChecks", allTests.getName());
+    assertEquals(2, allTests.getChildren().size());
+
+    SMTestProxy fastChecks = allTests.getChildren().getFirst();
+    assertEquals("idea.import.FastChecks", fastChecks.getName());
+    assertEquals(1, fastChecks.getChildren().size());
+    SMTestProxy arithmeticChecks = fastChecks.getChildren().getFirst();
+    assertEquals("idea.import.ArithmeticChecks", arithmeticChecks.getName());
+    assertEquals(4, arithmeticChecks.getChildren().size());
+    assertTrue(findTest(rootNode, "reportsUnexpectedProduct").isDefect());
+    assertTrue(findTest(rootNode, "skipsDivisionByZero").isIgnored());
+    assertTrue(findTest(rootNode, "reportsMissingOperand").isDefect());
+    MockPrinter fastChecksPrinter = MockPrinter.fillPrinter(fastChecks);
+    assertContains(fastChecksPrinter.getStdOut(), "Arithmetic checks produced diagnostic output");
+    assertContains(fastChecksPrinter.getStdOut(), "Fast checks finished");
+    assertContains(fastChecksPrinter.getStdErr(), "Arithmetic checks produced diagnostic warnings");
+
+    SMTestProxy serviceChecks = allTests.getChildren().get(1);
+    assertEquals("idea.import.ServiceChecks", serviceChecks.getName());
+    assertEquals(3, serviceChecks.getChildren().size());
+  }
+
+  @SuppressWarnings("UnnecessaryUnicodeEscape")
+  public void testProblemStringsArePreserved() throws Exception {
+    SMTestProxy.SMRootTestProxy rootNode = parseTestResultFixture("unusual-strings-junit-report.xml");
+
+    SMTestProxy failure = findTest(rootNode, "rendersCafeComparison");
+    assertEquals("\uFEFFExpected \u2018caf\u00E9\u2019 but was \u2018cafe\u2019", failure.getErrorMessage());
+    assertContains(failure.getStacktrace(), "Terminal-style markers: [31mDIFFERENT[0m");
+    MockPrinter failurePrinter = MockPrinter.fillPrinter(failure);
+    assertContains(failurePrinter.getStdOut(), "[32mencoded stdout[0m");
+    assertContains(failurePrinter.getStdErr(), "decoder warning [33mCHECK INPUT[0m");
+
+    SMTestProxy error = findTest(rootNode, "readsSymbol\uD834\uDD1EWithoutLoss");
+    assertEquals("java.nio.charset.MalformedInputException: Input length = 1", error.getErrorMessage());
+
+    SMTestProxy flaky = findTest(rootNode, "recoversAfterRetry   ");
+    assertEquals("recoversAfterRetry   ", flaky.getName());
+    MockPrinter flakyPrinter = MockPrinter.fillPrinter(flaky);
+    assertContains(flakyPrinter.getStdOut(), "retry output [32mRECOVERED[0m");
+    assertContains(flakyPrinter.getStdErr(), "first attempt compared decomposed text");
+    assertContains(flakyPrinter.getStdErr(), "second attempt rejected the byte sequence");
+
+    SMTestProxy retryChecks = rootNode.getChildren().get(1);
+    assertEquals("dev.acme.RetryTextChecks", retryChecks.getName());
+    assertEquals(2, retryChecks.getChildren().size());
+    SMTestProxy retried = findTest(rootNode, "continuesAfterReplacement\uFFFD");
+    assertTrue(retried.isPassed());
+    MockPrinter retriedPrinter = MockPrinter.fillPrinter(retried);
+    assertContains(retriedPrinter.getStdErr(), "first run saw a replacement character");
+    assertContains(retriedPrinter.getStdErr(), "second run reset the decoder");
+    assertTrue(findTest(rootNode, "stillRunsAfterOddName").isPassed());
+  }
+
   private static @NotNull SMTestProxy findTest(@NotNull SMTestProxy.SMRootTestProxy rootNode, @NotNull String testName) {
     SMTestProxy test = (SMTestProxy)findTestByName(testName, rootNode);
     assertNotNull(test);

--- a/plugins/junit_rt/src/com/intellij/junit4/ExpectedPatterns.java
+++ b/plugins/junit_rt/src/com/intellij/junit4/ExpectedPatterns.java
@@ -4,30 +4,9 @@ package com.intellij.junit4;
 import com.intellij.rt.execution.junit.ComparisonFailureData;
 import com.intellij.rt.execution.testFrameworks.AbstractExpectedPatterns;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
-
 public final class ExpectedPatterns extends AbstractExpectedPatterns {
-  private static final List<Pattern> PATTERNS = new ArrayList<>();
-
-  private static final String[] PATTERN_STRINGS = new String[]{
-    "\nexpected: is \"(.*)\"\n\\s*got: \"(.*)\"\n",
-    "\nexpected: is \"(.*)\"\n\\s*but:\\s+was \"(.*)\"",
-    "\nexpected: (.*)\n\\s*got: (.*)",
-    "expected same:<(.*)> was not:<(.*)>",
-    "\nexpected: \"(.*)\"\n\\s*but: was \"(.*)\"",
-    "expected: (.*)\n\\s*but: was (.*)",
-    "expected: (.*)\\s+but was: (.*)",
-    "expecting:\\s+<(.*)> to be equal to:\\s+<(.*)>\\s+but was not"
-  };
-
-  static {
-    registerPatterns(PATTERN_STRINGS, PATTERNS);
-  }
-
   public static ComparisonFailureData createExceptionNotification(String message) {
-    return createExceptionNotification(message, PATTERNS);
+    return parseComparisonFailure(message);
   }
 
   public static ComparisonFailureData createExceptionNotification(Throwable assertion) {


### PR DESCRIPTION
Importing external JUnit XML reports previously relied on a single SAX text buffer, so `failure` text could be overwritten by later output or `metadata` elements. Maven and Gradle reports also commonly use a single `testsuite` root, which the Ant/JUnit XML extension did not recognize before the detection work.

Keep the existing SM runner import path, but make the Ant/JUnit XML handler capture result elements, output, properties, and Surefire retry/flaky elements independently. Extra metadata is surfaced as ordinary test output so existing report presentation can show it without new UI fields.

Fixes 
* https://youtrack.jetbrains.com/issue/IDEA-354352/IDEA-cant-import-test-xml-produced-by-Gradle
* https://youtrack.jetbrains.com/issue/IDEA-380741/Import-tests-form-file-is-broken-on-this-testsuite-xml-report

<img width="1622" height="389" alt="Screenshot 2026-06-05 at 17 36 58" src="https://github.com/user-attachments/assets/f9bea1d5-7a9e-4f6f-9328-2103c2895709" />

<img width="1588" height="417" alt="Screenshot 2026-06-05 at 17 37 20" src="https://github.com/user-attachments/assets/dbcf1c9d-2350-4b18-8531-3e27fa95e3b9" />

By the way one of the only "spec" I found is https://github.com/testmoapp/junitxml, so I may have missed something.

----

I wonder if `AntTestContentHandler` should be renamed to something more JUnit report related than related to "Ant".

Related to 
* #3534 