### PR TITLE
[JEWEL-1355] Select first match when the selected item is filtered out

### DIFF
--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchAreaFilteringTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchAreaFilteringTest.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import org.jetbrains.jewel.foundation.lazy.SelectableLazyListState
 import org.jetbrains.jewel.foundation.lazy.rememberSelectableLazyListState
 import org.jetbrains.jewel.foundation.search.EmptySpeedSearchMatcher
 import org.jetbrains.jewel.foundation.search.filter
@@ -73,6 +74,8 @@ class SpeedSearchAreaFilteringTest {
     @get:Rule val rule = createComposeRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
+
+    private var capturedListState: SelectableLazyListState? = null
 
     private val ComposeContentTestRule.onLazyColumn
         get() = onNodeWithTag("LazyColumn")
@@ -209,6 +212,20 @@ class SpeedSearchAreaFilteringTest {
         onLazyColumn.performKeyPress(Key.DirectionUp, rule = this)
         onLazyColumnItem("Angular").assertIsDisplayed().assertIsSelected()
     }
+
+    @Test
+    fun `when the previously selected item is filtered out, the first visible match is selected`() =
+        runFilteringComposeTest {
+            capturedListState!!.selectedKeys = emptySet()
+            waitForIdle()
+
+            // Type "Angular" - two matches, both visible, first one at index 0 of the filtered list.
+            onLazyColumn.performKeyPress("Angular", rule = this)
+
+            // The first match must be selected, never the second one.
+            onLazyColumnItem("Angular").assertIsDisplayed().assertIsSelected()
+            onLazyColumnItem("AngularJS").assertIsDisplayed()
+        }
 
     @Test
     fun `partial match filtering should work correctly`() = runFilteringComposeTest {
@@ -442,6 +459,7 @@ class SpeedSearchAreaFilteringTest {
             val speedSearchState = rememberSpeedSearchState()
             capturedSpeedSearchState = speedSearchState
             val listState = rememberSelectableLazyListState()
+            capturedListState = listState
 
             // Filter the list based on the current matcher - same pattern as showcase
             val filteredItems by remember { derivedStateOf { listEntries.filter(speedSearchState.currentMatcher) } }

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableLazyColumnTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableLazyColumnTest.kt
@@ -281,6 +281,44 @@ class SpeedSearchableLazyColumnTest {
         onLazyColumnItem("Item 7").assertIsSelected()
     }
 
+    @Test
+    fun `with no matching selection, select the topmost visible match`() =
+        runComposeTest(listEntries = markedEntries(20, 45, 70)) {
+            onLazyColumn.performScrollToIndex(43)
+
+            onLazyColumn.performKeyPress("Banana", rule = this)
+
+            // 45 is inside the viewport; it wins over the global first match (20) and the one below (70)
+            onLazyColumnItem("Banana 45").assertIsDisplayed().assertIsSelected()
+        }
+
+    @Test
+    fun `with no visible match, select the first match below the viewport rather than the global first`() =
+        runComposeTest(listEntries = markedEntries(20, 70)) {
+            onLazyColumn.performScrollToIndex(43)
+
+            onLazyColumn.performKeyPress("Banana", rule = this)
+
+            // Neither match is visible; the forward scan reaches 70 (below) before wrapping to 20 (above)
+            onLazyColumnItem("Banana 70").assertIsDisplayed().assertIsSelected()
+        }
+
+    @Test
+    fun `with matches only above the viewport, wrap to the first match from the top`() =
+        runComposeTest(listEntries = markedEntries(5, 20)) {
+            onLazyColumn.performScrollToIndex(43)
+
+            onLazyColumn.performKeyPress("Banana", rule = this)
+
+            // The wrap selects the first match from the top of the list (5), not the nearest one above (20),
+            // matching SpeedSearchBase.findElement's wrap-around behavior
+            onLazyColumnItem("Banana 5").assertIsDisplayed().assertIsSelected()
+        }
+
+    /** 100 entries named `Item <index>`, except the given indexes, which are named `Banana <index>`. */
+    private fun markedEntries(vararg matchIndexes: Int) =
+        List(100) { index -> if (index in matchIndexes) "Banana $index" else "Item $index" }
+
     private fun runComposeTest(
         listEntries: List<String> = List(500) { "Item ${it + 1}" },
         dismissOnLoseFocus: Boolean = true,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableLazyColumn.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableLazyColumn.kt
@@ -281,6 +281,22 @@ internal class SpeedSearchableLazyColumnScopeImpl(
     }
 }
 
+/**
+ * Keeps the list selection in sync with the speed-search matches.
+ *
+ * Whenever [SpeedSearchState.matchingIndexes] changes while the search is active, the selection is decided as follows:
+ * 1. If a currently selected item still matches, keep it selected (scrolling to it if it is offscreen).
+ * 2. Otherwise, if a selection exists, select the visible match closest to it.
+ * 3. Otherwise, select the topmost visible match.
+ * 4. If no match is visible, select the first match after the viewport.
+ * 5. Failing that, select the first match before the viewport, i.e., the first match from the top of the list.
+ *
+ * Steps 3–5 amount to a single rule: a forward scan starting at the top of the viewport that wraps around to the top of
+ * the list. This deliberately preserves the user's rough position instead of always jumping to the first match, and
+ * mirrors Swing's `SpeedSearchBase.findElement` (forward from the current position, wrap to the top — including
+ * wrapping to the *first* match from the top rather than the nearest one above) rather than `ListWithFilter`'s
+ * always-select-row-0 behavior.
+ */
 @Composable
 internal fun SpeedSearchableLazyColumnScrollEffect(
     selectableLazyListState: SelectableLazyListState,
@@ -345,8 +361,9 @@ internal fun SpeedSearchableLazyColumnScrollEffect(
                     return@combine
                 }
 
-                // If any of the visible items match the filter, just select the one closest to any of the selected
-                // items
+                // If any of the visible items match the filter, select the one closest to any of the currently
+                // selected items. When there is no selection left to anchor to (e.g. the previously selected item
+                // was filtered out), fall back to the first visible match so the first result is always selected.
                 val indexOfVisibleMatches =
                     visibleItemIndexes.filter { indexesMatchingSearchText.binarySearch(it) >= 0 }
 
@@ -358,7 +375,7 @@ internal fun SpeedSearchableLazyColumnScrollEffect(
                                 ?.let { visibleMatchIndex to it }
                         }
                         .minByOrNull { (it.first - it.second).absoluteValue }
-                        ?.first
+                        ?.first ?: indexOfVisibleMatches.firstOrNull()
 
                 if (bestVisibleMatch != null) {
                     selectableLazyListState.selectedKeys = setOfNotNull(keyValues.getOrNull(bestVisibleMatch))


### PR DESCRIPTION
## Context

Typing a character triggers two reactions from the same state change, and they run on independent reactive graphs with nothing coordinating their order. One re-filters the list, recomposes, and drops the previously selected item from the selection when it no longer matches. The other, a `LaunchedEffect` in `SpeedSearchableLazyColumnScrollEffect`, reacts to the new `matchingIndexes` and decides what to select. Both hop through `flowOn(dispatcher)`, so the selection effect can run either while the old selection is still present or after the filter has already cleared it.

Walking through typing "Angular" while "Spring Boot" is selected (Spring Boot is not an Angular match, so it gets filtered out): when the effect runs while the old selection is still there, it picks the visible match closest to that selection, lands on "Angular", and the choice sticks. When the filter runs first, the effect reaches its selection logic with an empty selection. The "pick the closest visible match" step needs an existing selection to measure distance from, so with nothing to anchor to it produces nothing, and control slips into the next branch, which was written for matches that are scrolled off-screen. That branch computes the first match after the last visible item, which skips index 0 and selects "AngularJS". It then stays wrong, because on the following round "AngularJS" is itself a valid match and gets kept.

So the outcome depended purely on which reaction won the race. The correct answer was never guaranteed, only likely (wrap your head around this!).

```mermaid
flowchart TD
    K["User types 'Angular'"] --> S["attach(): one snapshot sets<br/>currentMatcher + matchingIndexes"]

    S --> A["Graph A — derivedStateOf re-filters the list<br/>LazyColumn recomposes<br/>'Spring Boot' no longer matches → selectedKeys becomes empty"]
    S --> B["Graph B — scroll effect reacts to matchingIndexes"]

    A -. "race: no ordering between the two" .-> B

    B --> Q1{"Is a currently selected<br/>item still a match?"}
    Q1 -- yes --> KEEP["Keep it selected"]
    Q1 -- "no (selection empty)" --> Q2{"bestVisibleMatch:<br/>visible match closest to<br/>an existing selection"}

    Q2 -- "selection exists →<br/>closest match found" --> GOOD["Select 'Angular' (index 0)"]
    Q2 -- "selection empty →<br/>produces null" --> FALL["Fall-through branch<br/>(meant for OFF-screen matches):<br/>first match after visibleItemsRange.last"]

    FALL --> BUG["Selects 'AngularJS' (index 1)<br/>and keeps it on the next round"]

    Q2 -. "FIX: ?: indexOfVisibleMatches.firstOrNull()" .-> FIX["Select first visible match<br/>= 'Angular' (index 0)"]

    style BUG fill:#4a1f1f,stroke:#cc4444,color:#fff
    style FALL fill:#4a3a1f,stroke:#cc9944,color:#fff
    style FIX fill:#1f4a2a,stroke:#44cc77,color:#fff
    style GOOD fill:#1f4a2a,stroke:#44cc77,color:#fff
```

## Changes

* In `SpeedSearchableLazyColumnScrollEffect`, when there is no current selection to anchor to, fall back to the first visible match (`?.first ?: indexOfVisibleMatches.firstOrNull()`) instead of leaking into the off-screen-scroll branch. First-match selection no longer depends on winning the race: whichever reaction runs first, the empty-selection case now resolves to the first result on its own. When a selection does exist, behavior is unchanged.
* Added a regression test that reproduces the losing side of the race deterministically. Instead of hoping CI timing lines up, it clears the selection first (the exact state the re-filter produces), types a query with two visible matches, and asserts the first one is selected. With the fix reverted the test selects "AngularJS" and fails; with the fix it passes. The previously flaky `navigation should cycle through filtered items only` test is stable for the same reason.

This also matches the IntelliJ Platform behavior: both `SpeedSearchBase` (no selection starts the scan at index 0 and returns the first match) and `ListWithFilter` / `ListPopupImpl` (the previously selected row leaving the filtered set falls back to row 0) resolve to the first result in this case.

* Documented the full selection algorithm on `SpeedSearchableLazyColumnScrollEffect`. With the fix in place, the no-matching-selection behavior forms one rule: a forward scan from the top of the viewport that wraps to the top of the list (topmost visible match → first match after the viewport → first match from the top). This preserves the user's rough position and mirrors Swing's `SpeedSearchBase.findElement` rather than `ListWithFilter`'s always-select-row-0.
* Added three tests pinning that rule with a viewport scrolled mid-list: matches inside the viewport (topmost visible wins), matches only below (first match below the viewport is preferred over the global first), and matches only above (wraps to the first match from the top, not the nearest one above).

## Screen recordings

No way for me to screen record this since it's a race condition :( but there is a regression unit test that verifies the fix is working as intended :)

## Release notes

### Bug fixes

* Fixed `SpeedSearchArea` over a filtered list selecting the second match instead of the first when the previously selected item was filtered out of the results.
