### PR TITLE
[KTIJ-25214]: Remove matching } when backspacing { in empty lambda

### DIFF
--- a/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/editor/KotlinLambdaBackspaceHandler.kt
+++ b/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/editor/KotlinLambdaBackspaceHandler.kt
@@ -1,0 +1,64 @@
+package org.jetbrains.kotlin.idea.editor
+
+import com.intellij.codeInsight.editorActions.BackspaceHandlerDelegate
+import com.intellij.codeInsight.highlighting.BraceMatchingUtil
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.idea.KotlinFileType
+
+class KotlinLambdaBackspaceHandler : BackspaceHandlerDelegate() {
+    private var deleteBrace = false
+
+    override fun beforeCharDeleted(c: Char, file: PsiFile, editor: Editor) {
+        val offset = editor.getCaretModel().offset - 1
+        deleteBrace = c == '{' && file.getFileType() === KotlinFileType.INSTANCE &&
+                isLambdaLBrace(file, offset)
+    }
+
+    override fun charDeleted(c: Char, file: PsiFile, editor: Editor): Boolean {
+        if (!deleteBrace || c != '{') {
+            return false
+        }
+
+        val document = editor.getDocument()
+        val offset = editor.getCaretModel().offset
+        if (document.textLength <= offset) {
+            return false
+        }
+
+        val chars = document.charsSequence
+        var rbraceOffset = offset
+        while (rbraceOffset < chars.length && Character.isWhitespace(chars[rbraceOffset])) {
+            rbraceOffset++
+        }
+        if (chars[rbraceOffset] != '}') {
+            return false
+        }
+
+        val afterRbrace = rbraceOffset + 1
+
+        val fileType = file.getFileType()
+        val iterator = editor.highlighter.createIterator(rbraceOffset)
+
+        val rparenOffset = BraceMatchingUtil.findRightmostRParen(iterator, iterator.getTokenType(), chars, fileType)
+
+        var wsStart = offset - 1
+        while (wsStart >= 0 && Character.isWhitespace(chars[wsStart])) {
+            wsStart--
+        }
+
+        wsStart++
+        if (rparenOffset >= 0) {
+            val iterator1 = editor.highlighter.createIterator(rparenOffset)
+            if (BraceMatchingUtil.matchBrace(chars, fileType, iterator1, false, true)) {
+                if (wsStart < offset) {
+                    document.deleteString(wsStart, offset)
+                }
+                return true
+            }
+        }
+
+        document.deleteString(wsStart, afterRbrace)
+        return true
+    }
+}

--- a/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/editor/typingUtils.kt
+++ b/plugins/kotlin/base/code-insight/minimal/src/org/jetbrains/kotlin/idea/editor/typingUtils.kt
@@ -1,0 +1,12 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.editor
+
+import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtFunctionLiteral
+
+
+fun isLambdaLBrace(file: PsiFile, offset: Int): Boolean {
+    val element = file.findElementAt(offset)
+    return element != null && element.getNode().getElementType() === KtTokens.LBRACE && element.getParent() is KtFunctionLiteral
+}

--- a/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/editor/editor/backspaceHandler/K2BackspaceHandlerTestGenerated.java
+++ b/plugins/kotlin/fir/tests/test/org/jetbrains/kotlin/idea/fir/editor/editor/backspaceHandler/K2BackspaceHandlerTestGenerated.java
@@ -59,6 +59,36 @@ public abstract class K2BackspaceHandlerTestGenerated extends AbstractK2Backspac
             runTest("../../idea/tests/testData/editor/backspaceHandler/FileStart.kt");
         }
 
+        @TestMetadata("lambdaInline.kt")
+        public void testLambdaInline() throws Exception {
+            runTest("../../idea/tests/testData/editor/backspaceHandler/lambdaInline.kt");
+        }
+
+        @TestMetadata("lambdaMultiline.kt")
+        public void testLambdaMultiline() throws Exception {
+            runTest("../../idea/tests/testData/editor/backspaceHandler/lambdaMultiline.kt");
+        }
+
+        @TestMetadata("lambdaWithCode.kt")
+        public void testLambdaWithCode() throws Exception {
+            runTest("../../idea/tests/testData/editor/backspaceHandler/lambdaWithCode.kt");
+        }
+
+        @TestMetadata("lambdaWithComment.kt")
+        public void testLambdaWithComment() throws Exception {
+            runTest("../../idea/tests/testData/editor/backspaceHandler/lambdaWithComment.kt");
+        }
+
+        @TestMetadata("lambdaWithOneSpaceBeforeCaret.kt")
+        public void testLambdaWithOneSpaceBeforeCaret() throws Exception {
+            runTest("../../idea/tests/testData/editor/backspaceHandler/lambdaWithOneSpaceBeforeCaret.kt");
+        }
+
+        @TestMetadata("lambdaWithoutCloseBrace.kt")
+        public void testLambdaWithoutCloseBrace() throws Exception {
+            runTest("../../idea/tests/testData/editor/backspaceHandler/lambdaWithoutCloseBrace.kt");
+        }
+
         @TestMetadata("rawStringDelete.kt")
         public void testRawStringDelete() throws Exception {
             runTest("../../idea/tests/testData/editor/backspaceHandler/rawStringDelete.kt");

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaInline.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaInline.kt
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo{<caret>}
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaInline.kt.after
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaInline.kt.after
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaMultiline.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaMultiline.kt
@@ -1,0 +1,6 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo {<caret>
+    }
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaMultiline.kt.after
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaMultiline.kt.after
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithCode.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithCode.kt
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo{<caret> println("Hello")}
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithCode.kt.after
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithCode.kt.after
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo<caret> println("Hello")}
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithComment.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithComment.kt
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo{<caret> /* Comment */}
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithComment.kt.after
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithComment.kt.after
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo<caret> /* Comment */}
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithOneSpaceBeforeCaret.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithOneSpaceBeforeCaret.kt
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo{ <caret>}
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithOneSpaceBeforeCaret.kt.after
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithOneSpaceBeforeCaret.kt.after
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo{<caret>}
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithoutCloseBrace.kt
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithoutCloseBrace.kt
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo {<caret>
+}

--- a/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithoutCloseBrace.kt.after
+++ b/plugins/kotlin/idea/tests/testData/editor/backspaceHandler/lambdaWithoutCloseBrace.kt.after
@@ -1,0 +1,5 @@
+fun foo(f: () -> Unit) = Unit
+
+fun bar() {
+    foo<caret>
+}

--- a/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
+++ b/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml
@@ -440,6 +440,7 @@
     <lang.smartEnterProcessor language="kotlin" implementationClass="org.jetbrains.kotlin.idea.codeInsight.handlers.KotlinSmartEnterHandler"/>
 
     <backspaceHandlerDelegate implementation="org.jetbrains.kotlin.idea.editor.KotlinBackspaceHandler"/>
+    <backspaceHandlerDelegate implementation="org.jetbrains.kotlin.idea.editor.KotlinLambdaBackspaceHandler"/>
     <backspaceHandlerDelegate implementation="org.jetbrains.kotlin.idea.editor.KotlinStringTemplateBackspaceHandler"/>
     <backspaceHandlerDelegate implementation="org.jetbrains.kotlin.idea.editor.KotlinRawStringBackspaceHandler"/>
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-25214/Automatically-delete-right-pairing-curly-brace-for-an-empty-lambda-argument

https://github.com/user-attachments/assets/d5314d56-40f6-41cc-b5c8-12d0ba4482de



