### PR TITLE
[collab] Add a hover Jump to Source icon to the review changes tree

### DIFF
--- a/platform/collaboration-tools/src/com/intellij/collaboration/ui/codereview/CodeReviewProgressRenderer.kt
+++ b/platform/collaboration-tools/src/com/intellij/collaboration/ui/codereview/CodeReviewProgressRenderer.kt
@@ -4,7 +4,11 @@ package com.intellij.collaboration.ui.codereview
 import com.intellij.collaboration.ui.HorizontalListPanel
 import com.intellij.collaboration.ui.layout.SizeRestrictedSingleComponentLayout
 import com.intellij.collaboration.ui.util.DimensionRestrictions
+import com.intellij.collaboration.util.RefComparisonChange
+import com.intellij.collaboration.util.filePath
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.vcs.changes.ui.ChangesBrowserNode
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.CellRendererPanel
 import com.intellij.ui.ClientProperty
 import com.intellij.ui.ColoredTreeCellRenderer
@@ -61,7 +65,18 @@ internal class CodeReviewProgressRendererComponent(
     verticalAlignment = JLabel.CENTER
   }
 
+  private val jumpToSourceIconLabel = JLabel().apply {
+    border = JBUI.Borders.empty()
+    icon = AllIcons.Actions.EditSource
+    horizontalAlignment = JLabel.CENTER
+    verticalAlignment = JLabel.CENTER
+  }
+
   private val invisiblePlaceholder = JLabel().apply {
+    isVisible = false
+  }
+
+  private val invisibleJumpToSourcePlaceholder = JLabel().apply {
     isVisible = false
   }
 
@@ -71,6 +86,21 @@ internal class CodeReviewProgressRendererComponent(
 
     val sizeRestriction = object : DimensionRestrictions {
       override fun getWidth(): Int = checkbox.preferredSize.width
+      override fun getHeight(): Int? = null
+    }
+    layout = SizeRestrictedSingleComponentLayout().apply {
+      prefSize = sizeRestriction
+      minSize = sizeRestriction
+      maxSize = sizeRestriction
+    }
+  }
+
+  private val jumpToSourceContainer = JPanel().apply {
+    isOpaque = false
+    border = JBUI.Borders.empty()
+
+    val sizeRestriction = object : DimensionRestrictions {
+      override fun getWidth(): Int = jumpToSourceIconLabel.preferredSize.width
       override fun getHeight(): Int? = null
     }
     layout = SizeRestrictedSingleComponentLayout().apply {
@@ -95,6 +125,12 @@ internal class CodeReviewProgressRendererComponent(
   }
 
   @RequiresEdt
+  fun jumpToSourceIconBounds(cellSize: Dimension): Rectangle? {
+    bounds = Rectangle(0, 0, cellSize.width, cellSize.height)
+    return jumpToSourceIconLabel.calculateBoundsWithin(this)
+  }
+
+  @RequiresEdt
   fun prepareComponent(tree: JTree, value: Any, selected: Boolean, expanded: Boolean, leaf: Boolean, row: Int, hasFocus: Boolean): JComponent {
     value as ChangesBrowserNode<*>
     val state = codeReviewProgressStateProvider(value)
@@ -108,7 +144,7 @@ internal class CodeReviewProgressRendererComponent(
 
     // if loading, don't show any icons yet
     if (isStateContainerShown(leaf, expanded) && !state.isLoading) {
-      add(updateStateContainer(tree, state, row, leaf), BorderLayout.EAST)
+      add(updateStateContainer(tree, value, state, row, leaf), BorderLayout.EAST)
     }
 
     return this
@@ -121,14 +157,24 @@ internal class CodeReviewProgressRendererComponent(
       (this as? JComponent)?.border = JBUI.Borders.empty()
     }
 
-  private fun updateStateContainer(tree: JTree, state: NodeCodeReviewProgressState, row: Int, isLeaf: Boolean): JComponent =
+  private fun updateStateContainer(tree: JTree, node: ChangesBrowserNode<*>, state: NodeCodeReviewProgressState, row: Int, isLeaf: Boolean): JComponent =
     stateContainer.apply {
       removeAll()
+
+      val isHovered = TreeHoverListener.getHoveredRow(tree) == row
 
       val commentIconLabel = updateCommentIconLabel(state)
       commentIconLabel?.let(::add)
 
-      val isHovered = TreeHoverListener.getHoveredRow(tree) == row
+      if (isLeaf) {
+        // the slot is reserved for every leaf so the row layout doesn't shift on hover
+        add(jumpToSourceContainer.apply {
+          removeAll()
+          val canJumpToSource = isHovered && node.navigatableVirtualFile() != null
+          add(if (canJumpToSource) jumpToSourceIconLabel else invisibleJumpToSourcePlaceholder)
+        })
+      }
+
       val rightSideComp = if (isLeaf && hasViewedState && (isHovered || state.isRead)) {
         updateViewedCheckbox(state)
       }
@@ -184,3 +230,6 @@ private fun JComponent.calculateBoundsWithin(parent: JComponent): Rectangle? {
 
   return bounds
 }
+
+internal fun ChangesBrowserNode<*>.navigatableVirtualFile(): VirtualFile? =
+  (userObject as? RefComparisonChange)?.filePath?.virtualFile

--- a/platform/collaboration-tools/src/com/intellij/collaboration/ui/codereview/CodeReviewProgressTreeModel.kt
+++ b/platform/collaboration-tools/src/com/intellij/collaboration/ui/codereview/CodeReviewProgressTreeModel.kt
@@ -7,6 +7,7 @@ import com.intellij.collaboration.async.stateInNow
 import com.intellij.collaboration.ui.codereview.details.model.CodeReviewChangeListViewModel
 import com.intellij.collaboration.util.RefComparisonChange
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.vcs.changes.ui.ChangesBrowserNode
 import com.intellij.openapi.vcs.changes.ui.ChangesBrowserNodeRenderer
 import com.intellij.openapi.vcs.changes.ui.ChangesTree
@@ -23,7 +24,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
+import java.awt.Dimension
 import java.awt.Point
+import java.awt.Rectangle
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.SwingUtilities
@@ -44,6 +47,7 @@ fun ChangesTree.setupCodeReviewProgressModel(vm: CodeReviewChangeListViewModel, 
     codeReviewProgressStateProvider = model::getState
   )
   installViewedStateToggleHandler(vm, model)
+  installJumpToSourceHandler(vm)
 
   model.addChangeListener {
     repaint()
@@ -66,42 +70,60 @@ private fun ChangesTree.installViewedStateToggleHandler(
   val tree = this
 
   if (vm is CodeReviewChangeListViewModel.WithViewedState) {
-    addMouseListener(object : MouseAdapter() {
-      override fun mouseClicked(e: MouseEvent) {
-        if (!SwingUtilities.isLeftMouseButton(e)) return
+    installRendererComponentClickHandler(CodeReviewProgressRendererComponent::checkboxBounds) { node ->
+      val change = node.userObject as? RefComparisonChange ?: return@installRendererComponentClickHandler
 
-        val row = getClosestRowForLocation(1, e.y)
-        if (row < 0) return
+      val state = model.getState(node)
+      val isViewed = !state.isRead
 
-        val path = getPathForRow(row)
-        val cellBounds = tree.ui?.asSafely<CustomBoundsTreeUI>()?.getActualPathBounds(tree, path) ?: return
-        val positionInCell = Point(e.x - cellBounds.x, e.y - cellBounds.y)
-
-        val node = path.lastPathComponent as? ChangesBrowserNode<*> ?: return
-
-        // get the top-level rendered cell component
-        val component = cellRenderer.getTreeCellRendererComponent(
-          tree, node,
-          isRowSelected(row),
-          isExpanded(row),
-          getModel().isLeaf(node),
-          row, true)
-
-        if (component !is CodeReviewProgressRendererComponent) return
-        val checkboxBounds = component.checkboxBounds(cellBounds.size) ?: return
-
-        if (checkboxBounds.contains(positionInCell)) {
-          val change = node.userObject as? RefComparisonChange ?: return
-
-          val state = model.getState(node)
-          val isViewed = !state.isRead
-
-          vm.setViewedState(listOf(change), isViewed)
-          tree.repaint()
-        }
-      }
-    })
+      vm.setViewedState(listOf(change), isViewed)
+      tree.repaint()
+    }
   }
+}
+
+private fun ChangesTree.installJumpToSourceHandler(vm: CodeReviewChangeListViewModel) {
+  installRendererComponentClickHandler(CodeReviewProgressRendererComponent::jumpToSourceIconBounds) { node ->
+    val file = node.navigatableVirtualFile() ?: return@installRendererComponentClickHandler
+    OpenFileDescriptor(vm.project, file).navigate(true)
+  }
+}
+
+private fun ChangesTree.installRendererComponentClickHandler(
+  boundsInCell: (CodeReviewProgressRendererComponent, Dimension) -> Rectangle?,
+  handler: (ChangesBrowserNode<*>) -> Unit,
+) {
+  val tree = this
+
+  addMouseListener(object : MouseAdapter() {
+    override fun mouseClicked(e: MouseEvent) {
+      if (!SwingUtilities.isLeftMouseButton(e)) return
+
+      val row = getClosestRowForLocation(1, e.y)
+      if (row < 0) return
+
+      val path = getPathForRow(row)
+      val cellBounds = tree.ui?.asSafely<CustomBoundsTreeUI>()?.getActualPathBounds(tree, path) ?: return
+      val positionInCell = Point(e.x - cellBounds.x, e.y - cellBounds.y)
+
+      val node = path.lastPathComponent as? ChangesBrowserNode<*> ?: return
+
+      // get the top-level rendered cell component
+      val component = cellRenderer.getTreeCellRendererComponent(
+        tree, node,
+        isRowSelected(row),
+        isExpanded(row),
+        getModel().isLeaf(node),
+        row, true)
+
+      if (component !is CodeReviewProgressRendererComponent) return
+      val componentBounds = boundsInCell(component, cellBounds.size) ?: return
+
+      if (componentBounds.contains(positionInCell)) {
+        handler(node)
+      }
+    }
+  })
 }
 
 /**


### PR DESCRIPTION
## What

Adds a hover "Jump to Source" icon to file rows of the code review changes tree (used by the GitHub pull request view). Hovering a file row now shows an `EditSource` pencil icon next to the viewed-state checkbox; a single click opens the file in the editor.

## Why

In the PR changes tree, opening the actual file currently requires the context menu (*Jump to Source*) or F4 — a double click is already taken by the diff preview. The Commit / Local Changes tree solves the same problem with hover icons (`ChangesViewNodeAction` + `HoverChangesTree`), but that mechanism does not apply here because the review tree uses its own renderer (`CodeReviewProgressRenderer`). This adds the equivalent affordance to that renderer.

## How

- `CodeReviewProgressRenderer`: a fixed-width icon slot (same pattern as the viewed-state checkbox slot, with an invisible placeholder) is reserved for every leaf row, so the row layout never shifts on hover. The icon only renders for the hovered row and only when the file resolves to a local `VirtualFile` (deleted files show nothing).
- `CodeReviewProgressTreeModel`: the existing checkbox hit-test click handler is generalized into `installRendererComponentClickHandler` and reused for the new icon; a click navigates via `OpenFileDescriptor`.

## Validation

- `bazel build //platform/collaboration-tools:collaboration-tools` passes.
- Manually reviewed against the checkbox hover behavior for layout-shift and hit-testing consistency.

## Note

I could not find an existing YouTrack ticket for this. I understand features need prior agreement per CONTRIBUTING.md — happy to file a YouTrack issue and link it here, or adjust/split the change as you prefer.

## Test

Consistent with context menu:

(1) The icon shows when the `Jump to Source` is in the context menu (right click menu)

<img width="644" height="535" alt="image" src="https://github.com/user-attachments/assets/a0845073-080c-464b-a432-3ae5628e2098" />

(2) No icon shows for the file if the file don't have `Jump to Source` in the context menu.

<img width="736" height="97" alt="image" src="https://github.com/user-attachments/assets/4dce55fc-3bc2-488b-9b5f-19ce95864639" />


