### PR TITLE
[KTIJ-24906]: Add all imports for ReplaceWith

### DIFF
--- a/plugins/kotlin/code-insight/fixes-k2/src/org/jetbrains/kotlin/idea/k2/codeinsight/fixes/replaceWith/DeprecatedSymbolUsageFixBase.kt
+++ b/plugins/kotlin/code-insight/fixes-k2/src/org/jetbrains/kotlin/idea/k2/codeinsight/fixes/replaceWith/DeprecatedSymbolUsageFixBase.kt
@@ -241,7 +241,8 @@ abstract class DeprecatedSymbolUsageFixBase(
 
                     val typeElement = typeReference?.typeElement as? KtUserType ?: return null
 
-                    return ClassUsageReplacementStrategy(typeElement, null, project)
+                    return ClassUsageReplacementStrategy(typeElement, null, project,
+                        replaceWith.imports.filter { !it.endsWith(".${typeElement.referencedName}") })
                 }
 
                 is KtCallableDeclaration -> {

--- a/plugins/kotlin/code-insight/fixes-k2/tests/test/org/jetbrains/kotlin/idea/k2/codeinsight/fixes/HighLevelQuickFixMultiFileTestGenerated.java
+++ b/plugins/kotlin/code-insight/fixes-k2/tests/test/org/jetbrains/kotlin/idea/k2/codeinsight/fixes/HighLevelQuickFixMultiFileTestGenerated.java
@@ -1767,9 +1767,29 @@ public abstract class HighLevelQuickFixMultiFileTestGenerated extends AbstractHi
             runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsClass.before.Main.kt");
         }
 
+        @TestMetadata("conflictingImportsConstructor.before.Main.kt")
+        public void testConflictingImportsConstructor() throws Exception {
+            runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.before.Main.kt");
+        }
+
         @TestMetadata("conflictingImportsObject.before.Main.kt")
         public void testConflictingImportsObject() throws Exception {
             runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsObject.before.Main.kt");
+        }
+
+        @TestMetadata("constructor.before.Main.kt")
+        public void testConstructor() throws Exception {
+            runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.before.Main.kt");
+        }
+
+        @TestMetadata("function.before.Main.kt")
+        public void testFunction() throws Exception {
+            runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.before.Main.kt");
+        }
+
+        @TestMetadata("property.before.Main.kt")
+        public void testProperty() throws Exception {
+            runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.before.Main.kt");
         }
 
         @TestMetadata("rootPackage.before.Main.kt")
@@ -2416,9 +2436,29 @@ public abstract class HighLevelQuickFixMultiFileTestGenerated extends AbstractHi
                 runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsClass.before.Main.kt");
             }
 
+            @TestMetadata("conflictingImportsConstructor.before.Main.kt")
+            public void testConflictingImportsConstructor() throws Exception {
+                runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.before.Main.kt");
+            }
+
             @TestMetadata("conflictingImportsObject.before.Main.kt")
             public void testConflictingImportsObject() throws Exception {
                 runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsObject.before.Main.kt");
+            }
+
+            @TestMetadata("constructor.before.Main.kt")
+            public void testConstructor() throws Exception {
+                runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.before.Main.kt");
+            }
+
+            @TestMetadata("function.before.Main.kt")
+            public void testFunction() throws Exception {
+                runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.before.Main.kt");
+            }
+
+            @TestMetadata("property.before.Main.kt")
+            public void testProperty() throws Exception {
+                runTest("../../../idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.before.Main.kt");
             }
 
             @TestMetadata("rootPackage.before.Main.kt")

--- a/plugins/kotlin/code-insight/impl-base/src/org/jetbrains/kotlin/idea/imports/Imports.kt
+++ b/plugins/kotlin/code-insight/impl-base/src/org/jetbrains/kotlin/idea/imports/Imports.kt
@@ -31,3 +31,13 @@ fun KtFile.addImportFor(fqName: FqName) {
 
     addImport(fqName)
 }
+
+fun KtFile.addImportsFromStrings(imports: List<String>) =
+    imports.map { ImportPath.fromString(it) }
+        .forEach {
+            if (it.isAllUnder) {
+                addImport(it.fqName, it.isAllUnder)
+            } else {
+                addImportFor(it.fqName)
+            }
+        }

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.after.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.after.kt
@@ -1,0 +1,4 @@
+// "Replace with 'New'" "true"
+import com.example.*
+
+val bar = New().bar()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.before.Dependency.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.before.Dependency.kt
@@ -1,0 +1,12 @@
+package com.example
+
+@Deprecated(
+    "message",
+    ReplaceWith("New", "com.example.New", "com.example.bar"),
+)
+class Old {
+    fun bar() = Unit
+}
+
+class New
+fun New.bar() = Unit

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.before.Main.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/conflictingImportsConstructor.before.Main.kt
@@ -1,0 +1,4 @@
+// "Replace with 'New'" "true"
+import com.example.*
+
+val bar = <caret>Old().bar()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.after.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.after.kt
@@ -1,0 +1,6 @@
+// "Replace with 'New'" "true"
+import com.example.New
+import com.example.Old
+import com.example.bar
+
+val bar = New().bar()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.before.Dependency.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.before.Dependency.kt
@@ -1,0 +1,12 @@
+package com.example
+
+@Deprecated(
+    "message",
+    ReplaceWith("New", "com.example.New", "com.example.bar"),
+)
+class Old {
+    fun bar() = Unit
+}
+
+class New
+fun New.bar() = Unit

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.before.Main.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/constructor.before.Main.kt
@@ -1,0 +1,4 @@
+// "Replace with 'New'" "true"
+import com.example.Old
+
+val bar = <caret>Old().bar()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.after.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.after.kt
@@ -1,0 +1,5 @@
+// "Replace with 'newFun()'" "true"
+import com.example.bar
+import com.example.newFun
+
+val bar = <caret>newFun().bar()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.before.Dependency.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.before.Dependency.kt
@@ -1,0 +1,17 @@
+package com.example
+
+class Old {
+    fun bar() = Unit
+}
+
+class New
+fun New.bar() = Unit
+
+
+@Deprecated(
+    "message",
+    ReplaceWith("newFun()", "com.example.newFun", "com.example.bar"),
+)
+fun oldFun() = Old()
+
+fun newFun() = New()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.before.Main.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/function.before.Main.kt
@@ -1,0 +1,4 @@
+// "Replace with 'newFun()'" "true"
+import com.example.oldFun
+
+val bar = <caret>oldFun().bar()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.after.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.after.kt
@@ -1,0 +1,5 @@
+// "Replace with 'newProp'" "true"
+import com.example.bar
+import com.example.newProp
+
+val bar = <caret>newProp.bar()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.before.Dependency.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.before.Dependency.kt
@@ -1,0 +1,17 @@
+package com.example
+
+class Old {
+    fun bar() = Unit
+}
+
+class New
+fun New.bar() = Unit
+
+
+@Deprecated(
+    "message",
+    ReplaceWith("newProp", "com.example.newProp", "com.example.bar"),
+)
+val oldProp = Old()
+
+val newProp = New()

--- a/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.before.Main.kt
+++ b/plugins/kotlin/idea/tests/testData/quickfix/deprecatedSymbolUsage/imports/property.before.Main.kt
@@ -1,0 +1,4 @@
+// "Replace with 'newProp'" "true"
+import com.example.oldProp
+
+val bar = <caret>oldProp.bar()

--- a/plugins/kotlin/refactorings/kotlin.refactorings.k2/src/org/jetbrains/kotlin/idea/k2/refactoring/inline/codeInliner/ClassUsageReplacementStrategy.kt
+++ b/plugins/kotlin/refactorings/kotlin.refactorings.k2/src/org/jetbrains/kotlin/idea/k2/refactoring/inline/codeInliner/ClassUsageReplacementStrategy.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.idea.base.analysis.api.utils.shortenReferences
 import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
 import org.jetbrains.kotlin.idea.base.psi.replaced
+import org.jetbrains.kotlin.idea.imports.addImportsFromStrings
 import org.jetbrains.kotlin.idea.refactoring.inline.codeInliner.CodeToInline
 import org.jetbrains.kotlin.idea.refactoring.inline.codeInliner.UsageReplacementStrategy
 import org.jetbrains.kotlin.idea.refactoring.modifyPsiWithOptimizedImports
@@ -29,7 +30,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
 class ClassUsageReplacementStrategy(
     typeReplacement: KtUserType?,
     constructorReplacement: CodeToInline?,
-    project: Project
+    project: Project,
+    val imports: List<String> = listOf(),
 ) : UsageReplacementStrategy {
 
     private val factory = KtPsiFactory(project)
@@ -133,6 +135,7 @@ class ClassUsageReplacementStrategy(
         else
             callExpression
 
+        callExpression.containingKtFile.addImportsFromStrings(imports)
         val result = modifyPsiWithOptimizedImports(callExpression.containingKtFile) {
             if (expressionToReplace != newExpression) {
                 expressionToReplace.replaced(newExpression)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-24906/ReplaceWith-doesnt-add-several-imports

https://github.com/user-attachments/assets/e2e949f4-2777-4e33-8163-6deb7e08060c



Hi all, I have a question regarding second part of provided video should I try to avoid import unused declarations?