### PR TITLE
[terminal] IJPL-165734 terminal was restarted after drag in editor splits

### DIFF
--- a/platform/platform-api/src/com/intellij/ui/tabs/impl/JBTabsImpl.kt
+++ b/platform/platform-api/src/com/intellij/ui/tabs/impl/JBTabsImpl.kt
@@ -2638,6 +2638,7 @@ open class JBTabsImpl internal constructor(
       return
     }
 
+    processRemove(tab = info, forcedNow = true, setSelectedToNull = selectedInfo == info)
     if (visibleInfos.isEmpty()) {
       removeDeferredNow()
     }

--- a/platform/platform-impl/src/com/intellij/ide/actions/SplitAction.java
+++ b/platform/platform-impl/src/com/intellij/ide/actions/SplitAction.java
@@ -42,7 +42,21 @@ public abstract class SplitAction extends AnAction implements DumbAware, ActionR
     VirtualFile file = window.getContextFile();
     if (closeSource && file != null) {
       file.putUserData(EditorWindow.DRAG_START_PINNED_KEY, window.isFilePinned(file));
-      window.closeFile(file, false, false);
+      boolean markClosingToReopen = FileEditorManagerImpl.forbidSplitFor(file) &&
+                                    file.getUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN) != Boolean.TRUE;
+      if (markClosingToReopen) {
+        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true);
+      }
+      try {
+        window.closeFile(file, false, false);
+        window.split(orientation, true, file, true);
+      }
+      finally {
+        if (markClosingToReopen) {
+          file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null);
+        }
+      }
+      return;
     }
 
     window.split(orientation, true, file, true);

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorTabbedContainer.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorTabbedContainer.kt
@@ -468,13 +468,13 @@ internal class EditorTabbedContainerDragOutDelegate(private val window: EditorWi
     val dragStartIndex = editorTabs.getIndexOf(info)
     val isPinnedAtStart = info.isPinned
 
-    // setting isHidden to true will hide the tab - we must select another tab now
     window.getTabToSelect(tabBeingClosed = info, fileBeingClosed = file, componentIndex = dragStartIndex)?.let {
+      // setting isHidden to true will hide the tab - we must select another tab now
       WriteIntentReadAction.run {
         window.setCurrentCompositeAndSelectTab(it)
       }
+      info.isHidden = true
     }
-    info.isHidden = true
 
     this.file = file
     file.putUserData(DRAG_START_INDEX_KEY, dragStartIndex)

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorWindow.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorWindow.kt
@@ -720,7 +720,7 @@ class EditorWindow internal constructor(
           }
 
           val info = editorTabs.getTabAt(componentIndex)
-          if (isDisposed || !manager.project.isOpen) {
+          if (info.isHidden || isDisposed || !manager.project.isOpen) {
             editorTabs.removeTabWithoutChangingSelection(info)
           }
           else {

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
@@ -654,8 +654,11 @@ open class EditorsSplitters internal constructor(
     return null
   }
 
-  fun closeFile(file: VirtualFile, moveFocus: Boolean) {
-    closeFileInWindows(file = file, windows = findWindows(file), moveFocus = moveFocus)
+  fun closeFile(file: VirtualFile, moveFocus: Boolean, openReplacementInEmptyWindow: Boolean = true) {
+    closeFileInWindows(file = file,
+                       windows = findWindows(file),
+                       moveFocus = moveFocus,
+                       openReplacementInEmptyWindow = openReplacementInEmptyWindow)
   }
 
   internal fun closeFileEditor(file: VirtualFile, editor: FileEditor, moveFocus: Boolean) {
@@ -665,17 +668,17 @@ open class EditorsSplitters internal constructor(
         composite.allEditorsWithProviders.any { it.fileEditor == editor }
       }
     }
-    closeFileInWindows(file = file, windows = windows, moveFocus = moveFocus)
+    closeFileInWindows(file = file, windows = windows, moveFocus = moveFocus, openReplacementInEmptyWindow = true)
   }
 
-  private fun closeFileInWindows(file: VirtualFile, windows: List<EditorWindow>, moveFocus: Boolean) {
+  private fun closeFileInWindows(file: VirtualFile, windows: List<EditorWindow>, moveFocus: Boolean, openReplacementInEmptyWindow: Boolean) {
     if (windows.isEmpty()) {
       return
     }
 
     val isProjectOpen = manager.project.isOpen
 
-    val nextFile = findNextFile(file)
+    val nextFile = if (openReplacementInEmptyWindow) findNextFile(file) else null
     for (window in windows) {
       val composite = window.getComposite(file) ?: continue
       window.closeFile(
@@ -705,7 +708,12 @@ open class EditorsSplitters internal constructor(
           continue
         }
         if (window.tabCount == 0) {
-          window.unsplit(setCurrent = false)
+          if (openReplacementInEmptyWindow) {
+            window.unsplit(setCurrent = false)
+          }
+          else {
+            window.removeFromSplitter()
+          }
         }
       }
     }

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/EditorsSplitters.kt
@@ -654,6 +654,9 @@ open class EditorsSplitters internal constructor(
     return null
   }
 
+  /**
+   * If [openReplacementInEmptyWindow] is false, an emptied source split is removed instead of being filled with another open file.
+   */
   fun closeFile(file: VirtualFile, moveFocus: Boolean, openReplacementInEmptyWindow: Boolean = true) {
     closeFileInWindows(file = file,
                        windows = findWindows(file),

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
@@ -918,6 +918,32 @@ open class FileEditorManagerImpl(
     closeFile(file = file, moveFocus = true, closeAllCopies = false, openReplacementInEmptyWindow = false)
   }
 
+  /**
+   * Moves a non-splittable file by closing its current editor before opening it in another window.
+   * The source split is not filled with an arbitrary replacement tab; if it becomes empty, it is removed.
+   * [FileEditorManagerKeys.CLOSING_TO_REOPEN] stays set across disposal and editor creation.
+   */
+  @RequiresEdt
+  private inline fun <T> moveNoSplitFileIfNeeded(file: VirtualFile, targetWindow: EditorWindow?, openFile: () -> T): T {
+    if (!forbidSplitFor(file) || !isFileOpen(file) || targetWindow?.isFileOpen(file) == true) {
+      return openFile()
+    }
+
+    val shouldMarkClosingToReopen = file.getUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN) != true
+    if (shouldMarkClosingToReopen) {
+      file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true)
+    }
+    try {
+      closeFileForMove(file)
+      return openFile()
+    }
+    finally {
+      if (shouldMarkClosingToReopen) {
+        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
+      }
+    }
+  }
+
   @RequiresEdt
   private fun closeFile(file: VirtualFile, moveFocus: Boolean, closeAllCopies: Boolean, openReplacementInEmptyWindow: Boolean) {
     if (closeAllCopies) {
@@ -1004,23 +1030,18 @@ open class FileEditorManagerImpl(
           }
         }
 
-        if (forbidSplitFor(file)) {
-          closeFileForMove(file)
-        }
-
         // Don't create a new window on backend for OpenMode.NEW_WINDOW,
         // it will lead to creating two windows -- one from backend (Lux-ed),
         // and another from frontend
         if (ClientId.isCurrentlyUnderLocalId) {
-          return (DockManager.getInstance(project) as DockManagerImpl).createNewDockContainerFor(
-            file = file,
-            fileEditorManager = this,
-            isSingletonEditorInWindow = options.isSingletonEditorInWindow,
-          ) { editorWindow ->
-            if (forbidSplitFor(file = file) && !editorWindow.isFileOpen(file = file)) {
-              closeFileForMove(file)
+          return moveNoSplitFileIfNeeded(file = file, targetWindow = null) {
+            (DockManager.getInstance(project) as DockManagerImpl).createNewDockContainerFor(
+              file = file,
+              fileEditorManager = this,
+              isSingletonEditorInWindow = options.isSingletonEditorInWindow,
+            ) { editorWindow ->
+              doOpenFile(file = file, windowToOpenIn = editorWindow, options = options)
             }
-            doOpenFile(file = file, windowToOpenIn = editorWindow, options = options)
           }
         }
       }
@@ -1034,17 +1055,13 @@ open class FileEditorManagerImpl(
     if (windowToOpenIn == null) {
       windowToOpenIn = getWindowToOpen(options, file)
     }
-    if (forbidSplitFor(file = file) && !windowToOpenIn.isFileOpen(file)) {
-      closeFileForMove(file)
-    }
-    return openFileImpl(window = windowToOpenIn, _file = file, entry = null, options = options)
+    return doOpenFile(file = file, windowToOpenIn = windowToOpenIn, options = options)
   }
 
   private fun doOpenFile(file: VirtualFile, windowToOpenIn: EditorWindow, options: FileEditorOpenOptions): FileEditorComposite {
-    if (forbidSplitFor(file = file) && !windowToOpenIn.isFileOpen(file)) {
-      closeFileForMove(file)
+    return moveNoSplitFileIfNeeded(file = file, targetWindow = windowToOpenIn) {
+      openFileImpl(window = windowToOpenIn, _file = file, entry = null, options = options)
     }
-    return openFileImpl(window = windowToOpenIn, _file = file, entry = null, options = options)
   }
 
   override suspend fun openFile(file: VirtualFile, options: FileEditorOpenOptions): FileEditorComposite {
@@ -1060,19 +1077,14 @@ open class FileEditorManagerImpl(
     val mode = options.openMode
     if (mode == OpenMode.NEW_WINDOW) {
       return withContext(Dispatchers.EDT) {
-        if (forbidSplitFor(file)) {
-          closeFileForMove(file)
-        }
-        (DockManager.getInstance(project) as DockManagerImpl).createNewDockContainerFor(
-          file = file,
-          fileEditorManager = this@FileEditorManagerImpl,
-          isSingletonEditorInWindow = false,
-        ) { editorWindow ->
-          if (forbidSplitFor(file = file) && !editorWindow.isFileOpen(file = file)) {
-            closeFileForMove(file)
+        moveNoSplitFileIfNeeded(file = file, targetWindow = null) {
+          (DockManager.getInstance(project) as DockManagerImpl).createNewDockContainerFor(
+            file = file,
+            fileEditorManager = this@FileEditorManagerImpl,
+            isSingletonEditorInWindow = false,
+          ) { editorWindow ->
+            doOpenFile(file = file, windowToOpenIn = editorWindow, options = options)
           }
-
-          doOpenFile(file = file, windowToOpenIn = editorWindow, options = options)
         }
       }
     }
@@ -1093,13 +1105,11 @@ open class FileEditorManagerImpl(
     val composite: FileEditorComposite? = withContext(Dispatchers.EDT) {
       writeIntentReadAction {
         val window = getWindowToOpen(options, file)
-        if (forbidSplitFor(file) && !window.isFileOpen(file)) {
-          closeFileForMove(file)
-        }
-
-        @Suppress("DuplicatedCode")
-        runBulkTabChangeInEdt(window.owner) {
-          doOpenInEdt(window = window, file = file, options = options, fileEntry = null)
+        moveNoSplitFileIfNeeded(file = file, targetWindow = window) {
+          @Suppress("DuplicatedCode")
+          runBulkTabChangeInEdt(window.owner) {
+            doOpenInEdt(window = window, file = file, options = options, fileEntry = null)
+          }
         }
       }
     }
@@ -1176,26 +1186,15 @@ open class FileEditorManagerImpl(
 
   @JvmOverloads
   fun openFileInNewWindow(file: VirtualFile, reuseOpen: Boolean = false): Pair<Array<FileEditor>, Array<FileEditorProvider>> {
-    val closingToReopen = forbidSplitFor(file)
-    if (closingToReopen) {
-      file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true)
-    }
-    try {
-      return openFile(
-        file = file,
-        window = null,
-        options = FileEditorOpenOptions(
-          reuseOpen = reuseOpen,
-          requestFocus = true,
-          openMode = OpenMode.NEW_WINDOW,
-        ),
-      ).retrofit()
-    }
-    finally {
-      if (closingToReopen) {
-        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
-      }
-    }
+    return openFile(
+      file = file,
+      window = null,
+      options = FileEditorOpenOptions(
+        reuseOpen = reuseOpen,
+        requestFocus = true,
+        openMode = OpenMode.NEW_WINDOW,
+      ),
+    ).retrofit()
   }
 
   @RequiresEdt
@@ -1228,32 +1227,44 @@ open class FileEditorManagerImpl(
   }
 
   open fun openFileImpl2(window: EditorWindow, file: VirtualFile, options: FileEditorOpenOptions): FileEditorComposite {
-    if (forbidSplitFor(file) && !window.isFileOpen(file)) {
-      closeFileForMove(file)
+    return moveNoSplitFileIfNeeded(file = file, targetWindow = window) {
+      openFileImpl(window = window, _file = file, entry = null, options = options)
     }
-    return openFileImpl(window = window, _file = file, entry = null, options = options)
   }
 
   internal suspend fun checkForbidSplitAndOpenFile(window: EditorWindow, file: VirtualFile, options: FileEditorOpenOptions) {
-    if (forbidSplitFor(file) && !window.isFileOpen(file)) {
-      withContext(Dispatchers.EDT) {
-        closeFileForMove(file)
-      }
-    }
-
     if (!ClientId.isCurrentlyUnderLocalId) {
-      clientFileEditorManager?.openFileAsync(
-        file = file,
-        // it used to be passed as forceCreate=false there, so we need to pass it as reuseOpen=true
-        // otherwise, any navigation will open a new editor composite which is invisible in RD mode
-        options = options.copy(reuseOpen = true),
-      )
+      val shouldMoveNoSplitFile = forbidSplitFor(file) && !window.isFileOpen(file)
+      val shouldMarkClosingToReopen = shouldMoveNoSplitFile && file.getUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN) != true
+      if (shouldMarkClosingToReopen) {
+        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true)
+      }
+      try {
+        if (shouldMoveNoSplitFile) {
+          withContext(Dispatchers.EDT) {
+            closeFileForMove(file)
+          }
+        }
+        clientFileEditorManager?.openFileAsync(
+          file = file,
+          // it used to be passed as forceCreate=false there, so we need to pass it as reuseOpen=true
+          // otherwise, any navigation will open a new editor composite which is invisible in RD mode
+          options = options.copy(reuseOpen = true),
+        )
+      }
+      finally {
+        if (shouldMarkClosingToReopen) {
+          file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
+        }
+      }
       return
     }
 
     withContext(Dispatchers.EDT) {
-      runBulkTabChangeInEdt(window.owner) {
-        doOpenInEdt(window = window, file = file, options = options, fileEntry = null)
+      moveNoSplitFileIfNeeded(file = file, targetWindow = window) {
+        runBulkTabChangeInEdt(window.owner) {
+          doOpenInEdt(window = window, file = file, options = options, fileEntry = null)
+        }
       }
     }
   }

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
@@ -910,11 +910,25 @@ open class FileEditorManagerImpl(
 
   @RequiresEdt
   fun closeFile(file: VirtualFile, moveFocus: Boolean, closeAllCopies: Boolean) {
+    closeFile(file = file, moveFocus = moveFocus, closeAllCopies = closeAllCopies, openReplacementInEmptyWindow = true)
+  }
+
+  @RequiresEdt
+  private fun closeFileForMove(file: VirtualFile) {
+    closeFile(file = file, moveFocus = true, closeAllCopies = false, openReplacementInEmptyWindow = false)
+  }
+
+  @RequiresEdt
+  private fun closeFile(file: VirtualFile, moveFocus: Boolean, closeAllCopies: Boolean, openReplacementInEmptyWindow: Boolean) {
     if (closeAllCopies) {
       ClientId.withExplicitClientId(ClientId.localId).use {
         openFileSetModificationCount.increment()
         for (each in getAllSplitters()) {
-          runBulkTabChangeInEdt(each) { each.closeFile(file = file, moveFocus = moveFocus) }
+          runBulkTabChangeInEdt(each) {
+            each.closeFile(file = file,
+                           moveFocus = moveFocus,
+                           openReplacementInEmptyWindow = openReplacementInEmptyWindow)
+          }
         }
       }
       for (manager in allClientFileEditorManagers) {
@@ -926,7 +940,9 @@ open class FileEditorManagerImpl(
         openFileSetModificationCount.increment()
         val activeSplitters = getActiveSplitterSync()
         runBulkTabChangeInEdt(activeSplitters) {
-          activeSplitters.closeFile(file = file, moveFocus = moveFocus)
+          activeSplitters.closeFile(file = file,
+                                    moveFocus = moveFocus,
+                                    openReplacementInEmptyWindow = openReplacementInEmptyWindow)
         }
       }
       else {
@@ -989,7 +1005,7 @@ open class FileEditorManagerImpl(
         }
 
         if (forbidSplitFor(file)) {
-          closeFile(file)
+          closeFileForMove(file)
         }
 
         // Don't create a new window on backend for OpenMode.NEW_WINDOW,
@@ -1002,7 +1018,7 @@ open class FileEditorManagerImpl(
             isSingletonEditorInWindow = options.isSingletonEditorInWindow,
           ) { editorWindow ->
             if (forbidSplitFor(file = file) && !editorWindow.isFileOpen(file = file)) {
-              closeFile(file = file)
+              closeFileForMove(file)
             }
             doOpenFile(file = file, windowToOpenIn = editorWindow, options = options)
           }
@@ -1019,14 +1035,14 @@ open class FileEditorManagerImpl(
       windowToOpenIn = getWindowToOpen(options, file)
     }
     if (forbidSplitFor(file = file) && !windowToOpenIn.isFileOpen(file)) {
-      closeFile(file)
+      closeFileForMove(file)
     }
     return openFileImpl(window = windowToOpenIn, _file = file, entry = null, options = options)
   }
 
   private fun doOpenFile(file: VirtualFile, windowToOpenIn: EditorWindow, options: FileEditorOpenOptions): FileEditorComposite {
     if (forbidSplitFor(file = file) && !windowToOpenIn.isFileOpen(file)) {
-      closeFile(file)
+      closeFileForMove(file)
     }
     return openFileImpl(window = windowToOpenIn, _file = file, entry = null, options = options)
   }
@@ -1045,7 +1061,7 @@ open class FileEditorManagerImpl(
     if (mode == OpenMode.NEW_WINDOW) {
       return withContext(Dispatchers.EDT) {
         if (forbidSplitFor(file)) {
-          closeFile(file)
+          closeFileForMove(file)
         }
         (DockManager.getInstance(project) as DockManagerImpl).createNewDockContainerFor(
           file = file,
@@ -1053,7 +1069,7 @@ open class FileEditorManagerImpl(
           isSingletonEditorInWindow = false,
         ) { editorWindow ->
           if (forbidSplitFor(file = file) && !editorWindow.isFileOpen(file = file)) {
-            closeFile(file = file)
+            closeFileForMove(file)
           }
 
           doOpenFile(file = file, windowToOpenIn = editorWindow, options = options)
@@ -1078,7 +1094,7 @@ open class FileEditorManagerImpl(
       writeIntentReadAction {
         val window = getWindowToOpen(options, file)
         if (forbidSplitFor(file) && !window.isFileOpen(file)) {
-          closeFile(file)
+          closeFileForMove(file)
         }
 
         @Suppress("DuplicatedCode")
@@ -1160,15 +1176,26 @@ open class FileEditorManagerImpl(
 
   @JvmOverloads
   fun openFileInNewWindow(file: VirtualFile, reuseOpen: Boolean = false): Pair<Array<FileEditor>, Array<FileEditorProvider>> {
-    return openFile(
-      file = file,
-      window = null,
-      options = FileEditorOpenOptions(
-        reuseOpen = reuseOpen,
-        requestFocus = true,
-        openMode = OpenMode.NEW_WINDOW,
-      ),
-    ).retrofit()
+    val closingToReopen = forbidSplitFor(file)
+    if (closingToReopen) {
+      file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true)
+    }
+    try {
+      return openFile(
+        file = file,
+        window = null,
+        options = FileEditorOpenOptions(
+          reuseOpen = reuseOpen,
+          requestFocus = true,
+          openMode = OpenMode.NEW_WINDOW,
+        ),
+      ).retrofit()
+    }
+    finally {
+      if (closingToReopen) {
+        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
+      }
+    }
   }
 
   @RequiresEdt
@@ -1202,7 +1229,7 @@ open class FileEditorManagerImpl(
 
   open fun openFileImpl2(window: EditorWindow, file: VirtualFile, options: FileEditorOpenOptions): FileEditorComposite {
     if (forbidSplitFor(file) && !window.isFileOpen(file)) {
-      closeFile(file)
+      closeFileForMove(file)
     }
     return openFileImpl(window = window, _file = file, entry = null, options = options)
   }
@@ -1210,7 +1237,7 @@ open class FileEditorManagerImpl(
   internal suspend fun checkForbidSplitAndOpenFile(window: EditorWindow, file: VirtualFile, options: FileEditorOpenOptions) {
     if (forbidSplitFor(file) && !window.isFileOpen(file)) {
       withContext(Dispatchers.EDT) {
-        closeFile(file)
+        closeFileForMove(file)
       }
     }
 

--- a/platform/platform-impl/testSrc/com/intellij/ui/tabs/impl/JBTabsImplTest.kt
+++ b/platform/platform-impl/testSrc/com/intellij/ui/tabs/impl/JBTabsImplTest.kt
@@ -1,0 +1,35 @@
+package com.intellij.ui.tabs.impl
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.junit5.RunInEdt
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.ui.tabs.TabInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.swing.JPanel
+
+@TestApplication
+@RunInEdt
+internal class JBTabsImplTest {
+  @Test
+  fun `remove hidden tab without changing selection removes tab`(@TestDisposable disposable: Disposable) {
+    val tabs = JBTabsImpl(
+      project = null,
+      parentDisposable = disposable,
+      tabListOptions = TabListOptions(),
+    )
+    val selectedTab = TabInfo(JPanel()).setText("selected")
+    val hiddenTab = TabInfo(JPanel()).setText("hidden")
+    tabs.addTab(selectedTab)
+    tabs.addTab(hiddenTab)
+    tabs.select(selectedTab, false)
+
+    hiddenTab.isHidden = true
+    tabs.removeTabWithoutChangingSelection(hiddenTab)
+
+    assertThat(tabs.tabs).containsExactly(selectedTab)
+    assertThat(tabs.getVisibleInfos()).containsExactly(selectedTab)
+    assertThat(tabs.selectedInfo).isSameAs(selectedTab)
+  }
+}

--- a/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
@@ -495,6 +495,76 @@ class FileEditorManagerTest {
   }
 
   @Test
+  fun testMovingNoSplitFileBetweenEditorSplitsKeepsSingleReopenedEditor(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
+    var closeToReopenCount = 0
+    registerReopenAwareProvider { closeToReopenCount++ }
+
+    val file = getSourceFile("1.txt")
+    val leftFile = getSourceFile("2.txt")
+    val rightFile = getSourceFile("3.txt")
+    manager.openFile(file, false)
+    val leftWindow = currentWindow()
+    manager.openFileImpl2(leftWindow, leftFile, FileEditorOpenOptions())
+    leftWindow.setSelectedComposite(file, false)
+    val rightWindow = createVerticalSplitter(leftWindow)
+    manager.openFileImpl2(rightWindow, rightFile, FileEditorOpenOptions().withRequestFocus(true))
+    manager.closeFile(file, rightWindow)
+    file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, true)
+
+    try {
+      repeat(6) { index ->
+        val targetWindow = if (index % 2 == 0) rightWindow else leftWindow
+        manager.openFileImpl2(targetWindow, file, FileEditorOpenOptions().withRequestFocus(true))
+
+        assertThat(manager.getAllEditorList(file)).hasSize(1)
+        assertThat(leftWindow.isFileOpen(file)).isEqualTo(targetWindow === leftWindow)
+        assertThat(rightWindow.isFileOpen(file)).isEqualTo(targetWindow === rightWindow)
+      }
+
+      assertThat(closeToReopenCount).isEqualTo(6)
+      assertThat(leftWindow.isFileOpen(leftFile)).isTrue()
+      assertThat(rightWindow.isFileOpen(rightFile)).isTrue()
+    }
+    finally {
+      manager.closeFile(file)
+      manager.closeFile(leftFile)
+      manager.closeFile(rightFile)
+      executeSomeCoroutineTasksAndDispatchAllInvocationEvents(project)
+      IndexingTestUtil.waitUntilIndexesAreReady(project)
+      file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, null)
+    }
+  }
+
+  @Test
+  fun testSuspendOpenFileInNewWindowKeepsNoSplitEditorReopened(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
+    var editorWasClosedToReopen = false
+    registerReopenAwareProvider { editorWasClosedToReopen = true }
+
+    val file = getSourceFile("1.txt")
+    manager.openFile(file, false)
+    file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, true)
+
+    try {
+      manager.openFile(
+        file,
+        FileEditorOpenOptions(
+          requestFocus = true,
+          openMode = FileEditorManagerImpl.OpenMode.NEW_WINDOW,
+        ),
+      )
+
+      assertThat(editorWasClosedToReopen).isTrue()
+      assertThat(manager.getAllEditorList(file)).hasSize(1)
+    }
+    finally {
+      manager.closeFile(file)
+      executeSomeCoroutineTasksAndDispatchAllInvocationEvents(project)
+      IndexingTestUtil.waitUntilIndexesAreReady(project)
+      file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, null)
+    }
+  }
+
+  @Test
   fun testMustNotAllowToTypeIntoFileRenamedToUnknownExtension(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
     val ioFile = IoTestUtil.createTestFile("test.txt", "")
     var file: VirtualFile? = null

--- a/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
@@ -42,6 +42,7 @@ import com.intellij.pom.Navigatable
 import com.intellij.testFramework.DumbModeTestUtils
 import com.intellij.testFramework.EditorTestUtil
 import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.VfsTestUtil
 import com.intellij.testFramework.common.timeoutRunBlocking
@@ -424,6 +425,76 @@ class FileEditorManagerTest {
   }
 
   @Test
+  fun testOpenFileInNewWindowClosesEmptyNoSplitSourceSplit(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
+    var editorWasClosedToReopen = false
+    registerReopenAwareProvider { editorWasClosedToReopen = true }
+
+    val file = getSourceFile("1.txt")
+    val siblingFile = getSourceFile("2.txt")
+    manager.openFile(file, false)
+    val sourceWindow = currentWindow()
+    val sourceSplitters = sourceWindow.owner
+    val siblingWindow = createVerticalSplitter(sourceWindow)
+    manager.openFileImpl2(siblingWindow, siblingFile, FileEditorOpenOptions().withRequestFocus(true))
+    manager.closeFile(file, siblingWindow)
+    file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, true)
+
+    try {
+      manager.openFileInNewWindow(file)
+
+      assertThat(editorWasClosedToReopen).isTrue()
+      assertThat(manager.getAllEditorList(file)).hasSize(1)
+      val sourceWindows = sourceSplitters.windows().toList()
+      assertThat(sourceWindows).hasSize(1)
+      assertThat(sourceWindows.single().isFileOpen(siblingFile)).isTrue()
+    }
+    finally {
+      manager.closeFile(file)
+      manager.closeFile(siblingFile)
+      executeSomeCoroutineTasksAndDispatchAllInvocationEvents(project)
+      IndexingTestUtil.waitUntilIndexesAreReady(project)
+      file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, null)
+    }
+  }
+
+  @Test
+  fun testOpenFileInNewWindowKeepsNoSplitSourceSplitWithOtherTabs(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
+    var editorWasClosedToReopen = false
+    registerReopenAwareProvider { editorWasClosedToReopen = true }
+
+    val file = getSourceFile("1.txt")
+    val sourceFile = getSourceFile("2.txt")
+    val siblingFile = getSourceFile("3.txt")
+    manager.openFile(file, false)
+    val sourceWindow = currentWindow()
+    val sourceSplitters = sourceWindow.owner
+    manager.openFileImpl2(sourceWindow, sourceFile, FileEditorOpenOptions())
+    sourceWindow.setSelectedComposite(file, false)
+    val siblingWindow = createVerticalSplitter(sourceWindow)
+    manager.openFileImpl2(siblingWindow, siblingFile, FileEditorOpenOptions().withRequestFocus(true))
+    manager.closeFile(file, siblingWindow)
+    file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, true)
+
+    try {
+      manager.openFileInNewWindow(file)
+
+      assertThat(editorWasClosedToReopen).isTrue()
+      assertThat(manager.getAllEditorList(file)).hasSize(1)
+      assertThat(sourceWindow.isFileOpen(file)).isFalse()
+      assertThat(sourceWindow.isFileOpen(sourceFile)).isTrue()
+      assertThat(sourceSplitters.windows().toList()).hasSize(2)
+    }
+    finally {
+      manager.closeFile(file)
+      manager.closeFile(sourceFile)
+      manager.closeFile(siblingFile)
+      executeSomeCoroutineTasksAndDispatchAllInvocationEvents(project)
+      IndexingTestUtil.waitUntilIndexesAreReady(project)
+      file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, null)
+    }
+  }
+
+  @Test
   fun testMustNotAllowToTypeIntoFileRenamedToUnknownExtension(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
     val ioFile = IoTestUtil.createTestFile("test.txt", "")
     var file: VirtualFile? = null
@@ -452,6 +523,31 @@ class FileEditorManagerTest {
     Disposer.register(disposable, providerDisposable)
     providerDisposables.add(providerDisposable)
     FileEditorProvider.EP_FILE_EDITOR_PROVIDER.point.registerExtension(provider, providerDisposable)
+  }
+
+  private fun registerReopenAwareProvider(onClosingToReopen: () -> Unit) {
+    registerProvider(object : MockFileEditorProvider(
+      editorTypeId = "reopenAware",
+      fileEditorName = "ReopenAware",
+      policy = FileEditorPolicy.HIDE_DEFAULT_EDITOR,
+    ), DumbAware {
+      override fun createEditor(project: Project, file: VirtualFile): FileEditor {
+        return object : Mock.MyFileEditor() {
+          override fun getComponent(): JComponent = JLabel()
+
+          override fun getName(): String = "ReopenAware"
+
+          override fun getFile(): VirtualFile = file
+
+          override fun dispose() {
+            if (file.getUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN) == true) {
+              onClosingToReopen()
+            }
+            super.dispose()
+          }
+        }
+      }
+    })
   }
 
   private fun getSourceFile(name: String): VirtualFile = getFile("/src/$name")

--- a/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
@@ -6,6 +6,10 @@ import com.intellij.ide.ui.UISettings
 import com.intellij.ide.ui.UISettingsState
 import com.intellij.mock.Mock
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.application.UiWithModelAccess
 import com.intellij.openapi.components.ExpandMacroToPathMap
 import com.intellij.openapi.editor.Document
@@ -44,6 +48,7 @@ import com.intellij.testFramework.EditorTestUtil
 import com.intellij.testFramework.HeavyPlatformTestCase
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.TestActionEvent
 import com.intellij.testFramework.VfsTestUtil
 import com.intellij.testFramework.common.timeoutRunBlocking
 import com.intellij.testFramework.executeSomeCoroutineTasksAndDispatchAllInvocationEvents
@@ -536,6 +541,72 @@ class FileEditorManagerTest {
   }
 
   @Test
+  fun testNoSplitEditorTabCanBeMovedAndUnsplit(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
+    val file = getSourceFile("1.txt")
+    val siblingFile = getSourceFile("2.txt")
+    val sourceFile = getSourceFile("3.txt")
+    manager.openFile(file, false)
+    val sourceWindow = currentWindow()
+    manager.openFileImpl2(sourceWindow, sourceFile, FileEditorOpenOptions())
+    val siblingWindow = createVerticalSplitter(sourceWindow)
+    manager.openFileImpl2(siblingWindow, siblingFile, FileEditorOpenOptions().withRequestFocus(true))
+    manager.closeFile(file, siblingWindow)
+    sourceWindow.setSelectedComposite(file, false)
+    file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, true)
+
+    try {
+      val dataContext = editorTabDataContext(file, sourceWindow)
+
+      assertActionEnabled("MoveTabRight", dataContext, true)
+      assertActionEnabled("MoveTabDown", dataContext, true)
+      assertActionEnabled("Unsplit", dataContext, true)
+    }
+    finally {
+      manager.closeFile(file)
+      manager.closeFile(siblingFile)
+      manager.closeFile(sourceFile)
+      file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, null)
+    }
+  }
+
+  @Test
+  fun testSplitAndMoveNoSplitEditorTabKeepsEditorReopened(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
+    var closeToReopenCount = 0
+    registerReopenAwareProvider { closeToReopenCount++ }
+
+    val file = getSourceFile("1.txt")
+    val siblingFile = getSourceFile("2.txt")
+    val sourceFile = getSourceFile("3.txt")
+    manager.openFile(file, false)
+    val sourceWindow = currentWindow()
+    manager.openFileImpl2(sourceWindow, sourceFile, FileEditorOpenOptions())
+    val siblingWindow = createVerticalSplitter(sourceWindow)
+    manager.openFileImpl2(siblingWindow, siblingFile, FileEditorOpenOptions().withRequestFocus(true))
+    manager.closeFile(file, siblingWindow)
+    sourceWindow.setSelectedComposite(file, false)
+    file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, true)
+
+    try {
+      performAction("MoveTabRight", editorTabDataContext(file, sourceWindow))
+      executeSomeCoroutineTasksAndDispatchAllInvocationEvents(project)
+
+      assertThat(closeToReopenCount).isEqualTo(1)
+      assertThat(manager.getAllEditorList(file)).hasSize(1)
+      assertThat(sourceWindow.isFileOpen(file)).isFalse()
+      assertThat(sourceWindow.isFileOpen(sourceFile)).isTrue()
+      assertThat(sourceWindow.owner.windows().toList().any { it !== sourceWindow && it.isFileOpen(file) }).isTrue()
+    }
+    finally {
+      manager.closeFile(file)
+      manager.closeFile(siblingFile)
+      manager.closeFile(sourceFile)
+      executeSomeCoroutineTasksAndDispatchAllInvocationEvents(project)
+      IndexingTestUtil.waitUntilIndexesAreReady(project)
+      file.putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, null)
+    }
+  }
+
+  @Test
   fun testSuspendOpenFileInNewWindowKeepsNoSplitEditorReopened(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
     var editorWasClosedToReopen = false
     registerReopenAwareProvider { editorWasClosedToReopen = true }
@@ -656,6 +727,33 @@ class FileEditorManagerTest {
     manager.openFileImpl2(secondaryWindow, getSourceFile("2.txt"), FileEditorOpenOptions().withRequestFocus(true))
     manager.closeFile(file, secondaryWindow)
     return SecondaryWindowFixture(file, secondaryWindow)
+  }
+
+  private fun editorTabDataContext(file: VirtualFile, window: EditorWindow): DataContext {
+    return SimpleDataContext.builder()
+      .add(CommonDataKeys.PROJECT, project)
+      .add(CommonDataKeys.VIRTUAL_FILE, file)
+      .add(EditorWindow.DATA_KEY, window)
+      .build()
+  }
+
+  private fun assertActionEnabled(actionId: String, dataContext: DataContext, enabled: Boolean) {
+    val action = assertThatNotNull(ActionManager.getInstance().getAction(actionId), actionId)
+    val event = TestActionEvent.createTestEvent(action, dataContext)
+
+    action.update(event)
+
+    assertThat(event.presentation.isEnabled).describedAs(actionId).isEqualTo(enabled)
+  }
+
+  private fun performAction(actionId: String, dataContext: DataContext) {
+    val action = assertThatNotNull(ActionManager.getInstance().getAction(actionId), actionId)
+    val event = TestActionEvent.createTestEvent(action, dataContext)
+
+    action.update(event)
+    assertThat(event.presentation.isEnabled).describedAs(actionId).isTrue()
+
+    action.actionPerformed(event)
   }
 
   private fun openSingleTextEditor(file: VirtualFile): Editor {

--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/editor/TerminalViewFileEditorProvider.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/editor/TerminalViewFileEditorProvider.kt
@@ -1,19 +1,12 @@
 package com.intellij.terminal.frontend.editor
 
 import com.intellij.openapi.fileEditor.FileEditor
-import com.intellij.openapi.fileEditor.FileEditorManagerKeys
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.FileEditorProvider
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.annotations.NonNls
-import org.jetbrains.plugins.terminal.JBTerminalSystemSettingsProvider
-import org.jetbrains.plugins.terminal.LocalTerminalDirectRunner
-import org.jetbrains.plugins.terminal.ShellStartupOptions
-import org.jetbrains.plugins.terminal.vfs.ClassicTerminalSessionEditor
-import org.jetbrains.plugins.terminal.vfs.TerminalSessionVirtualFileImpl
 
 internal class TerminalViewFileEditorProvider : FileEditorProvider, DumbAware {
   override fun accept(project: Project, file: VirtualFile): Boolean {
@@ -26,29 +19,7 @@ internal class TerminalViewFileEditorProvider : FileEditorProvider, DumbAware {
 
   override fun createEditor(project: Project, file: VirtualFile): FileEditor {
     val terminalFile = file as TerminalViewVirtualFile
-    if (file.getUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN) == true) {
-      return TerminalViewFileEditor(project, terminalFile)
-    }
-    else {
-      // Since there is no API to start Reworked Terminal outside of the terminal tool window,
-      // create the Classic terminal there similar to ClassicTerminalSessionEditorProvider
-      // TODO: we need to use Reworked Terminal there
-      val tempDisposable = Disposer.newDisposable()
-      val options = ShellStartupOptions.Builder().build()
-      val newWidget = LocalTerminalDirectRunner(project).startShellTerminalWidget(
-        tempDisposable,
-        options,
-        true
-      )
-      val newFile = TerminalSessionVirtualFileImpl(
-        terminalFile.name,
-        newWidget,
-        JBTerminalSystemSettingsProvider()
-      )
-      val editor = ClassicTerminalSessionEditor(project, newFile)
-      Disposer.dispose(tempDisposable) // newWidget's parent disposable should be changed now
-      return editor
-    }
+    return TerminalViewFileEditor(project, terminalFile)
   }
 
   override fun getEditorTypeId(): @NonNls String {

--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/editor/TerminalViewVirtualFile.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/editor/TerminalViewVirtualFile.kt
@@ -1,5 +1,6 @@
 package com.intellij.terminal.frontend.editor
 
+import com.intellij.openapi.fileEditor.FileEditorManagerKeys
 import com.intellij.terminal.frontend.toolwindow.impl.getTitleText
 import com.intellij.terminal.frontend.view.TerminalView
 import com.intellij.testFramework.LightVirtualFile
@@ -11,5 +12,6 @@ internal class TerminalViewVirtualFile(
   init {
     fileType = TerminalViewFileType
     isWritable = true // to be able to rename the file
+    putUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT, true)
   }
 }

--- a/plugins/terminal/tests/src/com/intellij/terminal/tests/reworked/frontend/TerminalViewFileEditorProviderTest.kt
+++ b/plugins/terminal/tests/src/com/intellij/terminal/tests/reworked/frontend/TerminalViewFileEditorProviderTest.kt
@@ -1,0 +1,137 @@
+package com.intellij.terminal.tests.reworked.frontend
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorManagerKeys
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.terminal.TerminalTitle
+import com.intellij.terminal.frontend.view.TerminalView
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.testFramework.junit5.fixture.projectFixture
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.plugins.terminal.session.TerminalStartupOptions
+import org.jetbrains.plugins.terminal.session.impl.TerminalSession
+import org.jetbrains.plugins.terminal.view.shellIntegration.TerminalShellIntegration
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import javax.swing.JPanel
+
+@TestApplication
+internal class TerminalViewFileEditorProviderTest {
+  private companion object {
+    val projectFixture = projectFixture(openAfterCreation = true)
+  }
+
+  private val project: Project
+    get() = projectFixture.get()
+
+  @Test
+  fun `provider reuses terminal view after closing flag is cleared before delayed reopen`(@TestDisposable disposable: Disposable) {
+    val terminalView = createTerminalView(disposable)
+    val file = createTerminalViewVirtualFile(terminalView)
+    val provider = createTerminalViewFileEditorProvider()
+
+    file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true)
+    try {
+      val originalEditor = provider.createEditor(project, file)
+      try {
+        assertTerminalViewFileEditor(originalEditor)
+      }
+      finally {
+        Disposer.dispose(originalEditor)
+      }
+
+      file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
+
+      val reopenedEditor = provider.createEditor(project, file)
+      try {
+        assertTerminalViewFileEditor(reopenedEditor)
+        assertThat(reopenedEditor.component).isSameAs(terminalView.component)
+        assertThat(terminalView.coroutineScope.isActive).isTrue()
+      }
+      finally {
+        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true)
+        Disposer.dispose(reopenedEditor)
+      }
+    }
+    finally {
+      file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
+    }
+  }
+
+  @Test
+  fun `provider reuses terminal view across repeated editor reopens`(@TestDisposable disposable: Disposable) {
+    val terminalView = createTerminalView(disposable)
+    val file = createTerminalViewVirtualFile(terminalView)
+    val provider = createTerminalViewFileEditorProvider()
+
+    try {
+      repeat(10) {
+        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, true)
+        val reopenedEditor = provider.createEditor(project, file)
+        try {
+          assertTerminalViewFileEditor(reopenedEditor)
+          assertThat(reopenedEditor.component).isSameAs(terminalView.component)
+        }
+        finally {
+          Disposer.dispose(reopenedEditor)
+        }
+
+        assertThat(terminalView.coroutineScope.isActive).isTrue()
+
+        file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
+      }
+    }
+    finally {
+      file.putUserData(FileEditorManagerKeys.CLOSING_TO_REOPEN, null)
+    }
+  }
+
+  private fun assertTerminalViewFileEditor(editor: FileEditor) {
+    assertThat(editor.javaClass.name).isEqualTo("com.intellij.terminal.frontend.editor.TerminalViewFileEditor")
+  }
+
+  private fun createTerminalViewVirtualFile(terminalView: TerminalView): VirtualFile {
+    val fileClass = Class.forName("com.intellij.terminal.frontend.editor.TerminalViewVirtualFile")
+    val constructor = fileClass.getDeclaredConstructor(TerminalView::class.java, Boolean::class.javaPrimitiveType)
+    constructor.isAccessible = true
+    return constructor.newInstance(terminalView, false) as VirtualFile
+  }
+
+  private fun createTerminalViewFileEditorProvider(): FileEditorProvider {
+    val providerClass = Class.forName("com.intellij.terminal.frontend.editor.TerminalViewFileEditorProvider")
+    val constructor = providerClass.getDeclaredConstructor()
+    constructor.isAccessible = true
+    return constructor.newInstance() as FileEditorProvider
+  }
+
+  private fun createTerminalView(disposable: Disposable): TerminalView {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    Disposer.register(disposable) { scope.cancel() }
+    val component = JPanel()
+
+    val title = TerminalTitle()
+    title.change { defaultTitle = "Terminal" }
+
+    return mock<TerminalView>().also { view ->
+      whenever(view.coroutineScope).thenReturn(scope)
+      whenever(view.component).thenReturn(component)
+      whenever(view.preferredFocusableComponent).thenReturn(component)
+      whenever(view.title).thenReturn(title)
+      whenever(view.shellIntegrationDeferred).thenReturn(CompletableDeferred<TerminalShellIntegration>())
+      whenever(view.startupOptionsDeferred).thenReturn(CompletableDeferred<TerminalStartupOptions>())
+      whenever(view.sessionDeferred).thenReturn(CompletableDeferred<TerminalSession>())
+    }
+  }
+}

--- a/plugins/terminal/tests/src/com/intellij/terminal/tests/reworked/frontend/TerminalViewFileEditorProviderTest.kt
+++ b/plugins/terminal/tests/src/com/intellij/terminal/tests/reworked/frontend/TerminalViewFileEditorProviderTest.kt
@@ -98,6 +98,14 @@ internal class TerminalViewFileEditorProviderTest {
     }
   }
 
+  @Test
+  fun `terminal editor file cannot be split`(@TestDisposable disposable: Disposable) {
+    val terminalView = createTerminalView(disposable)
+    val file = createTerminalViewVirtualFile(terminalView)
+
+    assertThat(file.getUserData(FileEditorManagerKeys.FORBID_TAB_SPLIT)).isTrue()
+  }
+
   private fun assertTerminalViewFileEditor(editor: FileEditor) {
     assertThat(editor.javaClass.name).isEqualTo("com.intellij.terminal.frontend.editor.TerminalViewFileEditor")
   }


### PR DESCRIPTION
In my last comment in this issue, I noticed that when dragging a reset terminal tab back to the tool window, the terminal "session" was revived.

https://youtrack.jetbrains.com/issue/IJPL-165734/Terminal-restarts-when-dragged-after-Move-to-Editor

This made me explore the the way terminal and editors were working. In my manual testing I also stumbled on an issue with moving an terminal _editor tab_ to another window, I took the opportunity to fix it. I had some trouble with editor splits. So unsure if my fix is ok.

Finally one thing I didn;t fix, but can take a look at it, is that when dragging a terminal tab to the editor tab, it doesn't trigger the "split" ability of editors. It's only when a terminal editor tab is already in the editors that it can be dragged to split.
(However if editors are already split, then dragging to one of the existing split works, but you can't create new ones)

Note: While testing this I noticed that _Split Right / Down_ needed special treatment, so I took inspiration from `FileEditorManagerImpl.moveNoSplitFileIfNeeded` and `MoveEditorToOppositeTabGroupAction`.


https://github.com/user-attachments/assets/a78e4cf8-374c-4b92-a5c8-a4962c830e17

