### PR TITLE
[JEWEL-1334] Gradle Scripts Migration to Bazel (Part 1)

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -20,3 +20,4 @@ import_run_configurations:
   tools/bazelRunConfigurations/Run___build_android_studio.xml
   tools/bazelRunConfigurations/Run___build_i_build_target.xml
   tools/bazelRunConfigurations/Run___build_idea_community.xml
+  tools/bazelRunConfigurations/Run___build_jewel_standalone_sample.xml

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -140,6 +140,8 @@ java_binary(
 ## see community/build/tests-options.bzl
 exports_files(["intellij.idea.community.main.iml"])
 
+exports_files(glob(["build.txt"]), visibility = ["//visibility:public"])
+
 ### auto-generated section `build intellij.idea.community.main` start
 
 jvm_library(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -92,6 +92,8 @@ kotlin_test_deps(name = "kotlin_test_deps")
 
 include("//:debugger_test_deps.MODULE.bazel")
 
+include("//platform/jewel:jewel_deps.MODULE.bazel")
+
 jbr_toolchains = use_extension("@community//build:jbr-toolchains.bzl", "jbr_toolchains")
 
 REMOTE_JBR25_REPOS = ["remotejbr25_" + platform for platform in [

--- a/platform/jewel/jewel_deps.MODULE.bazel
+++ b/platform/jewel/jewel_deps.MODULE.bazel
@@ -1,0 +1,22 @@
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "jewel_deps_kotlinpoet",
+    downloaded_file_path = "kotlinpoet.jar",
+    sha256 = "585b5673a86301e5e06d307a3327d5a73e213cb7600d1c856604ede016f1d656",
+    url = "https://https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/com/squareup/kotlinpoet-jvm/2.1.0/kotlinpoet-jvm-2.1.0.jar",
+)
+
+http_file(
+    name = "jewel_deps_ktfmt",
+    downloaded_file_path = "ktfmt.jar",
+    sha256 = "d13324023754112797d828e2f92117196190f7617d16ad1d1765e5be768cc5c2",
+    url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/com/facebook/ktfmt/0.55/ktfmt-0.55-with-dependencies.jar",
+)
+
+http_file(
+    name = "jewel_deps_detekt",
+    downloaded_file_path = "detekt.jar",
+    sha256 = "3afe89a11120303c73c9bdda3d8fe558dd9070a6937d27819ddc04b275381245",
+    url = "https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/io/gitlab/arturbosch/detekt/detekt-cli/1.23.8/detekt-cli-1.23.8-all.jar"
+)

--- a/platform/jewel/samples/standalone/BUILD.bazel
+++ b/platform/jewel/samples/standalone/BUILD.bazel
@@ -1,5 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_jvm//:jvm.bzl", "jvm_library")
 load("//build:compiler-options.bzl", "create_kotlinc_options")
+
+java_binary(
+    name = "standalone_sample",
+    runtime_deps = [":standalone"],
+    main_class = "org.jetbrains.jewel.samples.standalone.MainKt"
+)
 
 ### auto-generated section `build intellij.platform.jewel.samples.standalone` start
 

--- a/tools/bazelRunConfigurations/Run___build_jewel_standalone_sample.xml
+++ b/tools/bazelRunConfigurations/Run___build_jewel_standalone_sample.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run //jewel/standalone:standalone_sample" type="BazelRunConfigurationType">
+    <bsp-state handler-provider-id="JvmRunHandlerProvider" check-visibility="true">
+      <bsp-target>@//platform/jewel/samples/standalone:standalone_sample</bsp-target>
+      <handler-state />
+    </bsp-state>
+    <method v="2">
+      <option name="BuildScriptBeforeRunTaskProvider" enabled="false" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
# Context

This is the first PR in a long list of them (idk exactly how many of them yet) which aims to migrate all possible tooling we have for gradle to Bazel.

With this PR, we have the barebones files we'll need moving forward. It also adds the `standalone_sample` target so that we don't need to run `./gradlew :samples:standalone:run` anytime we want to test something on the standalone side of things