### PR TITLE
KTIJ-37471: KDoc: show documentation of original type for typealias

### DIFF
--- a/plugins/kotlin/code-insight/kotlin.code-insight.k2/src/org/jetbrains/kotlin/idea/k2/codeinsight/quickDoc/KotlinDocumentationTarget.kt
+++ b/plugins/kotlin/code-insight/kotlin.code-insight.k2/src/org/jetbrains/kotlin/idea/k2/codeinsight/quickDoc/KotlinDocumentationTarget.kt
@@ -78,7 +78,9 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
@@ -140,6 +142,22 @@ private fun computeLocalDocumentation(element: PsiElement, originalElement: PsiE
               return computeLocalDocumentation(declaration, originalElement, quickNavigation)
           }
       }
+
+      element is KtTypeAlias && element.docComment == null && element.getTypeReference() != null -> {
+          val typeRef = element.getTypeReference()!!
+          val resolved = (typeRef.typeElement as? KtUserType)?.referenceExpression?.mainReference?.resolve()
+          return buildString {
+              renderKotlinDeclaration(element, quickNavigation)
+              if (resolved != null) {
+                  computeLocalDocumentation(resolved, originalElement, quickNavigation)
+              } else {
+                  computeLocalDocumentation(typeRef, originalElement, quickNavigation)
+              }?.also {
+                  append(it)
+              }
+          }
+      }
+
       element is KtClass && element.isEnum() -> {
           return buildString {
               renderEnumSpecialFunction(originalElement, element, quickNavigation)

--- a/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/documentation/FirQuickDocTestGenerated.java
+++ b/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/documentation/FirQuickDocTestGenerated.java
@@ -2143,6 +2143,26 @@ public abstract class FirQuickDocTestGenerated extends AbstractFirQuickDocTest {
             public void testTypeAliasH() throws Exception {
                 runTest("../../idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasH.kt");
             }
+
+            @TestMetadata("TypeAliasI.kt")
+            public void testTypeAliasI() throws Exception {
+                runTest("../../idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasI.kt");
+            }
+
+            @TestMetadata("TypeAliasJ.kt")
+            public void testTypeAliasJ() throws Exception {
+                runTest("../../idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasJ.kt");
+            }
+
+            @TestMetadata("TypeAliasK.kt")
+            public void testTypeAliasK() throws Exception {
+                runTest("../../idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasK.kt");
+            }
+
+            @TestMetadata("TypeAliasL.kt")
+            public void testTypeAliasL() throws Exception {
+                runTest("../../idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasL.kt");
+            }
         }
     }
 }

--- a/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasI.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasI.kt
@@ -1,0 +1,9 @@
+/**
+ * This is class A
+ */
+class A
+
+typealias B = A
+
+fun test(b: B<caret>) {}
+//INFO: <div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">typealias</span> <span style="color:#000000;">B</span> = <span style="color:#000000;"><a href="psi_element://A">A</a></span></pre></div><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasI.kt<br/></div><div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">final</span> <span style="color:#000080;font-weight:bold;">class</span> <span style="color:#000000;">A</span></pre></div><div class='content'><p style='margin-top:0;padding-top:0;'>This is class A</p></div><table class='sections'></table><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasI.kt<br/></div>

--- a/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasJ.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasJ.kt
@@ -1,0 +1,12 @@
+/**
+ * This is class A
+ */
+class A
+
+/**
+ * This is class B
+ */
+typealias B = A
+
+fun test(b: B<caret>) {}
+//INFO: <div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">typealias</span> <span style="color:#000000;">B</span> = <span style="color:#000000;"><a href="psi_element://A">A</a></span></pre></div><div class='content'><p style='margin-top:0;padding-top:0;'>This is class B</p></div><table class='sections'></table><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasJ.kt<br/></div>

--- a/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasK.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasK.kt
@@ -1,0 +1,15 @@
+/**
+ * This is class A
+ */
+class A
+
+/**
+ * This is class B
+ */
+typealias B = A
+
+
+typealias C = B
+
+fun test(c: C<caret>) {}
+//INFO: <div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">typealias</span> <span style="color:#000000;">C</span> = <span style="color:#000000;"><a href="psi_element://B">B</a></span></pre></div><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasK.kt<br/></div><div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">typealias</span> <span style="color:#000000;">B</span> = <span style="color:#000000;"><a href="psi_element://A">A</a></span></pre></div><div class='content'><p style='margin-top:0;padding-top:0;'>This is class B</p></div><table class='sections'></table><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasK.kt<br/></div>

--- a/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasL.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/quickDoc/misc/typeAliases/TypeAliasL.kt
@@ -1,0 +1,11 @@
+/**
+ * This is class A
+ */
+class A
+
+typealias B = A
+
+typealias C = B
+
+fun test(c: C<caret>) {}
+//INFO: <div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">typealias</span> <span style="color:#000000;">C</span> = <span style="color:#000000;"><a href="psi_element://B">B</a></span></pre></div><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasL.kt<br/></div><div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">typealias</span> <span style="color:#000000;">B</span> = <span style="color:#000000;"><a href="psi_element://A">A</a></span></pre></div><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasL.kt<br/></div><div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">final</span> <span style="color:#000080;font-weight:bold;">class</span> <span style="color:#000000;">A</span></pre></div><div class='content'><p style='margin-top:0;padding-top:0;'>This is class A</p></div><table class='sections'></table><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasL.kt<br/></div>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-37471/KDoc-show-documentation-of-original-type-for-typealias-without-own-docs
`public typealias <caret>TypeAliasB = String
//INFO: <div class='definition'><pre><span style="color:#000080;font-weight:bold;">public</span> <span style="color:#000080;font-weight:bold;">typealias</span> <span style="color:#000000;">TypeAliasB</span> = <span style="color:#000000;"><a href="psi_element://kotlin.String">String</a></span></pre></div><div class='bottom'><icon src="KotlinBaseResourcesIcons.Kotlin_file"/>&nbsp;TypeAliasB.kt<br/></div>
` I have a question regarding this case should I change it if stdlib is included?
<img width="564" height="434" alt="image" src="https://github.com/user-attachments/assets/798fddc7-404c-4a2f-b0ee-e22bab6ea149" />
