### PR TITLE
KTIJ-39564: `uastParent` resolves to `UBlockExpression` instead of `UYieldExpression` for nested when expression

### DIFF
--- a/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/kotlinConvertParentUtils.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/src/org/jetbrains/uast/kotlin/kotlinConvertParentUtils.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.psi.KtAnnotation
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtWhenEntry
 import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassInitializer
@@ -173,6 +174,10 @@ internal fun convertParentImpl(
     }
 
     if (parent is KtPropertyDelegate) {
+        parent = parent.parent
+    }
+
+    if (parent is KtBlockExpression && parent.parent is KtWhenEntry) {
         parent = parent.parent
     }
 

--- a/plugins/kotlin/uast/uast-kotlin-base/tests/test/org/jetbrains/uast/test/kotlin/KotlinIDERenderLogTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-base/tests/test/org/jetbrains/uast/test/kotlin/KotlinIDERenderLogTest.kt
@@ -31,6 +31,9 @@ abstract class KotlinIDERenderLogTest : AbstractKotlinUastLightCodeInsightFixtur
     fun testWhenIs() = doTest("WhenIs")
 
     @Test
+    fun testWhenElse() = doTest("WhenElse")
+
+    @Test
     fun testDefaultImpls() = doTest("DefaultImpls")
 
     @Test

--- a/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/SimpleKotlinRenderLogTest.kt
+++ b/plugins/kotlin/uast/uast-kotlin-fir/tests/test/org/jetbrains/fir/uast/test/SimpleKotlinRenderLogTest.kt
@@ -29,6 +29,9 @@ class SimpleKotlinRenderLogTest : AbstractFirUastTest(), AbstractKotlinRenderLog
     fun testWhenIs() = doCheck("WhenIs.kt")
 
     @Test
+    fun testWhenElse() = doCheck("WhenElse.kt")
+
+    @Test
     fun testDefaultImpls() = doCheck("DefaultImpls.kt")
 
     @Test

--- a/plugins/kotlin/uast/uast-kotlin/tests/testData/WhenElse.kt
+++ b/plugins/kotlin/uast/uast-kotlin/tests/testData/WhenElse.kt
@@ -1,0 +1,9 @@
+fun foo() = when {
+    else -> {
+        when {
+            else -> {
+                ""
+            }
+        }
+    }
+}

--- a/plugins/kotlin/uast/uast-kotlin/tests/testData/WhenElse.log.txt
+++ b/plugins/kotlin/uast/uast-kotlin/tests/testData/WhenElse.log.txt
@@ -1,0 +1,17 @@
+UFile (package = )
+    UClass (name = WhenElseKt)
+        UMethod (name = foo)
+            UBlockExpression
+                UReturnExpression
+                    USwitchExpression
+                        UExpressionList (when)
+                            USwitchClauseExpressionWithBody
+                                UExpressionList (when_entry)
+                                    UYieldExpression
+                                        USwitchExpression
+                                            UExpressionList (when)
+                                                USwitchClauseExpressionWithBody
+                                                    UExpressionList (when_entry)
+                                                        UYieldExpression
+                                                            UPolyadicExpression (operator = +)
+                                                                ULiteralExpression (value = "")

--- a/plugins/kotlin/uast/uast-kotlin/tests/testData/WhenElse.render.txt
+++ b/plugins/kotlin/uast/uast-kotlin/tests/testData/WhenElse.render.txt
@@ -1,0 +1,17 @@
+public final class WhenElseKt {
+    public static final fun foo() : java.lang.String {
+        return switch  {
+             -> {
+                yield switch  {
+                     -> {
+                        yield ""
+                    }
+                    
+                }
+                
+            }
+            
+        }
+        
+    }
+}


### PR DESCRIPTION
This PR fixes the issue described in KTIJ-39564