### PR TITLE
IJPL-249905 macOS: make project tab synchronization idempotent

### DIFF
--- a/platform/platform-impl/src/com/intellij/ui/mac/MacWinTabsHandlerV2.java
+++ b/platform/platform-impl/src/com/intellij/ui/mac/MacWinTabsHandlerV2.java
@@ -148,12 +148,17 @@ public final class MacWinTabsHandlerV2 extends MacWinTabsHandler {
 
     IdeFrameImpl[] frames = new IdeFrameImpl[length];
 
-    for (int i = 0, founded = 0; i < allLength && founded < length; i++) {
+    int found = 0;
+    for (int i = 0; i < allLength && found < length; i++) {
       int index = Foundation.invoke(tabs, "indexOfObject:", allWindows[i]).intValue();
       if (index != -1) {
         frames[index] = allFrames[i];
-        founded++;
+        found++;
       }
+    }
+
+    if (found != length) {
+      return null; // native tab group and IDE frames are not synchronized yet
     }
 
     return new TabsInfo(frames, helpersMap);
@@ -171,7 +176,7 @@ public final class MacWinTabsHandlerV2 extends MacWinTabsHandler {
       int index = ArrayUtil.indexOfIdentity(info.frames, myFrame);
 
       for (IdeFrameImpl frame : info.frames) {
-        if (frame == myFrame || isTabsNotVisible(frame)) {
+        if (isTabsNotVisible(frame)) {
           createTabBarsForFrame(frame, info.helpersMap.get(frame), info.frames);
         }
         else {

--- a/platform/platform-impl/src/com/intellij/ui/mac/WindowTabsComponent.java
+++ b/platform/platform-impl/src/com/intellij/ui/mac/WindowTabsComponent.java
@@ -443,6 +443,10 @@ public final class WindowTabsComponent extends JBTabsImpl {
   }
 
   public void insertTabForFrame(@NotNull IdeFrameImpl tab, int index) {
+    if (myIndexes.containsKey(tab)) {
+      return;
+    }
+
     createTabItem(tab, index, false);
     recalculateIndexes();
   }

--- a/platform/platform-tests/testSrc/com/intellij/ui/mac/WindowTabsComponentTest.java
+++ b/platform/platform-tests/testSrc/com/intellij/ui/mac/WindowTabsComponentTest.java
@@ -1,0 +1,33 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.ui.mac;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.wm.impl.IdeFrameImpl;
+import com.intellij.testFramework.junit5.RunInEdt;
+import com.intellij.testFramework.junit5.TestApplication;
+import com.intellij.testFramework.junit5.TestDisposable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@RunInEdt
+@TestApplication
+public class WindowTabsComponentTest {
+  @Test
+  void insertingExistingFrameDoesNotCreateDuplicate(@TestDisposable Disposable disposable) {
+    IdeFrameImpl firstFrame = new IdeFrameImpl();
+    IdeFrameImpl secondFrame = new IdeFrameImpl();
+    try {
+      WindowTabsComponent tabs = new WindowTabsComponent(firstFrame, null, disposable);
+      tabs.createTabsForFrame(new IdeFrameImpl[]{firstFrame, secondFrame});
+
+      tabs.insertTabForFrame(secondFrame, 1);
+
+      assertEquals(2, tabs.getTabCount());
+    }
+    finally {
+      firstFrame.dispose();
+      secondFrame.dispose();
+    }
+  }
+}


### PR DESCRIPTION
## Issue

[IJPL-249905](https://youtrack.jetbrains.com/issue/IJPL-249905/Bug-Report-GoLand-Remote-Development-JetBrains-Client-window-tabs-become-stuck-fail-to-switch-and-duplicate)

## Root cause

JetBrains Client can queue multiple project-frame initialization updates while macOS has already merged the frames into one native tab group. The first update creates the complete Swing tab model, while a later update recreates the current frame's tab component and tries to insert the same `IdeFrameImpl` again. This can leave the native window tab group and the IDE tab model out of sync, causing duplicate tabs, failed switching, or stuck tabs.

## Fix

- Create tab components only for frames that do not already have one.
- Make incremental frame insertion idempotent by ignoring an `IdeFrameImpl` already present in the tab model.
- Ignore incomplete native tab-group snapshots until all native windows can be matched to IDE frames.

## Tests

- Added `WindowTabsComponentTest` covering duplicate insertion of the same frame.
- `./tests.cmd --module intellij.platform.tests --test com.intellij.ui.mac.WindowTabsComponentTest`
- Result: 1 test passed.