### PR TITLE
IJPL-245012 migrate kotlinx-collections-immutable from 0.4.0 to 0.5.0

### DIFF
--- a/.idea/libraries/kotlinx_collections_immutable.xml
+++ b/.idea/libraries/kotlinx_collections_immutable.xml
@@ -1,18 +1,18 @@
 <component name="libraryTable">
   <library name="kotlinx-collections-immutable" type="repository">
-    <properties include-transitive-deps="false" maven-id="org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.4.0">
+    <properties include-transitive-deps="false" maven-id="org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.5.0">
       <verification>
-        <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar">
-          <sha256sum>d767014ad0c9a27d27d26fd38e7afa030aee0d141338f108781ff02ecf2fdab5</sha256sum>
+        <artifact url="file://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.5.0/kotlinx-collections-immutable-jvm-0.5.0.jar">
+          <sha256sum>9481ed3b87e282ffb95d7e2a033702afa3af476e3b89137294aeccebb27c76f7</sha256sum>
         </artifact>
       </verification>
     </properties>
     <CLASSES>
-      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.5.0/kotlinx-collections-immutable-jvm-0.5.0.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES>
-      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0-sources.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.5.0/kotlinx-collections-immutable-jvm-0.5.0-sources.jar!/" />
     </SOURCES>
   </library>
 </component>

--- a/build/src/org/jetbrains/intellij/build/IdeaCommunityProperties.kt
+++ b/build/src/org/jetbrains/intellij/build/IdeaCommunityProperties.kt
@@ -162,8 +162,8 @@ open class AndroidStudioProperties(communityHomeDir: Path) : IdeaCommunityProper
     productLayout.productImplementationModules += "intellij.idea.android.customization"
 
     val defaultBundledPlugins = IDEA_BUNDLED_PLUGINS
-      .remove("intellij.mcpserver")
-      .remove("intellij.featuresTrainer")
+      .removing("intellij.mcpserver")
+      .removing("intellij.featuresTrainer")
 
     productLayout.bundledPluginModules = defaultBundledPlugins + persistentListOf(
       "intellij.android.compose-ide-plugin",

--- a/fleet/bifurcan/srcCommonMain/fleet/bifurcan/List.kt
+++ b/fleet/bifurcan/srcCommonMain/fleet/bifurcan/List.kt
@@ -121,20 +121,26 @@ open class List<V> : PersistentList<V> {
     return (if (isLinear) this else clone()).pushLast(value)
   }
 
-  override fun add(element: V): List<V> {
+  override fun adding(element: V): List<V> {
     return addLast(element)
   }
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun add(element: V): List<V> = adding(element)
 
   fun addFirst(value: V): List<V> {
     return (if (isLinear) this else clone()).pushFirst(value)
   }
 
-  override fun addAll(elements: Collection<V>): List<V> {
+  override fun addingAll(elements: Collection<V>): List<V> {
     var l = if (isLinear) this else clone()
 
     elements.forEach { elem -> l = l.addLast(elem) }
     return l
   }
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun addAll(elements: Collection<V>): List<V> = addingAll(elements)
 
   fun removeLast(): List<V> {
     return (if (isLinear) this else clone()).popLast()
@@ -144,26 +150,35 @@ open class List<V> : PersistentList<V> {
     return (if (isLinear) this else clone()).popFirst()
   }
 
-  override fun remove(element: V): List<V> {
+  override fun removing(element: V): List<V> {
     val ind = indexOf(element)
-    return if (ind == -1) this else removeAt(ind)
+    return if (ind == -1) this else removingAt(ind)
   }
 
-  override fun removeAll(elements: Collection<V>): List<V> {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun remove(element: V): List<V> = removing(element)
+
+  override fun removingAll(elements: Collection<V>): List<V> {
     var l = if (isLinear) this else clone()
     for (elem in elements) {
-      l = l.remove(elem)
+      l = l.removing(elem)
     }
     return l
   }
 
-  override fun removeAll(predicate: (V) -> Boolean): List<V> {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun removeAll(elements: Collection<V>): List<V> = removingAll(elements)
+
+  override fun removingAll(predicate: (V) -> Boolean): List<V> {
     val l = if (isLinear) this else clone()
-    return l.removeAll(this.filter(predicate))
+    return l.removingAll(this.filter(predicate))
 
   }
 
-  override fun removeAt(index: Int): List<V> {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun removeAll(predicate: (V) -> Boolean): List<V> = removingAll(predicate)
+
+  override fun removingAt(index: Int): List<V> {
     var l = (if (isLinear) this else clone())
     when (index) {
       0 -> {
@@ -182,11 +197,17 @@ open class List<V> : PersistentList<V> {
     return l
   }
 
-  override fun retainAll(elements: Collection<V>): List<V> {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun removeAt(index: Int): List<V> = removingAt(index)
+
+  override fun retainingAll(elements: Collection<V>): List<V> {
     val l = if (isLinear) this else clone()
     val elementsSet = HashSet(elements)
-    return l.removeAll { elem -> !elementsSet.contains(elem) }
+    return l.removingAll { elem -> !elementsSet.contains(elem) }
   }
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun retainAll(elements: Collection<V>): List<V> = retainingAll(elements)
 
   override val size: Int
     get() = size().toInt()
@@ -195,13 +216,16 @@ open class List<V> : PersistentList<V> {
     TODO("Not yet implemented")
   }
 
-  override fun clear(): List<V> {
+  override fun cleared(): List<V> {
     var l = (if (isLinear) this else clone())
     for (x in 1..l.size) {
       l = l.removeFirst()
     }
     return l
   }
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun clear(): List<V> = cleared()
 
   override fun get(index: Int): V {
     return this.nth(index.toLong())
@@ -231,7 +255,7 @@ open class List<V> : PersistentList<V> {
     return this.indexOf(element) != -1
   }
 
-  override fun addAll(index: Int, c: Collection<V>): PersistentList<V> {
+  override fun addingAllAt(index: Int, c: Collection<V>): PersistentList<V> {
     var l = if (isLinear) this else clone()
     when (index) {
       0 -> {
@@ -251,11 +275,17 @@ open class List<V> : PersistentList<V> {
     return l
   }
 
-  override fun set(index: Int, element: V): List<V> {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun addAll(index: Int, c: Collection<V>): PersistentList<V> = addingAllAt(index, c)
+
+  override fun replacingAt(index: Int, element: V): List<V> {
     return set(index.toLong(), element)
   }
 
-  override fun add(index: Int, element: V): List<V> {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun set(index: Int, element: V): List<V> = replacingAt(index, element)
+
+  override fun addingAt(index: Int, element: V): List<V> {
     // splice at index, insert at end and append again
     var l = if (isLinear) this else clone()
     if (0 > index || index >= l.size) {
@@ -277,6 +307,9 @@ open class List<V> : PersistentList<V> {
 
 
   }
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun add(index: Int, element: V): List<V> = addingAt(index, element)
 
 
   fun set(idx: Long, value: V): List<V> {
@@ -629,7 +662,7 @@ open class List<V> : PersistentList<V> {
     fun <V> from(iterator: Iterator<V>): List<V> {
       val list = List<V>().linear()
       while (iterator.hasNext()) {
-        list.add(iterator.next())
+        list.adding(iterator.next())
       }
       return list.forked()
     }

--- a/fleet/openmap/srcCommonMain/fleet/openmap/MutableBoundedOpenMapImpl.kt
+++ b/fleet/openmap/srcCommonMain/fleet/openmap/MutableBoundedOpenMapImpl.kt
@@ -13,11 +13,11 @@ internal class MutableBoundedOpenMapImpl<Domain, V : Any>(val map: AtomicReferen
   override fun isEmpty() = map.load().size == 0
 
   override fun <T : V> set(k: Key<T, Domain>, v: T) {
-    map.updateAndFetch { map -> map.put(k, v) }
+    map.updateAndFetch { map -> map.putting(k, v) }
   }
 
   override fun remove(k: Key<out V, Domain>) {
-    map.updateAndFetch { map -> map.remove(k) }
+    map.updateAndFetch { map -> map.removing(k) }
   }
 
   override fun <T : V> assoc(k: Key<T, Domain>, v: T): BoundedOpenMap<Domain, V> {
@@ -35,7 +35,7 @@ internal class MutableBoundedOpenMapImpl<Domain, V : Any>(val map: AtomicReferen
   override fun <T : V> update(key: Key<T, Domain>, f: (T?) -> T): T {
     return map.updateAndFetch { map ->
       val v1 = f(map.get(key) as T?)
-      map.put(key, v1)
+      map.putting(key, v1)
     }.get(key) as T
   }
 
@@ -43,7 +43,7 @@ internal class MutableBoundedOpenMapImpl<Domain, V : Any>(val map: AtomicReferen
     return map.updateAndFetch { map ->
       val v = map.get(key)
       if (v == null) {
-        map.put(key, init())
+        map.putting(key, init())
       }
       else {
         map

--- a/fleet/openmap/srcCommonMain/fleet/openmap/OpenMap.kt
+++ b/fleet/openmap/srcCommonMain/fleet/openmap/OpenMap.kt
@@ -68,7 +68,7 @@ private data class OpenMapAdapter<Domain>(val original: OpenMapView<Domain>,
   }
 
   fun <T : Any> dissoc(k: Key<T, Domain>): OpenMapAdapter<Domain> {
-    return if (k in added) copy(added = added.dissoc(k)) else copy(removedKeys = removedKeys.add(k))
+    return if (k in added) copy(added = added.dissoc(k)) else copy(removedKeys = removedKeys.adding(k))
   }
 }
 

--- a/fleet/openmap/srcCommonMain/fleet/openmap/PersistentBoundedOpenMap.kt
+++ b/fleet/openmap/srcCommonMain/fleet/openmap/PersistentBoundedOpenMap.kt
@@ -6,7 +6,7 @@ import kotlinx.collections.immutable.PersistentMap
 data class PersistentBoundedOpenMap<Domain, V : Any>(val map: PersistentMap<Key<out V, Domain>, V>) : BoundedOpenMap<Domain, V> {
 
   override fun <T : V> assoc(k: Key<T, Domain>, v: T): BoundedOpenMap<Domain, V> {
-    return BoundedOpenMap.from(map.put(k, v))
+    return BoundedOpenMap.from(map.putting(k, v))
   }
 
   override fun <T : Any> get(k: Key<T, Domain>): T? {
@@ -36,6 +36,6 @@ data class PersistentBoundedOpenMap<Domain, V : Any>(val map: PersistentMap<Key<
   }
 
   override fun dissoc(k: Key<out V, Domain>): BoundedOpenMap<Domain, V> {
-    return BoundedOpenMap.from(map.remove(k))
+    return BoundedOpenMap.from(map.removing(k))
   }
 }

--- a/fleet/openmap/srcCommonMain/fleet/openmap/SerializableOpenMap.kt
+++ b/fleet/openmap/srcCommonMain/fleet/openmap/SerializableOpenMap.kt
@@ -23,11 +23,11 @@ data class SerializableOpenMap<D>(internal val m: PersistentMap<String, Serializ
   }
 
   fun <T : Any> assoc(key: SerializableKey<T, D>, v: T): SerializableOpenMap<D> {
-    return SerializableOpenMap(m.put(key.key, SerializedValue.fromDeserializedValue(v, key.serializer)))
+    return SerializableOpenMap(m.putting(key.key, SerializedValue.fromDeserializedValue(v, key.serializer)))
   }
 
   fun <T : Any> dissoc(key: SerializableKey<out T, D>): SerializableOpenMap<D> {
-    return SerializableOpenMap(m.remove(key.key))
+    return SerializableOpenMap(m.removing(key.key))
   }
 
   fun mut(): Mut<D> =
@@ -57,7 +57,7 @@ data class SerializableOpenMap<D>(internal val m: PersistentMap<String, Serializ
     get() = m
 
   fun merge(other: SerializableOpenMap<D>): SerializableOpenMap<D> =
-    SerializableOpenMap(m.putAll(other.m))
+    SerializableOpenMap(m.puttingAll(other.m))
 
   fun isEmpty() = m.size == 0
 

--- a/fleet/rhizomedb.transactor.rebase/srcCommonMain/fleet/kernel/rebase/InstructionsRecording.kt
+++ b/fleet/rhizomedb.transactor.rebase/srcCommonMain/fleet/kernel/rebase/InstructionsRecording.kt
@@ -85,7 +85,7 @@ internal fun Mut.withIdMemoization(
       entityTypeEid: EID,
       initials: List<Pair<Attribute<*>, Any>>
     ): EID = run {
-      val key = (pipeline.impl.meta[KeyStack] ?: persistentListOf()).add(entityTypeEid)
+      val key = (pipeline.impl.meta[KeyStack] ?: persistentListOf()).adding(entityTypeEid)
       val defaultPart = pipeline.impl.defaultPart
       val eid = eidMemo.memo(true, key) { EidGen.freshEID(defaultPart) }
       val uid = uidMemo.memo(true, key) { UID.random() }

--- a/fleet/rhizomedb.transactor.rebase/srcCommonMain/fleet/kernel/rebase/Shared.kt
+++ b/fleet/rhizomedb.transactor.rebase/srcCommonMain/fleet/kernel/rebase/Shared.kt
@@ -32,7 +32,7 @@ internal object KeyStack : ChangeScopeKey<PersistentList<Any>>
 
 fun <T> SharedChangeScope.withKey(key: Any, body: SharedChangeScope.() -> T): T = run {
   val oldKey = meta[KeyStack]
-  meta[KeyStack] = (oldKey ?: persistentListOf()).add(key)
+  meta[KeyStack] = (oldKey ?: persistentListOf()).adding(key)
   val res = body()
   if (oldKey == null) {
     meta.remove(KeyStack)

--- a/fleet/rhizomedb.transactor/srcCommonMain/fleet/kernel/rete/impl/ObservableMatch.kt
+++ b/fleet/rhizomedb.transactor/srcCommonMain/fleet/kernel/rete/impl/ObservableMatch.kt
@@ -109,7 +109,7 @@ internal suspend fun <U> withObservableMatches(
     else ->
       withReteDbSource {
         var handles: List<DisposableHandle>? = null
-        val def = async(context = ContextMatches(contextMatches.addAll(addedMatches)),
+        val def = async(context = ContextMatches(contextMatches.addingAll(addedMatches)),
                         start = CoroutineStart.UNDISPATCHED) {
           val self = this
           // setup invalidation handles before launching [body]

--- a/fleet/rhizomedb/srcCommonMain/com/jetbrains/rhizomedb/QueryCache.kt
+++ b/fleet/rhizomedb/srcCommonMain/com/jetbrains/rhizomedb/QueryCache.kt
@@ -24,7 +24,7 @@ class QueryCache private constructor(private val cache: AtomicReference<QueryCac
       oldPatterns?.forEach { oldPattern ->
         if (!result.patterns.contains(oldPattern)) {
           val queries = patternToQueryPrime[oldPattern]!!
-          val queriesPrime = queries.remove(query)
+          val queriesPrime = queries.removing(query)
           when {
             queriesPrime.isEmpty() -> patternToQueryPrime.remove(oldPattern)
             else -> patternToQueryPrime[oldPattern] = queriesPrime
@@ -35,12 +35,12 @@ class QueryCache private constructor(private val cache: AtomicReference<QueryCac
       result.patterns.forEach { newPattern ->
         if (oldPatterns == null || !oldPatterns.contains(newPattern)) {
           patternToQueryPrime.computeShim(newPattern) { _, queries ->
-            (queries ?: persistentHashSetOf()).add(query)
+            (queries ?: persistentHashSetOf()).adding(query)
           }
         }
       }
       return QueryCacheData(patternToQuery = patternToQueryPrime.build(),
-                            queryToResult = queryToResult.put(query, result))
+                            queryToResult = queryToResult.putting(query, result))
     }
 
     fun invalidate(novelty: Iterable<Datom>): QueryCacheData {

--- a/fleet/rpc.server/srcCommonMain/fleet/rpc/server/ActiveConnections.kt
+++ b/fleet/rpc.server/srcCommonMain/fleet/rpc/server/ActiveConnections.kt
@@ -81,7 +81,7 @@ class ActiveConnections : ConnectionListener {
     )
     socket2endpoint.update {
       check(!it.containsKey(key)) { "key $key is not unique" }
-      it.put(key, endpoint)
+      it.putting(key, endpoint)
     }
   }
 
@@ -90,6 +90,6 @@ class ActiveConnections : ConnectionListener {
       socketId = socketId,
       kind = kind,
     )
-    socket2endpoint.update { it.remove(key) }
+    socket2endpoint.update { it.removing(key) }
   }
 }

--- a/fleet/rpc.server/srcCommonMain/fleet/rpc/server/RpcExecutor.kt
+++ b/fleet/rpc.server/srcCommonMain/fleet/rpc/server/RpcExecutor.kt
@@ -401,7 +401,7 @@ class RpcExecutor private constructor(
     }
 
     // Add dependency to the created remote object
-    children.compute(parent) { k, v -> v.orEmpty().toPersistentSet().add(path) }
+    children.compute(parent) { k, v -> v.orEmpty().toPersistentSet().adding(path) }
     parents[path] = parent
   }
 
@@ -422,7 +422,7 @@ class RpcExecutor private constructor(
     additionalStep?.invoke(path)
 
     // Remove from parent deps, and unregister children
-    parents.remove(path)?.let { parent -> children.computeIfPresent(parent) { _, deps -> deps.toPersistentSet().remove(path) } }
+    parents.remove(path)?.let { parent -> children.computeIfPresent(parent) { _, deps -> deps.toPersistentSet().removing(path) } }
     children.remove(path)?.forEach {
       unregisterRemoteObject(it, additionalStep)
     }

--- a/fleet/rpc/srcCommonMain/fleet/rpc/client/RpcClient.kt
+++ b/fleet/rpc/srcCommonMain/fleet/rpc/client/RpcClient.kt
@@ -154,7 +154,7 @@ private class RpcClient(
         ))
     )
 
-    remoteResources.compute(parentService) { k, s -> s.orEmpty().toPersistentSet().add(instanceId to resource) }
+    remoteResources.compute(parentService) { k, s -> s.orEmpty().toPersistentSet().adding(instanceId to resource) }
     resourceParents.put(instanceId, parentService)
 
     return resource

--- a/fleet/util/core/srcCommonMain/fleet/util/async/Handle.kt
+++ b/fleet/util/core/srcCommonMain/fleet/util/async/Handle.kt
@@ -97,10 +97,10 @@ private suspend fun<T> handleScopeImpl(outerScope: CoroutineScope, body: suspend
         override val coroutineContext: CoroutineContext get() = context
         override fun <T> handle(launcher: Launcher<T>): Handle<T> {
           val handle = outerScope.handle(launcher)
-          handles.updateAndFetch { hs -> hs.add(handle) }
+          handles.updateAndFetch { hs -> hs.adding(handle) }
           handle.job.invokeOnCompletion {
             handles.updateAndFetch { hs ->
-              hs.remove(handle)
+              hs.removing(handle)
             }
           }
           return handle

--- a/java/compiler/impl/src/com/intellij/packaging/impl/elements/PackagingElementFactoryImpl.java
+++ b/java/compiler/impl/src/com/intellij/packaging/impl/elements/PackagingElementFactoryImpl.java
@@ -106,7 +106,7 @@ public final class PackagingElementFactoryImpl extends PackagingElementFactory {
 
   @Override
   public @NotNull List<PackagingElementType> getAllElementTypes() {
-    return toPersistentList(PackagingElementType.EP_NAME.getExtensionList()).addAll(STANDARD_TYPES);
+    return toPersistentList(PackagingElementType.EP_NAME.getExtensionList()).addingAll(STANDARD_TYPES);
   }
 
   @Override

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -8957,17 +8957,17 @@ jvm_import(
 )
 
 copy_file(
-    name = "org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm-0.4.0.jar_copy",
-    src = "@org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_4_0_http//file",
-    out = "org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm-0.4.0.jar",
+    name = "org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm-0.5.0.jar_copy",
+    src = "@org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_5_0_http//file",
+    out = "org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm-0.5.0.jar",
     allow_symlink = True,
     visibility = ["//visibility:public"],
 )
 
 jvm_import(
     name = "kotlinx-collections-immutable",
-    jar = "@org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_4_0_http//file",
-    source_jar = "@org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_4_0-sources_http//file",
+    jar = "@org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_5_0_http//file",
+    source_jar = "@org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_5_0-sources_http//file",
     visibility = ["//visibility:public"],
 )
 

--- a/lib/MODULE.bazel
+++ b/lib/MODULE.bazel
@@ -6952,17 +6952,17 @@ http_file(
 )
 
 http_file(
-    name = "org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_4_0_http",
-    downloaded_file_path = "kotlinx-collections-immutable-jvm-0.4.0.jar",
-    sha256 = "d767014ad0c9a27d27d26fd38e7afa030aee0d141338f108781ff02ecf2fdab5",
-    url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar",
+    name = "org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_5_0_http",
+    downloaded_file_path = "kotlinx-collections-immutable-jvm-0.5.0.jar",
+    sha256 = "9481ed3b87e282ffb95d7e2a033702afa3af476e3b89137294aeccebb27c76f7",
+    url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.5.0/kotlinx-collections-immutable-jvm-0.5.0.jar",
 )
 
 http_file(
-    name = "org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_4_0-sources_http",
-    downloaded_file_path = "kotlinx-collections-immutable-jvm-0.4.0-sources.jar",
-    sha256 = "b5100e18f87ea5014838482f550046bac26b23f6c32eb681bfccf6e8f736c9b0",
-    url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0-sources.jar",
+    name = "org_jetbrains_kotlinx-kotlinx-collections-immutable-jvm-0_5_0-sources_http",
+    downloaded_file_path = "kotlinx-collections-immutable-jvm-0.5.0-sources.jar",
+    sha256 = "49cc02cb15dac26a800e9cc35f3fc76e647a202eaddf979276dd9eed95d5bb87",
+    url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.5.0/kotlinx-collections-immutable-jvm-0.5.0-sources.jar",
 )
 
 http_file(

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildContextImpl.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildContextImpl.kt
@@ -258,7 +258,7 @@ class BuildContextImpl internal constructor(
     }
     if (!options.compatiblePluginsToIgnore.isEmpty()) {
       productProperties.productLayout.compatiblePluginsToIgnore =
-        productProperties.productLayout.compatiblePluginsToIgnore.addAll(options.compatiblePluginsToIgnore)
+        productProperties.productLayout.compatiblePluginsToIgnore.addingAll(options.compatiblePluginsToIgnore)
     }
     check(options.isInDevelopmentMode || bundledRuntime.prefix == productProperties.runtimeDistribution.artifactPrefix || LibcImpl.current(OsFamily.currentOs) == LinuxLibcImpl.MUSL) {
       "The runtime type doesn't match the one specified in the product properties: ${bundledRuntime.prefix} != ${productProperties.runtimeDistribution.artifactPrefix}"
@@ -521,7 +521,7 @@ class BuildContextImpl internal constructor(
 
   override fun addExtraExecutablePattern(os: OsFamily, pattern: String) {
     extraExecutablePatterns.updateAndGet { prev ->
-      prev.with(os, (prev.get(os) ?: persistentListOf()).add(pattern))
+      prev.with(os, (prev.get(os) ?: persistentListOf()).adding(pattern))
     }
   }
 

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/PluginLayout.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/PluginLayout.kt
@@ -383,7 +383,7 @@ class PluginLayout(val mainModule: String, @Internal @JvmField val auto: Boolean
     fun withPlatformExecutable(os: OsFamily, arch: JvmArchitecture, libc: LibcImpl, pattern: String) {
       val key = SupportedDistribution(os, arch, libc)
       val existing = layout.executablePatterns.get(key) ?: persistentListOf()
-      layout.executablePatterns = layout.executablePatterns.put(key, existing.add(pattern))
+      layout.executablePatterns = layout.executablePatterns.putting(key, existing.adding(pattern))
     }
 
     /**
@@ -519,7 +519,7 @@ class PluginLayout(val mainModule: String, @Internal @JvmField val auto: Boolean
      * @param relativeOutputFile target path relative to the plugin root directory
      */
     fun withResourceArchiveFromModule(moduleName: String, resourcePath: String, relativeOutputFile: String) {
-      layout.resourcePaths = layout.resourcePaths.add(ModuleResourceData(
+      layout.resourcePaths = layout.resourcePaths.adding(ModuleResourceData(
         moduleName = moduleName,
         resourcePath = resourcePath,
         relativeOutputPath = relativeOutputFile,

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/RuntimeDependencyTraversal.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/RuntimeDependencyTraversal.kt
@@ -42,7 +42,7 @@ fun collectTransitiveRuntimeDependencies(
   while (frontier.isNotEmpty()) {
     val nextFrontier = ArrayList<Pair<String, PersistentList<String>>>()
     for ((moduleName, dependencyChain) in frontier) {
-      val chain = dependencyChain.add(moduleName)
+      val chain = dependencyChain.adding(moduleName)
       for (dependencyName in dependencyResolver.getRuntimeDependencies(moduleName)) {
         if (!blockedOrSeen.add(dependencyName)) {
           continue

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/sign.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/sign.kt
@@ -186,7 +186,7 @@ internal suspend fun signMacBinaries(
   val span = spanBuilder("sign binaries for macOS distribution")
   span.setAttribute("contentType", "application/x-mac-app-bin")
   span.setAttribute(AttributeKey.stringArrayKey("files"), files.map { it.name })
-  val options = macSigningOptions(contentType = "application/x-mac-app-bin", context).putAll(additionalOptions)
+  val options = macSigningOptions(contentType = "application/x-mac-app-bin", context).puttingAll(additionalOptions)
   span.use {
     context.proprietaryBuildTools.signTool.signFiles(files, context, options)
     if (!permissions.isEmpty()) {

--- a/platform/core-api/src/com/intellij/lang/Language.java
+++ b/platform/core-api/src/com/intellij/lang/Language.java
@@ -123,17 +123,17 @@ public abstract class Language extends UserDataHolderBase {
         }
 
         PersistentList<Language> list = registeredMimeTypes.get(mimeType);
-        registeredMimeTypes = with(registeredMimeTypes, mimeType, list == null ? persistentListOf(this) : list.add(this));
+        registeredMimeTypes = with(registeredMimeTypes, mimeType, list == null ? persistentListOf(this) : list.adding(this));
       }
     }
 
     if (baseLanguage != null) {
       synchronized (baseLanguage.instanceLock) {
-        baseLanguage.dialects = baseLanguage.dialects.add(this);
+        baseLanguage.dialects = baseLanguage.dialects.adding(this);
       }
       while (baseLanguage != null) {
         synchronized (baseLanguage.instanceLock) {
-          baseLanguage.transitiveDialects = baseLanguage.transitiveDialects.add(this);
+          baseLanguage.transitiveDialects = baseLanguage.transitiveDialects.adding(this);
         }
         baseLanguage = baseLanguage.getBaseLanguage();
       }
@@ -186,11 +186,11 @@ public abstract class Language extends UserDataHolderBase {
   @ApiStatus.Internal
   public void unregisterDialect(@NotNull Language language) {
     synchronized (instanceLock) {
-      dialects = dialects.remove(language);
+      dialects = dialects.removing(language);
     }
     for (Language baseLanguage = this; baseLanguage != null; baseLanguage = baseLanguage.getBaseLanguage()) {
       synchronized (baseLanguage.instanceLock) {
-        baseLanguage.transitiveDialects = baseLanguage.transitiveDialects.remove(language);
+        baseLanguage.transitiveDialects = baseLanguage.transitiveDialects.removing(language);
       }
     }
   }
@@ -329,11 +329,11 @@ public abstract class Language extends UserDataHolderBase {
   @ApiStatus.Internal
   protected void registerDialect(@NotNull Language dialect) {
     synchronized (instanceLock) {
-      dialects = dialects.add(dialect);
+      dialects = dialects.adding(dialect);
     }
     for (Language baseLanguage = this; baseLanguage != null; baseLanguage = baseLanguage.getBaseLanguage()) {
       synchronized (baseLanguage.instanceLock) {
-        baseLanguage.transitiveDialects = baseLanguage.transitiveDialects.add(dialect);
+        baseLanguage.transitiveDialects = baseLanguage.transitiveDialects.adding(dialect);
       }
     }
   }

--- a/platform/core-api/src/com/intellij/lang/LanguageExtension.java
+++ b/platform/core-api/src/com/intellij/lang/LanguageExtension.java
@@ -134,7 +134,7 @@ public class LanguageExtension<T> extends KeyedExtensionCollector<T, Language> {
   private @NotNull PersistentList<T> collectAllForLanguage(@NotNull Language language) {
     PersistentList<T> result = persistentListOf();
     for (Language l = language; l != null; l = l.getBaseLanguage()) {
-      result = result.addAll(forKey(l));
+      result = result.addingAll(forKey(l));
     }
     return result;
   }
@@ -154,7 +154,7 @@ public class LanguageExtension<T> extends KeyedExtensionCollector<T, Language> {
 
     PersistentList<T> result = collectAllForLanguage(language);
     if (!result.contains(defaultImplementation)) {
-      result = result.add(defaultImplementation);
+      result = result.adding(defaultImplementation);
     }
     return language.putUserDataIfAbsent(allCacheWithDefaultKey, result);
   }

--- a/platform/core-api/src/com/intellij/openapi/util/ClassExtension.java
+++ b/platform/core-api/src/com/intellij/openapi/util/ClassExtension.java
@@ -35,10 +35,10 @@ public class ClassExtension<T> extends KeyedExtensionCollector<T, Class<?>> {
     synchronized (lock) {
       PersistentList<T> result = persistentListOf();
       for (String aSuper : supers) {
-        result = result.addAll(buildExtensionsFromExplicitRegistration(key -> aSuper.equals(key)));
+        result = result.addingAll(buildExtensionsFromExplicitRegistration(key -> aSuper.equals(key)));
       }
       for (String aSuper : supers) {
-        result = result.addAll(buildExtensionsFromExtensionPoint(bean -> aSuper.equals(bean.getKey()), extensions));
+        result = result.addingAll(buildExtensionsFromExtensionPoint(bean -> aSuper.equals(bean.getKey()), extensions));
       }
       return result;
     }

--- a/platform/core-api/src/com/intellij/openapi/util/KeyedExtensionCollector.java
+++ b/platform/core-api/src/com/intellij/openapi/util/KeyedExtensionCollector.java
@@ -89,7 +89,7 @@ public class KeyedExtensionCollector<T, KeyT> implements ModificationTracker {
     String stringKey = keyToString(key);
     synchronized (lock) {
       PersistentList<T> value = explicitExtensions.get(stringKey);
-      explicitExtensions = with(explicitExtensions, stringKey, value == null ? persistentListOf(t) : value.add(t));
+      explicitExtensions = with(explicitExtensions, stringKey, value == null ? persistentListOf(t) : value.adding(t));
       invalidateCacheForExtension(stringKey);
     }
   }
@@ -104,7 +104,7 @@ public class KeyedExtensionCollector<T, KeyT> implements ModificationTracker {
     synchronized (lock) {
       PersistentList<T> list = explicitExtensions.get(stringKey);
       if (list != null) {
-        list = list.remove(t);
+        list = list.removing(t);
         explicitExtensions = list.isEmpty() ? without(explicitExtensions, stringKey) : with(explicitExtensions, stringKey, list);
       }
       invalidateCacheForExtension(stringKey);
@@ -152,7 +152,7 @@ public class KeyedExtensionCollector<T, KeyT> implements ModificationTracker {
     synchronized (lock) {
       PersistentList<T> explicit = explicitExtensions.get(stringKey);
       List<T> result = buildExtensionsFromExtensionPoint(bean -> stringKey.equals(bean.getKey()), extensions);
-      return explicit == null ? result : explicit.addAll(result);
+      return explicit == null ? result : explicit.addingAll(result);
     }
   }
 
@@ -246,7 +246,7 @@ public class KeyedExtensionCollector<T, KeyT> implements ModificationTracker {
 
         return keys.contains(key);
       }, extensions);
-      return toPersistentList(explicit).addAll(result);
+      return toPersistentList(explicit).addingAll(result);
     }
   }
 
@@ -255,7 +255,7 @@ public class KeyedExtensionCollector<T, KeyT> implements ModificationTracker {
     for (Map.Entry<String, PersistentList<T>> entry : explicitExtensions.entrySet()) {
       String key = entry.getKey();
       if (isMyBean.test(key)) {
-        result = result.addAll(entry.getValue());
+        result = result.addingAll(entry.getValue());
       }
     }
     return result;

--- a/platform/core-api/src/com/intellij/psi/search/searches/SmartExtensionPoint.java
+++ b/platform/core-api/src/com/intellij/psi/search/searches/SmartExtensionPoint.java
@@ -65,14 +65,14 @@ final class SmartExtensionPoint<T> {
 
   public void addExplicitExtension(@NotNull T extension) {
     synchronized (lock) {
-      explicitExtensions = explicitExtensions.add(extension);
+      explicitExtensions = explicitExtensions.adding(extension);
       cache = null;
     }
   }
 
   public void removeExplicitExtension(@NotNull T extension) {
     synchronized (lock) {
-      explicitExtensions = explicitExtensions.remove(extension);
+      explicitExtensions = explicitExtensions.removing(extension);
       cache = null;
     }
   }
@@ -99,7 +99,7 @@ final class SmartExtensionPoint<T> {
 
       // EP will not add duplicated listener, so, it is safe to not care about is already added
       extensionPoint.addExtensionPointListener(extensionPointAndAreaListener, false, null);
-      result = explicitExtensions.isEmpty() ? extensions : explicitExtensions.addAll(extensions);
+      result = explicitExtensions.isEmpty() ? extensions : explicitExtensions.addingAll(extensions);
       cache = result;
       return result;
     }

--- a/platform/extensions/src/com/intellij/openapi/extensions/impl/ExtensionPointImpl.kt
+++ b/platform/extensions/src/com/intellij/openapi/extensions/impl/ExtensionPointImpl.kt
@@ -579,7 +579,7 @@ sealed class ExtensionPointImpl<T : Any>(@JvmField val name: String,
       adapters = mutateAdapters(adapters) { it.removeAt(i) }
 
       if (!listeners.isEmpty()) {
-        removedAdapters = removedAdapters.add(adapter)
+        removedAdapters = removedAdapters.adding(adapter)
       }
 
       if (stopAfterFirstMatch) {
@@ -715,7 +715,7 @@ sealed class ExtensionPointImpl<T : Any>(@JvmField val name: String,
     listenerUpdater.updateAndGet(this) {
       @Suppress("UNCHECKED_CAST")
       val list = it as PersistentList<ExtensionPointListener<T>>
-      if (listener is ExtensionPointPriorityListener) list.add(0, listener) else list.add(listener)
+      if (listener is ExtensionPointPriorityListener) list.addingAt(0, listener) else list.adding(listener)
     }
     return true
   }
@@ -745,7 +745,7 @@ sealed class ExtensionPointImpl<T : Any>(@JvmField val name: String,
 
     listenerUpdater.updateAndGet(this) {
       @Suppress("UNCHECKED_CAST")
-      (it as PersistentList<ExtensionPointListener<T>>).add(listenerAdapter)
+      (it as PersistentList<ExtensionPointListener<T>>).adding(listenerAdapter)
     }
     return listenerAdapter
   }
@@ -753,7 +753,7 @@ sealed class ExtensionPointImpl<T : Any>(@JvmField val name: String,
   final override fun removeExtensionPointListener(listener: ExtensionPointListener<T>) {
     listenerUpdater.updateAndGet(this) {
       @Suppress("UNCHECKED_CAST")
-      (it as PersistentList<ExtensionPointListener<T>>).remove(listener)
+      (it as PersistentList<ExtensionPointListener<T>>).removing(listener)
     }
   }
 
@@ -768,7 +768,7 @@ sealed class ExtensionPointImpl<T : Any>(@JvmField val name: String,
     }
 
     // help GC
-    listenerUpdater.updateAndGet(this) { it.clear() }
+    listenerUpdater.updateAndGet(this) { it.cleared() }
     extensionClass = null
   }
 

--- a/platform/instanceContainer/src/internal/InstanceContainerState.kt
+++ b/platform/instanceContainer/src/internal/InstanceContainerState.kt
@@ -38,7 +38,7 @@ internal class InstanceContainerState private constructor(
       }
 
       val holder = getByName(keyClass.name)
-      val newValue = cache.put(keyClass, notNullizer.notNullize(holder))
+      val newValue = cache.putting(keyClass, notNullizer.notNullize(holder))
       val witness = cacheHandle.compareAndExchange(this, cache, newValue)
       if (witness === cache) {
         return holder
@@ -77,7 +77,7 @@ internal class InstanceContainerState private constructor(
      */
     return InstanceContainerState(
       holders = holders.with(keyClass.name, holder),
-      cache = cache.put(keyClass, holder),
+      cache = cache.putting(keyClass, holder),
     )
   }
 

--- a/platform/instanceContainer/src/internal/LazyInstanceHolder.kt
+++ b/platform/instanceContainer/src/internal/LazyInstanceHolder.kt
@@ -220,7 +220,7 @@ internal abstract class LazyInstanceHolder(
           error("Unexpected state")
         }
         is InProgress -> {
-          val newState = state.copy(waiters = state.waiters.add(waiter))
+          val newState = state.copy(waiters = state.waiters.adding(waiter))
           val witness = stateHandle.compareAndExchange(this, state, newState)
           if (witness === state) {
             waiter.invokeOnCancellation {
@@ -277,7 +277,7 @@ internal abstract class LazyInstanceHolder(
           error("Unexpected state")
         }
         is InProgress -> {
-          val newState = state.copy(waiters = state.waiters.remove(waiter))
+          val newState = state.copy(waiters = state.waiters.removing(waiter))
           val witness = stateHandle.compareAndExchange(this, state, newState)
           if (witness === state) {
             return

--- a/platform/instanceContainer/src/internal/ScopeHolder.kt
+++ b/platform/instanceContainer/src/internal/ScopeHolder.kt
@@ -39,7 +39,7 @@ class ScopeHolder(
       it.attachAsChildTo(pluginScope)
     }
     while (true) {
-      val newScopes = scopes.put(pluginScope, intersectionScope)
+      val newScopes = scopes.putting(pluginScope, intersectionScope)
       val witness = _registeredScopes.compareAndExchange(scopes, newScopes)
       if (witness === scopes) {
         intersectionScope.coroutineContext.job.invokeOnCompletion {
@@ -61,7 +61,7 @@ class ScopeHolder(
 
   private fun unregisterScope(scope: CoroutineScope) {
     _registeredScopes.updateAndGet { scopes ->
-      scopes.remove(scope)
+      scopes.removing(scope)
     }
   }
 }

--- a/platform/lang-impl/src/com/intellij/util/indexing/IndexingProgressReporter.kt
+++ b/platform/lang-impl/src/com/intellij/util/indexing/IndexingProgressReporter.kt
@@ -108,9 +108,9 @@ internal class IndexingProgressReporter {
       // First add, then remove. To avoid blinking if old text is the only text in the list
       // We insert to the beginning to make sure that the text is rendered immediately. Otherwise, there will be an impression that
       // indexing is slow, if the text does not change often enough.
-      subTaskTexts.update { it.add(0, value) }
+      subTaskTexts.update { it.addingAt(0, value) }
       if (oldText != null) {
-        subTaskTexts.update { it.remove(oldText!! /* this class should be used from single thread */) }
+        subTaskTexts.update { it.removing(oldText!! /* this class should be used from single thread */) }
       }
       oldText = value
     }
@@ -118,7 +118,7 @@ internal class IndexingProgressReporter {
     override fun close() {
       subTasksFinished.update { it + 1 }
       if (oldText != null) {
-        subTaskTexts.update { it.remove(oldText!! /* this class should be used from single thread */) }
+        subTaskTexts.update { it.removing(oldText!! /* this class should be used from single thread */) }
         oldText = null
       }
     }

--- a/platform/lang-impl/src/com/intellij/util/indexing/PerProjectIndexingQueue.kt
+++ b/platform/lang-impl/src/com/intellij/util/indexing/PerProjectIndexingQueue.kt
@@ -57,13 +57,13 @@ class PerProjectIndexingQueue(private val project: Project) {
 
     internal fun addFile(file: VirtualFile, scanningId: Long) {
       scanningIdsSoFar.add(scanningId)
-      requestsSoFar.update { it.add(FileIndexingRequest.updateRequest(file)) }
+      requestsSoFar.update { it.adding(FileIndexingRequest.updateRequest(file)) }
     }
 
     @Deprecated("Indexing should always start with scanning. You don't need this method - do scanning instead")
     internal fun addRequests(files: Collection<FileIndexingRequest>, scanningId: Collection<Long>) {
       scanningIdsSoFar.addAll(scanningId)
-      requestsSoFar.update { it.addAll(files) }
+      requestsSoFar.update { it.addingAll(files) }
     }
 
     fun asChannel(cs: CoroutineScope, bufferSize: Int): Channel<FileIndexingRequest> {

--- a/platform/lang-impl/src/com/intellij/util/indexing/UnindexedFilesScannerExecutorImpl.kt
+++ b/platform/lang-impl/src/com/intellij/util/indexing/UnindexedFilesScannerExecutorImpl.kt
@@ -427,12 +427,12 @@ class UnindexedFilesScannerExecutorImpl(private val project: Project, cs: Corout
    */
   @Suppress("OVERRIDE_DEPRECATION")
   override fun suspendScanningAndIndexingThenRun(activityName: @ProgressText String, runnable: Runnable) {
-    pauseReason.update { it.add(activityName) }
+    pauseReason.update { it.adding(activityName) }
     try {
       DumbService.getInstance(project).suspendIndexingAndRun(activityName, runnable)
     }
     finally {
-      pauseReason.update { it.remove(activityName) }
+      pauseReason.update { it.removing(activityName) }
     }
   }
 
@@ -440,12 +440,12 @@ class UnindexedFilesScannerExecutorImpl(private val project: Project, cs: Corout
     activityName: @ProgressText String,
     activity: suspend CoroutineScope.() -> Unit,
   ) {
-    pauseReason.update { it.add(activityName) }
+    pauseReason.update { it.adding(activityName) }
     try {
       project.serviceAsync<DumbService>().suspendIndexingAndRun(activityName, activity)
     }
     finally {
-      pauseReason.update { it.remove(activityName) }
+      pauseReason.update { it.removing(activityName) }
     }
   }
 

--- a/platform/lang-impl/src/com/intellij/util/indexing/diagnostic/ProjectIndexingHistoryImpl.kt
+++ b/platform/lang-impl/src/com/intellij/util/indexing/diagnostic/ProjectIndexingHistoryImpl.kt
@@ -77,7 +77,7 @@ data class ProjectScanningHistoryImpl(override val project: Project,
 
   fun addScanningStatistics(statistics: ScanningStatistics) {
     val jsonStatistics = statistics.toJsonStatistics()
-    scanningStatisticsItems.updateAndGet { it.add(jsonStatistics) }
+    scanningStatisticsItems.updateAndGet { it.adding(jsonStatistics) }
   }
 
   private sealed interface Event {

--- a/platform/platform-impl/src/com/intellij/ide/HoverService.java
+++ b/platform/platform-impl/src/com/intellij/ide/HoverService.java
@@ -39,7 +39,7 @@ final class HoverService {
         Component component = getDeepestComponentAt(parent, event.getX(), event.getY());
         while (component != null && !(component instanceof Window)) {
           if (!HoverListener.getAll(component).isEmpty()) {
-            components = components.add(0, component);
+            components = components.addingAt(0, component);
           }
           component = component.getParent();
         }

--- a/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/PreCachedDataContext.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/actionSystem/impl/PreCachedDataContext.kt
@@ -595,7 +595,7 @@ private fun composeKeyedProvider(
     data
   }
   existing !is KeyedDataProvider && lazyKey != null -> {
-    KeyedDataProvider(persistentHashMapOf<String, DataProvider>().put(lazyKey.name, data), existing)
+    KeyedDataProvider(persistentHashMapOf<String, DataProvider>().putting(lazyKey.name, data), existing)
   }
   existing is KeyedDataProvider && lazyKey == null -> {
     val first = if (toFront) data else existing
@@ -606,7 +606,7 @@ private fun composeKeyedProvider(
     val existingByKey = existing.map[lazyKey.name]
     val first = if (toFront) data else existingByKey
     val second = if (toFront) existingByKey else data
-    KeyedDataProvider((existing.map as PersistentMap).put(
+    KeyedDataProvider((existing.map as PersistentMap).putting(
       lazyKey.name, if (first == null) second!! else CompositeDataProvider.compose(first, second)), existing.generic)
   }
   else -> {

--- a/platform/platform-impl/src/com/intellij/openapi/client/ClientSessionImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/client/ClientSessionImpl.kt
@@ -73,7 +73,7 @@ abstract class ClientSessionImpl(
 
   override val supportedSignaturesOfLightServiceConstructors: List<MethodType> = persistentListOf(
     sessionConstructorMethodType,
-  ).addAll(super.supportedSignaturesOfLightServiceConstructors)
+  ).addingAll(super.supportedSignaturesOfLightServiceConstructors)
 
   fun preloadServices(syncScope: CoroutineScope) {
     assert(containerState.get() == ContainerState.PRE_INIT)
@@ -193,7 +193,7 @@ abstract class ClientAppSessionImpl(
   override val supportedSignaturesOfLightServiceConstructors: List<MethodType> = persistentListOf(
     appSessionConstructorMethodType,
     appSessionAndScopeConstructorMethodType
-  ).addAll(super.supportedSignaturesOfLightServiceConstructors)
+  ).addingAll(super.supportedSignaturesOfLightServiceConstructors)
 }
 
 private val sessionConstructorMethodType = MethodType.methodType(Void.TYPE, ClientAppSession::class.java)
@@ -231,7 +231,7 @@ open class ClientProjectSessionImpl(
     projectAndScopeMethodType,
     projectSessionConstructorMethodType,
     projectSessionAndScopeConstructorMethodType,
-  ).addAll(super.supportedSignaturesOfLightServiceConstructors)
+  ).addingAll(super.supportedSignaturesOfLightServiceConstructors)
 
   override fun getContainerDescriptor(pluginDescriptor: IdeaPluginDescriptorImpl): ContainerDescriptor {
     return pluginDescriptor.projectContainerDescriptor

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/HistoryEntry.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/HistoryEntry.kt
@@ -78,7 +78,7 @@ internal class HistoryEntry(
   fun getState(provider: FileEditorProvider): FileEditorState? = providerToState.get(provider)
 
   fun putState(provider: FileEditorProvider, state: FileEditorState) {
-    providerToState = providerToState.toPersistentMap().put(provider, state)
+    providerToState = providerToState.toPersistentMap().putting(provider, state)
   }
 
   fun destroy() {
@@ -120,7 +120,7 @@ internal class HistoryEntry(
     if (selectedProvider === provider) {
       selectedProvider = null
     }
-    providerToState = providerToState.toPersistentMap().remove(provider)
+    providerToState = providerToState.toPersistentMap().removing(provider)
   }
 }
 
@@ -156,7 +156,7 @@ private fun parseEntry(
     if (file != null) {
       val stateElement = providerElement.getChild(STATE_ELEMENT)
       val state = provider.readState(stateElement ?: EMPTY_ELEMENT, project, file)
-      providerStates = providerStates.add(provider to state)
+      providerStates = providerStates.adding(provider to state)
     }
   }
 

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/ToolWindowImpl.kt
@@ -645,7 +645,7 @@ private val LOG = logger<ToolWindowManagerImpl>()
       contentManager.value.addContentManagerListener(listener)
     }
     else {
-      pendingContentManagerListeners = pendingContentManagerListeners.add(listener)
+      pendingContentManagerListeners = pendingContentManagerListeners.adding(listener)
     }
   }
 

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/status/ChildStatusBarManager.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/status/ChildStatusBarManager.kt
@@ -39,11 +39,11 @@ internal class ChildStatusBarManager(
     bar.isVisible = parent.isVisible
 
     synchronized(parent) {
-      children = children.add(bar)
+      children = children.adding(bar)
     }
     coroutineScope.coroutineContext.job.invokeOnCompletion {
       synchronized(parent) {
-        children = children.remove(bar)
+        children = children.removing(bar)
       }
     }
 

--- a/platform/testFramework/core/src/com/intellij/testFramework/ErrorLog.kt
+++ b/platform/testFramework/core/src/com/intellij/testFramework/ErrorLog.kt
@@ -11,7 +11,7 @@ internal class ErrorLog {
   fun recordLoggedError(message: String?, t: Throwable?) {
     val logged = LoggedError(message, t)
     errors.updateAndGet {
-      it.add(logged)
+      it.adding(logged)
     }
   }
 

--- a/platform/util/coroutines/src/sync/OverflowSemaphore.kt
+++ b/platform/util/coroutines/src/sync/OverflowSemaphore.kt
@@ -169,14 +169,14 @@ private class DropOldestSemaphore(private val permits: Int) : DropOldestSemaphor
     while (true) {
       val activeJobs = _activeJobs.get()
       if (activeJobs.size < permits) {
-        val newJobs = activeJobs.add(currentJob)
+        val newJobs = activeJobs.adding(currentJob)
         if (_activeJobs.compareAndSet(activeJobs, newJobs)) {
           return null
         }
       }
       else {
         val oldestJob = activeJobs.first() // rely on ordering
-        val newJobs = activeJobs.remove(oldestJob).add(currentJob)
+        val newJobs = activeJobs.removing(oldestJob).adding(currentJob)
         if (_activeJobs.compareAndSet(activeJobs, newJobs)) {
           return oldestJob
         }
@@ -187,7 +187,7 @@ private class DropOldestSemaphore(private val permits: Int) : DropOldestSemaphor
   override fun removeCurrentJob(currentJob: Job) {
     while (true) {
       val activeJobs = _activeJobs.get()
-      val newJobs = activeJobs.remove(currentJob)
+      val newJobs = activeJobs.removing(currentJob)
       if (newJobs === activeJobs) {
         return // Job was already removed
       }

--- a/platform/workspace/storage/src/com/intellij/platform/workspace/storage/impl/WorkspaceBuilderChangeLog.kt
+++ b/platform/workspace/storage/src/com/intellij/platform/workspace/storage/impl/WorkspaceBuilderChangeLog.kt
@@ -95,7 +95,7 @@ internal class WorkspaceBuilderChangeLog {
       val newAddedParents = if (replaceEntity.references != null) {
         if (!replaceEntity.references.newParents.contains(newConnectionId, newParentId)
             && !replaceEntity.references.removedParents.contains(newConnectionId, newParentId)) {
-          replaceEntity.references.newParents.put(newConnectionId, newParentId)
+          replaceEntity.references.newParents.putting(newConnectionId, newParentId)
         }
         else {
           replaceEntity.references.newParents
@@ -104,7 +104,7 @@ internal class WorkspaceBuilderChangeLog {
       else persistentHashMapOf(newConnectionId to newParentId)
 
       val newRemovedParents = if (replaceEntity.references != null) {
-        replaceEntity.references.removedParents.remove(newConnectionId, newParentId)
+        replaceEntity.references.removedParents.removing(newConnectionId, newParentId)
       }
       else persistentHashMapOf()
 
@@ -160,14 +160,14 @@ internal class WorkspaceBuilderChangeLog {
       val newRemovedParents = if (replaceEntity.references != null) {
         if (!replaceEntity.references.removedParents.contains(removedConnectionId, removedParentId)
             && !replaceEntity.references.newParents.contains(removedConnectionId, removedParentId)) {
-          replaceEntity.references.removedParents.put(removedConnectionId, removedParentId)
+          replaceEntity.references.removedParents.putting(removedConnectionId, removedParentId)
         }
         else replaceEntity.references.removedParents
       }
       else persistentHashMapOf(removedConnectionId to removedParentId)
 
       val newAddedParents = if (replaceEntity.references != null) {
-        replaceEntity.references.newParents.remove(removedConnectionId, removedParentId)
+        replaceEntity.references.newParents.removing(removedConnectionId, removedParentId)
       }
       else persistentHashMapOf()
 
@@ -223,7 +223,7 @@ internal class WorkspaceBuilderChangeLog {
       val connectionToId = addedChildConnectionId to addedChildId
       val newAddedChildren = if (replaceEntity.references != null) {
         if (connectionToId !in replaceEntity.references.newChildren && connectionToId !in replaceEntity.references.removedChildren) {
-          replaceEntity.references.newChildren.add(connectionToId)
+          replaceEntity.references.newChildren.adding(connectionToId)
         }
         else {
           replaceEntity.references.newChildren
@@ -233,12 +233,12 @@ internal class WorkspaceBuilderChangeLog {
         persistentHashSetOf(connectionToId)
       }
       val newRemovedChildren = if (replaceEntity.references != null) {
-        replaceEntity.references.removedChildren.remove(connectionToId)
+        replaceEntity.references.removedChildren.removing(connectionToId)
       }
       else persistentHashSetOf()
 
       val newOrder = if (replaceEntity.references != null) {
-        replaceEntity.references.childrenOrdering.getOrElse(addedChildConnectionId) { persistentSetOf() }.add(addedChildId)
+        replaceEntity.references.childrenOrdering.getOrElse(addedChildConnectionId) { persistentSetOf() }.adding(addedChildId)
       } else {
         persistentSetOf(addedChildId)
       }
@@ -248,7 +248,7 @@ internal class WorkspaceBuilderChangeLog {
           if (replaceEntity.data == null) null else replaceEntity.copy(references = null)
         }
         else {
-          val ordering = replaceEntity.references.childrenOrdering.put(addedChildConnectionId, newOrder)
+          val ordering = replaceEntity.references.childrenOrdering.putting(addedChildConnectionId, newOrder)
           replaceEntity.copy(
             references = replaceEntity.references.copy(newChildren = newAddedChildren, removedChildren = newRemovedChildren,
                                                        childrenOrdering = ordering))
@@ -302,7 +302,7 @@ internal class WorkspaceBuilderChangeLog {
 
       val newRemovedChildren = if (replaceEntity.references != null) {
         if (connectionToId !in replaceEntity.references.removedChildren && connectionToId !in replaceEntity.references.newChildren) {
-          replaceEntity.references.removedChildren.add(connectionToId)
+          replaceEntity.references.removedChildren.adding(connectionToId)
         }
         else {
           replaceEntity.references.removedChildren
@@ -311,12 +311,12 @@ internal class WorkspaceBuilderChangeLog {
       else persistentHashSetOf(connectionToId)
 
       val newAddedChildren = if (replaceEntity.references != null) {
-        replaceEntity.references.newChildren.remove(connectionToId)
+        replaceEntity.references.newChildren.removing(connectionToId)
       }
       else persistentHashSetOf()
 
       val newOrder = if (replaceEntity.references != null) {
-        replaceEntity.references.childrenOrdering.getOrElse(removedChildConnectionId) { persistentSetOf() }.remove(removedChildId)
+        replaceEntity.references.childrenOrdering.getOrElse(removedChildConnectionId) { persistentSetOf() }.removing(removedChildId)
       } else {
         persistentSetOf()
       }
@@ -326,7 +326,7 @@ internal class WorkspaceBuilderChangeLog {
           if (replaceEntity.data == null) null else replaceEntity.copy(references = null)
         }
         else {
-          val ordering = replaceEntity.references.childrenOrdering.put(removedChildConnectionId, newOrder)
+          val ordering = replaceEntity.references.childrenOrdering.putting(removedChildConnectionId, newOrder)
           replaceEntity.copy(references = replaceEntity.references.copy(
             newChildren = newAddedChildren,
             removedChildren = newRemovedChildren,

--- a/platform/workspace/storage/src/com/intellij/platform/workspace/storage/impl/containers/PersistentBidirectionalMapImpl.kt
+++ b/platform/workspace/storage/src/com/intellij/platform/workspace/storage/impl/containers/PersistentBidirectionalMapImpl.kt
@@ -81,7 +81,7 @@ internal class PersistentBidirectionalMapImpl<K, V>(
         }
 
         val keys = valueToKeysMap[prevValue]!!
-        val newKeys = keys.remove(key)
+        val newKeys = keys.removing(key)
         if (newKeys.isEmpty()) {
           valueToKeysMap.remove(prevValue)
         }
@@ -91,7 +91,7 @@ internal class PersistentBidirectionalMapImpl<K, V>(
       }
 
       val existingKeys = valueToKeysMap[value]
-      val newKeys = existingKeys?.add(key) ?: persistentListOf(key)
+      val newKeys = existingKeys?.adding(key) ?: persistentListOf(key)
       valueToKeysMap[value] = newKeys
       return prevValue
     }
@@ -104,7 +104,7 @@ internal class PersistentBidirectionalMapImpl<K, V>(
       check(keys.isNotEmpty()) { "Map is broken. Cannot find keys of removed value." }
 
       if (keys.size > 1) {
-        val updatedKeysList = keys.remove(key)
+        val updatedKeysList = keys.removing(key)
         valueToKeysMap[value] = updatedKeysList
       }
       else {

--- a/platform/workspace/storage/src/com/intellij/platform/workspace/storage/impl/indices/VirtualFileIndex.kt
+++ b/platform/workspace/storage/src/com/intellij/platform/workspace/storage/impl/indices/VirtualFileIndex.kt
@@ -200,14 +200,14 @@ public open class VirtualFileIndex internal constructor(
             if (existingVfu != null) {
               val cleanedVfu = cleanExistingVfu(existingVfu)
               val newPropertyVfu = if (cleanedVfu == null) {
-                property2Vfu.remove(propertyName)
+                property2Vfu.removing(propertyName)
               } else {
-                property2Vfu.put(propertyName, cleanedVfu)
+                property2Vfu.putting(propertyName, cleanedVfu)
               }
               if (newPropertyVfu.isEmpty()) {
-                entityId2VirtualFileUrl = entityId2VirtualFileUrl.remove(id)
+                entityId2VirtualFileUrl = entityId2VirtualFileUrl.removing(id)
               } else {
-                entityId2VirtualFileUrl = entityId2VirtualFileUrl.put(id, newPropertyVfu)
+                entityId2VirtualFileUrl = entityId2VirtualFileUrl.putting(id, newPropertyVfu)
               }
             }
           }
@@ -216,9 +216,9 @@ public open class VirtualFileIndex internal constructor(
             if (existingPropertyName == propertyName) {
               val cleanedVfu = cleanExistingVfu(property2Vfu.second!!)
               if (cleanedVfu == null) {
-                entityId2VirtualFileUrl = entityId2VirtualFileUrl.remove(id)
+                entityId2VirtualFileUrl = entityId2VirtualFileUrl.removing(id)
               } else {
-                entityId2VirtualFileUrl = entityId2VirtualFileUrl.put(id, Pair(propertyName, cleanedVfu))
+                entityId2VirtualFileUrl = entityId2VirtualFileUrl.putting(id, Pair(propertyName, cleanedVfu))
               }
               
             }
@@ -255,7 +255,7 @@ public open class VirtualFileIndex internal constructor(
       startWrite()
       entityId2JarDir.removeKey(id)
       val removedProperty2Vfu = entityId2VirtualFileUrl[id] ?: return
-      entityId2VirtualFileUrl = entityId2VirtualFileUrl.remove(id)
+      entityId2VirtualFileUrl = entityId2VirtualFileUrl.removing(id)
       when (removedProperty2Vfu) {
         is Pair<*, *> -> removeFromVfu2EntityIdMap(id, removedProperty2Vfu.first as String, removedProperty2Vfu.second!!)
         is Map<*, *> -> removedProperty2Vfu.forEach { (property, vfu) ->
@@ -268,7 +268,7 @@ public open class VirtualFileIndex internal constructor(
     @TestOnly
     internal fun clear() {
       startWrite()
-      entityId2VirtualFileUrl = entityId2VirtualFileUrl.clear()
+      entityId2VirtualFileUrl = entityId2VirtualFileUrl.cleared()
       vfu2EntityId.clear()
       entityId2JarDir.clear()
     }
@@ -296,7 +296,7 @@ public open class VirtualFileIndex internal constructor(
     private fun addVfuToExisting(vfu: Any, virtualFileUrl: VirtualFileUrl): Set<VirtualFileUrl> {
       when (vfu) {
         is Set<*> -> {
-          return (vfu as PersistentSet<VirtualFileUrl>).add(virtualFileUrl)
+          return (vfu as PersistentSet<VirtualFileUrl>).adding(virtualFileUrl)
         }
         is VirtualFileUrl -> {
           return persistentHashSetOf(vfu, virtualFileUrl)
@@ -314,11 +314,11 @@ public open class VirtualFileIndex internal constructor(
             property2Vfu as PersistentMap<String, Any>
             val vfu = property2Vfu[propertyName]
             if (vfu == null) {
-              property2Vfu.put(propertyName, virtualFileUrl)
+              property2Vfu.putting(propertyName, virtualFileUrl)
             }
             else {
               val newVfu = addVfuToExisting(vfu, virtualFileUrl)
-              property2Vfu.put(propertyName, newVfu)
+              property2Vfu.putting(propertyName, newVfu)
             }
           }
           is Pair<*, *> -> {
@@ -333,10 +333,10 @@ public open class VirtualFileIndex internal constructor(
           }
           else -> throw WrongProperty2VfuInfoTypeException(property2Vfu::class.java.canonicalName)
         }
-        entityId2VirtualFileUrl = entityId2VirtualFileUrl.put(id, newProperty2Vfu)
+        entityId2VirtualFileUrl = entityId2VirtualFileUrl.putting(id, newProperty2Vfu)
       }
       else {
-        entityId2VirtualFileUrl = entityId2VirtualFileUrl.put(id, Pair(propertyName, virtualFileUrl))
+        entityId2VirtualFileUrl = entityId2VirtualFileUrl.putting(id, Pair(propertyName, virtualFileUrl))
       }
 
       val property2EntityId = vfu2EntityId.getOrDefault(virtualFileUrl, Object2LongWithDefaultMap())
@@ -350,18 +350,18 @@ public open class VirtualFileIndex internal constructor(
         is Map<*, *> -> {
           property2vfu as PersistentMap<String, Any>
           val removedVfu = property2vfu[propertyName] ?: return
-          val newProperty2Vfu = property2vfu.remove(propertyName)
+          val newProperty2Vfu = property2vfu.removing(propertyName)
           if (newProperty2Vfu.isEmpty()) {
-            entityId2VirtualFileUrl = entityId2VirtualFileUrl.remove(id)
+            entityId2VirtualFileUrl = entityId2VirtualFileUrl.removing(id)
           } else {
-            entityId2VirtualFileUrl = entityId2VirtualFileUrl.put(id, newProperty2Vfu)
+            entityId2VirtualFileUrl = entityId2VirtualFileUrl.putting(id, newProperty2Vfu)
           }
           removeFromVfu2EntityIdMap(id, propertyName, removedVfu)
         }
         is Pair<*, *> -> {
           val existingPropertyName = property2vfu.first as String
           if (existingPropertyName != propertyName) return
-          entityId2VirtualFileUrl = entityId2VirtualFileUrl.remove(id)
+          entityId2VirtualFileUrl = entityId2VirtualFileUrl.removing(id)
           removeFromVfu2EntityIdMap(id, propertyName, property2vfu.second!!)
         }
         else -> throw WrongProperty2VfuInfoTypeException(property2vfu::class.java.canonicalName)

--- a/plugins/compilation-charts/src/com/intellij/compilation/charts/impl/CompilationChartsImpl.kt
+++ b/plugins/compilation-charts/src/com/intellij/compilation/charts/impl/CompilationChartsImpl.kt
@@ -146,7 +146,7 @@ class CompilationChartsImpl(
     fun add(event: ModuleChartEvent) {
       if (start > event.nanoTime()) start = event.nanoTime()
       if (end < event.nanoTime()) end = event.nanoTime()
-      events.compute(event.key()) { _, list -> list?.add(event) ?: persistentListOf(event) }
+      events.compute(event.key()) { _, list -> list?.adding(event) ?: persistentListOf(event) }
     }
     fun ModuleChartEvent.key(): ModuleKey = ModuleKey(name(), type(), isTest(), threadId())
   }

--- a/plugins/kotlin/code-insight/kotlin.code-insight.k2/src/org/jetbrains/kotlin/idea/k2/codeinsight/hints/compilerPlugins/declaration/CompilerPluginDeclarationHighlighter.kt
+++ b/plugins/kotlin/code-insight/kotlin.code-insight.k2/src/org/jetbrains/kotlin/idea/k2/codeinsight/hints/compilerPlugins/declaration/CompilerPluginDeclarationHighlighter.kt
@@ -148,7 +148,7 @@ internal object CompilerPluginDeclarationHighlighter {
 
         private fun withNewTag(tag: TokenTag, action: () -> Unit) {
             val oldTags = tagsInTheCurrentScope
-            tagsInTheCurrentScope = tagsInTheCurrentScope.add(tag)
+            tagsInTheCurrentScope = tagsInTheCurrentScope.adding(tag)
             try {
                 action()
             } finally {

--- a/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/preferences/PreferencesRegistryImpl.kt
+++ b/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/preferences/PreferencesRegistryImpl.kt
@@ -20,7 +20,7 @@ class PreferencesRegistryBuilder(private val weigher: TextMateSelectorWeigher) {
     fillHighlightingBraces(preferences.highlightingPairs)
     fillSmartTypingBraces(preferences.smartTypingPairs)
     this.preferences.update {
-      it.add(preferences)
+      it.adding(preferences)
     }
   }
 
@@ -28,10 +28,10 @@ class PreferencesRegistryBuilder(private val weigher: TextMateSelectorWeigher) {
     if (highlightingPairs != null) {
       for (pair in highlightingPairs) {
         if (!pair.left.isEmpty()) {
-          leftHighlightingBraces.update { it.add(pair.left[0].code) }
+          leftHighlightingBraces.update { it.adding(pair.left[0].code) }
         }
         if (!pair.right.isEmpty()) {
-          rightHighlightingBraces.update { it.add(pair.right[pair.right.length - 1].code) }
+          rightHighlightingBraces.update { it.adding(pair.right[pair.right.length - 1].code) }
         }
       }
     }
@@ -41,10 +41,10 @@ class PreferencesRegistryBuilder(private val weigher: TextMateSelectorWeigher) {
     if (smartTypingPairs != null) {
       for (pair in smartTypingPairs) {
         if (!pair.left.isEmpty()) {
-          leftSmartTypingBraces.update { it.add(pair.left[pair.left.length - 1].code) }
+          leftSmartTypingBraces.update { it.adding(pair.left[pair.left.length - 1].code) }
         }
         if (!pair.right.isEmpty()) {
-          rightSmartTypingBraces.update { it.add(pair.right[pair.right.length - 1].code) }
+          rightSmartTypingBraces.update { it.adding(pair.right[pair.right.length - 1].code) }
         }
       }
     }

--- a/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/preferences/ShellVariablesRegistryImpl.kt
+++ b/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/preferences/ShellVariablesRegistryImpl.kt
@@ -15,7 +15,7 @@ class ShellVariablesRegistryBuilder(private val weigher: TextMateSelectorWeigher
   fun addVariable(variable: TextMateShellVariable) {
     if (variable.name.isNotEmpty()) {
       variables.update {
-        it.put(variable.name, it[variable.name]?.add(variable) ?: persistentListOf(variable))
+        it.putting(variable.name, it[variable.name]?.adding(variable) ?: persistentListOf(variable))
       }
     }
   }

--- a/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/preferences/SnippetsRegistryImpl.kt
+++ b/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/preferences/SnippetsRegistryImpl.kt
@@ -14,7 +14,7 @@ class SnippetsRegistryBuilder(private val weigher: TextMateSelectorWeigher) {
 
   fun register(snippet: TextMateSnippet) {
     snippets.update {
-      it.put(snippet.key, it[snippet.key]?.add(snippet) ?: persistentListOf(snippet))
+      it.putting(snippet.key, it[snippet.key]?.adding(snippet) ?: persistentListOf(snippet))
     }
   }
 

--- a/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/syntax/TextMateSyntaxTableBuilder.kt
+++ b/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/syntax/TextMateSyntaxTableBuilder.kt
@@ -28,7 +28,7 @@ class TextMateSyntaxTableBuilder(private val interner: TextMateInterner) {
   fun addSyntax(plist: Plist): CharSequence? {
     return loadLanguageDescriptor(plist)?.let { languageDescriptor ->
       syntaxNodes.update {
-        it.put(languageDescriptor.scopeName, languageDescriptor)
+        it.putting(languageDescriptor.scopeName, languageDescriptor)
       }
       languageDescriptor.scopeName
     }

--- a/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/syntax/lexer/TextMateLexerCore.kt
+++ b/plugins/textmate/core/src/org/jetbrains/plugins/textmate/language/syntax/lexer/TextMateLexerCore.kt
@@ -120,7 +120,7 @@ class TextMateLexerCore(
         var whileStates = states
         while (!whileStates.isEmpty()) {
           val whileState = whileStates.last()
-          whileStates = whileStates.removeAt(whileStates.size - 1)
+          whileStates = whileStates.removingAt(whileStates.size - 1)
           if (whileState.syntaxRule.getStringAttribute(Constants.StringKey.WHILE) != null) {
             val matchWhile = mySyntaxMatcher.matchStringRegex(keyName = Constants.StringKey.WHILE,
                                                               string = string,
@@ -178,7 +178,7 @@ class TextMateLexerCore(
             // if begin hasn't matched EOL, it was performed on the same line; we need to use its anchor
             anchorByteOffset = poppedState.matchData.byteRange().end
           }
-          states = states.removeAt(states.size - 1)
+          states = states.removingAt(states.size - 1)
 
           val endRange = endMatch.charRange(string)
           endPosition = endRange.start
@@ -206,7 +206,7 @@ class TextMateLexerCore(
           endPosition = currentRange.end
 
           if (currentRule.getStringAttribute(Constants.StringKey.BEGIN) != null) {
-            states = states.add(currentState)
+            states = states.adding(currentState)
 
             val name = getStringAttribute(Constants.StringKey.NAME, currentRule, string, currentMatch)
             openScopeSelector(output, name, startPosition + lineStartOffset)
@@ -333,7 +333,7 @@ class TextMateLexerCore(
                                                 line = capturedTextMateString)
           parseLine(line = capturedString,
                     output = output,
-                    states = states.add(captureState),
+                    states = states.adding(captureState),
                     lineStartOffset = startLineOffset,
                     linePosition = captureRange.start,
                     lineByteOffset = byteRange.start,

--- a/plugins/textmate/core/tests/src/org/jetbrains/plugins/textmate/cache/SLRUTextMateCacheTest.kt
+++ b/plugins/textmate/core/tests/src/org/jetbrains/plugins/textmate/cache/SLRUTextMateCacheTest.kt
@@ -259,9 +259,9 @@ class SLRUTextMateCacheTest {
             assertEquals("value-key-$taskId", value)
             "result-$taskId"
           }
-          results.update { it.add(result) }
+          results.update { it.adding(result) }
         }.onFailure { e ->
-          exceptions.update { it.add(e) }
+          exceptions.update { it.adding(e) }
         }
       }
     }
@@ -291,7 +291,7 @@ class SLRUTextMateCacheTest {
           cache.get("evict-key-${counter++}").close()
           realDelay(1.milliseconds)
         }.onFailure { e ->
-          exceptions.update { it.add(e) }
+          exceptions.update { it.adding(e) }
         }
       }
     }
@@ -306,7 +306,7 @@ class SLRUTextMateCacheTest {
               value
             }
           }.onFailure { e ->
-            exceptions.update { it.add(e) }
+            exceptions.update { it.adding(e) }
           }
         }
       }
@@ -335,7 +335,7 @@ class SLRUTextMateCacheTest {
           cache.cleanup()
           realDelay(10.milliseconds)
         }.onFailure { e ->
-          exceptions.update { it.add(e) }
+          exceptions.update { it.adding(e) }
         }
       }
     }
@@ -348,7 +348,7 @@ class SLRUTextMateCacheTest {
             cache.get("key-$coroutineId-$iteration").close()
             realDelay(1.milliseconds)
           }.onFailure { e ->
-            exceptions.update { it.add(e) }
+            exceptions.update { it.adding(e) }
           }
         }
       }
@@ -395,7 +395,7 @@ class SLRUTextMateCacheTest {
             // Small random delay
             realDelay((0..5).random().milliseconds)
           }.onFailure { e ->
-            exceptions.update { it.add(e) }
+            exceptions.update { it.adding(e) }
           }
         }
       }
@@ -438,7 +438,7 @@ class SLRUTextMateCacheTest {
           realDelay(1.milliseconds)
           "fast-result-$value"
         }
-        results.update { it.add(result) }
+        results.update { it.adding(result) }
       })
     }
 
@@ -449,7 +449,7 @@ class SLRUTextMateCacheTest {
           realDelay(10.milliseconds) // Longer async work
           "slow-result-$value"
         }
-        results.update { it.add(result) }
+        results.update { it.adding(result) }
       })
     }
 
@@ -467,7 +467,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 2,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     cache.get("key1").close()
@@ -486,7 +486,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 2,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     val key1IsInUse = Job()
@@ -519,7 +519,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 2,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     suspend fun useKeyAndWaitUntilReallyUsed(): Job {
@@ -554,7 +554,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 10,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     // Add entries
@@ -576,7 +576,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 10,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     repeat(5) { i ->
@@ -597,7 +597,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 10,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     cache.get("key1").close()
@@ -655,7 +655,7 @@ class SLRUTextMateCacheTest {
       capacity = 2,
       computeFn = { key -> "value-$key" },
       disposeFn = { value ->
-        disposeAttempts.update { it.add(value) }
+        disposeAttempts.update { it.adding(value) }
         if (value == "value-key1") {
           error("Dispose failed")
         }
@@ -723,7 +723,7 @@ class SLRUTextMateCacheTest {
             value
           }
         }.onFailure { e ->
-          exceptions.update { it.add(e) }
+          exceptions.update { it.adding(e) }
         }
       }
     }
@@ -919,7 +919,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 10,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } },
+      disposeFn = { value -> disposedValues.update { it.adding(value) } },
       timeSource = testTimeSource
     )
 
@@ -951,7 +951,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 10,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     repeat(5) { i ->
@@ -972,7 +972,7 @@ class SLRUTextMateCacheTest {
     val cache = SLRUTextMateCache<String, String>(
       capacity = 10,
       computeFn = { key -> "value-$key" },
-      disposeFn = { value -> disposedValues.update { it.add(value) } }
+      disposeFn = { value -> disposedValues.update { it.adding(value) } }
     )
 
     repeat(5) { i ->

--- a/python/build/src/org/jetbrains/intellij/build/pycharm/PyCharmPropertiesBase.kt
+++ b/python/build/src/org/jetbrains/intellij/build/pycharm/PyCharmPropertiesBase.kt
@@ -24,7 +24,7 @@ abstract class PyCharmPropertiesBase(enlargeWelcomeScreen: Boolean) : JetBrainsP
     reassignAltClickToMultipleCarets = true
     useSplash = true
     buildCrossPlatformDistribution = true
-    mavenArtifacts.additionalModules = mavenArtifacts.additionalModules.addAll(listOf(
+    mavenArtifacts.additionalModules = mavenArtifacts.additionalModules.addingAll(listOf(
       "intellij.java.compiler.antTasks",
       "intellij.platform.testFramework.common",
       "intellij.platform.testFramework.junit5",
@@ -32,7 +32,7 @@ abstract class PyCharmPropertiesBase(enlargeWelcomeScreen: Boolean) : JetBrainsP
       "intellij.platform.testFramework",
     ))
 
-    productLayout.compatiblePluginsToIgnore = productLayout.compatiblePluginsToIgnore.addAll(
+    productLayout.compatiblePluginsToIgnore = productLayout.compatiblePluginsToIgnore.addingAll(
       //workaround (IJPL-209175) for IDEA-366600
       persistentListOf("intellij.java.plugin"))
   }

--- a/tools/apiDump/src/impl.kt
+++ b/tools/apiDump/src/impl.kt
@@ -39,8 +39,8 @@ class ApiIndex private constructor(
 
   operator fun plus(other: ApiIndex): ApiIndex {
     return ApiIndex(
-      this.packages.putAll(other.packages),
-      this.classes.putAll(other.classes),
+      this.packages.puttingAll(other.packages),
+      this.classes.puttingAll(other.classes),
     )
   }
 
@@ -92,7 +92,7 @@ class ApiIndex private constructor(
 
     return ApiIndex(
       packages,
-      classes = classes.put(className, signature),
+      classes = classes.putting(className, signature),
     )
   }
 }


### PR DESCRIPTION
Builders and `mutate {}` blocks keep their imperative names by design, and lockfiles of separate dependency closures (`maven_install.json`, `build/jvm-rules/libs.lock.json`) are intentionally not bumped. fleet/bifurcan's `List`, the only `PersistentList` implementer, follows the upstream implementer pattern: implementations move to the participial methods, the deprecated names delegate to them.

Fixes [IJPL-245012](https://youtrack.jetbrains.com/issue/IJPL-245012)