### PR TITLE
[JEWEL-1341] Add Jewel Markdown agent skill

### DIFF
--- a/.agents/skills/jewel-markdown/SKILL.md
+++ b/.agents/skills/jewel-markdown/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: jewel-markdown
+description:
+  Use when building, modifying, troubleshooting, or extending JetBrains Jewel Markdown rendering in Compose Desktop or IntelliJ-plugin UI: Markdown previews, Markdown chat output, GFM tables/alerts/strikethrough/autolinks/images, custom Markdown syntax, custom renderers, or MarkdownStyling.
+---
+
+# Jewel Markdown
+
+Jewel Markdown is a two-stage renderer: parse raw Markdown into Jewel's `MarkdownBlock` / `InlineMarkdown` model, then render that model
+with Jewel Compose renderers. Choose the smallest customization point that matches the job.
+
+The Jewel Markdown sources live in JetBrains `intellij-community` under `platform/jewel/markdown/`. Confirm exact API/file/symbol names by reading those sources (grep/read) rather than trusting memory before proposing code. For deeper topic detail, read the matching reference only when that topic is in play:
+
+- `references/CODE-HIGHLIGHTING.md` — fenced/indented code highlighting, `CodeHighlighter`, why code is unstyled by default.
+- `references/IMAGE-LOADING.md` — `ImageRendererExtension` + `ImageSourceResolver`, Coil3, path resolution.
+- `references/SCROLL-SYNC.md` — editor-preview scroll synchronization and its `ScrollState`-only limitation.
+- `references/HTML-PARSING.md` — embedded HTML, built-in tag conversion, `MarkdownHtmlConverterExtension`, alignment.
+
+## First decision: what are you changing?
+
+1. Visual styling only — customize `MarkdownStyling` and theme-specific styling helpers.
+2. Existing block UI behavior — use a custom `MarkdownBlockRenderer`, usually by subclassing `DefaultMarkdownBlockRenderer` and overriding
+   the specific `Render*` method.
+3. Existing inline text behavior — use a custom `InlineMarkdownRenderer`, usually by subclassing `DefaultInlineMarkdownRenderer`.
+4. New Markdown syntax — write a processor extension and a renderer extension.
+5. Images — use an `ImageRendererExtension`, not a general block renderer.
+6. Embedded HTML — enable `parseEmbeddedHtml` on the `MarkdownProcessor`, and for custom HTML→Markdown mapping add a
+   `MarkdownHtmlConverterExtension`.
+7. A live editor preview — use `MarkdownMode.EditorPreview` with a dedicated `MarkdownProcessor` instance and render with `LazyMarkdown`.
+
+Do not start with a custom renderer when styling or an extension solves the problem.
+
+## High-level rendering flow
+
+1. `MarkdownProcessor` parses raw Markdown into `List<MarkdownBlock>`.
+2. Blocks may contain `InlineMarkdown` nodes.
+3. `Markdown` renders short/simple content in a `Column`; `LazyMarkdown` renders larger or editor-preview content in a `LazyColumn`.
+4. `MarkdownBlockRenderer` renders block nodes and delegates inline content to `InlineMarkdownRenderer`.
+5. `ProvideMarkdownStyling` wires `LocalMarkdownStyling`, `LocalMarkdownProcessor`, `LocalMarkdownBlockRenderer`, and code/image support
+   into `JewelTheme`.
+6. Extensions can plug into processing, block rendering, and inline rendering (with some limitations).
+
+Prefer processing Markdown outside composition for non-trivial or frequently changing text. The string-taking `Markdown(...)` overload is
+convenient, but it parses from composition and is best for small, mostly static snippets.
+
+## Built-in and existing extension choices
+
+Use the existing extension modules before inventing syntax:
+
+- Plain URLs are not becoming links: add `AutolinkProcessorExtension` to the `MarkdownProcessor`.
+- GFM tables: add `GitHubTableProcessorExtension` and `GitHubTableRendererExtension`. The processor extension also bundles a
+  `MarkdownHtmlConverterExtension` for `<table>` (active when `parseEmbeddedHtml = true`).
+- GFM strikethrough: add `GitHubStrikethroughProcessorExtension` and `GitHubStrikethroughRendererExtension`. The processor extension also
+  bundles a `MarkdownHtmlConverterExtension` for `<s>`, `<strike>`, and `<del>` (active when `parseEmbeddedHtml = true`).
+- GFM alerts: add `GitHubAlertProcessorExtension` and `GitHubAlertRendererExtension`.
+- Images: add an `ImageRendererExtension`, commonly `Coil3ImageRendererExtension`, to the renderer extensions and provide an image source
+  resolver where needed. For details read `references/IMAGE-LOADING.md`.
+- Code syntax highlighting: in a plugin, use the `Project`-aware bridge `ProvideMarkdownStyling`, which wires an IJPL-backed highlighter by
+  default; in standalone (or a bridge overload without a `Project`) the default is a no-op and you must provide a `CodeHighlighter`. For
+  details read `references/CODE-HIGHLIGHTING.md`.
+
+For a worked example of combining several extensions (processor + renderer + theme-specific styling, parsing off composition, `LazyMarkdown`), read the standalone sample at `platform/jewel/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/markdown/MarkdownPreview.kt`.
+
+Keep parser and renderer extensions paired when a feature has both sides. If a processor creates a custom block or inline node and no
+renderer extension claims it, the content will not render usefully. Do not invent renderer extensions for parse-only features such as
+autolink, and do not invent processor extensions for renderer-only image loading.
+
+## Embedded HTML
+
+HTML support is off by default: a `MarkdownProcessor` ignores embedded HTML unless you construct it with `parseEmbeddedHtml = true`. There
+are two distinct HTML paths, do not conflate them:
+
+- Native HTML mapped to Markdown: when `parseEmbeddedHtml` is on, a fixed set of built-in tags is converted into normal `MarkdownBlock`s (
+  `p`, `li`, `ol`, `ul`, `h1`-`h6`, `code`, `pre`, `img`). These render through the standard block/inline renderers, not through a raw-HTML
+  renderer.
+- Custom tag conversion: to map an additional HTML tag onto a Markdown block your code understands (e.g., `<table>` to a tables block),
+  implement a `MarkdownHtmlConverterExtension` and expose it from your `MarkdownProcessorExtension.htmlConverterExtension`. It declares
+  `supportedTags` and returns an `HtmlElementConverter` per tag; the converter turns an HTML element into a `MarkdownBlock` (or inline
+  list), delegating children/inlines via the provided lambdas. Existing GFM extensions ship these: `gfm-tables` converts `<table>` (block),
+  and `gfm-strikethrough` converts `<s>`/`<strike>`/`<del>` (inline). Use them as references and add the extension whose tags you need
+  rather than reimplementing it.
+
+For full details, models, and wiring, read `references/HTML-PARSING.md`.
+
+Key points and gotchas:
+
+- `htmlConverterExtension`s are only collected when `parseEmbeddedHtml = true`; adding one without enabling embedded HTML does nothing.
+- HTML that is not converted is preserved as an `HtmlBlock` (raw HTML string) or inline HTML; the default renderer shows it via the
+  `htmlBlock` styling, it is not interpreted as native UI. Jewel does not do general inline-HTML rendering.
+- HTML carrying layout attributes (e.g., an `align` attribute) becomes a `MarkdownBlock.HtmlBlockWithAttributes` wrapping the converted
+  block; the default renderer reads the `align` attribute and propagates text alignment to children. A custom renderer that overrides this
+  path must preserve that alignment behavior (see Gotchas for custom renderers).
+- Custom HTML conversion is parse-side only. If a converter emits a custom block type, you still need a matching renderer extension to
+  display it.
+
+## Live Markdown editor/preview
+
+`MarkdownMode.EditorPreview` optimizes for small, frequent edits (a user typing): the `MarkdownProcessor` keeps state between calls and
+re-parses only the block(s) that changed instead of the whole document. That statefulness is why an editor-preview processor is tied to one
+evolving document and must not be shared across unrelated documents (doing so busts the cache and is slower than `Standalone`). Use
+`MarkdownMode.Standalone` (the default, stateless) for content that is parsed once and doesn't change.
+
+For a side-by-side editor and preview:
+
+1. Keep raw text/editing state in the presenter or state holder, not hidden inside the preview leaf.
+2. Create one `MarkdownProcessor(markdownMode = MarkdownMode.EditorPreview(scrollingSynchronizer = ...))` per editable document/preview
+   stream. Do not share editor-preview processors across unrelated documents.
+3. Process edits off the UI path when practical, debounce/drop stale work if the editor can emit faster than rendering.
+4. Render with `LazyMarkdown` for documents and previews.
+5. Add the expected dialect extensions: autolink is processor-only, tables/strikethrough/alerts need processor and renderer pieces, and
+   images need an image renderer extension.
+6. If scroll sync matters, use the scrolling synchronizer/rendering support rather than ad-hoc list scrolling. Read `references/SCROLL-SYNC.md` — note the synchronizer currently supports `ScrollState`, not `LazyListState`.
+
+## AI chat with Markdown
+
+For chat timelines, do not make Markdown own the chat architecture.
+
+Use a presenter/coordinator to project message state, roles, streaming status, and parsed Markdown blocks. The UI should render a
+`LazyColumn` of message rows and use `Markdown` or `LazyMarkdown` inside text-bearing rows as appropriate. Keep networking, agent protocol,
+message mutation, and Markdown parsing policy outside leaf composables. Use stable lazy-list keys and content types for heterogeneous chat
+rows.
+
+## Custom syntax: extension or renderer?
+
+Write a custom extension when the Markdown input language changes, e.g., task list items, custom admonitions, `::file:/path/foo.kt::`, or
+another syntax that must parse into a domain model.
+
+Write a custom renderer when the existing parsed model is right, but the UI should change, e.g., headings need link buttons, code blocks
+need copy buttons, list markers need different layout, or inline images need product-specific treatment.
+
+Many features need both: an extension to parse syntax into model nodes, and a renderer to display those nodes. Some may need more than two
+parts. See the examples below.
+
+## How to write a custom block extension
+
+Use `gfm-alerts` and `gfm-tables` as templates.
+
+1. Define a model type implementing `MarkdownBlock.CustomBlock`.
+2. Add a `MarkdownProcessorExtension`.
+3. If CommonMark needs help recognizing the syntax, expose a CommonMark `ParserExtension`.
+4. Expose a `MarkdownBlockProcessorExtension` that checks `canProcess(CustomBlock)` and returns your `MarkdownBlock.CustomBlock` from
+   `processMarkdownBlock`.
+5. Set `allowsMergingWithNextBlock = true` only when incremental editor parsing must reparse a following block that can merge into this one,
+   as tables do.
+6. Add a `MarkdownRendererExtension` exposing a `MarkdownBlockRendererExtension`.
+7. In `RenderCustomBlock`, render native Jewel Compose UI and delegate nested Markdown back to the provided `MarkdownBlockRenderer` /
+   `InlineMarkdownRenderer` where possible.
+8. Add standalone and bridge styling helpers when the feature has colors, spacing, borders, or icons.
+9. If the block will be used in an editor preview and should be a scroll-sync target, opt in: the scroll-sync renderer does not wrap custom
+   blocks automatically. Wrap your content in `AutoScrollableBlock` in `RenderCustomBlock`. See `references/SCROLL-SYNC.md`.
+10. Add processor tests and renderer tests or validated sample coverage.
+
+## How to write a custom delimited inline extension
+
+Use `gfm-strikethrough` as the template.
+
+1. Define a model type implementing `InlineMarkdown.CustomDelimitedNode`.
+2. Add a `MarkdownProcessorExtension` with a CommonMark parser extension if needed.
+3. Expose a `MarkdownDelimitedInlineProcessorExtension` that turns supported CommonMark `Delimited` nodes into your custom inline node.
+4. Add a `MarkdownRendererExtension` exposing `MarkdownDelimitedInlineRendererExtension`.
+5. Render to an `AnnotatedString`, recursively delegating nested inline content to the supplied `InlineMarkdownRenderer`.
+6. Add an HTML converter only if embedded HTML should map to the same inline model.
+
+### Example: inline icons and rich inline content
+
+`MarkdownDelimitedInlineRendererExtension` returns only an `AnnotatedString`. If custom inline syntax must show an icon or other
+`InlineTextContent` — for example `::file:/my/path/foo.kt::` with the file icon and name — plan for an extension encompassing parsing plus
+renderer customization:
+
+1. Parse the syntax into a custom inline node.
+2. Provide an inline renderer or block renderer path that appends inline-content placeholders for those nodes.
+3. Override the block rendering for text-bearing blocks (`Paragraph`, headings, table cells, or whichever contexts you support) so the Jewel
+   `Text` receives the matching `inlineContent` map.
+4. Use Jewel icon APIs (`IconKey`, `AllIconsKeys`, or platform file-type icon APIs in bridge/plugin context) inside the `InlineTextContent`.
+5. Document supported contexts rather than pretending every Markdown block can host the custom inline content automatically.
+
+## Example: GFM task lists
+
+Do not claim Jewel already supports GFM task lists. They are listed as missing/roadmap in Jewel docs. To support `- [ ]` / `- [x]` task list
+items, create and validate a new extension:
+
+1. Decide whether the model is a custom block/list item wrapper or an extension of list rendering.
+2. Parse checked/unchecked state into an explicit model.
+3. Render with native Jewel checkbox-like visuals, preserving Markdown semantics and disabled/read-only behavior as appropriate.
+4. Validate both processor output and rendering. Include editor-preview incremental parsing if task-list syntax can interact with
+   neighboring list blocks.
+5. If you're rendering interactive components such as checkboxes, make sure their status is managed, and that changes are reflected in the
+   underlying Markdown (e.g., checked state for a checkbox should manifest as `[ ]` or `[x]` in text).
+
+## Gotchas for custom renderers
+
+When overriding or replacing rendering, preserve the behaviors the default renderer relies on. Each item below is something a custom
+renderer can silently break.
+
+- Text alignment: every text-bearing block in `DefaultMarkdownBlockRenderer` passes `textAlign = LocalTextAlignment.current` to its Jewel
+  `Text`. That composition local is set when an aligned block (e.g., an HTML block with an `align` attribute) wraps its children, so
+  alignment propagates into nested text. A custom `Render*` override or a renderer written from scratch that emits `Text` without forwarding
+  the current text alignment will silently lose center/right alignment. Always apply the provided text alignment in custom text rendering.
+  Note `LocalTextAlignment` is internal to `DefaultMarkdownBlockRenderer`; prefer subclassing it (and still forwarding `textAlign` in your
+  override) rather than reimplementing block rendering and dropping this wiring.
+- Content color: text-bearing rendering resolves color via the styling text style falling back to `LocalContentColor`. Preserve that
+  fallback instead of hardcoding a color.
+- Inline content / images: paragraphs that contain images render through an `inlineContent` map. If you override paragraph or other
+  text-bearing rendering, keep passing the `inlineContent` map so images and other inline placeholders still appear.
+- Enabled/disabled state: honor the `enabled` flag (links non-interactive, disabled styling) rather than always rendering the enabled
+  appearance.
+- Delegation: render nested blocks/inlines through the provided `MarkdownBlockRenderer` / `InlineMarkdownRenderer` so styling, extensions,
+  and these behaviors stay consistent.
+- Editor-preview scroll sync: scroll sync is implemented entirely by `ScrollSyncMarkdownBlockRenderer` (a `DefaultMarkdownBlockRenderer`
+  subclass that wraps blocks in `AutoScrollableBlock` and reports layout). If you supply your own block renderer for an editor preview, you
+  bypass that subclass and lose scroll sync. Subclass `ScrollSyncMarkdownBlockRenderer` instead of `DefaultMarkdownBlockRenderer` (calling
+  `super` from your overrides), or re-implement the `AutoScrollableBlock` wiring yourself. See `references/SCROLL-SYNC.md`.
+
+General rule: when you override one `Render*` method, mirror the default implementation's wiring (alignment, color, inline content, enabled
+state, and editor-preview scroll sync) and change only what you intend to change.
+
+## Validation checklist
+
+Before finishing Jewel Markdown work:
+
+- Confirm runtime context: standalone uses int-ui standalone styling; IntelliJ plugin/bridge uses IDE LaF bridge styling.
+- Confirm required processor and renderer extensions are both wired.
+- Confirm `MarkdownProcessor` editor-preview instances are not shared across unrelated documents.
+- Confirm heavy parsing is not happening in a hot `LazyColumn` item body.
+- Confirm code highlighting, image loading, and URL click handling are provided where the UX requires them.
+- Confirm custom syntax has tests for parsing and rendering; for new extensions, use existing extension tests as guides.
+- Confirm task lists or other missing GFM features were implemented/validated, not merely mentioned as supported.
+- Confirm custom text rendering forwards `LocalTextAlignment` (text alignment), preserves the content-color fallback, keeps the
+  `inlineContent` map, and honors `enabled`.
+- Confirm HTML expectations: embedded HTML needs `parseEmbeddedHtml = true`; custom tag mapping needs a `MarkdownHtmlConverterExtension`;
+  and unconverted/inline HTML is shown as raw text, not interpreted as native UI.

--- a/.agents/skills/jewel-markdown/evals/evals.json
+++ b/.agents/skills/jewel-markdown/evals/evals.json
@@ -1,0 +1,115 @@
+{
+  "skill_name": "jewel-markdown",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "I need a side-by-side Markdown editor and preview in a Jewel Compose Desktop app. Give me a concise implementation plan and mention which Markdown extensions I should consider for GitHub-like Markdown.",
+      "expected_output": "A plan that uses a dedicated MarkdownProcessor in MarkdownMode.EditorPreview, renders the preview with LazyMarkdown, keeps raw editor state and parsed blocks outside leaf composition, and suggests relevant extensions for GitHub-like Markdown without inventing non-existent autolink/image pairs.",
+      "files": [],
+      "expectations": [
+        "Uses MarkdownMode.EditorPreview for the live preview rather than a plain shared Standalone processor.",
+        "States that an editor-preview MarkdownProcessor is stateful/not thread-safe and should be per document/preview stream, not shared globally.",
+        "Recommends LazyMarkdown for document/preview rendering.",
+        "Keeps parsing/state projection outside hot LazyColumn item bodies or leaf preview composition.",
+        "Suggests relevant extensions for GitHub-like Markdown: autolink as processor-only, tables/strikethrough/alerts as processor plus renderer, and images as renderer/image-loading support.",
+        "Mentions scroll synchronization only through Jewel's editor-preview/scrolling support or as an optional dedicated concern, not ad-hoc scrolling hacks."
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "In Jewel Markdown, I want rendered Markdown to show images and GitHub tables. What do I need to wire?",
+      "expected_output": "An answer that names the images and GFM tables extension points and explains that parser and renderer extensions must both be wired for tables, while images need an ImageRendererExtension such as Coil3ImageRendererExtension and any required image source/loading setup.",
+      "files": [],
+      "expectations": [
+        "Names GitHubTableProcessorExtension for parsing tables.",
+        "Names GitHubTableRendererExtension for rendering tables.",
+        "Mentions table styling such as GfmTableStyling or theme-specific table styling.",
+        "Names ImageRendererExtension or Coil3ImageRendererExtension for images.",
+        "Explains that images are not solved by a table/block extension and require image-loading/source resolver wiring where applicable.",
+        "Warns to keep processor and renderer extension lists paired for features that produce custom nodes."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Why aren't plain URLs like https://example.com clickable when I render Markdown with Jewel? Links written as [label](https://example.com) work, but bare URLs do not.",
+      "expected_output": "A troubleshooting answer that explains bare URL autolinking is extension-backed and recommends adding AutolinkProcessorExtension to the MarkdownProcessor, while retaining normal onUrlClick handling for link clicks.",
+      "files": [],
+      "expectations": [
+        "Identifies missing autolink support as the likely cause for bare URLs.",
+        "Recommends AutolinkProcessorExtension on the MarkdownProcessor.",
+        "Distinguishes bare URLs from explicit Markdown links, which already parse as links.",
+        "Mentions providing/keeping onUrlClick handling for click behavior.",
+        "Does not recommend regex-rewriting Markdown text in composition as the primary fix."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I need Jewel Markdown to render GitHub task list items like '- [ ] todo' and '- [x] done'. Please outline the implementation approach; assume this is for upstream Jewel work and mention how to validate it.",
+      "expected_output": "A plan that does not assume task lists already exist. It proposes a new extension inspired by existing GFM extensions, models checked/unchecked state explicitly, renders native Jewel read-only checkbox-like visuals, and validates processor and renderer behavior, including editor-preview cases if relevant.",
+      "files": [],
+      "expectations": [
+        "States or implies that task lists are not currently a built-in Jewel Markdown extension and must be implemented.",
+        "Mentions checking current issue/source context such as JEWEL-475 without relying on memory alone.",
+        "Proposes a MarkdownProcessorExtension and suitable processor model for checked/unchecked task items.",
+        "Proposes a renderer path using native Jewel checkbox-like/read-only visuals rather than leaving literal '[ ]' text.",
+        "Uses existing extensions such as gfm-tables, gfm-alerts, or gfm-strikethrough as implementation guides.",
+        "Requires validation of parser output and rendering behavior, and considers editor-preview incremental parsing if list/task syntax can merge or change neighboring blocks.",
+        "Proposes handling the click events on the checkboxes and updating the underlying Markdown value."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "How do I create an AI chat UI in Compose Desktop where assistant messages support Markdown? I care about architecture, not just the Markdown call.",
+      "expected_output": "A Compose Desktop architecture answer that recommends a LazyColumn chat timeline, message-row composables that render Markdown, and a strong separation where presenter/coordinator/state holder owns message state, streaming, parsing policy, and business logic while UI renders projected state and callbacks.",
+      "files": [],
+      "expectations": [
+        "Recommends LazyColumn for the chat timeline with stable keys/content types or equivalent lazy-list discipline.",
+        "Uses Markdown or LazyMarkdown inside message rows rather than making Markdown own the entire chat screen.",
+        "Keeps presenter/coordinator/state holder responsible for message state, streaming status, and business logic.",
+        "Keeps Markdown parsing policy or parsed block projection outside leaf composables for non-trivial chat output.",
+        "Mentions onUrlClick/link handling as a UI callback boundary.",
+        "Avoids Android-specific ViewModel/lifecycle prescriptions unless explicitly framed as an analogy."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I want Jewel Markdown to support inline file markup like ::file:/my/path/foo.kt:: and render it as the file icon plus the file name. How should I implement that?",
+      "expected_output": "An answer that proposes custom inline parsing plus renderer customization for InlineTextContent. It should explain that a simple MarkdownDelimitedInlineRendererExtension returning AnnotatedString is not enough for icons; text-bearing block rendering must pass an inlineContent map to Text, with scope limitations documented.",
+      "files": [],
+      "expectations": [
+        "Proposes a custom inline extension/model for the ::file:/path:: syntax.",
+        "Notes that MarkdownDelimitedInlineRendererExtension returns AnnotatedString and alone is insufficient for an icon InlineTextContent solution.",
+        "Recommends custom inline renderer and/or block renderer overrides for text-bearing blocks so Text receives inlineContent placeholders and a matching inlineContent map.",
+        "Mentions using Jewel/IntelliJ icon APIs or file-type icon lookup for the icon instead of text/emoji glyphs.",
+        "Calls out supported contexts such as paragraphs/headings/table cells and says unsupported contexts should be documented or explicitly handled.",
+        "Keeps processor and renderer responsibilities separate instead of suggesting a regex replacement in the composable."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "I'm writing a custom Jewel MarkdownBlockRenderer because I want paragraphs to have extra padding. I'll override the paragraph rendering and emit my own Text. Anything I need to be careful about so I don't break existing behavior?",
+      "expected_output": "An answer that warns a custom paragraph/text renderer must preserve the default renderer's wiring: forward the current text alignment (LocalTextAlignment) to Text, keep the content-color fallback, keep the inlineContent map for images, and honor the enabled flag. It should recommend subclassing DefaultMarkdownBlockRenderer and overriding only the targeted method rather than reimplementing block rendering and dropping these behaviors.",
+      "files": [],
+      "expectations": [
+        "Explicitly says the custom text rendering must apply the text alignment provided by LocalTextAlignment (or the renderer's current text alignment), not drop it.",
+        "Recommends subclassing DefaultMarkdownBlockRenderer and overriding only the targeted Render method instead of reimplementing rendering from scratch.",
+        "Mentions preserving the inlineContent map so images/inline content still render.",
+        "Mentions preserving content color fallback (LocalContentColor) and honoring the enabled flag.",
+        "Frames the general rule that overriding one Render method should mirror the default implementation's wiring and change only the intended behavior."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "My Markdown contains embedded HTML, including some <table> elements and a few <div align=\"center\"> wrappers. When I render it with Jewel Markdown, the HTML is just ignored or shown as raw text. How does Jewel handle embedded HTML, and what do I need to do?",
+      "expected_output": "An explanation that embedded HTML is opt-in via parseEmbeddedHtml on MarkdownProcessor, that a fixed set of built-in tags is converted to native Markdown blocks, that custom tags like <table> require a MarkdownHtmlConverterExtension (as gfm-tables does), and that unconverted/inline HTML is shown as raw text rather than interpreted as native UI.",
+      "files": [],
+      "expectations": [
+        "States that embedded HTML support is off by default and must be enabled with parseEmbeddedHtml = true on the MarkdownProcessor.",
+        "Explains that only a fixed set of built-in HTML tags is converted to native Markdown blocks.",
+        "Says custom tags such as <table> require a MarkdownHtmlConverterExtension (exposed from a MarkdownProcessorExtension), and points to gfm-tables as the reference.",
+        "Notes that unconverted or inline HTML is preserved as raw HTML (HtmlBlock / inline HTML) and not interpreted as native UI.",
+        "Does not claim Jewel does general inline-HTML rendering or that enabling a flag alone renders arbitrary HTML."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/jewel-markdown/references/CODE-HIGHLIGHTING.md
+++ b/.agents/skills/jewel-markdown/references/CODE-HIGHLIGHTING.md
@@ -1,0 +1,80 @@
+# Code highlighting
+
+How fenced/indented code blocks get syntax highlighting in Jewel Markdown. Read this when code blocks render as plain text, when wiring a
+highlighter, or when writing a custom renderer that must keep highlighting working.
+
+## How it works
+
+- The block renderer renders code via `LocalCodeHighlighter.current` (a composition local of type `CodeHighlighter`), not via a hardcoded
+  lexer.
+- `CodeHighlighter` (file: `platform/jewel/foundation/.../code/highlighting/CodeHighlighter.kt`) exposes:
+  - `highlight(code: String, language: String = ""): Flow<AnnotatedString>` — current API. `language` is the fenced info string (`kt`,
+    `python`, `js`, etc.).
+  - `highlight(code, mimeType: MimeType?)` — deprecated; do not use in new code.
+- It returns a `Flow<AnnotatedString>`, not a single value, so a highlighter can emit progressively (e.g., a fast pass, then a richer one)
+  and re-emit when the color scheme changes. The renderer collects it with `collectAsState(AnnotatedString(content))`, so the raw text shows
+  until the first highlighted value arrives.
+- For static highlighting, emit a single value (`flowOf(highlighted)`); the renderer uses the first emission.
+
+## Default behavior
+
+Whether you get highlighting out of the box depends on which `ProvideMarkdownStyling` you use:
+
+- IDE bridge (`ide-laf-bridge-styling`), `Project`-aware overloads: **highlighting is on by default.** These overloads build an IJPL-backed
+  highlighter via `project.service<CodeHighlighterFactory>().createHighlighter()`, so fenced code is highlighted using the IDE's own syntax
+  highlighting. Prefer these overloads inside a plugin.
+- IDE bridge, overloads **without** a `Project`: default to `NoOpCodeHighlighter` (no highlighting) unless you pass a `codeHighlighter`. The
+  KDoc explicitly steers you to the `Project` overload when you have one.
+- Standalone (`int-ui-standalone-styling`): currently defaults to `NoOpCodeHighlighter`, so standalone apps that want the highlighting must
+  supply a `CodeHighlighter`.
+  - This is changing: JEWEL-1313 adds lexer-based highlighting for standalone, initially for a limited set of languages, expected to expand
+    over time. Validate against ground truth before assuming standalone has no built-in highlighting.
+
+The underlying default value of the `codeHighlighter` parameter is `NoOpCodeHighlighter`: it emits the code as a plain `AnnotatedString`
+with no styling. So "no colors" is expected
+only when a no-op highlighter is in effect (standalone, or a bridge overload without a `Project`), not in the `Project`-aware bridge path.
+
+## How the default renderer dispatches
+
+In `DefaultMarkdownBlockRenderer.RenderFencedCodeBlock`:
+
+- If the info string looks like a MIME type (matches `^\w+/.+$`), it goes through the deprecated `RenderCodeWithMimeType` path.
+- Otherwise, it calls `RenderCodeWithLanguage`, which calls `highlighter.highlight(content, block.language.orEmpty())`.
+
+Prefer plain language names/extensions in fenced blocks (` ```kotlin `) so the modern `highlight(code, language)` path is used.
+
+## Wiring a highlighter
+
+```kotlin
+ProvideMarkdownStyling(
+  markdownStyling = styling,
+  markdownBlockRenderer = blockRenderer,
+  codeHighlighter = myCodeHighlighter, // defaults to NoOpCodeHighlighter
+) {
+  Markdown(blocks)
+}
+```
+
+Or provide `LocalCodeHighlighter` directly if you are composing your own provider stack.
+
+In a plugin, prefer the `Project`-aware bridge `ProvideMarkdownStyling` overload: it wires the IJPL `CodeHighlighterFactory` highlighter for
+you, so don't hand-roll one. Only standalone apps (or bridge code with no `Project`) need to supply their own `CodeHighlighter`
+implementation (e.g., backed by TextMate bundles or another lexer).
+
+## Implementing a custom `CodeHighlighter`
+
+- Implement `highlight(code, language)`. Resolve the language from the raw string yourself; do not rely on the deprecated `MimeType`
+  resolution.
+- Return a `Flow`. Emit once for static highlighting or multiple times if you support theme changes/async enrichment.
+- If `language` is blank or unknown, emit the original code as a plain `AnnotatedString` (mirror `NoOpCodeHighlighter`).
+
+## Gotchas
+
+- "No colors": check which styling path is in use. In the `Project`-aware bridge overload highlighting is already on; in standalone or a
+  bridge overload without a `Project` the default is `NoOpCodeHighlighter` and you must provide a highlighter. If a plugin shows no colors,
+  check whether the non-`Project` overload was used by mistake.
+- The flow's first emission should be safe/cheap; the UI shows raw text until then. Don't block.
+- A custom block renderer that re-implements code block rendering must still read `LocalCodeHighlighter.current` and collect its flow, or
+  highlighting breaks. Prefer subclassing `DefaultMarkdownBlockRenderer` and overriding only what you need.
+- The `MimeType`-based APIs are deprecated and don't scale to languages defined outside the `MimeType` enum (e.g. TextMate grammars). Use
+  the `language`-string overload.

--- a/.agents/skills/jewel-markdown/references/HTML-PARSING.md
+++ b/.agents/skills/jewel-markdown/references/HTML-PARSING.md
@@ -1,0 +1,96 @@
+# HTML parsing
+
+How Jewel handles embedded HTML in Markdown. Read this when HTML is ignored/shown as raw text, when mapping custom tags to Markdown blocks,
+or when HTML alignment attributes matter.
+
+## Opt-in
+
+Embedded HTML is off by default. A `MarkdownProcessor` ignores it unless constructed with `parseEmbeddedHtml = true`:
+
+```kotlin
+val processor = MarkdownProcessor(extensions = extensions, parseEmbeddedHtml = true)
+```
+
+When off, `htmlConverterExtension`s are not even collected, and HTML stays as raw `HtmlBlock` / inline HTML.
+
+## Three outcomes for an HTML fragment
+
+With `parseEmbeddedHtml = true`, an HTML fragment ends up as one of:
+
+1. A native `MarkdownBlock`, via a built-in converter for a known tag.
+2. A native `MarkdownBlock` produced by a `MarkdownHtmlConverterExtension` you supplied (custom tag).
+3. Raw, uninterpreted HTML — `MarkdownBlock.HtmlBlock` (block) or `InlineMarkdown.HtmlInline` (inline) — rendered as text via the
+   `htmlBlock` styling. Jewel does **not** do general inline-HTML rendering.
+
+## Built-in tag converters
+
+Tags converted to native Markdown when embedded HTML is on:
+
+`p`, `li`, `ol`, `ul`, `h1`-`h6`, `code`, `pre`, `img`.
+
+These produce normal blocks/inlines and render through the standard renderers. Parsing of the raw HTML into an intermediate tree uses
+Jsoup in `MarkdownHtmlNode`; a single CommonMark HTML block can yield multiple Markdown blocks.
+
+## Custom tag conversion: `MarkdownHtmlConverterExtension`
+
+To map an extra tag (e.g. `<table>`) onto a Markdown block your code understands:
+
+- Implement `MarkdownHtmlConverterExtension`:
+  - `val supportedTags: Set<String>` — tags this extension handles.
+  - `fun provideConverter(tagName): HtmlElementConverter` — converter per tag.
+- Expose it from your `MarkdownProcessorExtension.htmlConverterExtension`.
+- `HtmlElementConverter`:
+  - `convert(htmlElement, convertChildren, convertInlines): MarkdownBlock?` — produce a block; use the `convertChildren` / `convertInlines`
+    lambdas to recurse into children instead of reparsing.
+  - `convertInlines(element, convertSubInlines): List<InlineMarkdown>?` — produce inline content instead of a block.
+  - Return `null` when the element doesn't apply.
+- The processor selects a converter via `provideExtensionHtmlElementConverterFor(tag)` — the first extension whose `supportedTags` contains
+  the tag.
+
+References (both ship a `MarkdownHtmlConverterExtension` from their processor extension):
+
+- `gfm-tables`: `GitHubTableProcessorExtension` converts `<table>` into a table block (block-level converter).
+- `gfm-strikethrough`: `GitHubStrikethroughProcessorExtension` converts `<s>`, `<strike>`, `<del>` into strikethrough inline nodes (inline converter, via `convertInlines`).
+
+Use these as the models to copy. If you just need those tags, add the corresponding extension rather than reimplementing the converter.
+
+Custom conversion is parse-side only. If your converter emits a custom block type, you still need a matching renderer extension to display
+it.
+
+## Attribute-carrying HTML and alignment
+
+HTML that carries layout attributes (notably `align`) becomes a `MarkdownBlock.HtmlBlockWithAttributes(mdBlock, attributes)` (file:
+`core/.../MarkdownBlock.kt`) wrapping the converted inner block.
+
+- `DefaultMarkdownBlockRenderer.RenderHtmlBlockWithAttributes(...)` reads `attributes["align"]` (`left`/`center`/`right`), wraps the child
+  in a width-filling `Box` with the matching alignment, and provides the corresponding `TextAlign` to the (internal) `LocalTextAlignment` so
+  nested text inherits it.
+- This is why custom renderers must forward text alignment: a renderer that overrides text-bearing blocks but ignores the current text
+  alignment will silently break centered/right-aligned HTML. See the custom-renderer gotchas in `SKILL.md`.
+
+## Wiring
+
+```kotlin
+val processor =
+  MarkdownProcessor(
+    extensions = listOf(GitHubTableProcessorExtension), // exposes an htmlConverterExtension for <table>
+    parseEmbeddedHtml = true,                            // required, or the converter is ignored
+  )
+
+// Renderer side still needs the matching renderer extension for the produced block:
+val blockRenderer =
+  MarkdownBlockRenderer.light(
+    styling = styling,
+    rendererExtensions = listOf(GitHubTableRendererExtension(GfmTableStyling.light(), styling)),
+  )
+```
+
+## Gotchas
+
+- `htmlConverterExtension` added but nothing happens: `parseEmbeddedHtml` is still `false`.
+- Expecting arbitrary HTML to render as UI: only the built-in tag set plus your converters become native UI; everything else is raw text.
+  There is no general HTML renderer.
+- Converter emits a custom block but it doesn't show: missing the paired renderer extension.
+- Don't re-parse raw HTML yourself inside a converter; use the provided `convertChildren` / `convertInlines` lambdas.
+- Inline-HTML rendering and most non-CommonMark HTML features are explicitly out of scope upstream; validate against current sources before
+  promising support.

--- a/.agents/skills/jewel-markdown/references/IMAGE-LOADING.md
+++ b/.agents/skills/jewel-markdown/references/IMAGE-LOADING.md
@@ -1,0 +1,124 @@
+# Image loading
+
+How images in Markdown become visible pixels in Jewel. Read this when images don't show, when wiring image loading, or when resolving
+relative/custom image paths.
+
+## Two independent pieces
+
+Image support needs both of these; they solve different problems:
+
+1. `ImageRendererExtension` — actually loads and renders the image. Without one, images are not displayed; the default inline renderer falls
+   back to rendering the image's raw Markdown syntax as text.
+2. `ImageSourceResolver` — turns the raw Markdown destination string (`![alt](my-image.png)`) into a fully qualified, loadable source
+   string. Provided via the `LocalMarkdownImageSourceResolver` composition local.
+
+A renderer extension without a resolver may fail on relative paths; a resolver without a renderer extension still shows nothing. Wire both
+for non-trivial cases.
+
+## ImageRendererExtension
+
+- Interface `ImageRendererExtension`.
+- It is exposed from a `MarkdownRendererExtension.imageRendererExtension` and added to the renderer's extension list.
+- The default block renderer collects images from a block's inline content and asks the first available `imageRendererExtension` to render
+  each one (`renderedImages(...)` in `DefaultMarkdownBlockRenderer`). Returning `null` means "no image" (e.g., load error) and the renderer
+  drops the placeholder.
+
+### Coil3 reference implementation
+
+- See `Coil3ImageRendererExtension`.
+- Construct with an app-wide Coil `ImageLoader`: `Coil3ImageRendererExtension(imageLoader)`.
+- Convenience: `Coil3ImageRendererExtension.withDefaultLoader()` / `withDefaultLoader(context)` create a loader with a small in-memory
+  cache. Each call creates a new `ImageLoader`; create one and share it process-wide rather than calling repeatedly.
+- The impl resolves the source via `LocalMarkdownImageSourceResolver.current`, requests `Size.ORIGINAL`, renders into an `InlineTextContent`
+  whose placeholder is resized to the loaded image's pixel size, and returns `null` on error.
+
+## ImageSourceResolver
+
+- Interface `ImageSourceResolver`.
+- Provided via `LocalMarkdownImageSourceResolver`; the default value is `ImageSourceResolver.create()` with default capabilities.
+- Build one with `ImageSourceResolver.create(resolveCapabilities, logResolveFailure)` or
+  `ImageSourceResolver.create(rootDir, logResolveFailure)`.
+
+### Default capabilities
+
+`ImageSourceResolver.create()` supports:
+
+- `PlainUri` — absolute URIs returned as-is (`https://...`, `file:///...`).
+- `RelativePathInResources(resourceClass?)` — relative path looked up in a classloader's resources.
+- `AbsolutePath` — absolute filesystem paths returned as-is.
+
+The `create(rootDir, ...)` overload adds `RelativePath(rootDir)` so relative paths resolve against a base directory.
+
+Capabilities are tried in order; the first non-null result wins. If none resolve and `logResolveFailure` is true, the resolver logs the
+failure and returns `null` (image won't load).
+
+## Wiring
+
+```kotlin
+// Provide a resolver (e.g. resolve relative paths against a doc root)
+val resolver = ImageSourceResolver.create(rootDir = docRoot, logResolveFailure = true)
+
+ProvideMarkdownStyling(
+  imageSourceResolver = resolver,           // overload that seeds LocalMarkdownImageSourceResolver
+  markdownStyling = styling,
+  markdownBlockRenderer =
+    MarkdownBlockRenderer.light(
+      styling = styling,
+      rendererExtensions = listOf(Coil3ImageRendererExtension(imageLoader)),
+    ),
+  codeHighlighter = codeHighlighter,
+) {
+  Markdown(blocks)
+}
+```
+
+For a fully custom scheme (e.g., a base URL or asset pipeline), implement `ImageSourceResolver` directly and provide it via
+`LocalMarkdownImageSourceResolver` or `ProvideMarkdownStyling`.
+
+## Sized images
+
+Images can carry explicit dimensions, parsed into `InlineMarkdown.Image.width`/`height` (type `DimensionSize?`).
+
+Two source syntaxes are parsed:
+
+- GitLab Markdown image attribute block: `![alt](image.png){width=100 height=50}` — appended immediately after the image. Values may be
+  unquoted, single-, or double-quoted; a unitless number or a `px` suffix is accepted. The attribute block is consumed from the following
+  text node, so it does not show up as literal text.
+- HTML `<img>` attributes: `<img src="image.png" width="100" height="50">` (requires `parseEmbeddedHtml = true`). The `width`/`height`
+  attributes are parsed the same way.
+
+`DimensionSize` currently has a single variant, `DimensionSize.Pixels(value)` (non-negative). Only pixel/unitless values are supported right
+now; percentage and other units are not yet parsed (`%` is tracked as a TODO under JEWEL-1333). Unparseable or unsupported values resolve to
+`null` (treated as unspecified), and a `{ ... }` block that yields no width/height is left as literal text.
+
+### How dimensions affect rendering
+
+`InlineMarkdown.Image`'s KDoc defines the contract that standard renderers follow, and `Coil3ImageRendererExtensionImpl` implements it:
+
+- Both `width` and `height` specified: the image is rendered at exactly those dimensions (`ContentScale.FillBounds`), stretching if the
+  aspect ratio differs from the original.
+- Only one specified: the other is scaled proportionally from the loaded image's aspect ratio (`ContentScale.Fit`).
+- Neither specified: the image renders at its intrinsic loaded size (existing behavior).
+
+While loading, a known pixel dimension is reserved for the placeholder; unspecified dimensions fall back to a minimal placeholder until the
+image loads.
+
+If you write a custom `ImageRendererExtension`, read `image.width` / `image.height` and apply the same three-way rule yourself; the
+dimensions are data on the node, not something the renderer gets for free.
+
+## Custom image rendering
+
+Implement `ImageRendererExtension.renderImageContent` to return your own `InlineTextContent` (size placeholder + composable). Resolve the
+raw source through `LocalMarkdownImageSourceResolver.current` so path handling stays consistent. Return `null` to render nothing for an
+image (e.g., on error).
+
+## Gotchas
+
+- "Images show as text/markdown": no `ImageRendererExtension` is wired. Add one.
+- "Remote images work, local ones don't": the resolver lacks a capability for that path shape (e.g., relative path with no `rootDir`). Use
+  the `rootDir` overload or a custom resolver.
+- Styling vs loading: `MarkdownStyling.Image` controls alignment/scale/border/background; it does not load images. Loading is the
+  extension + resolver.
+- Share a single Coil `ImageLoader`; don't call `withDefaultLoader()` repeatedly.
+- Sized images: only pixel/unitless dimensions are supported; `%` and other units are ignored (parsed as unspecified) for now. A custom
+  `ImageRendererExtension` must honor `image.width` / `image.height` itself, or sizing silently has no effect.

--- a/.agents/skills/jewel-markdown/references/SCROLL-SYNC.md
+++ b/.agents/skills/jewel-markdown/references/SCROLL-SYNC.md
@@ -1,0 +1,115 @@
+# Scroll synchronization (editor preview)
+
+How to keep a Markdown preview scrolled in sync with a source editor. Read this when building an editor + preview, or when preview scrolling
+behaves oddly.
+
+## When it applies
+
+Scroll sync is an editor-preview feature. It only works when:
+
+- the `MarkdownProcessor` is in `MarkdownMode.EditorPreview(scrollingSynchronizer = ...)`, and
+- the block renderer is scroll-sync-aware (`ScrollSyncMarkdownBlockRenderer`, which the editor-preview styling wires up), and
+- the source view reports the current line so the preview can scroll to it.
+
+In `MarkdownMode.Standalone` there is no synchronizer and nothing to sync.
+
+## Core type: `ScrollingSynchronizer`
+
+File: `core/.../scrolling/ScrollingSynchronizer.kt`.
+
+- Create one with `ScrollingSynchronizer.create(scrollState)`:
+  - `ScrollState` → returns a working `PerLine` synchronizer.
+  - `LazyListState` → currently **not supported**; it logs a warning and returns `null`. This is the key gotcha (see below).
+- Pass it into `MarkdownMode.EditorPreview(scrollingSynchronizer)`, which you give to the `MarkdownProcessor`.
+- Drive it from the editor: `suspend fun scrollToLine(sourceLine: Int, animationSpec)` scrolls the preview to the best match for that source
+  line.
+- `process(action)` wraps a reparse with `beforeProcessing()` / `afterProcessing()`; `MarkdownProcessor.processMarkdownDocument` already
+  calls this when a synchronizer is present.
+
+## How the mapping is built
+
+The synchronizer maintains source-line ↔ rendered-position mappings, fed by three renderer callbacks (handled for you by
+`ScrollSyncMarkdownBlockRenderer`):
+
+- `acceptBlockSpans(block, sourceRange)` — maps each block to the source lines it spans (depth-first; innermost block wins per line). Wraps
+  blocks as `LocatableMarkdownBlock` to disambiguate equal blocks.
+- `acceptGlobalPosition(block, coordinates)` — maps a block to its global Y position; triggered on first composition, the changed block, and
+  blocks below it.
+- `acceptTextLayout(block, textLayout)` — maps per-line offsets inside code blocks, so scrolling can target a specific line within a
+  fenced/indented code block (1:1 source-to-preview line mapping).
+
+`scrollToLine` finds the block on the line (or the closest following/preceding block) and scrolls to its top, adding the intra-code-block
+offset when applicable.
+
+## Identity gotcha: `LocatableMarkdownBlock`
+
+Many `MarkdownBlock`s are value-equal by content (two identical paragraphs are `equals`). Using raw blocks as map keys would let one block's
+layout overwrite another's, causing erratic scrolling. The synchronizer decorates blocks with their source line range via
+`LocatableMarkdownBlock` so equal blocks in different places stay distinct. If you implement a custom synchronizer, preserve this identity
+discipline.
+
+## Gotcha: custom renderers must preserve scroll-sync wiring
+
+Scroll sync is not in `DefaultMarkdownBlockRenderer`. It is implemented entirely by its subclass `ScrollSyncMarkdownBlockRenderer` (file:
+`core/.../scrolling/ScrollSyncMarkdownBlockRenderer.kt`), which overrides the standard `Render*` methods to wrap blocks in
+`AutoScrollableBlock` (reporting global position) and to call `acceptTextLayout` for code blocks. The IntelliJ Markdown plugin instantiates
+this subclass directly for its editor preview; the core/standalone/bridge `MarkdownBlockRenderer` factories do **not** return it.
+
+Two consequences:
+
+- Custom block renderer: if you provide your own `MarkdownBlockRenderer` for an editor preview by subclassing `DefaultMarkdownBlockRenderer`
+  (or building one from scratch), you bypass `ScrollSyncMarkdownBlockRenderer` and lose scroll sync for every block. Subclass
+  `ScrollSyncMarkdownBlockRenderer` instead and call `super` from your overrides, or replicate its `AutoScrollableBlock` wiring.
+- Custom block from an extension: even when `ScrollSyncMarkdownBlockRenderer` is in use, it only wraps the standard blocks it overrides
+  (paragraph, heading, fenced/indented code). It does **not** wrap `CustomBlock`s rendered by a `MarkdownBlockRendererExtension`, so a custom
+  block does not report its position and the preview cannot scroll to lines inside it (the synchronizer falls back to the nearest standard
+  block).
+
+If scroll sync matters for your custom block, opt in from the extension's `RenderCustomBlock` (this works regardless of which of the two
+cases above applies, as long as a `ScrollingSynchronizer` is present):
+
+- Wrap your block content in `AutoScrollableBlock(block, synchronizer) { ... }` (public experimental API, file:
+  `core/.../scrolling/AutoScrollingUtil.kt`). It reports global position via `onGloballyPositioned` for you.
+- Get the synchronizer from `(JewelTheme.markdownMode as? MarkdownMode.EditorPreview)?.scrollingSynchronizer`; if it's `null` (standalone
+  mode), render normally without the wrapper. Mirror the default renderer's pattern.
+- For a multi-line custom block where scrolling to an inner line matters (like code blocks), also call
+  `synchronizer.acceptTextLayout(block, textLayoutResult)` from the relevant `Text`'s `onTextLayout`. Without it the block still scrolls as
+  a unit, just not to a specific inner line.
+- The block you pass should be the one handed to `RenderCustomBlock`; the default renderer uses the `LocatableMarkdownBlock` wrapper
+  internally, but `AutoScrollableBlock` unwraps it, so passing your block is fine.
+
+This is opt-in by design: custom blocks that don't wrap simply won't be scroll-sync targets, which is acceptable for many extensions. Only
+add the wrapper when the editor-preview UX needs to scroll into your block.
+
+## Wiring sketch
+
+```kotlin
+// Source editor exposes a verticalScrollState: ScrollState and a current caret/first-visible line.
+val synchronizer = remember(scrollState) { ScrollingSynchronizer.create(scrollState) }
+
+val processor =
+  remember(synchronizer) {
+    MarkdownProcessor(
+      markdownMode = MarkdownMode.EditorPreview(scrollingSynchronizer = synchronizer),
+    )
+  }
+
+// When the editor scrolls / caret moves:
+LaunchedEffect(currentSourceLine, synchronizer) {
+  synchronizer?.scrollToLine(currentSourceLine)
+}
+```
+
+Use the editor-preview-aware styling/renderer (which installs `ScrollSyncMarkdownBlockRenderer`) so the accept* callbacks are emitted.
+Render with `LazyMarkdown` for documents.
+
+## Gotchas
+
+- `LazyListState` is not supported by `create(...)` yet — it returns `null`. For working scroll sync today, back the preview with a
+  `ScrollState`-based scroll container (the `PerLine` synchronizer), even though large docs otherwise favor `LazyMarkdown`. Confirm against
+  current sources before promising lazy-list scroll sync.
+- A `null` synchronizer silently means "no sync"; check the `create(...)` return value.
+- Don't share an `EditorPreview` processor (and its synchronizer) across unrelated documents — editor mode is stateful.
+- Scroll sync depends on the scroll-sync renderer being active; a plain `DefaultMarkdownBlockRenderer` won't emit the position callbacks.
+- Editing reshuffles mappings: `acceptGlobalPosition` fires for the changed block and those below it, `acceptTextLayout` not always for
+  blocks below the change. Don't assume every block re-reports on every edit.

--- a/.agents/skills/jewel-markdown/skill-source.json
+++ b/.agents/skills/jewel-markdown/skill-source.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "skill": "jewel-markdown",
+  "attribution": "Skill authored by Sebastiano Poggi for the Android Studio team (Google); its canonical home is the Android Studio agent-skills marketplace, and this JetBrains/intellij-community copy is a downstream mirror. Jewel Markdown API evidence is derived from intellij-community itself (https://github.com/JetBrains/intellij-community), Apache-2.0 (sources under platform/jewel/markdown/).",
+  "sources": [
+    {
+      "type": "upstream-skill",
+      "role": "upstream-source",
+      "label": "Android Studio agent-skills marketplace jewel-markdown (canonical origin)",
+      "url": "https://android.googlesource.com/platform/tools/vendor/google/",
+      "version": "2026-06-22",
+      "versionSource": "fetchDate",
+      "fetchedAt": "2026-06-22",
+      "license": "unknown",
+      "check": {
+        "type": "manual",
+        "reason": "Canonical source is the Google-internal Android Studio marketplace (tools/vendor/google/agent-skills-marketplace); not publicly checkable."
+      }
+    },
+    {
+      "type": "upstream-reference",
+      "role": "supporting-reference",
+      "label": "JetBrains intellij-community (Jewel Markdown sources)",
+      "url": "https://github.com/JetBrains/intellij-community/tree/master/platform/jewel/markdown",
+      "version": "master",
+      "versionSource": "fetchDate",
+      "fetchedAt": "2026-06-22",
+      "license": "Apache-2.0",
+      "check": {
+        "type": "github",
+        "repository": "JetBrains/intellij-community",
+        "path": "platform/jewel/markdown",
+        "trackingRef": "master"
+      }
+    }
+  ]
+}

--- a/platform/jewel/markdown/README.md
+++ b/platform/jewel/markdown/README.md
@@ -15,12 +15,12 @@ Additional supported Markdown, via extensions:
 * Tables ([GitHub Flavored Markdown](https://github.github.com/gfm/#tables-extension-)) — see [
   `extension-gfm-tables`](extension/gfm-tables)
 * Strikethrough ([GitHub Flavored Markdown](https://github.github.com/gfm/#strikethrough-extension-))
+* Image loading (via [Coil 3](https://coil-kt.github.io/coil/upgrading_to_coil3/)) — see [`extension-images`](extension/images)
 
 [alerts-specs]: https://github.com/orgs/community/discussions/16925
 
 On the roadmap, but not currently supported — in no particular order:
 
-* Image loading (via [Coil 3](https://coil-kt.github.io/coil/upgrading_to_coil3/))
 * Task list items ([GitHub Flavored Markdown](https://github.github.com/gfm/#task-list-items-extension-))
 * Keyboard shortcuts highlighting (specialized HTML handling)
 * Collapsing sections ([GitHub Flavored Markdown][details-specs])
@@ -121,10 +121,6 @@ By default, the processor will ignore any kind of Markdown it doesn't support. T
 ones found in GitHub Flavored Markdown, you can use extensions. If you don't specify any extension, the processor will
 be restricted to the [CommonMark specs](https://specs.commonmark.org) as supported by
 [`commonmark-java`](https://github.com/commonmark/commonmark-java).
-
-> [!NOTE]
-> Images are not supported yet, even if they are part of the CommonMark specs.
-> See https://github.com/JetBrains/Jewel/issues/472 for status updates.
 
 Extensions are composed of two parts: a parsing and a rendering part. The two parts need to be passed to the
 `MarkdownProcessor` and `MarkdownBlockRenderer`, respectively. For example, in a standalone project:


### PR DESCRIPTION
Adds a project-local agent skill for Jewel Markdown rendering under `.agents/skills/jewel-markdown`, so agents working in `platform/jewel/markdown` have grounded guidance for the experimental Markdown API instead of guessing. Also refreshes `platform/jewel/markdown/README.md` to reflect that image loading is now supported.

This is a contributor-facing docs/skill change: it adds no production code and does not touch any Jewel module sources, API dumps, or module structure.

## Changes

* Add the `jewel-markdown` agent skill: `SKILL.md` covering the two-stage parse/render pipeline (`MarkdownProcessor` → `MarkdownBlock`/`InlineMarkdown` → `MarkdownBlockRenderer`/`InlineMarkdownRenderer`), choosing between `MarkdownStyling` / a custom renderer / an extension, the existing GFM extensions (autolink, tables, strikethrough, alerts) and the images extension, and how to write custom block and delimited-inline extensions using the existing extensions as templates.
* Document custom-renderer gotchas: forwarding `LocalTextAlignment`, preserving the content-color fallback / `inlineContent` map / `enabled`, and not losing editor-preview scroll sync by bypassing `ScrollSyncMarkdownBlockRenderer`.
* Add topic references loaded on demand: code highlighting (`CodeHighlighter`, bridge vs standalone defaults), image loading (`ImageRendererExtension` + `ImageSourceResolver`, Coil3, sized images), embedded HTML conversion (`MarkdownHtmlConverterExtension`), and editor-preview scroll sync (`ScrollingSynchronizer`, `AutoScrollableBlock`, custom-block opt-in).
* Add an eval suite (`evals/evals.json`) exercising the skill's guidance.
* Reference in-repo sources rather than a duplicated API map, since the sources are authoritative and a static index would drift.
* Update `platform/jewel/markdown/README.md`: move image loading (via the Coil 3 extension) out of the roadmap list into the supported-extensions list, and remove the stale "images are not supported yet" note.