### PR TITLE
[JEWEL-1317] Add portable typography text style APIs

### DIFF
--- a/platform/jewel/ide-laf-bridge/api-dump.txt
+++ b/platform/jewel/ide-laf-bridge/api-dump.txt
@@ -16,6 +16,9 @@ f:org.jetbrains.jewel.bridge.BridgeTypography
 - getMedium(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
 - getRegular(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
 - getSmall(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
+- rememberConsoleTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- rememberDefaultTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- rememberEditorTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
 f:org.jetbrains.jewel.bridge.BridgeUriHandler
 - androidx.compose.ui.platform.UriHandler
 - sf:$stable:I
@@ -125,6 +128,12 @@ f:org.jetbrains.jewel.bridge.theme.IntUiBridgeSplitButtonKt
 - sf:readOutlinedSplitButtonStyle():org.jetbrains.jewel.ui.component.styling.SplitButtonStyle
 f:org.jetbrains.jewel.bridge.theme.IntUiBridgeTextKt
 - sf:retrieveConsoleTextStyle():androidx.compose.ui.text.TextStyle
+- sf:retrieveConsoleTextStyle-2z3RXDk(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle):androidx.compose.ui.text.TextStyle
+- bs:retrieveConsoleTextStyle-2z3RXDk$default(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,I,java.lang.Object):androidx.compose.ui.text.TextStyle
 - sf:retrieveDefaultTextStyle():androidx.compose.ui.text.TextStyle
+- sf:retrieveDefaultTextStyle-2z3RXDk(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle):androidx.compose.ui.text.TextStyle
+- bs:retrieveDefaultTextStyle-2z3RXDk$default(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,I,java.lang.Object):androidx.compose.ui.text.TextStyle
 - sf:retrieveEditorTextStyle():androidx.compose.ui.text.TextStyle
+- sf:retrieveEditorTextStyle-2z3RXDk(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle):androidx.compose.ui.text.TextStyle
+- bs:retrieveEditorTextStyle-2z3RXDk$default(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,I,java.lang.Object):androidx.compose.ui.text.TextStyle
 f:org.jetbrains.jewel.bridge.theme.SwingBridgeThemeKt

--- a/platform/jewel/ide-laf-bridge/metalava/ide-laf-bridge-api-0.40.0.txt
+++ b/platform/jewel/ide-laf-bridge/metalava/ide-laf-bridge-api-0.40.0.txt
@@ -17,6 +17,9 @@ package org.jetbrains.jewel.bridge {
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getMedium();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getRegular();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getSmall();
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberConsoleTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberDefaultTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberEditorTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle editorTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle h0TextStyle;
@@ -178,9 +181,12 @@ package org.jetbrains.jewel.bridge.theme {
 
   public final class IntUiBridgeTextKt {
     method public static androidx.compose.ui.text.TextStyle retrieveConsoleTextStyle();
+    method public static androidx.compose.ui.text.TextStyle retrieveConsoleTextStyle(long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
     method public static androidx.compose.ui.text.TextStyle retrieveDefaultTextStyle();
     method @SuppressCompatibility @org.jetbrains.annotations.ApiStatus.Experimental @org.jetbrains.jewel.foundation.ExperimentalJewelApi public static androidx.compose.ui.text.TextStyle retrieveDefaultTextStyle(float lineHeightMultiplier);
+    method public static androidx.compose.ui.text.TextStyle retrieveDefaultTextStyle(long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
     method public static androidx.compose.ui.text.TextStyle retrieveEditorTextStyle();
+    method public static androidx.compose.ui.text.TextStyle retrieveEditorTextStyle(long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
   }
 
   public final class SwingBridgeThemeKt {

--- a/platform/jewel/ide-laf-bridge/metalava/ide-laf-bridge-api-stable-0.40.0.txt
+++ b/platform/jewel/ide-laf-bridge/metalava/ide-laf-bridge-api-stable-0.40.0.txt
@@ -17,6 +17,9 @@ package org.jetbrains.jewel.bridge {
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getMedium();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getRegular();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getSmall();
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberConsoleTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberDefaultTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberEditorTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle editorTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle h0TextStyle;
@@ -164,8 +167,11 @@ package org.jetbrains.jewel.bridge.theme {
 
   public final class IntUiBridgeTextKt {
     method public static androidx.compose.ui.text.TextStyle retrieveConsoleTextStyle();
+    method public static androidx.compose.ui.text.TextStyle retrieveConsoleTextStyle(long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
     method public static androidx.compose.ui.text.TextStyle retrieveDefaultTextStyle();
+    method public static androidx.compose.ui.text.TextStyle retrieveDefaultTextStyle(long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
     method public static androidx.compose.ui.text.TextStyle retrieveEditorTextStyle();
+    method public static androidx.compose.ui.text.TextStyle retrieveEditorTextStyle(long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
   }
 
 }

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeTypography.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeTypography.kt
@@ -26,6 +26,36 @@ import org.jetbrains.jewel.ui.Typography
  * [JBFont] as a reference for font sizes and style.
  */
 public object BridgeTypography : Typography {
+    @Composable
+    override fun rememberDefaultTextStyle(
+        fontSize: TextUnit,
+        fontWeight: FontWeight?,
+        fontStyle: FontStyle?,
+    ): TextStyle =
+        remember(JewelTheme.instanceUuid, fontSize, fontWeight, fontStyle) {
+            retrieveDefaultTextStyle(fontSize, fontWeight, fontStyle)
+        }
+
+    @Composable
+    override fun rememberEditorTextStyle(
+        fontSize: TextUnit,
+        fontWeight: FontWeight?,
+        fontStyle: FontStyle?,
+    ): TextStyle =
+        remember(JewelTheme.instanceUuid, fontSize, fontWeight, fontStyle) {
+            retrieveEditorTextStyle(fontSize, fontWeight, fontStyle)
+        }
+
+    @Composable
+    override fun rememberConsoleTextStyle(
+        fontSize: TextUnit,
+        fontWeight: FontWeight?,
+        fontStyle: FontStyle?,
+    ): TextStyle =
+        remember(JewelTheme.instanceUuid, fontSize, fontWeight, fontStyle) {
+            retrieveConsoleTextStyle(fontSize, fontWeight, fontStyle)
+        }
+
     @get:Composable
     override val labelTextStyle: TextStyle
         get() = remember(JewelTheme.instanceUuid) { retrieveDefaultTextStyle() }

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeText.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeText.kt
@@ -2,9 +2,15 @@ package org.jetbrains.jewel.bridge.theme
 
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.platform.asComposeFontFamily
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.isUnspecified
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.takeOrElse
 import com.intellij.ide.ui.UISettingsUtils
 import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorFontType
@@ -12,7 +18,7 @@ import com.intellij.openapi.editor.impl.FontInfo
 import com.intellij.openapi.editor.impl.view.FontLayoutService
 import com.intellij.util.ui.ImageUtil
 import com.intellij.util.ui.JBFont
-import java.awt.Font
+import java.awt.Font as AwtFont
 import java.awt.image.BufferedImage.TYPE_INT_ARGB
 import javax.swing.UIManager
 import kotlin.math.roundToInt
@@ -49,6 +55,37 @@ public fun retrieveDefaultTextStyle(lineHeightMultiplier: Float): TextStyle {
 }
 
 /**
+ * Retrieves the default text style from the Swing LaF with the requested font attributes.
+ *
+ * Prefer
+ * [`JewelTheme.typography.rememberDefaultTextStyle(...)`][org.jetbrains.jewel.ui.Typography.rememberDefaultTextStyle]
+ * in Jewel UI code.
+ *
+ * @param fontSize The font size to use. If unspecified, the Swing LaF default is used.
+ * @param fontWeight The typeface thickness to use. If null, the Swing LaF default is used.
+ * @param fontStyle The typeface variant to use. If null, the Swing LaF default is used.
+ * @return The default [TextStyle] from the Swing LaF with the requested font attributes.
+ */
+@OptIn(ExperimentalTextApi::class)
+public fun retrieveDefaultTextStyle(
+    fontSize: TextUnit,
+    fontWeight: FontWeight? = null,
+    fontStyle: FontStyle? = null,
+): TextStyle {
+    val lafFont = UIManager.getFont(KEY_LABEL_FONT) ?: keyNotFound(KEY_LABEL_FONT, "Font")
+    val font = JBFont.create(lafFont, false).deriveBridgeFont(fontWeight, fontStyle)
+    return retrieveDefaultTextStyle().withBridgeTypographyRequest(
+        fontSize,
+        fontWeight,
+        fontStyle,
+        fontFamily = font.asComposeFontFamily(),
+    ) { requestedFontSize ->
+        val scaledFontSize = requestedFontSize.value * UISettingsUtils.getInstance().currentIdeScale
+        computeBaseLineHeightFor(font.deriveFont(scaledFontSize), treatAsUnscaled = false)
+    }
+}
+
+/**
  * Compensates for some difference in how line height is applied between Skia and Swing. Matches perfectly with the
  * default editor font.
  */
@@ -75,6 +112,38 @@ public fun retrieveEditorTextStyle(): TextStyle {
             lineHeight = computedLineHeight,
             fontFeatureSettings = if (!editorColorScheme.isUseLigatures) "liga 0, calt 0" else "liga 1, calt 1",
         )
+}
+
+/**
+ * Retrieves the editor text style from the Swing LaF with the requested font attributes.
+ *
+ * Prefer
+ * [`JewelTheme.typography.rememberEditorTextStyle(...)`][org.jetbrains.jewel.ui.Typography.rememberEditorTextStyle] in
+ * Jewel UI code.
+ *
+ * @param fontSize The font size to use. If unspecified, the editor color scheme default is used.
+ * @param fontWeight The typeface thickness to use. If null, the editor color scheme default is used.
+ * @param fontStyle The typeface variant to use. If null, the editor color scheme default is used.
+ * @return The editor [TextStyle] from the Swing LaF with the requested font attributes.
+ */
+@OptIn(ExperimentalTextApi::class)
+public fun retrieveEditorTextStyle(
+    fontSize: TextUnit,
+    fontWeight: FontWeight? = null,
+    fontStyle: FontStyle? = null,
+): TextStyle {
+    val editorColorScheme = retrieveEditorColorScheme()
+    val font = editorColorScheme.getFont(EditorFontType.PLAIN).deriveBridgeFont(fontWeight, fontStyle)
+    return retrieveEditorTextStyle().withBridgeTypographyRequest(
+        fontSize,
+        fontWeight,
+        fontStyle,
+        fontFamily = font.asComposeFontFamily(),
+    ) { requestedFontSize ->
+        computeBaseLineHeightFor(font.deriveFont(requestedFontSize.value), treatAsUnscaled = true) *
+            editorColorScheme.lineSpacing *
+            EDITOR_LINE_HEIGHT_FACTOR
+    }
 }
 
 /**
@@ -106,6 +175,104 @@ public fun retrieveConsoleTextStyle(): TextStyle {
         )
 }
 
+/**
+ * Retrieves the console text style from the Swing LaF with the requested font attributes.
+ *
+ * Prefer
+ * [`JewelTheme.typography.rememberConsoleTextStyle(...)`][org.jetbrains.jewel.ui.Typography.rememberConsoleTextStyle]
+ * in Jewel UI code.
+ *
+ * @param fontSize The font size to use. If unspecified, the console color scheme default is used.
+ * @param fontWeight The typeface thickness to use. If null, the console color scheme default is used.
+ * @param fontStyle The typeface variant to use. If null, the console color scheme default is used.
+ * @return The console [TextStyle] from the Swing LaF with the requested font attributes.
+ */
+@OptIn(ExperimentalTextApi::class)
+public fun retrieveConsoleTextStyle(
+    fontSize: TextUnit,
+    fontWeight: FontWeight? = null,
+    fontStyle: FontStyle? = null,
+): TextStyle {
+    val editorColorScheme = retrieveEditorColorScheme()
+    val baseFont =
+        if (editorColorScheme.isUseEditorFontPreferencesInConsole) {
+            editorColorScheme.getFont(EditorFontType.PLAIN)
+        } else {
+            editorColorScheme.getFont(EditorFontType.CONSOLE_PLAIN)
+        }
+    val font = baseFont.deriveBridgeFont(fontWeight, fontStyle)
+    return retrieveConsoleTextStyle().withBridgeTypographyRequest(
+        fontSize,
+        fontWeight,
+        fontStyle,
+        fontFamily = font.asComposeFontFamily(),
+    ) { requestedFontSize ->
+        computeBaseLineHeightFor(font.deriveFont(requestedFontSize.value), treatAsUnscaled = true) *
+            editorColorScheme.lineSpacing *
+            EDITOR_LINE_HEIGHT_FACTOR
+    }
+}
+
+private fun TextStyle.withBridgeTypographyRequest(
+    fontSize: TextUnit,
+    fontWeight: FontWeight?,
+    fontStyle: FontStyle?,
+    fontFamily: FontFamily,
+    spLineHeight: (TextUnit) -> TextUnit,
+): TextStyle =
+    copy(
+        fontSize = fontSize.takeOrElse { this.fontSize },
+        fontWeight = fontWeight ?: this.fontWeight,
+        fontStyle = fontStyle ?: this.fontStyle,
+        fontFamily = fontFamily,
+        lineHeight =
+            lineHeight.forBridgeTypographyRequest(
+                baseFontSize = this.fontSize,
+                requestedFontSize = fontSize,
+                recomputeForFontAttributes = fontWeight != null || fontStyle != null,
+                spLineHeight = spLineHeight,
+            ),
+    )
+
+private fun AwtFont.deriveBridgeFont(fontWeight: FontWeight?, fontStyle: FontStyle?): AwtFont {
+    var awtStyle = style
+    if (fontWeight != null) {
+        awtStyle =
+            if (fontWeight.weight >= FontWeight.SemiBold.weight) {
+                awtStyle or AwtFont.BOLD
+            } else {
+                awtStyle and AwtFont.BOLD.inv()
+            }
+    }
+    if (fontStyle != null) {
+        awtStyle =
+            if (fontStyle == FontStyle.Italic) {
+                awtStyle or AwtFont.ITALIC
+            } else {
+                awtStyle and AwtFont.ITALIC.inv()
+            }
+    }
+    return deriveFont(awtStyle)
+}
+
+private fun TextUnit.forBridgeTypographyRequest(
+    baseFontSize: TextUnit,
+    requestedFontSize: TextUnit,
+    recomputeForFontAttributes: Boolean,
+    spLineHeight: (TextUnit) -> TextUnit,
+): TextUnit =
+    when {
+        requestedFontSize.isUnspecified && recomputeForFontAttributes && baseFontSize.isSp -> spLineHeight(baseFontSize)
+        requestedFontSize.isUnspecified -> this
+        requestedFontSize.isSp -> spLineHeight(requestedFontSize)
+        isSp && baseFontSize.isSp && requestedFontSize.isEm -> {
+            val baseLineHeight = if (recomputeForFontAttributes) spLineHeight(baseFontSize) else this
+            val lineHeightToFontSizeRatio = baseLineHeight.value / baseFontSize.value
+            lineHeightToFontSizeRatio.em
+        }
+        else -> this
+    }
+
 private val image = ImageUtil.createImage(1, 1, TYPE_INT_ARGB)
 
 /**
@@ -115,7 +282,7 @@ private val image = ImageUtil.createImage(1, 1, TYPE_INT_ARGB)
  * @param treatAsUnscaled When true, the font metrics are treated as "unscaled" (i.e., they do not need compensation for
  *   the IDE scale). This is useful e.g., for editor scheme fonts, which are not scaled, contrary to LaF fonts.
  */
-internal fun computeBaseLineHeightFor(font: Font, treatAsUnscaled: Boolean): TextUnit {
+internal fun computeBaseLineHeightFor(font: AwtFont, treatAsUnscaled: Boolean): TextUnit {
     // We need to create a Graphics2D to get its FontRendererContext. The only way we have is
     // by requesting a BufferedImage to create one for us. We can't reuse it because the FRC
     // instance is cached inside the Graphics2D and may lead to incorrect scales being applied.

--- a/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/api-dump.txt
@@ -30,6 +30,9 @@ f:org.jetbrains.jewel.intui.standalone.IntUiTypography
 - getMedium(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
 - getRegular(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
 - getSmall(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
+- rememberConsoleTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- rememberDefaultTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- rememberEditorTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
 f:org.jetbrains.jewel.intui.standalone.InterFontKt
 - sf:getInter(androidx.compose.ui.text.font.FontFamily$Companion):androidx.compose.ui.text.font.FontFamily
 f:org.jetbrains.jewel.intui.standalone.JetBrainsMonoFontKt

--- a/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-0.40.0.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-0.40.0.txt
@@ -41,6 +41,9 @@ package org.jetbrains.jewel.intui.standalone {
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getMedium();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getRegular();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getSmall();
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberConsoleTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberDefaultTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberEditorTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle editorTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle h0TextStyle;

--- a/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-stable-0.40.0.txt
+++ b/platform/jewel/int-ui/int-ui-standalone/metalava/int-ui-standalone-api-stable-0.40.0.txt
@@ -41,6 +41,9 @@ package org.jetbrains.jewel.intui.standalone {
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getMedium();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getRegular();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getSmall();
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberConsoleTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberDefaultTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle rememberEditorTextStyle(long fontSize, androidx.compose.ui.text.font.FontWeight? fontWeight, androidx.compose.ui.text.font.FontStyle? fontStyle);
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle editorTextStyle;
     property @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle h0TextStyle;

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/IntUiTypography.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/IntUiTypography.kt
@@ -4,9 +4,12 @@ package org.jetbrains.jewel.intui.standalone
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.isUnspecified
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.takeOrElse
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.standalone.theme.DefaultFontSize
 import org.jetbrains.jewel.intui.standalone.theme.createDefaultTextStyle
@@ -17,6 +20,60 @@ import org.jetbrains.jewel.ui.component.plus
 
 /** An implementation of [Typography] that uses default Int UI typography information. */
 public object IntUiTypography : Typography {
+    @Composable
+    override fun rememberDefaultTextStyle(
+        fontSize: TextUnit,
+        fontWeight: FontWeight?,
+        fontStyle: FontStyle?,
+    ): TextStyle =
+        if (fontSize.isUnspecified || fontSize.isSp) {
+            remember(fontSize, fontWeight, fontStyle) {
+                JewelTheme.createDefaultTextStyle(
+                    fontSize = fontSize.takeOrElse { DefaultFontSize },
+                    fontWeight = fontWeight ?: FontWeight.Normal,
+                    fontStyle = fontStyle ?: FontStyle.Normal,
+                )
+            }
+        } else {
+            super.rememberDefaultTextStyle(fontSize, fontWeight, fontStyle)
+        }
+
+    @Composable
+    override fun rememberEditorTextStyle(
+        fontSize: TextUnit,
+        fontWeight: FontWeight?,
+        fontStyle: FontStyle?,
+    ): TextStyle =
+        if (fontSize.isUnspecified || fontSize.isSp) {
+            remember(fontSize, fontWeight, fontStyle) {
+                JewelTheme.createEditorTextStyle(
+                    fontSize = fontSize.takeOrElse { DefaultFontSize },
+                    fontWeight = fontWeight ?: FontWeight.Normal,
+                    fontStyle = fontStyle ?: FontStyle.Normal,
+                )
+            }
+        } else {
+            super.rememberEditorTextStyle(fontSize, fontWeight, fontStyle)
+        }
+
+    @Composable
+    override fun rememberConsoleTextStyle(
+        fontSize: TextUnit,
+        fontWeight: FontWeight?,
+        fontStyle: FontStyle?,
+    ): TextStyle =
+        if (fontSize.isUnspecified || fontSize.isSp) {
+            remember(fontSize, fontWeight, fontStyle) {
+                JewelTheme.createEditorTextStyle(
+                    fontSize = fontSize.takeOrElse { DefaultFontSize },
+                    fontWeight = fontWeight ?: FontWeight.Normal,
+                    fontStyle = fontStyle ?: FontStyle.Normal,
+                )
+            }
+        } else {
+            super.rememberConsoleTextStyle(fontSize, fontWeight, fontStyle)
+        }
+
     @get:Composable
     override val labelTextStyle: TextStyle
         get() = remember { JewelTheme.createDefaultTextStyle() }

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -106,6 +106,16 @@ org.jetbrains.jewel.ui.Typography
 - a:getMedium(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
 - a:getRegular(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
 - a:getSmall(androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
+- rememberConsoleTextStyle-bgE_P6U(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
+- b:rememberConsoleTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- rememberDefaultTextStyle-bgE_P6U(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
+- b:rememberDefaultTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- rememberEditorTextStyle-bgE_P6U(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I):androidx.compose.ui.text.TextStyle
+- b:rememberEditorTextStyle-e402vg0(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+f:org.jetbrains.jewel.ui.Typography$ComposeDefaultImpls
+- sf:rememberConsoleTextStyle$default-otp-t0o(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,org.jetbrains.jewel.ui.Typography,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- sf:rememberDefaultTextStyle$default-otp-t0o(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,org.jetbrains.jewel.ui.Typography,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
+- sf:rememberEditorTextStyle$default-otp-t0o(J,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,org.jetbrains.jewel.ui.Typography,androidx.compose.runtime.Composer,I,I):androidx.compose.ui.text.TextStyle
 f:org.jetbrains.jewel.ui.TypographyKt
 - sf:getLocalTypography():androidx.compose.runtime.ProvidableCompositionLocal
 - sf:getTypography(org.jetbrains.jewel.foundation.theme.JewelTheme$Companion,androidx.compose.runtime.Composer,I):org.jetbrains.jewel.ui.Typography

--- a/platform/jewel/ui/metalava/ui-api-0.40.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-0.40.0.txt
@@ -154,6 +154,9 @@ package org.jetbrains.jewel.ui {
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getMedium();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getRegular();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getSmall();
+    method @androidx.compose.runtime.Composable public default androidx.compose.ui.text.TextStyle rememberConsoleTextStyle(optional long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public default androidx.compose.ui.text.TextStyle rememberDefaultTextStyle(optional long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public default androidx.compose.ui.text.TextStyle rememberEditorTextStyle(optional long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
     property @androidx.compose.runtime.Composable public abstract androidx.compose.ui.text.TextStyle consoleTextStyle;
     property @androidx.compose.runtime.Composable public abstract androidx.compose.ui.text.TextStyle editorTextStyle;
     property @androidx.compose.runtime.Composable public abstract androidx.compose.ui.text.TextStyle h0TextStyle;

--- a/platform/jewel/ui/metalava/ui-api-stable-0.40.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-stable-0.40.0.txt
@@ -154,6 +154,9 @@ package org.jetbrains.jewel.ui {
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getMedium();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getRegular();
     method @androidx.compose.runtime.Composable public androidx.compose.ui.text.TextStyle getSmall();
+    method @androidx.compose.runtime.Composable public default androidx.compose.ui.text.TextStyle rememberConsoleTextStyle(optional long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public default androidx.compose.ui.text.TextStyle rememberDefaultTextStyle(optional long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
+    method @androidx.compose.runtime.Composable public default androidx.compose.ui.text.TextStyle rememberEditorTextStyle(optional long fontSize, optional androidx.compose.ui.text.font.FontWeight? fontWeight, optional androidx.compose.ui.text.font.FontStyle? fontStyle);
     property @androidx.compose.runtime.Composable public abstract androidx.compose.ui.text.TextStyle consoleTextStyle;
     property @androidx.compose.runtime.Composable public abstract androidx.compose.ui.text.TextStyle editorTextStyle;
     property @androidx.compose.runtime.Composable public abstract androidx.compose.ui.text.TextStyle h0TextStyle;

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/Typography.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/Typography.kt
@@ -1,11 +1,19 @@
-// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the
+// Apache 2.0 license.
 package org.jetbrains.jewel.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.isUnspecified
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.takeOrElse
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 
 /**
@@ -15,6 +23,63 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
  * These match the functionality provided by `JBFont` in the IntelliJ Platform.
  */
 public interface Typography {
+    /**
+     * Remembers the default text style for this typography implementation.
+     *
+     * @param fontSize The font size to use. If unspecified, the implementation default is used.
+     * @param fontWeight The typeface thickness to use. If null, the implementation default is used.
+     * @param fontStyle The typeface variant to use. If null, the implementation default is used.
+     */
+    @Composable
+    public fun rememberDefaultTextStyle(
+        fontSize: TextUnit = TextUnit.Unspecified,
+        fontWeight: FontWeight? = null,
+        fontStyle: FontStyle? = null,
+    ): TextStyle {
+        val baseStyle = labelTextStyle
+        return remember(baseStyle, fontSize, fontWeight, fontStyle) {
+            baseStyle.withTypographyRequest(fontSize, fontWeight, fontStyle)
+        }
+    }
+
+    /**
+     * Remembers the editor text style for this typography implementation.
+     *
+     * @param fontSize The font size to use. If unspecified, the implementation default is used.
+     * @param fontWeight The typeface thickness to use. If null, the implementation default is used.
+     * @param fontStyle The typeface variant to use. If null, the implementation default is used.
+     */
+    @Composable
+    public fun rememberEditorTextStyle(
+        fontSize: TextUnit = TextUnit.Unspecified,
+        fontWeight: FontWeight? = null,
+        fontStyle: FontStyle? = null,
+    ): TextStyle {
+        val baseStyle = editorTextStyle
+        return remember(baseStyle, fontSize, fontWeight, fontStyle) {
+            baseStyle.withTypographyRequest(fontSize, fontWeight, fontStyle)
+        }
+    }
+
+    /**
+     * Remembers the console text style for this typography implementation.
+     *
+     * @param fontSize The font size to use. If unspecified, the implementation default is used.
+     * @param fontWeight The typeface thickness to use. If null, the implementation default is used.
+     * @param fontStyle The typeface variant to use. If null, the implementation default is used.
+     */
+    @Composable
+    public fun rememberConsoleTextStyle(
+        fontSize: TextUnit = TextUnit.Unspecified,
+        fontWeight: FontWeight? = null,
+        fontStyle: FontStyle? = null,
+    ): TextStyle {
+        val baseStyle = consoleTextStyle
+        return remember(baseStyle, fontSize, fontWeight, fontStyle) {
+            baseStyle.withTypographyRequest(fontSize, fontWeight, fontStyle)
+        }
+    }
+
     /**
      * The text style to use for labels. Identical to
      * [`JewelTheme.defaultTextStyle`][org.jetbrains.jewel.foundation.theme.JewelTheme.defaultTextStyle].
@@ -57,6 +122,32 @@ public interface Typography {
     /** The text style used for code consoles. Usually is a monospaced font. Can be the same as [editorTextStyle]. */
     @get:Composable public val consoleTextStyle: TextStyle
 }
+
+private fun TextStyle.withTypographyRequest(
+    fontSize: TextUnit,
+    fontWeight: FontWeight?,
+    fontStyle: FontStyle?,
+): TextStyle =
+    copy(
+        fontSize = fontSize.takeOrElse { this.fontSize },
+        fontWeight = fontWeight ?: this.fontWeight,
+        fontStyle = fontStyle ?: this.fontStyle,
+        lineHeight = lineHeight.scaledFrom(this.fontSize, fontSize),
+    )
+
+private fun TextUnit.scaledFrom(baseFontSize: TextUnit, requestedFontSize: TextUnit): TextUnit =
+    when {
+        requestedFontSize.isUnspecified -> this
+        isSp && baseFontSize.isSp && requestedFontSize.isSp -> {
+            val scale = requestedFontSize.value / baseFontSize.value
+            (value * scale).sp
+        }
+        isSp && baseFontSize.isSp && requestedFontSize.isEm -> {
+            val lineHeightToFontSizeRatio = value / baseFontSize.value
+            lineHeightToFontSizeRatio.em
+        }
+        else -> this
+    }
 
 public val LocalTypography: ProvidableCompositionLocal<Typography> = staticCompositionLocalOf {
     error("No Typography provided. Have you forgotten the theme?")

--- a/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/ui/TypographyTest.kt
+++ b/platform/jewel/ui/src/test/kotlin/org/jetbrains/jewel/ui/TypographyTest.kt
@@ -1,0 +1,144 @@
+package org.jetbrains.jewel.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import org.jetbrains.jewel.BasicJewelUiTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+public class TypographyTest : BasicJewelUiTest() {
+    @Test
+    public fun `unspecified default text style request preserves base style values`() {
+        val typography = FakeTypography(labelStyle = TextStyle(fontSize = 12.sp, lineHeight = 18.sp))
+        lateinit var textStyle: TextStyle
+
+        runComposeTest({ textStyle = typography.rememberDefaultTextStyle() }) { waitForIdle() }
+
+        assertEquals(12.sp, textStyle.fontSize)
+        assertEquals(18.sp, textStyle.lineHeight)
+    }
+
+    @Test
+    public fun `sp default text style request scales line height`() {
+        val typography = FakeTypography(labelStyle = TextStyle(fontSize = 12.sp, lineHeight = 18.sp))
+        lateinit var textStyle: TextStyle
+
+        runComposeTest({ textStyle = typography.rememberDefaultTextStyle(fontSize = 16.sp) }) { waitForIdle() }
+
+        assertEquals(16.sp, textStyle.fontSize)
+        assertEquals(24.sp, textStyle.lineHeight)
+    }
+
+    @Test
+    public fun `em default text style request keeps the base line height ratio`() {
+        val typography = FakeTypography(labelStyle = TextStyle(fontSize = 12.sp, lineHeight = 18.sp))
+        lateinit var textStyle: TextStyle
+
+        runComposeTest({ textStyle = typography.rememberDefaultTextStyle(fontSize = 1.em) }) { waitForIdle() }
+
+        // Line height in em is a multiplier of the resolved font size, so preserve the base 18.sp / 12.sp ratio.
+        assertEquals(1.em, textStyle.fontSize)
+        assertEquals(1.5.em, textStyle.lineHeight)
+    }
+
+    @Test
+    public fun `larger em default text style request keeps the base line height ratio`() {
+        val typography = FakeTypography(labelStyle = TextStyle(fontSize = 12.sp, lineHeight = 18.sp))
+        lateinit var textStyle: TextStyle
+
+        runComposeTest({ textStyle = typography.rememberDefaultTextStyle(fontSize = 2.em) }) { waitForIdle() }
+
+        // Line height in em is a multiplier of the resolved font size, so preserve the base 18.sp / 12.sp ratio.
+        assertEquals(2.em, textStyle.fontSize)
+        assertEquals(1.5.em, textStyle.lineHeight)
+    }
+
+    @Test
+    public fun `font attributes override base style only when requested`() {
+        val typography =
+            FakeTypography(labelStyle = TextStyle(fontWeight = FontWeight.Light, fontStyle = FontStyle.Italic))
+        lateinit var preservedStyle: TextStyle
+        lateinit var overriddenStyle: TextStyle
+
+        runComposeTest({
+            preservedStyle = typography.rememberDefaultTextStyle()
+            overriddenStyle =
+                typography.rememberDefaultTextStyle(fontWeight = FontWeight.Bold, fontStyle = FontStyle.Normal)
+        }) {
+            waitForIdle()
+        }
+
+        assertEquals(FontWeight.Light, preservedStyle.fontWeight)
+        assertEquals(FontStyle.Italic.value, preservedStyle.fontStyle?.value)
+        assertEquals(FontWeight.Bold, overriddenStyle.fontWeight)
+        assertEquals(FontStyle.Normal.value, overriddenStyle.fontStyle?.value)
+    }
+
+    @Test
+    public fun `editor request derives from editor base style`() {
+        val typography = FakeTypography(editorStyle = TextStyle(fontSize = 10.sp, lineHeight = 14.sp))
+        lateinit var textStyle: TextStyle
+
+        runComposeTest({ textStyle = typography.rememberEditorTextStyle(fontSize = 15.sp) }) { waitForIdle() }
+
+        assertEquals(15.sp, textStyle.fontSize)
+        assertEquals(21.sp, textStyle.lineHeight)
+    }
+
+    @Test
+    public fun `console request derives from console base style`() {
+        val typography = FakeTypography(consoleStyle = TextStyle(fontSize = 20.sp, lineHeight = 30.sp))
+        lateinit var textStyle: TextStyle
+
+        runComposeTest({ textStyle = typography.rememberConsoleTextStyle(fontSize = 10.sp) }) { waitForIdle() }
+
+        assertEquals(10.sp, textStyle.fontSize)
+        assertEquals(15.sp, textStyle.lineHeight)
+    }
+
+    private class FakeTypography(
+        private val labelStyle: TextStyle = TextStyle.Default,
+        private val editorStyle: TextStyle = TextStyle.Default,
+        private val consoleStyle: TextStyle = TextStyle.Default,
+    ) : Typography {
+        override val labelTextStyle: TextStyle
+            @Composable get() = labelStyle
+
+        override val labelTextSize
+            @Composable get() = labelStyle.fontSize
+
+        override val h0TextStyle: TextStyle
+            @Composable get() = labelStyle
+
+        override val h1TextStyle: TextStyle
+            @Composable get() = labelStyle
+
+        override val h2TextStyle: TextStyle
+            @Composable get() = labelStyle
+
+        override val h3TextStyle: TextStyle
+            @Composable get() = labelStyle
+
+        override val h4TextStyle: TextStyle
+            @Composable get() = labelStyle
+
+        override val regular: TextStyle
+            @Composable get() = labelStyle
+
+        override val medium: TextStyle
+            @Composable get() = labelStyle
+
+        override val small: TextStyle
+            @Composable get() = labelStyle
+
+        override val editorTextStyle: TextStyle
+            @Composable get() = editorStyle
+
+        override val consoleTextStyle: TextStyle
+            @Composable get() = consoleStyle
+    }
+}


### PR DESCRIPTION
Adds portable Jewel typography helpers for default, editor, and console text styles so callers can use `JewelTheme.typography` instead of platform-specific bridge or standalone APIs.

## Changes

* Adds `rememberDefaultTextStyle`, `rememberEditorTextStyle`, and `rememberConsoleTextStyle` to portable `Typography`.
* Implements the new APIs in bridge and standalone typography implementations.
* Adds bridge helper overloads that preserve Swing/editor font metric behavior for `sp` sizes and proportional `em` line-height behavior.
* Updates Jewel `0.40.0` Metalava API dumps for the affected modules.

## Release notes

### New features

* Added portable typography APIs for deriving default, editor, and console text styles via `JewelTheme.typography`.
