### PR TITLE
IJPL-249980 Core. Plugin Management: respect custom plugin repositories in the plugin advertiser dialog

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/InstallAndEnableTask.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/InstallAndEnableTask.kt
@@ -6,6 +6,7 @@ import com.intellij.ide.plugins.PluginManagementPolicy
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.ide.plugins.PluginNode
 import com.intellij.ide.plugins.RepositoryHelper
+import com.intellij.ide.plugins.marketplace.IdeCompatibleUpdate
 import com.intellij.ide.plugins.marketplace.MarketplaceRequests
 import com.intellij.ide.plugins.marketplace.MarketplaceRequests.Companion.getLastCompatiblePluginUpdate
 import com.intellij.ide.plugins.newui.PluginNodeModelBuilderFactory
@@ -24,11 +25,11 @@ import com.intellij.openapi.updateSettings.impl.PluginDownloader
 import com.intellij.platform.ide.progress.ModalTaskOwner
 import com.intellij.platform.ide.progress.TaskCancellation
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
-import com.intellij.util.containers.ContainerUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.annotations.VisibleForTesting
 import kotlin.coroutines.cancellation.CancellationException
 
 @ApiStatus.Internal
@@ -90,19 +91,9 @@ class InstallAndEnableTask(
         val marketplace = MarketplaceRequests.getInstance()
         val descriptorIds: Set<PluginId> = descriptors.mapTo(mutableSetOf()) { it.pluginId }
         val compatiblePluginUpdates = runBlockingCancellable { getLastCompatiblePluginUpdate(descriptorIds) }
-        for (update in compatiblePluginUpdates) {
-          val index = ContainerUtil.indexOf(descriptors) { d -> d.pluginId.idString == update.pluginId }
-          if (index != -1) {
-            val descriptor = descriptors[index]
-
-            descriptor.externalPluginId = update.externalPluginId
-            descriptor.externalUpdateId = update.externalUpdateId
-            descriptor.description = null
-
-            runBlockingCancellable { marketplace.loadPluginDetails(descriptor) }?.let { pluginModel ->
-              loadAllPluginDetailsSync(descriptor, pluginModel)
-              descriptors[index] = pluginModel
-            }
+        applyMarketplaceDetails(descriptors, compatiblePluginUpdates) { descriptor ->
+          runBlockingCancellable { marketplace.loadPluginDetails(descriptor) }?.also { pluginModel ->
+            loadAllPluginDetailsSync(descriptor, pluginModel)
           }
         }
       }
@@ -145,6 +136,34 @@ class InstallAndEnableTask(
   private fun runOnSuccess(success: Boolean) {
     if (success) {
       onSuccess.run()
+    }
+  }
+}
+
+@VisibleForTesting
+@ApiStatus.Internal
+fun applyMarketplaceDetails(
+  descriptors: MutableList<PluginUiModel>,
+  compatiblePluginUpdates: List<IdeCompatibleUpdate>,
+  loadPluginDetails: (PluginUiModel) -> PluginUiModel?,
+) {
+  for (update in compatiblePluginUpdates) {
+    val index = descriptors.indexOfFirst { it.pluginId.idString == update.pluginId }
+    if (index == -1) continue
+
+    val descriptor = descriptors[index]
+    if (descriptor.repositoryName != null) {
+      // the descriptor was resolved to a custom repository serving a newer version than the Marketplace (see
+      // RepositoryHelper.mergePluginModelsFromRepositories); replacing it with the Marketplace model would revert that choice
+      continue
+    }
+
+    descriptor.externalPluginId = update.externalPluginId
+    descriptor.externalUpdateId = update.externalUpdateId
+    descriptor.description = null
+
+    loadPluginDetails(descriptor)?.let { pluginModel ->
+      descriptors[index] = pluginModel
     }
   }
 }

--- a/platform/platform-tests/testSrc/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/InstallAndEnableTaskTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/InstallAndEnableTaskTest.kt
@@ -1,0 +1,58 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.openapi.updateSettings.impl.pluginsAdvertisement
+
+import com.intellij.ide.plugins.PluginNode
+import com.intellij.ide.plugins.marketplace.IdeCompatibleUpdate
+import com.intellij.ide.plugins.newui.PluginUiModel
+import com.intellij.ide.plugins.newui.PluginUiModelAdapter
+import com.intellij.openapi.extensions.PluginId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+internal class InstallAndEnableTaskTest {
+  @Test
+  fun `descriptor resolved to a custom repository is not replaced by the marketplace model`() {
+    val customNode = PluginNode(PluginId.getId(PLUGIN_ID))
+    customNode.repositoryName = "https://plugins.example.com/plugins.xml"
+    customNode.description = "custom description"
+    val customModel = PluginUiModelAdapter(customNode)
+    val descriptors = mutableListOf<PluginUiModel>(customModel)
+
+    var detailsRequested = false
+    applyMarketplaceDetails(descriptors, listOf(marketplaceUpdate())) {
+      detailsRequested = true
+      marketplaceModel()
+    }
+
+    assertSame(customModel, descriptors.single())
+    assertFalse(detailsRequested)
+    assertNull(customModel.externalPluginId)
+    assertNull(customModel.externalUpdateId)
+    assertEquals("custom description", customModel.description)
+  }
+
+  @Test
+  fun `marketplace descriptor is replaced by the detailed marketplace model`() {
+    val descriptors = mutableListOf(marketplaceModel())
+
+    val update = marketplaceUpdate()
+    val detailedModel = marketplaceModel()
+    applyMarketplaceDetails(descriptors, listOf(update)) { descriptor ->
+      assertEquals(update.externalPluginId, descriptor.externalPluginId)
+      assertEquals(update.externalUpdateId, descriptor.externalUpdateId)
+      detailedModel
+    }
+
+    assertSame(detailedModel, descriptors.single())
+  }
+
+  private fun marketplaceUpdate(): IdeCompatibleUpdate =
+    IdeCompatibleUpdate(externalUpdateId = "999", externalPluginId = "888", pluginId = PLUGIN_ID, version = "1.0")
+
+  private fun marketplaceModel(): PluginUiModel = PluginUiModelAdapter(PluginNode(PluginId.getId(PLUGIN_ID)))
+}
+
+private const val PLUGIN_ID = "com.example.plugin"


### PR DESCRIPTION
Hi! 👋 
This fixes YouTrack issue [IJPL-249980](https://youtrack.jetbrains.com/issue/IJPL-249980/Choose-Plugins-to-Install-or-Enable-popup-ignores-custom-repositories).

Essentially, the install-required-plugins dialog used to overwrite newer version of plugins coming from a custom repository with older versions from the official marketplace. Now it should leave custom-repository plugins alone.

Hope this is all up to your standards and guidelines. I have verified this with a test and by building the IDE from sources and reproducing the problem.
Cheers.