### PR TITLE
[JEWEL-1319] Draw circular progress indicator on Canvas

### DIFF
--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/CircularProgressIndicator.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/CircularProgressIndicator.kt
@@ -1,32 +1,29 @@
 package org.jetbrains.jewel.ui.component
 
-import androidx.compose.animation.core.InfiniteRepeatableSpec
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.VectorConverter
-import androidx.compose.animation.core.animateValue
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.takeOrElse
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.jetbrains.compose.resources.ExperimentalResourceApi
-import org.jetbrains.compose.resources.decodeToSvgPainter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.styling.CircularProgressStyle
 import org.jetbrains.jewel.ui.theme.circularProgressStyle
-import org.jetbrains.jewel.ui.util.toRgbaHexString
 
 @Composable
 public fun CircularProgressIndicator(
@@ -36,12 +33,9 @@ public fun CircularProgressIndicator(
 ) {
     CircularProgressIndicatorImpl(
         modifier = modifier,
-        iconSize = DpSize(16.dp, 16.dp),
+        iconSize = 16.dp,
         style = style,
-        dispatcher = loadingDispatcher,
-        frameRetriever = { color ->
-            SpinnerProgressIconGenerator.Small.generateSvgFrames(color.toRgbaHexString(omitAlphaWhenFullyOpaque = true))
-        },
+        loadingDispatcher = loadingDispatcher,
     )
 }
 
@@ -53,133 +47,65 @@ public fun CircularProgressIndicatorBig(
 ) {
     CircularProgressIndicatorImpl(
         modifier = modifier,
-        iconSize = DpSize(32.dp, 32.dp),
+        iconSize = 32.dp,
         style = style,
-        dispatcher = loadingDispatcher,
-        frameRetriever = { color ->
-            SpinnerProgressIconGenerator.Big.generateSvgFrames(color.toRgbaHexString(omitAlphaWhenFullyOpaque = true))
-        },
+        loadingDispatcher = loadingDispatcher,
     )
 }
 
-@OptIn(ExperimentalResourceApi::class)
+@Suppress("UNUSED_PARAMETER")
 @Composable
 private fun CircularProgressIndicatorImpl(
-    iconSize: DpSize,
+    iconSize: Dp,
     style: CircularProgressStyle,
-    dispatcher: CoroutineDispatcher,
-    frameRetriever: (Color) -> List<String>,
+    loadingDispatcher: CoroutineDispatcher,
     modifier: Modifier = Modifier,
 ) {
     val defaultColor = if (JewelTheme.isDark) Color(0xFF6F737A) else Color(0xFFA8ADBD)
+    val color = style.color.takeOrElse { defaultColor }
+    val framesCount = spinnerSegmentOpacities.size
+    val frameTimeMillis = style.frameTime.inWholeMilliseconds.toInt()
 
-    val density = LocalDensity.current
-    val frames by
-        produceState(emptyList(), density, style.color, defaultColor, dispatcher, frameRetriever) {
-            value =
-                withContext(dispatcher) {
-                    frameRetriever(style.color.takeOrElse { defaultColor }).map {
-                        it.toByteArray().decodeToSvgPainter(density)
-                    }
+    val transition = rememberInfiniteTransition("CircularProgressIndicator")
+    val rotationRatio by
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation = tween(easing = LinearEasing, durationMillis = frameTimeMillis * framesCount),
+                    repeatMode = RepeatMode.Restart,
+                ),
+        )
+
+    Canvas(modifier = modifier.size(iconSize)) {
+        val frameIndex = (rotationRatio * framesCount).toInt() % framesCount
+        val snappedRotation = frameIndex * FULL_ROTATION_DEGREES / framesCount
+
+        val diameter = size.minDimension
+        val rectWidth = diameter * 2f / ICON_VIEW_BOX_SIZE
+        val rectHeight = diameter * 4f / ICON_VIEW_BOX_SIZE
+        val cornerRadius = CornerRadius(diameter / ICON_VIEW_BOX_SIZE)
+        val segmentTopLeft = Offset(x = center.x - rectWidth / 2f, y = diameter / ICON_VIEW_BOX_SIZE)
+        val segmentSize = Size(rectWidth, rectHeight)
+
+        rotate(degrees = snappedRotation, pivot = center) {
+            for (i in 0 until framesCount) {
+                rotate(degrees = -i * FULL_ROTATION_DEGREES / framesCount, pivot = center) {
+                    drawRoundRect(
+                        color = color,
+                        topLeft = segmentTopLeft,
+                        size = segmentSize,
+                        cornerRadius = cornerRadius,
+                        alpha = spinnerSegmentOpacities[i],
+                    )
                 }
-        }
-
-    if (frames.isEmpty()) {
-        Box(modifier.size(iconSize))
-    } else {
-        val framesCount = frames.size
-        val transition = rememberInfiniteTransition("CircularProgressIndicator")
-        val currentIndex by
-            transition.animateValue(
-                initialValue = 0,
-                targetValue = framesCount,
-                typeConverter = Int.VectorConverter,
-                animationSpec =
-                    InfiniteRepeatableSpec(
-                        tween(
-                            easing = LinearEasing,
-                            durationMillis = (style.frameTime.inWholeMilliseconds * framesCount).toInt(),
-                        ),
-                        repeatMode = RepeatMode.Restart,
-                    ),
-            )
-
-        val currentPainter = frames[currentIndex]
-        Icon(modifier = modifier.size(iconSize), painter = currentPainter, contentDescription = null)
-    }
-}
-
-private object SpinnerProgressIconGenerator {
-    private val opacityList = listOf(1.0f, 0.93f, 0.78f, 0.69f, 0.62f, 0.48f, 0.38f, 0.0f)
-
-    private fun StringBuilder.closeRoot() = append("</svg>")
-
-    private fun StringBuilder.openRoot(sizePx: Int) =
-        append(
-            "<svg width=\"$sizePx\" height=\"$sizePx\" viewBox=\"0 0 16 16\" fill=\"none\" " +
-                "xmlns=\"http://www.w3.org/2000/svg\">"
-        )
-
-    private fun generateSvgIcon(size: Int, opacityListShifted: List<Float>, colorHex: String) = buildString {
-        openRoot(size)
-        elements(colorHex = colorHex, opacityList = opacityListShifted)
-        closeRoot()
-    }
-
-    private fun StringBuilder.elements(colorHex: String, opacityList: List<Float>) {
-        appendLine()
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[0]}" x="7" y="1" width="2" height="4" rx="1"/>"""
-        )
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[1]}" x="2.34961" y="3.76416" width="2" height="4" rx="1""""
-        )
-        appendLine("""          transform="rotate(-45 2.34961 3.76416)"/>""")
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[2]}" x="1" y="7" width="4" height="2" rx="1"/>"""
-        )
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[3]}" x="5.17871" y="9.40991" width="2" height="4" rx="1""""
-        )
-        appendLine("""          transform="rotate(45 5.17871 9.40991)"/>""")
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[4]}" x="7" y="11" width="2" height="4" rx="1"/>"""
-        )
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[5]}" x="9.41016" y="10.8242" width="2" height="4" rx="1""""
-        )
-        appendLine("""          transform="rotate(-45 9.41016 10.8242)"/>""")
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[6]}" x="11" y="7" width="4" height="2" rx="1"/>"""
-        )
-        appendLine(
-            """    <rect fill="$colorHex" opacity="${opacityList[7]}" x="12.2383" y="2.3501" width="2" height="4" rx="1""""
-        )
-        appendLine("""          transform="rotate(45 12.2383 2.3501)"/>""")
-    }
-
-    object Small {
-        fun generateSvgFrames(colorHex: String): List<String> = buildList {
-            val opacityListShifted = opacityList.toMutableList()
-            repeat(opacityList.count()) {
-                add(generateSvgIcon(size = 16, colorHex = colorHex, opacityListShifted = opacityListShifted))
-                opacityListShifted.shtr()
             }
         }
     }
-
-    object Big {
-        fun generateSvgFrames(colorHex: String): List<String> = buildList {
-            val opacityListShifted = opacityList.toMutableList()
-            repeat(opacityList.count()) {
-                add(generateSvgIcon(size = 32, colorHex = colorHex, opacityListShifted = opacityListShifted))
-                opacityListShifted.shtr()
-            }
-        }
-    }
-
-    private fun <T> MutableList<T>.shtr() {
-        add(first())
-        removeFirst()
-    }
 }
+
+private const val FULL_ROTATION_DEGREES = 360f
+private const val ICON_VIEW_BOX_SIZE = 16f
+
+private val spinnerSegmentOpacities = listOf(1f, 0.93f, 0.78f, 0.69f, 0.62f, 0.48f, 0.38f, 0f)


### PR DESCRIPTION
`CircularProgressIndicator` currently builds spinner frames by generating SVG strings, converting them to byte arrays, and decoding them into painters. This replaces that pipeline with direct Canvas drawing while preserving the existing public API, styling, frame timing, size variants, and intended visual output.

## Changes

* Reimplemented `CircularProgressIndicator` and `CircularProgressIndicatorBig` on top of a shared Canvas-based implementation.
* Preserved `CircularProgressStyle` color fallback and `frameTime` behavior.
* Kept the existing `loadingDispatcher` parameter for API compatibility, though it is no longer needed now that there is no background SVG decoding work.
* Matched the original SVG segment winding by keeping the animated rotation positive and placing individual segments with negative per-segment rotation.
* Derived segment geometry from the actual draw scope size so the spinner scales correctly with the final Canvas constraints.

## Performance validation

* Local temporary recomposition harness, not committed: advanced the Compose test clock by 80 frames at 16 ms per frame and compared an old-style composition-read animation path with the new Canvas draw-phase path. Result: old-style path recomposed 11 times; new Canvas path recomposed 1 time.
* Local throwaway JVM micro-harness, not committed: compared old SVG string + byte-array preparation against the new geometry calculation path. This intentionally excluded `decodeToSvgPainter`, so it undercounts the removed work. Old SVG string + byte preparation measured roughly 7.7–11.3 µs/op; new geometry calculation measured roughly 0.04–0.12 µs/op.
* No screenshots are included because this is intended to preserve the existing spinner visuals; the change is focused on removing unnecessary composition and SVG decode work.

## Testing

* `cd platform/jewel && ./gradlew check --continue --no-daemon`
* `cd platform/jewel && ./gradlew detekt detektMain detektTest --continue --no-daemon`
* `cd platform/jewel && ./gradlew :ui:checkMetalavaApi --no-daemon --max-workers=1`
* `cd platform/jewel && ./gradlew :ui:validatePublicApi --no-daemon --max-workers=1`
* `cd platform/jewel && ./gradlew :ui:test --tests org.jetbrains.jewel.ui.component.CircularProgressIndicatorRecompositionHarnessTest --no-daemon` using a temporary local-only test harness, removed after collecting the counts.
* `git diff --check`

Could not complete `./bazel.cmd build //platform/jewel/ui:ui` locally because Bazel dependency fetching was blocked with `Operation not permitted` while downloading `rules_kotlin` into the local `MonorepoBazel` cache.

## Release notes

### Bug fixes

* Improved `CircularProgressIndicator` performance by drawing the spinner directly on Canvas instead of generating and decoding SVG frames.
