### PR TITLE
https://youtrack.jetbrains.com/issue/IJPL-173018/Scroll-to-results-du…

### DIFF
--- a/platform/core-api/src/com/intellij/openapi/application/ApplicationListener.java
+++ b/platform/core-api/src/com/intellij/openapi/application/ApplicationListener.java
@@ -19,7 +19,7 @@ public interface ApplicationListener extends EventListener {
   }
 
   /**
-   * This method is called before restarting an application (e.g., after installing a plugin). 
+   * This method is called before restarting an application (e.g., after installing a plugin).
    * Return {@code true} if the application can be restarted, or {@code false} to cancel restarting.
    */
   default boolean canRestartApplication() {

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
@@ -1096,13 +1096,7 @@ open class FileEditorManagerImpl(
       ?.composites()?.firstOrNull { it.file == file }
   }
 
-  @Suppress("DeprecatedCallableAddReplaceWith")
-  @Deprecated("Use public API.", level = DeprecationLevel.ERROR)
-  fun openFileImpl2(window: EditorWindow, file: VirtualFile, focusEditor: Boolean): Pair<Array<FileEditor>, Array<FileEditorProvider>> {
-    return openFileImpl2(window = window, file = file, options = FileEditorOpenOptions(requestFocus = focusEditor)).retrofit()
-  }
-
-  open fun openFileImpl2(window: EditorWindow, file: VirtualFile, options: FileEditorOpenOptions): FileEditorComposite {
+    open fun openFileImpl2(window: EditorWindow, file: VirtualFile, options: FileEditorOpenOptions): FileEditorComposite {
     if (forbidSplitFor(file) && !window.isFileOpen(file)) {
       closeFile(file)
     }

--- a/platform/platform-impl/src/com/intellij/ui/SpeedSearchBase.java
+++ b/platform/platform-impl/src/com/intellij/ui/SpeedSearchBase.java
@@ -94,6 +94,7 @@ public abstract class SpeedSearchBase<Comp extends JComponent> extends SpeedSear
   private String myRecentEnteredPrefix;
   private SpeedSearchComparator myComparator = new SpeedSearchComparator(false);
   private boolean myClearSearchOnNavigateNoMatch;
+  protected boolean mySelectionFromNavigation;
 
   private Disposable myListenerDisposable;
 
@@ -650,6 +651,7 @@ public abstract class SpeedSearchBase<Comp extends JComponent> extends SpeedSear
 
           String newText = oldText.substring(0, offs) + str + oldText.substring(offs);
           super.insertString(offs, str, a);
+          mySelectionFromNavigation = false;
           handleInsert(newText);
           updateSelection(findElement(newText), mySearchField.getText());
         }
@@ -706,6 +708,7 @@ public abstract class SpeedSearchBase<Comp extends JComponent> extends SpeedSear
 
         int navKeyCode = getNavigationKeyCode(e);
         if (navKeyCode != 0) {
+          mySelectionFromNavigation = true;
           element = findTargetElement(navKeyCode, s);
           if (myClearSearchOnNavigateNoMatch && element == null) {
             manageSearchPopup(null);
@@ -713,6 +716,7 @@ public abstract class SpeedSearchBase<Comp extends JComponent> extends SpeedSear
           }
         }
         else {
+          mySelectionFromNavigation = false;
           UIEventLogger.IncrementalSearchKeyTyped.log(myComponent.getClass());
           element = findElement(s);
         }
@@ -724,6 +728,7 @@ public abstract class SpeedSearchBase<Comp extends JComponent> extends SpeedSear
     public void processInputMethodEvent(InputMethodEvent e) {
       mySearchField.processInputMethodEvent(e);
       if (e.isConsumed()) {
+        mySelectionFromNavigation = false;
         updateLastPattern();
         String s = mySearchField.getText();
         updateSelection(findElement(s), s);

--- a/platform/platform-impl/src/com/intellij/ui/TreeSpeedSearch.java
+++ b/platform/platform-impl/src/com/intellij/ui/TreeSpeedSearch.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.IdeActions;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.util.Conditions;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.containers.ContainerUtil;
@@ -201,7 +202,18 @@ public class TreeSpeedSearch extends SpeedSearchBase<JTree> {
 
   @Override
   protected void selectElement(Object element, String selectedText) {
-    TreeUtil.selectPath(myComponent, (TreePath)element);
+    if (shouldAutoSelect()) {
+      TreeUtil.selectPath(myComponent, (TreePath)element);
+    }
+  }
+
+  /**
+   * Determines whether speed search should automatically select matching elements.
+   * When false, only highlighting is shown and navigation requires explicit arrow key usage.
+   * Subclasses can override to customize behavior.
+   */
+  protected boolean shouldAutoSelect() {
+    return mySelectionFromNavigation || Registry.is("ide.speed.search.tree.auto.select", true);
   }
 
   @Override

--- a/platform/util/resources/misc/registry.properties
+++ b/platform/util/resources/misc/registry.properties
@@ -113,6 +113,9 @@ ide.popup.horizontal.scroll.bar.opaque.description=Disables translucent horizont
 ide.speed.search.close.when.empty=false
 ide.speed.search.close.when.empty.description=Allows closing the speed search popup if the search pattern is empty
 
+ide.speed.search.tree.auto.select=true
+ide.speed.search.tree.auto.select.description=When enabled, typing in tree speed search automatically selects the first match. When disabled, only highlights matches and navigation requires arrow keys.
+
 ide.recent.files.speed.search=true
 ide.recent.files.speed.search.description=Allows using speed search functionality in the Recent Files popup
 


### PR DESCRIPTION
Scroll to results during typing  in project view option - stop jumping around in Project View

https://youtrack.jetbrains.com/issue/IJPL-173018/Scroll-to-results-during-typing-in-project-view-option-stop-jumping-around-in-Project-View

This does not attempt to solve it in a clean way .. but does it through the registry which is good enough for me 