### PR TITLE
IJPL-249299 fix: Keep stripped empty lines when copying a vertical section in editor (and reworked terminal)

### DIFF
--- a/platform/lang-impl/src/com/intellij/codeInsight/editorActions/CopyHandler.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/editorActions/CopyHandler.java
@@ -117,9 +117,13 @@ public final class CopyHandler extends EditorActionHandler implements CopyAction
                   ? EditorCopyPasteHelperImpl.getSelectedTextForClipboard(editor, options, transferableDataList)
                   : selectionModel.getSelectedText();
     String rawText = TextBlockTransferable.convertLineSeparators(text, "\n", transferableDataList);
-    String plainText = supportsMultipleCarets
-                       ? TextBlockTransferable.convertPureVirtualSelectionRowsToEmptyLines(rawText, editor.getCaretModel())
-                       : rawText;
+    String plainText = rawText;
+    if (supportsMultipleCarets) {
+      TextBlockTransferable.VirtualSelectionText selectionText =
+        TextBlockTransferable.convertVirtualSelectionRowsToEmptyLines(rawText, editor, transferableDataList);
+      rawText = selectionText.rawText();
+      plainText = selectionText.text();
+    }
     String escapedText = null;
     for (CopyPastePreProcessor processor : CopyPastePreProcessor.EP_NAME.getExtensionList()) {
       try {
@@ -136,8 +140,8 @@ public final class CopyHandler extends EditorActionHandler implements CopyAction
       }
     }
     String transferableText = escapedText != null ? escapedText : plainText;
-    if (supportsMultipleCarets) {
-      transferableText = TextBlockTransferable.convertPureVirtualSelectionRowsToEmptyLines(transferableText, editor.getCaretModel());
+    if (supportsMultipleCarets && escapedText != null) {
+      transferableText = TextBlockTransferable.convertVirtualSelectionRowsToEmptyLines(transferableText, editor);
     }
     return new TextBlockTransferable(transferableText,
                                      transferableDataList,

--- a/platform/lang-impl/src/com/intellij/codeInsight/editorActions/CopyHandler.java
+++ b/platform/lang-impl/src/com/intellij/codeInsight/editorActions/CopyHandler.java
@@ -112,10 +112,14 @@ public final class CopyHandler extends EditorActionHandler implements CopyAction
       }
     });
 
-    String text = editor.getCaretModel().supportsMultipleCarets()
+    boolean supportsMultipleCarets = editor.getCaretModel().supportsMultipleCarets();
+    String text = supportsMultipleCarets
                   ? EditorCopyPasteHelperImpl.getSelectedTextForClipboard(editor, options, transferableDataList)
                   : selectionModel.getSelectedText();
     String rawText = TextBlockTransferable.convertLineSeparators(text, "\n", transferableDataList);
+    String plainText = supportsMultipleCarets
+                       ? TextBlockTransferable.convertPureVirtualSelectionRowsToEmptyLines(rawText, editor.getCaretModel())
+                       : rawText;
     String escapedText = null;
     for (CopyPastePreProcessor processor : CopyPastePreProcessor.EP_NAME.getExtensionList()) {
       try {
@@ -131,8 +135,12 @@ public final class CopyHandler extends EditorActionHandler implements CopyAction
         break;
       }
     }
-    return new TextBlockTransferable(escapedText != null ? escapedText : rawText,
+    String transferableText = escapedText != null ? escapedText : plainText;
+    if (supportsMultipleCarets) {
+      transferableText = TextBlockTransferable.convertPureVirtualSelectionRowsToEmptyLines(transferableText, editor.getCaretModel());
+    }
+    return new TextBlockTransferable(transferableText,
                                      transferableDataList,
-                                     escapedText != null ? new RawText(rawText) : null);
+                                     escapedText != null || !transferableText.equals(rawText) ? new RawText(rawText) : null);
   }
 }

--- a/platform/platform-impl/api-dump-unreviewed.txt
+++ b/platform/platform-impl/api-dump-unreviewed.txt
@@ -302,8 +302,15 @@ f:com.intellij.codeInsight.editorActions.TextBlockTransferable
 - s:convertLineSeparators(com.intellij.openapi.editor.Editor,java.lang.String):java.lang.String
 - s:convertLineSeparators(com.intellij.openapi.editor.Editor,java.lang.String,java.util.Collection):java.lang.String
 - s:convertLineSeparators(java.lang.String,java.lang.String,java.util.Collection):java.lang.String
-- s:convertPureVirtualSelectionRowsToEmptyLines(com.intellij.openapi.editor.Editor,java.lang.String):java.lang.String
+- s:convertVirtualSelectionRowsToEmptyLines(java.lang.String,com.intellij.openapi.editor.Editor):java.lang.String
+- s:convertVirtualSelectionRowsToEmptyLines(java.lang.String,com.intellij.openapi.editor.Editor,java.util.Collection):com.intellij.codeInsight.editorActions.TextBlockTransferable$VirtualSelectionText
 - getSize():I
+f:com.intellij.codeInsight.editorActions.TextBlockTransferable$VirtualSelectionText
+- <init>(java.lang.String,java.lang.String):V
+- equals(java.lang.Object):Z
+- hashCode():I
+- rawText():java.lang.String
+- text():java.lang.String
 f:com.intellij.codeInsight.folding.impl.FoldingUtil
 - s:createFoldTreeIterator(com.intellij.openapi.editor.Editor):java.util.Iterator
 - s:findFoldRegion(com.intellij.openapi.editor.Editor,I,I):com.intellij.openapi.editor.FoldRegion
@@ -3319,6 +3326,8 @@ f:com.intellij.openapi.editor.impl.ScrollingModelImpl
 - scrollVertically(I):V
 f:com.intellij.openapi.editor.impl.SelectionModelImpl
 - copySelectionToClipboard():V
+- getBlockSelectionEnd():com.intellij.openapi.editor.LogicalPosition
+- getBlockSelectionStart():com.intellij.openapi.editor.LogicalPosition
 - getEditor():com.intellij.openapi.editor.Editor
 - getTextAttributes():com.intellij.openapi.editor.markup.TextAttributes
 - removeSelectionListener(com.intellij.openapi.editor.event.SelectionListener):V

--- a/platform/platform-impl/api-dump-unreviewed.txt
+++ b/platform/platform-impl/api-dump-unreviewed.txt
@@ -302,6 +302,7 @@ f:com.intellij.codeInsight.editorActions.TextBlockTransferable
 - s:convertLineSeparators(com.intellij.openapi.editor.Editor,java.lang.String):java.lang.String
 - s:convertLineSeparators(com.intellij.openapi.editor.Editor,java.lang.String,java.util.Collection):java.lang.String
 - s:convertLineSeparators(java.lang.String,java.lang.String,java.util.Collection):java.lang.String
+- s:convertPureVirtualSelectionRowsToEmptyLines(com.intellij.openapi.editor.Editor,java.lang.String):java.lang.String
 - getSize():I
 f:com.intellij.codeInsight.folding.impl.FoldingUtil
 - s:createFoldTreeIterator(com.intellij.openapi.editor.Editor):java.util.Iterator

--- a/platform/platform-impl/src/com/intellij/codeInsight/editorActions/TextBlockTransferable.java
+++ b/platform/platform-impl/src/com/intellij/codeInsight/editorActions/TextBlockTransferable.java
@@ -5,7 +5,9 @@ package com.intellij.codeInsight.editorActions;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.CaretModel;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.editor.RawText;
+import com.intellij.openapi.editor.impl.SelectionModelImpl;
 import com.intellij.openapi.ide.Sizeable;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.SystemInfo;
@@ -120,24 +122,9 @@ public final class TextBlockTransferable implements Transferable, Sizeable {
                                              String newSeparator,
                                              Collection<? extends TextBlockTransferableData> itemsToUpdate) {
     if (!itemsToUpdate.isEmpty()){
-      int size = 0;
-      for(TextBlockTransferableData data: itemsToUpdate) {
-        size += data.getOffsetCount();
-      }
-
-      int[] offsets = new int[size];
-      int index = 0;
-      for(TextBlockTransferableData data: itemsToUpdate) {
-        index = data.getOffsets(offsets, index);
-      }
-
+      int[] offsets = getOffsets(itemsToUpdate);
       text = Strings.convertLineSeparators(text, newSeparator, offsets);
-
-      index = 0;
-      for(TextBlockTransferableData data: itemsToUpdate) {
-        index = data.setOffsets(offsets, index);
-      }
-
+      setOffsets(itemsToUpdate, offsets);
       return text;
     }
     else{
@@ -145,13 +132,68 @@ public final class TextBlockTransferable implements Transferable, Sizeable {
     }
   }
 
-  @ApiStatus.Internal
-  public static @NotNull String convertPureVirtualSelectionRowsToEmptyLines(@NotNull String text, @NotNull CaretModel model) {
+  private static @NotNull String includeVirtualSelectionRows(@NotNull String text, @NotNull Editor editor,
+                                                             @NotNull Collection<? extends TextBlockTransferableData> itemsToUpdate) {
+    CaretModel model = editor.getCaretModel();
     if (!model.supportsMultipleCarets()) {
       return text;
     }
 
     List<Caret> carets = model.getAllCarets();
+    List<TextLine> lines = getLines(text);
+    BlockSelectionLines blockSelectionLines = getBlockSelectionLines(editor);
+    if (blockSelectionLines == null || lines.size() != carets.size() || !fitsBlockSelectionLines(carets, blockSelectionLines)) {
+      return text;
+    }
+
+    int[] offsets = getOffsets(itemsToUpdate);
+    StringBuilder result = new StringBuilder(text.length() + blockSelectionLines.lineCount() - carets.size());
+    int caretIndex = 0;
+    int appliedShift = 0;
+    for (int line = blockSelectionLines.startLine; line <= blockSelectionLines.endLine; line++) {
+      if (line > blockSelectionLines.startLine) {
+        result.append('\n');
+      }
+      if (caretIndex < carets.size() && carets.get(caretIndex).getLogicalPosition().line == line) {
+        TextLine textLine = lines.get(caretIndex);
+        int newShift = result.length() - textLine.startOffset;
+        int shiftDelta = newShift - appliedShift;
+        if (shiftDelta != 0) {
+          shiftOffsets(offsets, textLine.startOffset, shiftDelta);
+          appliedShift = newShift;
+        }
+        result.append(text, textLine.startOffset, textLine.endOffset);
+        caretIndex++;
+      }
+    }
+    setOffsets(itemsToUpdate, offsets);
+    return result.toString();
+  }
+
+  @ApiStatus.Internal
+  public static @NotNull String convertVirtualSelectionRowsToEmptyLines(@NotNull String text, @NotNull Editor editor) {
+    return convertVirtualSelectionRowsToEmptyLines(text, editor, Collections.emptyList()).text();
+  }
+
+  @ApiStatus.Internal
+  public static @NotNull VirtualSelectionText convertVirtualSelectionRowsToEmptyLines(@NotNull String rawText, @NotNull Editor editor,
+                                                                                      @NotNull Collection<? extends TextBlockTransferableData> itemsToUpdate) {
+    CaretModel model = editor.getCaretModel();
+    if (!model.supportsMultipleCarets()) {
+      return new VirtualSelectionText(rawText, rawText);
+    }
+
+    String text = removePureVirtualSelectionText(rawText, model.getAllCarets());
+    rawText = includeVirtualSelectionRows(rawText, editor, itemsToUpdate);
+    text = includeVirtualSelectionRows(text, editor, Collections.emptyList());
+    return new VirtualSelectionText(rawText, text);
+  }
+
+  @ApiStatus.Internal
+  public record VirtualSelectionText(@NotNull String rawText, @NotNull String text) {
+  }
+
+  private static @NotNull String removePureVirtualSelectionText(@NotNull String text, @NotNull List<Caret> carets) {
     StringBuilder result = new StringBuilder(text.length());
     int lineStart = 0;
     int caretIndex = 0;
@@ -170,8 +212,84 @@ public final class TextBlockTransferable implements Transferable, Sizeable {
     return result.toString();
   }
 
+  private static @NotNull List<TextLine> getLines(@NotNull String text) {
+    List<TextLine> result = new ArrayList<>();
+    int lineStart = 0;
+    for (int i = 0; i <= text.length(); i++) {
+      if (i == text.length() || text.charAt(i) == '\n') {
+        result.add(new TextLine(lineStart, i));
+        lineStart = i + 1;
+      }
+    }
+    return result;
+  }
+
+  private static @Nullable BlockSelectionLines getBlockSelectionLines(@NotNull Editor editor) {
+    if (!(editor.getSelectionModel() instanceof SelectionModelImpl selectionModel)) {
+      return null;
+    }
+
+    LogicalPosition blockStart = selectionModel.getBlockSelectionStart();
+    LogicalPosition blockEnd = selectionModel.getBlockSelectionEnd();
+    if (blockStart == null || blockEnd == null) {
+      return null;
+    }
+
+    return new BlockSelectionLines(Math.min(blockStart.line, blockEnd.line), Math.max(blockStart.line, blockEnd.line));
+  }
+
+  private static boolean fitsBlockSelectionLines(@NotNull List<Caret> carets, @NotNull BlockSelectionLines blockSelectionLines) {
+    int previousLine = -1;
+    for (Caret caret : carets) {
+      int line = caret.getLogicalPosition().line;
+      if (line < blockSelectionLines.startLine || line > blockSelectionLines.endLine || line <= previousLine) {
+        return false;
+      }
+      previousLine = line;
+    }
+    return true;
+  }
+
+  private static int @NotNull [] getOffsets(@NotNull Collection<? extends TextBlockTransferableData> itemsToUpdate) {
+    int size = 0;
+    for (TextBlockTransferableData data : itemsToUpdate) {
+      size += data.getOffsetCount();
+    }
+
+    int[] offsets = new int[size];
+    int index = 0;
+    for (TextBlockTransferableData data : itemsToUpdate) {
+      index = data.getOffsets(offsets, index);
+    }
+    return offsets;
+  }
+
+  private static void setOffsets(@NotNull Collection<? extends TextBlockTransferableData> itemsToUpdate, int @NotNull [] offsets) {
+    int index = 0;
+    for (TextBlockTransferableData data : itemsToUpdate) {
+      index = data.setOffsets(offsets, index);
+    }
+  }
+
+  private static void shiftOffsets(int @NotNull [] offsets, int startOffset, int shift) {
+    for (int i = 0; i < offsets.length; i++) {
+      if (offsets[i] >= startOffset) {
+        offsets[i] += shift;
+      }
+    }
+  }
+
   private static boolean isPureVirtualSelection(@NotNull Caret caret) {
     return caret.hasSelection() && caret.getSelectionStart() == caret.getSelectionEnd();
+  }
+
+  private record TextLine(int startOffset, int endOffset) {
+  }
+
+  private record BlockSelectionLines(int startLine, int endLine) {
+    int lineCount() {
+      return endLine - startLine + 1;
+    }
   }
 
   private record DataFlavorWithPriority(DataFlavor flavor, int priority) {

--- a/platform/platform-impl/src/com/intellij/codeInsight/editorActions/TextBlockTransferable.java
+++ b/platform/platform-impl/src/com/intellij/codeInsight/editorActions/TextBlockTransferable.java
@@ -2,6 +2,8 @@
 
 package com.intellij.codeInsight.editorActions;
 
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.CaretModel;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.RawText;
 import com.intellij.openapi.ide.Sizeable;
@@ -11,6 +13,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.util.text.Strings;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -140,6 +143,35 @@ public final class TextBlockTransferable implements Transferable, Sizeable {
     else{
       return StringUtil.convertLineSeparators(text, newSeparator);
     }
+  }
+
+  @ApiStatus.Internal
+  public static @NotNull String convertPureVirtualSelectionRowsToEmptyLines(@NotNull String text, @NotNull CaretModel model) {
+    if (!model.supportsMultipleCarets()) {
+      return text;
+    }
+
+    List<Caret> carets = model.getAllCarets();
+    StringBuilder result = new StringBuilder(text.length());
+    int lineStart = 0;
+    int caretIndex = 0;
+    for (int i = 0; i <= text.length(); i++) {
+      if (i == text.length() || text.charAt(i) == '\n') {
+        if (caretIndex >= carets.size() || !isPureVirtualSelection(carets.get(caretIndex))) {
+          result.append(text, lineStart, i);
+        }
+        if (i < text.length()) {
+          result.append('\n');
+        }
+        lineStart = i + 1;
+        caretIndex++;
+      }
+    }
+    return result.toString();
+  }
+
+  private static boolean isPureVirtualSelection(@NotNull Caret caret) {
+    return caret.hasSelection() && caret.getSelectionStart() == caret.getSelectionEnd();
   }
 
   private record DataFlavorWithPriority(DataFlavor flavor, int priority) {

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorCopyPasteHelperImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorCopyPasteHelperImpl.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorCopyPasteHelper;
 import com.intellij.openapi.editor.EditorModificationUtil;
 import com.intellij.openapi.editor.EditorModificationUtilEx;
+import com.intellij.openapi.editor.RawText;
 import com.intellij.openapi.editor.VisualPosition;
 import com.intellij.openapi.editor.actions.BasePasteHandler;
 import com.intellij.openapi.editor.ex.util.EditorUtil;
@@ -57,13 +58,18 @@ public final class EditorCopyPasteHelperImpl extends EditorCopyPasteHelper {
 
     ThreadingAssertions.assertEventDispatchThread();
     List<TextBlockTransferableData> extraData = new ArrayList<>();
-    String s = editor.getCaretModel().supportsMultipleCarets() ? getSelectedTextForClipboard(editor, options, extraData)
-                                                               : editor.getSelectionModel().getSelectedText();
-    if (StringUtil.isEmpty(s)) return null;
+    boolean supportsMultipleCarets = editor.getCaretModel().supportsMultipleCarets();
+    String rawText = supportsMultipleCarets ? getSelectedTextForClipboard(editor, options, extraData)
+                                            : editor.getSelectionModel().getSelectedText();
+    if (StringUtil.isEmpty(rawText)) return null;
 
-    s = TextBlockTransferable.convertLineSeparators(s, "\n", extraData);
-    return editor.getCaretModel().supportsMultipleCarets() ? new TextBlockTransferable(s, extraData, null)
-                                                           : new StringSelection(s);
+    rawText = TextBlockTransferable.convertLineSeparators(rawText, "\n", extraData);
+    if (!supportsMultipleCarets) {
+      return new StringSelection(rawText);
+    }
+
+    String text = TextBlockTransferable.convertPureVirtualSelectionRowsToEmptyLines(rawText, editor.getCaretModel());
+    return new TextBlockTransferable(text, extraData, text.equals(rawText) ? null : new RawText(rawText));
   }
 
   @SuppressWarnings("unused")  // external usages

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorCopyPasteHelperImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorCopyPasteHelperImpl.java
@@ -68,7 +68,10 @@ public final class EditorCopyPasteHelperImpl extends EditorCopyPasteHelper {
       return new StringSelection(rawText);
     }
 
-    String text = TextBlockTransferable.convertPureVirtualSelectionRowsToEmptyLines(rawText, editor.getCaretModel());
+    TextBlockTransferable.VirtualSelectionText selectionText =
+      TextBlockTransferable.convertVirtualSelectionRowsToEmptyLines(rawText, editor, extraData);
+    rawText = selectionText.rawText();
+    String text = selectionText.text();
     return new TextBlockTransferable(text, extraData, text.equals(rawText) ? null : new RawText(rawText));
   }
 

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/EditorImpl.java
@@ -3446,6 +3446,7 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
     List<CaretState> caretStates = new ArrayList<>(myCaretStateBeforeLastPress);
     if (myRectangularSelectionInProgress) {
       caretStates.addAll(EditorModificationUtil.calcBlockSelectionState(this, myLastMousePressedLocation, targetPosition));
+      mySelectionModel.setCaretsAndBlockSelection(myLastMousePressedLocation, targetPosition, caretStates);
     }
     else {
       LogicalPosition selectionStart = myLastMousePressedLocation;
@@ -3471,8 +3472,8 @@ public final class EditorImpl extends UserDataHolderBase implements EditorEx, Hi
         cancelAutoResetForMouseSelectionState();
       }
       caretStates.add(new CaretState(targetPosition, selectionStart, selectionEnd));
+      myCaretModel.setCaretsAndSelections(caretStates);
     }
-    myCaretModel.setCaretsAndSelections(caretStates);
   }
 
   private @NotNull Caret getLeadCaret() {

--- a/platform/platform-impl/src/com/intellij/openapi/editor/impl/SelectionModelImpl.java
+++ b/platform/platform-impl/src/com/intellij/openapi/editor/impl/SelectionModelImpl.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.editor.event.SelectionListener;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.ui.ColorUtil;
+import com.intellij.util.MathUtil;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -36,6 +37,9 @@ public final class SelectionModelImpl implements SelectionModel {
 
   private TextAttributes myActiveSelection;
   private TextAttributes myInactiveSelection;
+  private @Nullable LogicalPosition myBlockSelectionStart;
+  private @Nullable LogicalPosition myBlockSelectionEnd;
+  private boolean mySettingBlockSelection;
 
   @ApiStatus.Internal
   public SelectionModelImpl(EditorImpl editor) {
@@ -64,6 +68,10 @@ public final class SelectionModelImpl implements SelectionModel {
   }
 
   void fireSelectionChanged(SelectionEvent event) {
+    if (!mySettingBlockSelection) {
+      myBlockSelectionStart = null;
+      myBlockSelectionEnd = null;
+    }
     TextRange[] oldRanges = event.getOldRanges();
     TextRange[] newRanges = event.getNewRanges();
     int count = Math.min(oldRanges.length, newRanges.length);
@@ -99,8 +107,35 @@ public final class SelectionModelImpl implements SelectionModel {
 
   @Override
   public void setBlockSelection(@NotNull LogicalPosition blockStart, @NotNull LogicalPosition blockEnd) {
-    List<CaretState> caretStates = EditorModificationUtil.calcBlockSelectionState(myEditor, blockStart, blockEnd);
-    myEditor.getCaretModel().setCaretsAndSelections(caretStates);
+    setCaretsAndBlockSelection(blockStart, blockEnd, EditorModificationUtil.calcBlockSelectionState(myEditor, blockStart, blockEnd));
+  }
+
+  @ApiStatus.Internal
+  void setCaretsAndBlockSelection(@NotNull LogicalPosition blockStart, @NotNull LogicalPosition blockEnd, @NotNull List<CaretState> caretStates) {
+    myBlockSelectionStart = clampBlockSelectionPosition(blockStart);
+    myBlockSelectionEnd = clampBlockSelectionPosition(blockEnd);
+    mySettingBlockSelection = true;
+    try {
+      myEditor.getCaretModel().setCaretsAndSelections(caretStates);
+    }
+    finally {
+      mySettingBlockSelection = false;
+    }
+  }
+
+  @ApiStatus.Internal
+  public @Nullable LogicalPosition getBlockSelectionStart() {
+    return myBlockSelectionStart;
+  }
+
+  @ApiStatus.Internal
+  public @Nullable LogicalPosition getBlockSelectionEnd() {
+    return myBlockSelectionEnd;
+  }
+
+  private @NotNull LogicalPosition clampBlockSelectionPosition(@NotNull LogicalPosition position) {
+    int line = MathUtil.clamp(position.line, 0, myEditor.getDocument().getLineCount() - 1);
+    return line == position.line ? position : new LogicalPosition(line, position.column);
   }
 
   @Override

--- a/platform/platform-tests/testSrc/com/intellij/openapi/editor/EditorMultiCaretColumnModeTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/editor/EditorMultiCaretColumnModeTest.java
@@ -331,6 +331,54 @@ public class EditorMultiCaretColumnModeTest extends AbstractEditorTest {
                         opq<caret># mnopqr""");
   }
 
+  public void testCopyPreservesEmptyLinesInBlockSelectionAfterLineEndWithoutColumnMode() {
+    init("""
+           # abcdef
+           #\s
+           # mnopqr""");
+    ((EditorEx)getEditor()).setColumnMode(false);
+    getEditor().getSelectionModel().setBlockSelection(new LogicalPosition(0, 4), new LogicalPosition(2, 7));
+    assertEquals(2, getEditor().getCaretModel().getCaretCount());
+
+    copy();
+
+    Transferable contents = CopyPasteManager.getInstance().getContents();
+    assertNotNull(contents);
+    assertEquals("cde\n\nopq", CopyPasteManager.getInstance().getContents(DataFlavor.stringFlavor));
+  }
+
+  public void testCopyPreservesOnlyDocumentLinesInBlockSelectionAfterLineEndWithoutColumnMode() {
+    init("""
+           # abcdef
+           #\s
+           # mnopqr""");
+    ((EditorEx)getEditor()).setColumnMode(false);
+    getEditor().getSelectionModel().setBlockSelection(new LogicalPosition(0, 4), new LogicalPosition(1000, 7));
+    assertEquals(2, getEditor().getCaretModel().getCaretCount());
+
+    copy();
+
+    Transferable contents = CopyPasteManager.getInstance().getContents();
+    assertNotNull(contents);
+    assertEquals("cde\n\nopq", CopyPasteManager.getInstance().getContents(DataFlavor.stringFlavor));
+  }
+
+  public void testMouseCopyPreservesEmptyLinesInBlockSelectionAfterLineEndWithoutColumnMode() {
+    init("""
+           # abcdef
+           #\s
+           # mnopqr""");
+    ((EditorEx)getEditor()).setColumnMode(false);
+    mouse().alt().pressAt(0, 4).dragTo(2, 7).release();
+    assertEquals(2, getEditor().getCaretModel().getCaretCount());
+
+    copy();
+
+    Transferable contents = CopyPasteManager.getInstance().getContents();
+    assertNotNull(contents);
+    assertEquals("cde\n\nopq", CopyPasteManager.getInstance().getContents(DataFlavor.stringFlavor));
+  }
+
   public void testCopyHelperPreservesEmptyLinesInBlockSelection() throws Exception {
     init("""
            # abcdef

--- a/platform/platform-tests/testSrc/com/intellij/openapi/editor/EditorMultiCaretColumnModeTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/editor/EditorMultiCaretColumnModeTest.java
@@ -1,9 +1,18 @@
 // Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.intellij.openapi.editor;
 
+import com.intellij.codeInsight.editorActions.CopyPastePreProcessor;
 import com.intellij.openapi.actionSystem.IdeActions;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.editor.impl.AbstractEditorTest;
+import com.intellij.openapi.ide.CopyPasteManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
 
 public class EditorMultiCaretColumnModeTest extends AbstractEditorTest {
   public void testUpDown() {
@@ -296,6 +305,74 @@ public class EditorMultiCaretColumnModeTest extends AbstractEditorTest {
                           <caret>a
                         b <caret>bbb
                         cc<caret>ccccc""");
+  }
+
+  public void testCopyPreservesEmptyLinesInBlockSelection() {
+    init("""
+           # abcdef
+           #\s
+           # mnopqr""");
+    mouse().pressAt(0, 4).dragTo(2, 7).release();
+
+    copy();
+
+    Transferable contents = CopyPasteManager.getInstance().getContents();
+    assertNotNull(contents);
+    assertEquals("cde\n\nopq", CopyPasteManager.getInstance().getContents(DataFlavor.stringFlavor));
+    RawText rawText = RawText.fromTransferable(contents);
+    assertNotNull(rawText);
+    assertEquals("cde\n   \nopq", rawText.rawText);
+
+    home();
+    paste();
+    checkResultByText("""
+                        cde<caret># abcdef
+                           <caret>#\s
+                        opq<caret># mnopqr""");
+  }
+
+  public void testCopyHelperPreservesEmptyLinesInBlockSelection() throws Exception {
+    init("""
+           # abcdef
+           #\s
+           # mnopqr""");
+    mouse().pressAt(0, 4).dragTo(2, 7).release();
+
+    Transferable contents = EditorCopyPasteHelper.getInstance().getSelectionTransferable(getEditor(), EditorCopyPasteHelper.CopyPasteOptions.DEFAULT);
+
+    assertNotNull(contents);
+    assertEquals("cde\n\nopq", contents.getTransferData(DataFlavor.stringFlavor));
+    RawText rawText = RawText.fromTransferable(contents);
+    assertNotNull(rawText);
+    assertEquals("cde\n   \nopq", rawText.rawText);
+  }
+
+  public void testCopyPreprocessorPreservesEmptyLinesInBlockSelection() {
+    CopyPastePreProcessor.EP_NAME.getPoint().registerExtension(new CopyPastePreProcessor() {
+      @Override
+      public @Nullable String preprocessOnCopy(PsiFile file, int[] startOffsets, int[] endOffsets, String text) {
+        return text;
+      }
+
+      @Override
+      public @NotNull String preprocessOnPaste(Project project, PsiFile file, Editor editor, String text, RawText rawText) {
+        return text;
+      }
+    }, getTestRootDisposable());
+    init("""
+           # abcdef
+           #\s
+           # mnopqr""");
+    mouse().pressAt(0, 4).dragTo(2, 7).release();
+
+    copy();
+
+    Transferable contents = CopyPasteManager.getInstance().getContents();
+    assertNotNull(contents);
+    assertEquals("cde\n\nopq", CopyPasteManager.getInstance().getContents(DataFlavor.stringFlavor));
+    RawText rawText = RawText.fromTransferable(contents);
+    assertNotNull(rawText);
+    assertEquals("cde\n   \nopq", rawText.rawText);
   }
 
   public void testPasteOfBlockToASingleCaret() {

--- a/plugins/terminal/frontend/src/com/intellij/terminal/frontend/view/impl/CopyOnSelectionHandler.kt
+++ b/plugins/terminal/frontend/src/com/intellij/terminal/frontend/view/impl/CopyOnSelectionHandler.kt
@@ -1,5 +1,6 @@
 package com.intellij.terminal.frontend.view.impl
 
+import com.intellij.codeInsight.editorActions.TextBlockTransferable
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.SelectionEvent
@@ -44,7 +45,8 @@ internal class CopyOnSelectionHandler private constructor(private val settings: 
       // In most cases it is, but if the selection was updated through the API, it may not be the case.
       if (!settings.copyOnSelect() || e.editor?.contentComponent?.isFocusOwner != true) return
       // Take only if not empty. `getSelectedText(allCarets=true)` returns an empty string if there is no selection.
-      val text = e.editor.selectionModel.getSelectedText(true)?.takeIf { it.isNotEmpty() } ?: return
+      val selectedText = e.editor.selectionModel.getSelectedText(true)?.takeIf { it.isNotEmpty() } ?: return
+      val text = TextBlockTransferable.convertVirtualSelectionRowsToEmptyLines(selectedText, e.editor)
       copy(text)
     }
   }

--- a/plugins/terminal/tests/src/com/intellij/terminal/tests/reworked/frontend/TerminalCopyOnSelectionTest.kt
+++ b/plugins/terminal/tests/src/com/intellij/terminal/tests/reworked/frontend/TerminalCopyOnSelectionTest.kt
@@ -94,6 +94,18 @@ internal class TerminalCopyOnSelectionTest : BasePlatformTestCase() {
     assertEquals("irs\neco\nhir", afterClear!!.getTransferData(DataFlavor.stringFlavor))
   }
 
+  @Test
+  fun `copy on selection preserves empty rows for block selection after line end`() {
+    val editor = createTerminalEditor()
+    editor.emitOnTerminal("# abcdef\n# \n# mnopqr")
+
+    editor.selectionModel.setBlockSelection(LogicalPosition(0, 4), LogicalPosition(2, 7))
+    val copied = copiedTransferable()
+
+    assertNotNull(copied)
+    assertEquals("cde\n\nopq", copied!!.getTransferData(DataFlavor.stringFlavor))
+  }
+
   private fun createTerminalEditor(): Editor {
     val scope = terminalProjectScope(project).childScope("TerminalOutputEditor").also {
       Disposer.register(testRootDisposable) { it.cancel() }


### PR DESCRIPTION
Fix block selection copy when the selected rectangle crosses lines shorter than the selected columns.

See https://youtrack.jetbrains.com/issue/IJPL-249299/Column-selection-copy-blank-lines-are-stripped-from-pasted-text

The editor can omit carets for rows that are fully in virtual space. Copy then used to concatenate only caret selections, so those logical rows disappeared from the clipboard. This preserves those rows as empty lines while keeping raw rectangular text available for IDE paste paths and copy preprocessors.

The fix stores the logical block-selection row bounds, reuses them in `TextBlockTransferable`, and applies the same conversion through editor copy, direct copy-paste helper usage, and terminal copy-on-selection.
I believe the newly created VirtualSelectionText to be interesting, but it's integration in the API feels clumsy as well.

https://github.com/user-attachments/assets/64111ac1-5826-482a-85d8-40638d9f139f



----

I honestly asked some help from agents for this, but I'm quite unsure about the outcome, for example I choose to add a new internal API in `TextBlockTransferable` because that's a class that is available in both modules, and there's already a static method there. But this doesn't look great is it surfaces an internal API.