### PR TITLE
[KTIJ-38341]: Mark functional interface argument contexts as blocking

### DIFF
--- a/plugins/kotlin/code-insight/inspections-k2/src/org/jetbrains/kotlin/idea/codeInsight/inspections/blockingCallsDetection/CoroutineNonBlockingContextChecker.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/src/org/jetbrains/kotlin/idea/codeInsight/inspections/blockingCallsDetection/CoroutineNonBlockingContextChecker.kt
@@ -90,12 +90,14 @@ internal class CoroutineNonBlockingContextChecker : NonBlockingContextChecker {
                 val blockingFriendlyDispatcherUsed = checkBlockingFriendlyDispatcherUsed(call, callExpression)
                 if (blockingFriendlyDispatcherUsed.isDefinitelyKnown) return blockingFriendlyDispatcherUsed
 
-                val parameterForArgument = call.argumentMapping[containingLambda] ?: return Blocking
+                val parameterForArgument = call.valueArgumentMapping[containingLambda] ?: return Blocking
                 val type = parameterForArgument.returnType
 
                 if (type is KaFunctionType) {
                     val hasRestrictSuspensionAnnotation = type.receiverType?.isRestrictsSuspensionReceiver() == true
                     return if (!hasRestrictSuspensionAnnotation && type.isSuspend) Unsure else Blocking
+                } else if (type.isFunctionalInterface) {
+                    return Blocking
                 }
             }
         }

--- a/plugins/kotlin/code-insight/inspections-k2/tests/test/org/jetbrains/kotlin/idea/codeInsight/inspections/SharedK2CoroutineNonBlockingContextDetectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/test/org/jetbrains/kotlin/idea/codeInsight/inspections/SharedK2CoroutineNonBlockingContextDetectionTestGenerated.java
@@ -59,6 +59,11 @@ public class SharedK2CoroutineNonBlockingContextDetectionTestGenerated extends A
         runTest("testData/inspections/blockingCallsDetection/InsideCoroutine_unknownAsBlocking.kt");
     }
 
+    @TestMetadata("InsideLambdaInCoroutine.kt")
+    public void testInsideLambdaInCoroutine() throws Exception {
+        runTest("testData/inspections/blockingCallsDetection/InsideLambdaInCoroutine.kt");
+    }
+
     @TestMetadata("LambdaAssignmentCheck.kt")
     public void testLambdaAssignmentCheck() throws Exception {
         runTest("testData/inspections/blockingCallsDetection/LambdaAssignmentCheck.kt");

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspections/blockingCallsDetection/InsideLambdaInCoroutine.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspections/blockingCallsDetection/InsideLambdaInCoroutine.kt
@@ -1,0 +1,17 @@
+// CONSIDER_UNKNOWN_AS_BLOCKING: true
+// CONSIDER_SUSPEND_CONTEXT_NON_BLOCKING: false
+@file:Suppress("UNUSED_PARAMETER")
+
+import kotlin.concurrent.thread
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+suspend fun myDelay(timeInMillis: Long) {
+    suspendCoroutine { continuation: Continuation<Unit> ->
+        Thread {
+            Thread.sleep(timeInMillis)
+            continuation.resume(Unit)
+        }.start()
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-38341/False-positive-Possibly-blocking-call-in-non-blocking-context-could-lead-to-thread-starvation
Here I added FunctionalInterface lambdas inspection support 
<img width="357" height="130" alt="image" src="https://github.com/user-attachments/assets/8786aaad-dd21-4f9a-adee-a91e60523a4e" />
I have a question about the full blocking/nonblocking inspection. It looks like inline functions are analyzed incorrectly. In the following example, the Thread.sleep call inside the inline run block is not highlighted, while the subsequent Thread.sleep call is
<img width="290" height="110" alt="image" src="https://github.com/user-attachments/assets/a0a5ba13-bf52-419d-872e-c696f8562a52" />
