### PR TITLE
[JEWEL-1327] Fix Markdown Ordered List Crash

### DIFF
--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
@@ -471,7 +471,7 @@ public class MarkdownStyling(
 
                     public object Decimal : NumberFormatStyle {
                         override fun formatNumber(number: Int): String {
-                            require(number > 0) { "Input must be a positive integer" }
+                            require(number >= 0) { "Input must not be a negative integer" }
 
                             return number.toString()
                         }
@@ -479,7 +479,8 @@ public class MarkdownStyling(
 
                     public object Roman : NumberFormatStyle {
                         override fun formatNumber(number: Int): String {
-                            require(number > 0) { "Input must be a positive integer" }
+                            // Roman numerals can't represent 0; just render it as the literal "0".
+                            if (number < 1) return number.toString()
 
                             val values = intArrayOf(1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1)
                             val symbols = arrayOf("m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i")
@@ -498,7 +499,8 @@ public class MarkdownStyling(
 
                     public object Alphabetical : NumberFormatStyle {
                         override fun formatNumber(number: Int): String {
-                            require(number > 0) { "Input must be a positive integer" }
+                            // Letters can't represent 0; just render it as the literal "0".
+                            if (number < 1) return number.toString()
 
                             var num = number
                             return buildString {

--- a/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/rendering/OrderedListRenderingTest.kt
+++ b/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/rendering/OrderedListRenderingTest.kt
@@ -1,0 +1,113 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the
+// Apache 2.0 license.
+package org.jetbrains.jewel.markdown.rendering
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
+import org.jetbrains.jewel.markdown.testing.MarkdownTestTheme
+import org.jetbrains.jewel.markdown.testing.createMarkdownTestStyling
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+public class OrderedListRenderingTest {
+    @Test
+    public fun `rendering zero-start lists across all number-format levels does not crash`() {
+        runComposeUiTest {
+            val processor = MarkdownProcessor()
+            // Blank lines let each indented sub-list START at 0 (a non-1 start can't interrupt a paragraph, but it can
+            // begin a list after a blank line). Levels 0/1/2 -> Decimal/Roman/Alphabetical, each formatting 0.
+            val blocks = processor.processMarkdownDocument("0. a\n\n    0. b\n\n        0. c")
+
+            setContent {
+                MarkdownTestTheme {
+                    val renderer = DefaultMarkdownBlockRenderer(createMarkdownTestStyling(), emptyList())
+                    renderer.render(blocks, enabled = true, onUrlClick = {}, onTextClick = {}, modifier = Modifier)
+                }
+            }
+
+            waitForIdle()
+            // All three styles fall back to the literal "0" for a zero value, so every marker renders as "0.".
+            onAllNodesWithText("0.").assertCountEquals(3)
+            onNodeWithText("a").assertExists()
+            onNodeWithText("b").assertExists()
+            onNodeWithText("c").assertExists()
+        }
+    }
+
+    @Test
+    public fun `Roman second level renders zero as 0 then resumes with Roman numerals`() {
+        runComposeUiTest {
+            val processor = MarkdownProcessor()
+            // Nested list starting at 0 -> level-1 (Roman) items are numbered 0, 1 -> "0." then "i.".
+            val blocks = processor.processMarkdownDocument("0. a\n\n    0. b\n    1. c")
+
+            setContent {
+                MarkdownTestTheme {
+                    val renderer = DefaultMarkdownBlockRenderer(createMarkdownTestStyling(), emptyList())
+                    renderer.render(blocks, enabled = true, onUrlClick = {}, onTextClick = {}, modifier = Modifier)
+                }
+            }
+
+            waitForIdle()
+            onNodeWithText("i.").assertExists() // Roman(1), proving the level actually uses Roman formatting
+            onNodeWithText("b").assertExists()
+            onNodeWithText("c").assertExists()
+        }
+    }
+
+    @Test
+    public fun `non-one ordered sub-item folds into the parent item's line`() {
+        runComposeUiTest {
+            val processor = MarkdownProcessor()
+            // No blank line before the indented sub-list: "0. c" can't interrupt the "b" paragraph (non-1 start), so
+            // it folds into item "b" on the same line. "1. d" does interrupt and becomes the nested Roman item "i.".
+            //   1. a
+            //   2. b 0. c
+            //        i. d
+            val blocks = processor.processMarkdownDocument("1. a\n2. b\n    0. c\n    1. d")
+
+            setContent {
+                MarkdownTestTheme {
+                    val renderer = DefaultMarkdownBlockRenderer(createMarkdownTestStyling(), emptyList())
+                    renderer.render(blocks, enabled = true, onUrlClick = {}, onTextClick = {}, modifier = Modifier)
+                }
+            }
+
+            waitForIdle()
+            // The folded text lives in a single content node alongside "b"
+            onNode(hasText("b", substring = true).and(hasText("0. c", substring = true))).assertExists()
+            // "0. c" is plain text, not a marker, so no standalone "0." marker exists.
+            onNodeWithText("0.").assertDoesNotExist()
+            // "1. d" interrupted the paragraph and nested as Roman(1) -> "i.".
+            onNodeWithText("i.").assertExists()
+        }
+    }
+
+    @Test
+    public fun `ordered list with leading zeros renders the stripped start number`() {
+        runComposeUiTest {
+            val processor = MarkdownProcessor()
+            // CommonMark spec example 268: "003." -> OrderedList(startFrom = 3).
+            val blocks = processor.processMarkdownDocument("003. ok")
+
+            setContent {
+                MarkdownTestTheme {
+                    val renderer = DefaultMarkdownBlockRenderer(createMarkdownTestStyling(), emptyList())
+                    renderer.render(blocks, enabled = true, onUrlClick = {}, onTextClick = {}, modifier = Modifier)
+                }
+            }
+
+            waitForIdle()
+            // Leading zeros are stripped at parse time, so the marker is "3.", never "003.".
+            onNodeWithText("3.").assertExists()
+            onNodeWithText("003.").assertDoesNotExist()
+            onNodeWithText("ok").assertExists()
+        }
+    }
+}

--- a/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/styling/OrderedListNumberFormatStylesTest.kt
+++ b/platform/jewel/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/styling/OrderedListNumberFormatStylesTest.kt
@@ -22,10 +22,10 @@ public class OrderedListNumberFormatStylesTest {
     }
 
     @Test
-    public fun `decimal format should throw exception for zero value`() {
+    public fun `decimal format should not throw exception for zero value`() {
         val style = NumberFormatStyle.Decimal
 
-        assertThrows(IllegalArgumentException::class.java) { style.formatNumber(0) }
+        assertEquals("0", style.formatNumber(0))
     }
 
     @Test
@@ -56,17 +56,17 @@ public class OrderedListNumberFormatStylesTest {
     }
 
     @Test
-    public fun `roman format should throw exception for zero value`() {
+    public fun `roman format should not throw exception for zero value`() {
         val style = NumberFormatStyle.Roman
 
-        assertThrows(IllegalArgumentException::class.java) { style.formatNumber(0) }
+        assertEquals("0", style.formatNumber(0))
     }
 
     @Test
     public fun `roman format should throw exception on non-positive numbers`() {
         val style = NumberFormatStyle.Roman
 
-        assertThrows(IllegalArgumentException::class.java) { style.formatNumber(-5) }
+        assertEquals("-5", style.formatNumber(-5))
     }
 
     @Test
@@ -84,16 +84,16 @@ public class OrderedListNumberFormatStylesTest {
     }
 
     @Test
-    public fun `alphabetical format should throw exception for zero value`() {
+    public fun `alphabetical format should not throw exception for zero value`() {
         val style = NumberFormatStyle.Alphabetical
 
-        assertThrows(IllegalArgumentException::class.java) { style.formatNumber(0) }
+        assertEquals("0", style.formatNumber(0))
     }
 
     @Test
-    public fun `alphabetical format should throw exception on non-positive numbers`() {
+    public fun `alphabetical format should not throw exception for negative value`() {
         val style = NumberFormatStyle.Alphabetical
 
-        assertThrows(IllegalArgumentException::class.java) { style.formatNumber(-5) }
+        assertEquals("-1", style.formatNumber(-1))
     }
 }

--- a/platform/jewel/markdown/testing/src/main/kotlin/org/jetbrains/jewel/markdown/testing/MarkdownTestTheme.kt
+++ b/platform/jewel/markdown/testing/src/main/kotlin/org/jetbrains/jewel/markdown/testing/MarkdownTestTheme.kt
@@ -205,7 +205,11 @@ fun createMarkdownTestStyling(codeEditorTextStyle: TextStyle = TextStyle.Default
                         itemVerticalSpacingTight = 2.dp,
                         padding = PaddingValues(4.dp),
                         numberFormatStyles =
-                            MarkdownStyling.List.Ordered.NumberFormatStyles(firstLevel = NumberFormatStyle.Decimal),
+                            MarkdownStyling.List.Ordered.NumberFormatStyles(
+                                firstLevel = NumberFormatStyle.Decimal,
+                                secondLevel = NumberFormatStyle.Roman,
+                                thirdLevel = NumberFormatStyle.Alphabetical,
+                            ),
                     ),
                 unordered =
                     MarkdownStyling.List.Unordered(


### PR DESCRIPTION
# Context

We have a crash that occurs whenever users try to start an ordered list with 0. [CommonMark does list this scenario as valid](https://spec.commonmark.org/0.31.2/#list-items) and funnily enough our processor does test for these scenarios exactly like in the specifications but in our renderer we require such values to be `>0`.

This PR fixes this scenario, allowing all format number styles to accept `0` as a value, but for roman/alphabetical formats we fallback to `0`, like github does:

```
0. a
1. b
    0. c
    1. d
        0. e
        1. f
```

Is rendered as:

0. a
1. b
    0. c
    1. d
        0. e
        1. f

# Changes

- Removed the check for `number > 0` in all number format style.
- Added a new test class just for rendering ordered lists `OrderedListRenderingTest`.
- Updated `MarkdownTestTheme` to use roman format as secondary level and alphabetical as the third to mirror our default prod behaviour (and to make it easier to test stuff, ngl)


# Screen Recordings
| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/d0c1025f-b1e0-49dd-bf85-5d2f1d059ee3" /> | <video src="https://github.com/user-attachments/assets/af1a57ce-0bea-4ae3-94e6-4e6dfbabd6c6" /> |

**Note:** Yes, this is [the default behavior for CommonMark](https://github.com/commonmark/commonmark-java/blob/main/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java#L94). It only interrupts a paragraph if it starts with `1`, so that's why it renders both zeros in the secondary and third levels in the same line as the previous list item.

## Release notes

### Bug fixes
 * Markdown ordered lists won't crash if you start your list with 0. For number formats such as roman and alphabetical, an item with index 0 will render as 0 and then render as the expected number format (i.e, `i` for roman, `a` for alphabetical)