### PR TITLE
[JEWEL-1239] Render failed to load images as hyperlinks

### DIFF
--- a/platform/jewel/markdown/core/api-dump-experimental.txt
+++ b/platform/jewel/markdown/core/api-dump-experimental.txt
@@ -242,8 +242,38 @@ f:org.jetbrains.jewel.markdown.SemanticsKt
 - a:getInlineContent():java.util.List
 *:org.jetbrains.jewel.markdown.WithTextContent
 - a:getContent():java.lang.String
+*:org.jetbrains.jewel.markdown.extensions.ImageRenderResult
+*f:org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Failed
+- org.jetbrains.jewel.markdown.extensions.ImageRenderResult
+- sf:$stable:I
+- sf:INSTANCE:org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Failed
+- equals(java.lang.Object):Z
+- hashCode():I
+*f:org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Loading
+- org.jetbrains.jewel.markdown.extensions.ImageRenderResult
+- sf:$stable:I
+- <init>():V
+- <init>(androidx.compose.foundation.text.InlineTextContent):V
+- b:<init>(androidx.compose.foundation.text.InlineTextContent,I,kotlin.jvm.internal.DefaultConstructorMarker):V
+- f:component1():androidx.compose.foundation.text.InlineTextContent
+- f:copy(androidx.compose.foundation.text.InlineTextContent):org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Loading
+- bs:copy$default(org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Loading,androidx.compose.foundation.text.InlineTextContent,I,java.lang.Object):org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Loading
+- equals(java.lang.Object):Z
+- f:getContent():androidx.compose.foundation.text.InlineTextContent
+- hashCode():I
+*f:org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Success
+- org.jetbrains.jewel.markdown.extensions.ImageRenderResult
+- sf:$stable:I
+- <init>(androidx.compose.foundation.text.InlineTextContent):V
+- f:component1():androidx.compose.foundation.text.InlineTextContent
+- f:copy(androidx.compose.foundation.text.InlineTextContent):org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Success
+- bs:copy$default(org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Success,androidx.compose.foundation.text.InlineTextContent,I,java.lang.Object):org.jetbrains.jewel.markdown.extensions.ImageRenderResult$Success
+- equals(java.lang.Object):Z
+- f:getContent():androidx.compose.foundation.text.InlineTextContent
+- hashCode():I
 *:org.jetbrains.jewel.markdown.extensions.ImageRendererExtension
-- a:renderImageContent(org.jetbrains.jewel.markdown.InlineMarkdown$Image,androidx.compose.runtime.Composer,I):androidx.compose.foundation.text.InlineTextContent
+- renderImage(org.jetbrains.jewel.markdown.InlineMarkdown$Image,androidx.compose.runtime.Composer,I):org.jetbrains.jewel.markdown.extensions.ImageRenderResult
+- renderImageContent(org.jetbrains.jewel.markdown.InlineMarkdown$Image,androidx.compose.runtime.Composer,I):androidx.compose.foundation.text.InlineTextContent
 *:org.jetbrains.jewel.markdown.extensions.MarkdownBlockProcessorExtension
 - a:canProcess(org.commonmark.node.CustomBlock):Z
 - getAllowsMergingWithNextBlock():Z

--- a/platform/jewel/markdown/core/metalava/core-api-0.41.0.txt
+++ b/platform/jewel/markdown/core/metalava/core-api-0.41.0.txt
@@ -243,7 +243,7 @@ package org.jetbrains.jewel.markdown {
     property public abstract java.util.List<org.jetbrains.jewel.markdown.MarkdownBlock> children;
   }
 
-  @SuppressCompatibility @org.jetbrains.annotations.ApiStatus.Experimental @org.jetbrains.jewel.foundation.ExperimentalJewelApi public interface WithInlineMarkdown {
+  @SuppressCompatibility @androidx.compose.runtime.Stable @org.jetbrains.annotations.ApiStatus.Experimental @org.jetbrains.jewel.foundation.ExperimentalJewelApi public interface WithInlineMarkdown {
     method public java.util.List<org.jetbrains.jewel.markdown.InlineMarkdown> getInlineContent();
     property public abstract java.util.List<org.jetbrains.jewel.markdown.InlineMarkdown> inlineContent;
   }
@@ -257,8 +257,33 @@ package org.jetbrains.jewel.markdown {
 
 package org.jetbrains.jewel.markdown.extensions {
 
+  @SuppressCompatibility @androidx.compose.runtime.Immutable @org.jetbrains.annotations.ApiStatus.Experimental @org.jetbrains.jewel.foundation.ExperimentalJewelApi public sealed interface ImageRenderResult {
+  }
+
+  public static final class ImageRenderResult.Failed implements org.jetbrains.jewel.markdown.extensions.ImageRenderResult {
+    field public static final org.jetbrains.jewel.markdown.extensions.ImageRenderResult.Failed INSTANCE;
+  }
+
+  public static final class ImageRenderResult.Loading implements org.jetbrains.jewel.markdown.extensions.ImageRenderResult {
+    ctor public ImageRenderResult.Loading();
+    ctor public ImageRenderResult.Loading(optional androidx.compose.foundation.text.InlineTextContent? content);
+    method public androidx.compose.foundation.text.InlineTextContent? component1();
+    method public org.jetbrains.jewel.markdown.extensions.ImageRenderResult.Loading copy(optional androidx.compose.foundation.text.InlineTextContent? content);
+    method public androidx.compose.foundation.text.InlineTextContent? getContent();
+    property public androidx.compose.foundation.text.InlineTextContent? content;
+  }
+
+  public static final class ImageRenderResult.Success implements org.jetbrains.jewel.markdown.extensions.ImageRenderResult {
+    ctor public ImageRenderResult.Success(androidx.compose.foundation.text.InlineTextContent content);
+    method public androidx.compose.foundation.text.InlineTextContent component1();
+    method public org.jetbrains.jewel.markdown.extensions.ImageRenderResult.Success copy(optional androidx.compose.foundation.text.InlineTextContent content);
+    method public androidx.compose.foundation.text.InlineTextContent getContent();
+    property public androidx.compose.foundation.text.InlineTextContent content;
+  }
+
   @SuppressCompatibility @org.jetbrains.annotations.ApiStatus.Experimental @org.jetbrains.jewel.foundation.ExperimentalJewelApi public interface ImageRendererExtension {
-    method @androidx.compose.runtime.Composable public androidx.compose.foundation.text.InlineTextContent? renderImageContent(org.jetbrains.jewel.markdown.InlineMarkdown.Image image);
+    method @androidx.compose.runtime.Composable public default org.jetbrains.jewel.markdown.extensions.ImageRenderResult renderImage(org.jetbrains.jewel.markdown.InlineMarkdown.Image image);
+    method @Deprecated @androidx.compose.runtime.Composable public default androidx.compose.foundation.text.InlineTextContent? renderImageContent(org.jetbrains.jewel.markdown.InlineMarkdown.Image image);
   }
 
   @SuppressCompatibility @org.jetbrains.annotations.ApiStatus.Experimental @org.jetbrains.jewel.foundation.ExperimentalJewelApi public interface MarkdownBlockProcessorExtension {

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithInlineMarkdown.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithInlineMarkdown.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.jewel.markdown
 
+import androidx.compose.runtime.Stable
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 
 /** An inline Markdown node that contains other [InlineMarkdown] nodes. */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
+@Stable
 public interface WithInlineMarkdown {
     /** Child inline Markdown nodes. */
     public val inlineContent: List<InlineMarkdown>

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/ImageRendererExtension.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/ImageRendererExtension.kt
@@ -2,6 +2,7 @@ package org.jetbrains.jewel.markdown.extensions
 
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
@@ -12,7 +13,7 @@ import org.jetbrains.jewel.markdown.InlineMarkdown
  * Implement this interface to provide a custom renderer for images. This is useful for handling image loading from
  * different sources (e.g., network, local files) or for applying custom visual treatments to images.
  *
- * The [renderImageContent] function will be called for each image found in the Markdown content.
+ * The [renderImage] function will be called for each image found in the Markdown content.
  */
 @ApiStatus.Experimental
 @ExperimentalJewelApi
@@ -24,7 +25,65 @@ public interface ImageRendererExtension {
      * [androidx.compose.ui.unit.TextUnitType.Sp] units for both `width` and `height` so that they can properly scale.
      *
      * @param image The image data, containing information like the image URL and alt text.
-     * @return An [InlineTextContent] that will be embedded in the text flow, which will be used to display the image.
+     * @return An [InlineTextContent] that will be embedded in the text flow, which will be used to display the image,
+     *   or `null` if the image could not be loaded.
+     * @see renderImage
      */
-    @Composable public fun renderImageContent(image: InlineMarkdown.Image): InlineTextContent?
+    @Deprecated(
+        message = "Use renderImage instead, which provides explicit loading/success/failed states",
+        replaceWith = ReplaceWith("renderImage(image)"),
+    )
+    @Composable
+    public fun renderImageContent(image: InlineMarkdown.Image): InlineTextContent? = null
+
+    /**
+     * Renders an image from a Markdown document.
+     *
+     * Override this function to provide custom image rendering with explicit state handling. The default implementation
+     * delegates to the deprecated [renderImageContent] for backward compatibility.
+     *
+     * @param image The image data, containing information like the image URL and alt text.
+     * @return An [ImageRenderResult] indicating the current state of the image: [ImageRenderResult.Loading] while the
+     *   image is being fetched, [ImageRenderResult.Success] with the content when loaded, or [ImageRenderResult.Failed]
+     *   if loading failed.
+     */
+    @Composable
+    public fun renderImage(image: InlineMarkdown.Image): ImageRenderResult {
+        @Suppress("DEPRECATION") val content = renderImageContent(image)
+        return if (content != null) {
+            ImageRenderResult.Success(content)
+        } else {
+            ImageRenderResult.Failed
+        }
+    }
+}
+
+/**
+ * Represents the result of rendering an image in Markdown.
+ *
+ * This sealed class allows callers to distinguish between loading, success, and failure states, enabling appropriate UI
+ * handling for each case (e.g., showing a loading indicator during loading, the image on success, or a fallback link on
+ * failure).
+ */
+@ApiStatus.Experimental
+@ExperimentalJewelApi
+@Immutable
+public sealed interface ImageRenderResult {
+    /**
+     * The image is currently loading.
+     *
+     * @param content Optional inline content to display while loading (e.g., a loading indicator). If null, the
+     *   placeholder text from the Markdown will be shown.
+     */
+    public data class Loading(val content: InlineTextContent? = null) : ImageRenderResult
+
+    /**
+     * The image loaded successfully.
+     *
+     * @param content The inline content to display for the loaded image.
+     */
+    public data class Success(val content: InlineTextContent) : ImageRenderResult
+
+    /** The image failed to load. */
+    public data object Failed : ImageRenderResult
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
@@ -210,9 +210,11 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
         enabled: Boolean,
         currentTextStyle: TextStyle,
     ) {
-        // Each image source corresponds to one rendered image.
+        // The inline-content id must match the key the block renderer uses to look up the rendered image and
+        // its occurrence-specific fallback text, so both sides derive it from inlineContentId(). Any override
+        // of this function must use the same id.
         appendInlineContent(
-            node.source,
+            node.inlineContentId(),
             buildString {
                 append(" ![")
                 if (node.alt.isNotEmpty()) append(node.alt)
@@ -244,90 +246,105 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
         action(node)
         pop(popTo)
     }
+}
 
-    /**
-     * Merges the current [TextStyle]into the given [TextLinkStyles] using the [smartMerge] algorithm.
-     *
-     * This function smartly merges the [SpanStyle]s within the provided [TextLinkStyles] with the current [TextStyle].
-     * The merge takes the [enabled] parameter into consideration, too. For each state (style, focusedStyle,
-     * hoveredStyle, pressedStyle) within [TextLinkStyles]:
-     * - If the style exists, it's smart-merged with the current [TextStyle].
-     * - If the style doesn't exist, it's ignored.
-     *
-     * @param linkStyles The [TextLinkStyles] to merge into.
-     * @param enabled Indicates if the text is enabled, affecting the merge behavior.
-     * @return A new [TextLinkStyles] object with the merged styles.
-     * @see smartMerge
-     */
-    private fun TextStyle.smartMerge(linkStyles: TextLinkStyles, enabled: Boolean) =
-        TextLinkStyles(
-            style = linkStyles.style?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
-            focusedStyle = linkStyles.focusedStyle?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
-            hoveredStyle = linkStyles.hoveredStyle?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
-            pressedStyle = linkStyles.pressedStyle?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
-        )
+/**
+ * A stable identity for an image occurrence, used as its inline-content id.
+ *
+ * The id is derived from every rendering-relevant field, so occurrences that differ in alt text, title, or size get
+ * distinct ids and keep their own fallback link text and placeholder size instead of collapsing onto each other.
+ * Occurrences that are identical in all of these share an id, which is harmless. Both [DefaultInlineMarkdownRenderer]
+ * (when emitting the annotation) and the block renderer (when keying the rendered image and its failure state) must use
+ * this function so their ids agree.
+ */
+internal fun InlineMarkdown.Image.inlineContentId(): String =
+    // We assume that the NUL separator won't appear in none of the properties, so distinct field tuples can't collide
+    // into one id
+    listOf(source, alt, title.orEmpty(), width?.toString().orEmpty(), height?.toString().orEmpty())
+        .joinToString(separator = "\u0000")
 
-    /**
-     * Merges the [TextStyle] into the provided [SpanStyle], applying a smart merging strategy.
-     *
-     * The logic is as follows:
-     * - **Font Style**: If `other` has a non-normal font style, it's used. Otherwise, the current style's font style is
-     *   used. This is to ensure that italic styles are preserved.
-     * - **Font Weight**: If only one style has a non-null font weight, that weight is used. If both have non-null
-     *   weights, the heavier weight is used, preventing any reduction in weight.
-     * - **Color**: The color from `other` is used if it's specified, unless `enabled` is false. If `other`'s color is
-     *   unspecified and `enabled` is true, the current style's color is used.
-     * - **Platform Style**: The platform span style is merged, if available.
-     * - **Other Properties**: All other properties (fontSize, fontFamily, etc.) are taken directly from `other`.
-     *
-     * @param other The [SpanStyle] to merge the current [TextStyle] into.
-     * @param enabled Indicates if the text is enabled. If false, the color will be set to [Color.Unspecified],
-     *   effectively hiding it.
-     * @return A new [TextStyle] with the properties merged according to the logic.
-     */
-    private fun TextStyle.smartMerge(other: SpanStyle, enabled: Boolean): TextStyle {
-        val otherFontWeight = other.fontWeight
-        val thisFontWeight = fontWeight
+/**
+ * Merges the current [TextStyle] into the given [TextLinkStyles] using the [smartMerge] algorithm.
+ *
+ * This function smartly merges the [SpanStyle]s within the provided [TextLinkStyles] with the current [TextStyle]. The
+ * merge takes the [enabled] parameter into consideration, too. For each state (style, focusedStyle, hoveredStyle,
+ * pressedStyle) within [TextLinkStyles]:
+ * - If the style exists, it's smart-merged with the current [TextStyle].
+ * - If the style doesn't exist, it's ignored.
+ *
+ * @param linkStyles The [TextLinkStyles] to merge into.
+ * @param enabled Indicates if the text is enabled, affecting the merge behavior.
+ * @return A new [TextLinkStyles] object with the merged styles.
+ * @see smartMerge
+ */
+internal fun TextStyle.smartMerge(linkStyles: TextLinkStyles, enabled: Boolean) =
+    TextLinkStyles(
+        style = linkStyles.style?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
+        focusedStyle = linkStyles.focusedStyle?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
+        hoveredStyle = linkStyles.hoveredStyle?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
+        pressedStyle = linkStyles.pressedStyle?.let { spanStyle -> smartMerge(spanStyle, enabled).toSpanStyle() },
+    )
 
-        return merge(
-            // We use the other's FontStyle (if any) when it's not just Normal, otherwise we keep
-            // our own FontStyle. This preserves incoming Italic, since Markdown has no way to
-            // reset it to Normal anyway.
-            fontStyle =
-                if (other.fontStyle != null && other.fontStyle != FontStyle.Normal) {
-                    other.fontStyle
-                } else {
-                    fontStyle
-                },
-            // If only one FontWeight is non-null, we use that; if both are null, it's also null.
-            // If they're both non-null, we take the highest one, since Markdown has no way to
-            // decrease the weight of text.
-            fontWeight =
-                when {
-                    otherFontWeight != null && thisFontWeight == null -> otherFontWeight
-                    otherFontWeight == null && thisFontWeight != null -> thisFontWeight
-                    otherFontWeight != null && thisFontWeight != null ->
-                        FontWeight(max(thisFontWeight.weight, otherFontWeight.weight))
+/**
+ * Merges the [TextStyle] into the provided [SpanStyle], applying a smart merging strategy.
+ *
+ * The logic is as follows:
+ * - **Font Style**: If `other` has a non-normal font style, it's used. Otherwise, the current style's font style is
+ *   used. This is to ensure that italic styles are preserved.
+ * - **Font Weight**: If only one style has a non-null font weight, that weight is used. If both have non-null weights,
+ *   the heavier weight is used, preventing any reduction in weight.
+ * - **Color**: The color from `other` is used if it's specified, unless `enabled` is false. If `other`'s color is
+ *   unspecified and `enabled` is true, the current style's color is used.
+ * - **Platform Style**: The platform span style is merged, if available.
+ * - **Other Properties**: All other properties (fontSize, fontFamily, etc.) are taken directly from `other`.
+ *
+ * @param other The [SpanStyle] to merge the current [TextStyle] into.
+ * @param enabled Indicates if the text is enabled. If false, the color will be set to [Color.Unspecified], effectively
+ *   hiding it.
+ * @return A new [TextStyle] with the properties merged according to the logic.
+ */
+internal fun TextStyle.smartMerge(other: SpanStyle, enabled: Boolean): TextStyle {
+    val otherFontWeight = other.fontWeight
+    val thisFontWeight = fontWeight
 
-                    else -> null
-                },
-            // The color is taken from the other, unless it's unspecified, or enabled is false
-            color = if (enabled) other.color.takeOrElse { color } else Color.Unspecified,
-            // Everything else comes from other
-            fontSize = other.fontSize,
-            fontSynthesis = other.fontSynthesis,
-            fontFamily = other.fontFamily,
-            fontFeatureSettings = other.fontFeatureSettings,
-            letterSpacing = other.letterSpacing,
-            baselineShift = other.baselineShift,
-            textGeometricTransform = other.textGeometricTransform,
-            localeList = other.localeList,
-            background = other.background,
-            textDecoration = other.textDecoration,
-            shadow = other.shadow,
-            drawStyle = other.drawStyle,
-            platformStyle =
-                PlatformTextStyle(platformStyle?.spanStyle?.merge(other.platformStyle), platformStyle?.paragraphStyle),
-        )
-    }
+    return merge(
+        // We use the other's FontStyle (if any) when it's not just Normal, otherwise we keep
+        // our own FontStyle. This preserves incoming Italic, since Markdown has no way to
+        // reset it to Normal anyway.
+        fontStyle =
+            if (other.fontStyle != null && other.fontStyle != FontStyle.Normal) {
+                other.fontStyle
+            } else {
+                fontStyle
+            },
+        // If only one FontWeight is non-null, we use that; if both are null, it's also null.
+        // If they're both non-null, we take the highest one, since Markdown has no way to
+        // decrease the weight of text.
+        fontWeight =
+            when {
+                otherFontWeight != null && thisFontWeight == null -> otherFontWeight
+                otherFontWeight == null && thisFontWeight != null -> thisFontWeight
+                otherFontWeight != null && thisFontWeight != null ->
+                    FontWeight(max(thisFontWeight.weight, otherFontWeight.weight))
+
+                else -> null
+            },
+        // The color is taken from the other, unless it's unspecified, or enabled is false
+        color = if (enabled) other.color.takeOrElse { color } else Color.Unspecified,
+        // Everything else comes from other
+        fontSize = other.fontSize,
+        fontSynthesis = other.fontSynthesis,
+        fontFamily = other.fontFamily,
+        fontFeatureSettings = other.fontFeatureSettings,
+        letterSpacing = other.letterSpacing,
+        baselineShift = other.baselineShift,
+        textGeometricTransform = other.textGeometricTransform,
+        localeList = other.localeList,
+        background = other.background,
+        textDecoration = other.textDecoration,
+        shadow = other.shadow,
+        drawStyle = other.drawStyle,
+        platformStyle =
+            PlatformTextStyle(platformStyle?.spanStyle?.merge(other.platformStyle), platformStyle?.paragraphStyle),
+    )
 }

--- a/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/platform/jewel/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -18,9 +18,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withCompositionLocal
@@ -51,6 +53,7 @@ import androidx.compose.ui.platform.LocalFontFamilyResolver
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.ParagraphIntrinsics
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.TextLayoutResult
@@ -92,6 +95,7 @@ import org.jetbrains.jewel.markdown.MarkdownBlock.ListItem
 import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
 import org.jetbrains.jewel.markdown.MarkdownBlock.ThematicBreak
 import org.jetbrains.jewel.markdown.WithInlineMarkdown
+import org.jetbrains.jewel.markdown.extensions.ImageRenderResult
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.List.Ordered.NumberFormatStyles
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling.List.Unordered.BulletCharStyles
@@ -226,16 +230,14 @@ public open class DefaultMarkdownBlockRenderer(
         softWrap: Boolean = true,
         maxLines: Int = Int.MAX_VALUE,
     ) {
-        val originalImages = renderedImages(block)
-
-        val renderedContent = rememberRenderedContent(block, inlinesStyling, enabled, onUrlClick)
+        val (loadedImages, renderedContent) = rememberRenderedContent(block, inlinesStyling, enabled, onUrlClick)
         val textColor = inlinesStyling.textStyle.color.takeOrElse { LocalContentColor.current }
         val mergedStyle = inlinesStyling.textStyle.merge(TextStyle(color = textColor))
         val density = LocalDensity.current
 
         TextWithScalableInlineContent(
             text = renderedContent,
-            inlineContent = originalImages,
+            inlineContent = loadedImages,
             density = density,
             modifier = modifier,
             overflow = overflow,
@@ -632,27 +634,65 @@ public open class DefaultMarkdownBlockRenderer(
         styling: InlinesStyling,
         enabled: Boolean,
         onUrlClick: ((String) -> Unit)? = null,
-    ) =
-        remember(block.inlineContent, styling, enabled, onUrlClick) {
-            inlineRenderer.renderAsAnnotatedString(block.inlineContent, styling, enabled, onUrlClick)
-        }
+    ): Pair<Map<String, InlineTextContent>, AnnotatedString> {
+        val (originalImages, failedImages) = resolveImages(block)
+        val original =
+            remember(block.inlineContent, styling, enabled, onUrlClick) {
+                inlineRenderer.renderAsAnnotatedString(block.inlineContent, styling, enabled, onUrlClick)
+            }
+        // Note: failedImages is a SnapshotStateSet, so we use derivedStateOf to properly track
+        // changes to its contents.
+        val renderedContent by
+            remember(original, block, styling, enabled, onUrlClick) {
+                derivedStateOf {
+                    if (failedImages.isEmpty()) {
+                        original
+                    } else {
+                        rebuildWithFailedImagesAsLinks(original, failedImages, block, styling, enabled, onUrlClick)
+                    }
+                }
+            }
+        return originalImages to renderedContent
+    }
 
     @Composable
-    private fun renderedImages(blockInlineContent: WithInlineMarkdown): Map<String, InlineTextContent> {
+    private fun resolveImages(blockInlineContent: WithInlineMarkdown): ResolvedImages {
         val map = remember(blockInlineContent) { mutableStateMapOf<String, InlineTextContent>() }
-
+        val failedSources = remember(blockInlineContent) { mutableStateSetOf<String>() }
         val imagesRenderer = rendererExtensions.firstNotNullOfOrNull { it.imageRendererExtension }
+        val images = remember(blockInlineContent) { getImages(blockInlineContent) }
 
-        for (image in getImages(blockInlineContent)) {
-            val renderedImage = imagesRenderer?.renderImageContent(image)
-            if (renderedImage == null) {
-                map.remove(image.source)
-            } else {
-                map[image.source] = renderedImage
+        for (image in images) {
+            val imageId = image.inlineContentId()
+            when (val result = imagesRenderer?.renderImage(image)) {
+                is ImageRenderResult.Success -> {
+                    map[imageId] = result.content
+                    failedSources.remove(imageId)
+                }
+
+                is ImageRenderResult.Loading -> {
+                    failedSources.remove(imageId)
+                    // Show the provided indicator, or with none drop any previous (now stale) success content so the
+                    // slot falls back to its placeholder text.
+                    if (result.content != null) {
+                        map[imageId] = result.content
+                    } else {
+                        map.remove(imageId)
+                    }
+                }
+
+                is ImageRenderResult.Failed -> {
+                    failedSources.add(imageId)
+                    map.remove(imageId)
+                }
+
+                null -> {
+                    // No renderer available, skip
+                }
             }
         }
 
-        return map
+        return map to failedSources
     }
 
     /**
@@ -1041,6 +1081,80 @@ private fun getImages(input: WithInlineMarkdown): List<InlineMarkdown.Image> = b
     collectImagesRecursively(input.inlineContent)
 }
 
+internal const val INLINE_CONTENT_TAG = "androidx.compose.foundation.text.inlineContent"
+
+/** Unicode picture frame character followed by a non-breaking space, used to indicate a failed image link. */
+internal const val BROKEN_IMAGE_INDICATOR = "\uD83D\uDDBC\u00A0" // 🖼 + NBSP
+
+private fun rebuildWithFailedImagesAsLinks(
+    old: AnnotatedString,
+    failedImages: Set<String>,
+    block: WithInlineMarkdown,
+    styling: InlinesStyling,
+    enabled: Boolean,
+    onUrlClick: ((String) -> Unit)?,
+): AnnotatedString {
+    // The inline-content id is content-derived (see InlineMarkdown.Image.inlineContentId), so occurrences that
+    // differ in alt text have distinct ids and each keeps its own fallback text.
+    val imagesById = getImages(block).associateBy { it.inlineContentId() }
+    val failedImageRanges =
+        old.getStringAnnotations(0, old.length)
+            .filter { it.tag == INLINE_CONTENT_TAG && it.item in failedImages }
+            .sortedBy { it.start }
+
+    if (failedImageRanges.isEmpty()) {
+        return old
+    }
+
+    return buildAnnotatedString {
+        var currentPos = 0
+        for (annotation in failedImageRanges) {
+            if (currentPos < annotation.start) {
+                append(old.subSequence(currentPos, annotation.start))
+            }
+            val image = imagesById[annotation.item]
+            val imageSource = image?.source.orEmpty()
+
+            // If the failed image was nested inside a link (e.g. a linked badge like [![alt](img)](dest)), point
+            // the fallback link at the enclosing link's destination.
+            val linkDestination =
+                old.getLinkAnnotations(annotation.start, annotation.end)
+                    .firstOrNull { it.start <= annotation.start && it.end >= annotation.end }
+                    ?.let { (it.item as? LinkAnnotation.Clickable)?.tag } ?: imageSource
+
+            // Fallback text is the alt; with no alt, show where the link points so the visible text matches the
+            // click target (the enclosing link's destination, or the image source when standalone).
+            val altText = image?.alt?.ifEmpty { null } ?: linkDestination
+
+            // Preserve the effective inline style at the replaced range
+            val enclosingStyle =
+                old.spanStyles
+                    .filter { it.start <= annotation.start && it.end >= annotation.end }
+                    .fold(styling.textStyle) { style, range -> style.merge(range.item) }
+
+            val index =
+                if (enabled) {
+                    val link =
+                        LinkAnnotation.Clickable(
+                            tag = linkDestination,
+                            linkInteractionListener = { onUrlClick?.invoke(linkDestination) },
+                            styles = enclosingStyle.smartMerge(styling.textLinkStyles, enabled = true),
+                        )
+                    pushLink(link)
+                } else {
+                    pushStyle(enclosingStyle.smartMerge(styling.linkDisabled, enabled = false).toSpanStyle())
+                }
+            append(BROKEN_IMAGE_INDICATOR)
+            append(altText)
+            pop(index)
+            currentPos = annotation.end
+        }
+        if (currentPos < old.length) {
+            append(old.subSequence(currentPos, old.length))
+        }
+    }
+}
+
 @Deprecated(
     message =
         "The MimeType class is deprecated in favor of using the code block info strings (e.g., \"kt\", \"python\"). " +
@@ -1092,6 +1206,8 @@ private fun MimeType.Known.fromMimeTypeString(mimeType: String): MimeType =
 
         else -> UNKNOWN
     }
+
+private typealias ResolvedImages = Pair<Map<String, InlineTextContent>, Set<String>>
 
 /** Test tag applied to the scalable inline content layout when SubcomposeLayout path is used. */
 @ApiStatus.Internal

--- a/platform/jewel/markdown/extensions/images/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImpl.kt
+++ b/platform/jewel/markdown/extensions/images/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImpl.kt
@@ -1,30 +1,43 @@
 package org.jetbrains.jewel.markdown.extensions.images
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.unit.sp
 import coil3.ImageLoader
 import coil3.compose.LocalPlatformContext
-import coil3.compose.rememberAsyncImagePainter
+import coil3.compose.asPainter
+import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.size.Size
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 import org.jetbrains.jewel.foundation.util.JewelLogger
 import org.jetbrains.jewel.markdown.DimensionSize
 import org.jetbrains.jewel.markdown.InlineMarkdown
+import org.jetbrains.jewel.markdown.extensions.ImageRenderResult
 import org.jetbrains.jewel.markdown.extensions.ImageRendererExtension
 import org.jetbrains.jewel.markdown.rendering.LocalMarkdownImageSourceResolver
+import org.jetbrains.jewel.ui.component.CircularProgressIndicator
+import org.jetbrains.jewel.ui.component.styling.CircularProgressStyle
 
 /**
  * An [ImageRendererExtension] that uses Coil 3 to render images from Markdown.
@@ -48,60 +61,99 @@ internal class Coil3ImageRendererExtensionImpl(private val imageLoader: ImageLoa
      *
      * @param image The [InlineMarkdown.Image] data object containing the source, alt text, title, and optional
      *   dimensions.
-     * @return An [InlineTextContent] that can be used by a `Text` or `BasicText` composable to render the image inline.
+     * @return An [ImageRenderResult] representing the current loading state of the image.
      */
     @Composable
-    public override fun renderImageContent(image: InlineMarkdown.Image): InlineTextContent? {
+    public override fun renderImage(image: InlineMarkdown.Image): ImageRenderResult {
         val imageSourceResolver = LocalMarkdownImageSourceResolver.current
         val resolvedImageSource = remember(image.source) { imageSourceResolver.resolve(image.source) }
-        var imageResult by remember(resolvedImageSource) { mutableStateOf<SuccessResult?>(null) }
-        var hasError by remember { mutableStateOf(false) }
 
-        val painter =
-            rememberAsyncImagePainter(
-                model =
-                    ImageRequest.Builder(LocalPlatformContext.current)
-                        .data(resolvedImageSource)
-                        // make sure image doesn't get downscaled to the placeholder size
-                        .size(Size.ORIGINAL)
-                        .build(),
-                imageLoader = imageLoader,
-                onLoading = { hasError = false },
-                onSuccess = { successState ->
+        // Known limitation (JEWEL-1364): the state remembered here (debouncedSource, and displayed/hasError below) is
+        // keyed to this composable's call position, not to the specific image occurrence, so
+        // inserting, removing, or reordering images can therefore briefly show a previous occurrence's image or
+        // failure state in a reused slot before the new load settles.
+        // Debounce source changes as to avoid trying to fetch images needlessly while the user is not done typing.
+        var debouncedSource by remember { mutableStateOf(resolvedImageSource) }
+        LaunchedEffect(resolvedImageSource) {
+            if (debouncedSource != resolvedImageSource) {
+                delay(SOURCE_DEBOUNCE)
+                debouncedSource = resolvedImageSource
+            }
+        }
+
+        // Only swap the current image displayed once a new load succeeds (stale-while-revalidate) so the switching
+        // never blanks. If an image fails to load, then we show the hyperlink.
+        val platformContext = LocalPlatformContext.current
+        var displayed by remember { mutableStateOf<DisplayedImage?>(null) }
+        var hasError by remember(debouncedSource) { mutableStateOf(false) }
+        LaunchedEffect(debouncedSource, platformContext) {
+            val request =
+                ImageRequest.Builder(platformContext)
+                    .data(debouncedSource)
+                    // make sure the image isn't downscaled to the placeholder size
+                    .size(Size.ORIGINAL)
+                    .build()
+
+            when (val result = imageLoader.execute(request)) {
+                is SuccessResult -> {
                     hasError = false
-                    // onSuccess should only be called once, but adding additional protection from
-                    // unnecessary rerender
-                    if (imageResult == null) {
-                        imageResult = successState.result
-                    }
-                },
-                onError = { error ->
-                    hasError = true
-                    JewelLogger.getInstance(this.javaClass).warn("AsyncImage loading failed.", error.result.throwable)
-                },
-            )
+                    displayed = DisplayedImage(result.image.asPainter(platformContext), result)
+                }
 
-        if (hasError) {
-            return null
+                is ErrorResult -> {
+                    hasError = true
+                    displayed = null
+                    JewelLogger.getInstance(this@Coil3ImageRendererExtensionImpl.javaClass)
+                        .warn("Failed to load AsyncImage from $debouncedSource:", result.throwable)
+                }
+            }
+        }
+
+        if (hasError) return ImageRenderResult.Failed
+
+        val current = displayed
+        if (current == null) {
+            // Reserve the specified size while loading so the layout doesn't jump when the image arrives
+            val loadingPlaceholder =
+                computePlaceholder(imageResult = null, specifiedWidth = image.width, specifiedHeight = image.height)
+            val hasReservedSize = image.width != null || image.height != null
+            val description = image.title?.takeIf { hasReservedSize } ?: LOADING_INDICATOR_DESCRIPTION
+            return ImageRenderResult.Loading(createLoadingIndicator(loadingPlaceholder, description))
         }
 
         val placeholder =
-            computePlaceholder(imageResult = imageResult, specifiedWidth = image.width, specifiedHeight = image.height)
-
-        return InlineTextContent(placeholder) {
-            Image(
-                painter = painter,
-                contentDescription = image.title,
-                modifier = Modifier.fillMaxSize(),
-                contentScale =
-                    if (image.width != null && image.height != null) {
-                        ContentScale.FillBounds
-                    } else {
-                        ContentScale.Fit
-                    },
+            computePlaceholder(
+                imageResult = current.result,
+                specifiedWidth = image.width,
+                specifiedHeight = image.height,
             )
-        }
+
+        val content =
+            InlineTextContent(placeholder) {
+                Image(
+                    painter = current.painter,
+                    contentDescription = image.title,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale =
+                        if (image.width != null && image.height != null) {
+                            ContentScale.FillBounds
+                        } else {
+                            ContentScale.Fit
+                        },
+                )
+            }
+        return ImageRenderResult.Success(content)
     }
+
+    private fun createLoadingIndicator(placeholder: Placeholder, description: String): InlineTextContent =
+        InlineTextContent(placeholder) {
+            Box(
+                modifier = Modifier.fillMaxSize().semantics { contentDescription = description },
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(style = DefaultLoadingIndicatorStyle)
+            }
+        }
 
     /**
      * Computes the placeholder size for the image.
@@ -148,16 +200,19 @@ internal class Coil3ImageRendererExtensionImpl(private val imageLoader: ImageLoa
                 resolvedWidth != null && resolvedHeight != null -> {
                     resolvedWidth to resolvedHeight
                 }
+
                 resolvedWidth != null -> {
                     // Scale height proportionally
                     val scaledHeight = (resolvedWidth.toFloat() / loadedWidth * loadedHeight).toInt()
                     resolvedWidth to scaledHeight
                 }
+
                 resolvedHeight != null -> {
                     // Scale width proportionally
                     val scaledWidth = (resolvedHeight.toFloat() / loadedHeight * loadedWidth).toInt()
                     scaledWidth to resolvedHeight
                 }
+
                 else -> {
                     // No dimensions specified, use original
                     loadedWidth to loadedHeight
@@ -177,4 +232,15 @@ internal class Coil3ImageRendererExtensionImpl(private val imageLoader: ImageLoa
         when (this) {
             is DimensionSize.Pixels -> value
         }
+
+    /** The currently displayed image: a stable painter over the loaded bytes plus its result (for sizing). */
+    private data class DisplayedImage(val painter: Painter, val result: SuccessResult)
+
+    internal companion object {
+        const val LOADING_INDICATOR_DESCRIPTION = "Image loading indicator"
+        val DefaultLoadingIndicatorStyle = CircularProgressStyle(frameTime = 125.milliseconds, color = Color.Gray)
+
+        /** How long the resolved image source must stay unchanged before a load is triggered. */
+        private val SOURCE_DEBOUNCE = 300.milliseconds
+    }
 }

--- a/platform/jewel/markdown/extensions/images/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImplTest.kt
+++ b/platform/jewel/markdown/extensions/images/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/images/Coil3ImageRendererExtensionImplTest.kt
@@ -4,24 +4,36 @@ package org.jetbrains.jewel.markdown.extensions.images
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertHeightIsEqualTo
-import androidx.compose.ui.test.assertWidthIsAtLeast
 import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil3.ColorImage
 import coil3.ImageLoader
 import coil3.PlatformContext
@@ -30,6 +42,7 @@ import coil3.decode.DataSource
 import coil3.request.ErrorResult
 import coil3.request.SuccessResult
 import coil3.test.FakeImageLoaderEngine
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.ceil
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,9 +53,14 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.markdown.DimensionSize
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
+import org.jetbrains.jewel.markdown.extensions.ImageRenderResult
+import org.jetbrains.jewel.markdown.extensions.ImageRendererExtension
+import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 import org.jetbrains.jewel.markdown.rendering.DOWNSCALED_INLINE_CONTENT_TAG
 import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
+import org.jetbrains.jewel.markdown.rendering.InlinesStyling
+import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 import org.jetbrains.jewel.markdown.testing.createMarkdownTestStyling
 import org.jetbrains.jewel.markdown.testing.createMarkdownTestThemeDefinition
 import org.jetbrains.jewel.ui.component.Text as JewelText
@@ -59,8 +77,9 @@ public class Coil3ImageRendererExtensionImplTest {
     @get:Rule public val composeTestRule: ComposeContentTestRule = createComposeRule()
 
     private val platformContext: PlatformContext = PlatformContext.INSTANCE
-    private val imageUrl = "https://example.com/image.png"
-    private val imageUrl2 = "https://example.com/image2.png"
+    private val loadingImageUrl = "https://example.com/image.png"
+    private val failingImageUrl = "https://example.com/nonexistent.png"
+    private val loadingImageUrl2 = "https://example.com/image2.png"
 
     @Test
     public fun `image renders with correct size on success`() {
@@ -68,15 +87,14 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Red.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
 
         val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
         val imageMarkdown =
-            InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Image loaded successfully")
+            InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "Image loaded successfully")
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoaderWithFakeEngine, imageMarkdown)
 
         composeTestRule
             .onNodeWithContentDescription("Image loaded successfully")
@@ -85,38 +103,18 @@ public class Coil3ImageRendererExtensionImplTest {
             .assertHeightIsEqualTo(fakeImageHeight.dp)
     }
 
-    @Test
-    public fun `placeholder remains small on error`() {
-        val engine =
-            FakeImageLoaderEngine.Builder()
-                .intercept(
-                    predicate = { it == imageUrl },
-                    interceptor = { ErrorResult(null, it.request, IllegalStateException("Failed to load")) },
-                )
-                .build()
-
-        val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
-
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
-        val imageMarkdown = InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Failed to load image")
-
-        setContent(extension, imageMarkdown)
-
-        composeTestRule.onNodeWithContentDescription("Failed to load image").assertDoesNotExist()
-    }
-
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    public fun `placeholder remains small during loading state then changes to image size`() {
+    public fun `loading indicator shows during loading state then image appears on success`() {
         val testDispatcher = StandardTestDispatcher()
 
-        val fakeImageWidth = 150
-        val fakeImageHeight = 150
+        val fakeImageWidth = 50
+        val fakeImageHeight = 50
         val fakeImage = ColorImage(Color.Red.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
         val engine =
             FakeImageLoaderEngine.Builder()
                 .intercept(
-                    predicate = { it == imageUrl },
+                    predicate = { it == loadingImageUrl },
                     interceptor = {
                         delay(500.milliseconds) // simulating network delay
 
@@ -128,25 +126,106 @@ public class Coil3ImageRendererExtensionImplTest {
         val imageLoader =
             ImageLoader.Builder(platformContext).components { add(engine) }.coroutineContext(testDispatcher).build()
 
-        val extension = Coil3ImageRendererExtensionImpl(imageLoader)
-        val imageMarkdown = InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "A loading image")
+        val imageMarkdown = InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "A loading image")
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoader, imageMarkdown)
 
+        // fast forwarding coil's internal dispatcher
+        testDispatcher.scheduler.advanceTimeBy(250)
+        testDispatcher.scheduler.runCurrent()
+
+        // The actual image with its content description doesn't exist yet
+        composeTestRule.onNodeWithContentDescription("A loading image").assertDoesNotExist()
+
+        // Verify loading indicator is shown
         composeTestRule
-            .onNodeWithContentDescription("A loading image")
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertExists()
+
+        // fast forwarding coil's internal dispatcher
+        testDispatcher.scheduler.advanceTimeBy(251)
+        testDispatcher.scheduler.runCurrent()
+
+        // After loading completes, image should appear and loading indicator should disappear
+        composeTestRule.onNodeWithContentDescription("A loading image").assertExists()
+        composeTestRule
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertDoesNotExist()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    public fun `loading indicator shows during loading state then disappears on failure`() {
+        val testDispatcher = StandardTestDispatcher()
+
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = {
+                        delay(500.milliseconds) // simulating network delay
+
+                        ErrorResult(null, it.request, IllegalStateException("Not found"))
+                    },
+                )
+                .build()
+
+        val imageLoader =
+            ImageLoader.Builder(platformContext).components { add(engine) }.coroutineContext(testDispatcher).build()
+        val altText = "Missing image"
+        val failingImageMarkdown = InlineMarkdown.Image(source = failingImageUrl, alt = altText, title = null)
+
+        setContent(imageLoader, failingImageMarkdown)
+
+        // fast forwarding coil's internal dispatcher
+        testDispatcher.scheduler.advanceTimeBy(250)
+        testDispatcher.scheduler.runCurrent()
+
+        // The actual image with its content description doesn't exist yet
+        composeTestRule.onNodeWithContentDescription(altText).assertDoesNotExist()
+
+        // Verify loading indicator is shown
+        composeTestRule
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
             .assertExists()
             .assertWidthIsEqualTo(1.dp)
             .assertHeightIsEqualTo(1.dp)
 
         // fast forwarding coil's internal dispatcher
-        testDispatcher.scheduler.advanceTimeBy(501)
+        testDispatcher.scheduler.advanceTimeBy(251)
         testDispatcher.scheduler.runCurrent()
 
         composeTestRule
-            .onNodeWithContentDescription("A loading image")
-            .assertWidthIsAtLeast(fakeImageWidth.dp)
-            .assertHeightIsAtLeast(fakeImageHeight.dp)
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertDoesNotExist()
+
+        // After loading completes, image should appear and loading indicator should disappear
+        assertFailedLinkExists(altText)
+    }
+
+    @Test
+    public fun `failed image is rendered as link with alt text`() {
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = { ErrorResult(null, it.request, IllegalStateException("Not found")) },
+                )
+                .build()
+
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+        val altText = "Missing image"
+        val failingImageMarkdown = InlineMarkdown.Image(source = failingImageUrl, alt = altText, title = null)
+
+        setContent(imageLoader, failingImageMarkdown)
+
+        // Image should not be rendered
+        composeTestRule
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertDoesNotExist()
+
+        // Failed image should be rendered as a link with alt text
+        assertFailedLinkExists(altText)
     }
 
     @Test
@@ -155,26 +234,23 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Blue.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
-
-        val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
-
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
 
         // Specify different dimensions than the actual image
         val specifiedWidth = 100
         val specifiedHeight = 50
         val imageMarkdown =
             InlineMarkdown.Image(
-                source = imageUrl,
+                source = loadingImageUrl,
                 alt = "Alt text",
                 title = "Sized image",
                 width = DimensionSize.Pixels(specifiedWidth),
                 height = DimensionSize.Pixels(specifiedHeight),
                 inlineContent = emptyList(),
             )
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoader, imageMarkdown)
 
         composeTestRule
             .onNodeWithContentDescription("Sized image")
@@ -189,11 +265,7 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Green.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
-
-        val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
-
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
 
         // Specify only width - height should be scaled proportionally
         val specifiedWidth = 100
@@ -201,15 +273,16 @@ public class Coil3ImageRendererExtensionImplTest {
         val expectedHeight = 50
         val imageMarkdown =
             InlineMarkdown.Image(
-                source = imageUrl,
+                source = loadingImageUrl,
                 alt = "Alt text",
                 title = "Width only image",
                 width = DimensionSize.Pixels(specifiedWidth),
                 height = null,
                 inlineContent = emptyList(),
             )
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoader, imageMarkdown)
 
         composeTestRule
             .onNodeWithContentDescription("Width only image")
@@ -224,11 +297,7 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Yellow.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
-
-        val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
-
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
 
         // Specify only height - width should be scaled proportionally
         val specifiedHeight = 50
@@ -236,15 +305,16 @@ public class Coil3ImageRendererExtensionImplTest {
         val expectedWidth = 100
         val imageMarkdown =
             InlineMarkdown.Image(
-                source = imageUrl,
+                source = loadingImageUrl,
                 alt = "Alt text",
                 title = "Height only image",
                 width = null,
                 height = DimensionSize.Pixels(specifiedHeight),
                 inlineContent = emptyList(),
             )
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoader, imageMarkdown)
 
         composeTestRule
             .onNodeWithContentDescription("Height only image")
@@ -264,9 +334,9 @@ public class Coil3ImageRendererExtensionImplTest {
         val engine =
             FakeImageLoaderEngine.Builder()
                 .intercept(
-                    predicate = { it == imageUrl },
+                    predicate = { it == loadingImageUrl },
                     interceptor = {
-                        delay(500) // simulating network delay
+                        delay(500.milliseconds) // simulating network delay
 
                         SuccessResult(fakeImage, it.request, DataSource.MEMORY)
                     },
@@ -276,13 +346,11 @@ public class Coil3ImageRendererExtensionImplTest {
         val imageLoader =
             ImageLoader.Builder(platformContext).components { add(engine) }.coroutineContext(testDispatcher).build()
 
-        val extension = Coil3ImageRendererExtensionImpl(imageLoader)
-
         val specifiedWidth = 150
         val specifiedHeight = 75
         val imageMarkdown =
             InlineMarkdown.Image(
-                source = imageUrl,
+                source = loadingImageUrl,
                 alt = "Alt text",
                 title = "Loading sized image",
                 width = DimensionSize.Pixels(specifiedWidth),
@@ -290,7 +358,7 @@ public class Coil3ImageRendererExtensionImplTest {
                 inlineContent = emptyList(),
             )
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoader, imageMarkdown)
 
         // During loading, placeholder should have the specified dimensions
         composeTestRule
@@ -299,7 +367,7 @@ public class Coil3ImageRendererExtensionImplTest {
             .assertWidthIsEqualTo(specifiedWidth.dp)
             .assertHeightIsEqualTo(specifiedHeight.dp)
 
-        // Fast forward to complete loading
+        // Fast-forward to complete loading
         testDispatcher.scheduler.advanceTimeBy(501)
         testDispatcher.scheduler.runCurrent()
 
@@ -317,16 +385,14 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Green.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
 
         val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
-
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
 
         // Specify 100x100 (1:1 aspect ratio) - image will be stretched/squished
         val imageMarkdown =
             InlineMarkdown.Image(
-                source = imageUrl,
+                source = loadingImageUrl,
                 alt = "Alt text",
                 title = "Stretched square image",
                 width = DimensionSize.Pixels(100),
@@ -334,7 +400,7 @@ public class Coil3ImageRendererExtensionImplTest {
                 inlineContent = emptyList(),
             )
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoaderWithFakeEngine, imageMarkdown)
 
         // Both dimensions should be exactly as specified, even though aspect ratio differs
         composeTestRule
@@ -351,16 +417,14 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Yellow.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
 
         val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
-
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
 
         // Specify 50x200 (1:4 aspect ratio) - very different from original 2:1
         val imageMarkdown =
             InlineMarkdown.Image(
-                source = imageUrl,
+                source = loadingImageUrl,
                 alt = "Alt text",
                 title = "Tall stretched image",
                 width = DimensionSize.Pixels(50),
@@ -368,7 +432,7 @@ public class Coil3ImageRendererExtensionImplTest {
                 inlineContent = emptyList(),
             )
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoaderWithFakeEngine, imageMarkdown)
 
         composeTestRule
             .onNodeWithContentDescription("Tall stretched image")
@@ -384,16 +448,14 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Magenta.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
 
         val imageLoaderWithFakeEngine = ImageLoader.Builder(platformContext).components { add(engine) }.build()
-
-        val extension = Coil3ImageRendererExtensionImpl(imageLoaderWithFakeEngine)
 
         // Specify 300x50 (6:1 aspect ratio) - wider than original 2:1
         val imageMarkdown =
             InlineMarkdown.Image(
-                source = imageUrl,
+                source = loadingImageUrl,
                 alt = "Alt text",
                 title = "Wide stretched image",
                 width = DimensionSize.Pixels(300),
@@ -401,7 +463,7 @@ public class Coil3ImageRendererExtensionImplTest {
                 inlineContent = emptyList(),
             )
 
-        setContent(extension, imageMarkdown)
+        setContent(imageLoaderWithFakeEngine, imageMarkdown)
 
         composeTestRule
             .onNodeWithContentDescription("Wide stretched image")
@@ -417,10 +479,11 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 100
         val fakeImage = ColorImage(Color.Blue.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
-        val paragraph = Paragraph(InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"))
+        val paragraph =
+            Paragraph(InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "HUGE image"))
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
 
@@ -444,10 +507,11 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 100
         val fakeImage = ColorImage(Color.Blue.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
-        val paragraph = Paragraph(InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"))
+        val paragraph =
+            Paragraph(InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "HUGE image"))
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
 
@@ -464,10 +528,11 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 200
         val fakeImage = ColorImage(Color.Green.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
-        val paragraph = Paragraph(InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "smol image"))
+        val paragraph =
+            Paragraph(InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "smol image"))
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
 
@@ -488,12 +553,12 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 100
         val fakeImage = ColorImage(Color.Red.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
         val paragraph =
             Paragraph(
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "HUGE image"),
                 InlineMarkdown.Text(" and then some!"),
             )
 
@@ -516,13 +581,13 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 100
         val fakeImage = ColorImage(Color.Blue.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
         val paragraph =
             Paragraph(
                 InlineMarkdown.Text("Behold the "),
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "HUGE image"),
             )
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
@@ -544,13 +609,13 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 100
         val fakeImage = ColorImage(Color.Green.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
         val paragraph =
             Paragraph(
                 InlineMarkdown.Text("Behold, the "),
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "HUGE image"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "HUGE image"),
                 InlineMarkdown.Text("!!!"),
             )
 
@@ -572,12 +637,12 @@ public class Coil3ImageRendererExtensionImplTest {
         val fakeImageHeight = 100
         val fakeImage = ColorImage(Color.Yellow.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
         val paragraph =
             Paragraph(
                 InlineMarkdown.Text("Prefix "),
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Intrinsic image"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "Intrinsic image"),
                 InlineMarkdown.Text("followedbyanincrediblelonguninterrupredsequenceofwords"),
             )
 
@@ -644,16 +709,16 @@ public class Coil3ImageRendererExtensionImplTest {
 
         val engine =
             FakeImageLoaderEngine.Builder()
-                .intercept({ it == imageUrl }, fakeImage1)
-                .intercept({ it == imageUrl2 }, fakeImage2)
+                .intercept({ it == loadingImageUrl }, fakeImage1)
+                .intercept({ it == loadingImageUrl2 }, fakeImage2)
                 .build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
         val paragraph =
             Paragraph(
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text 1", title = "First image"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text 1", title = "First image"),
                 InlineMarkdown.Text(" text between "),
-                InlineMarkdown.Image(source = imageUrl2, alt = "Alt text 2", title = "Second image"),
+                InlineMarkdown.Image(source = loadingImageUrl2, alt = "Alt text 2", title = "Second image"),
             )
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
@@ -699,13 +764,13 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 50
         val fakeImage = ColorImage(Color.Cyan.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
         val paragraph =
             Paragraph(
                 InlineMarkdown.Text("Zero width: "),
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Zero width image"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "Zero width image"),
             )
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
@@ -727,16 +792,16 @@ public class Coil3ImageRendererExtensionImplTest {
 
         val engine =
             FakeImageLoaderEngine.Builder()
-                .intercept({ it == imageUrl }, fakeImage1)
-                .intercept({ it == imageUrl2 }, fakeImage2)
+                .intercept({ it == loadingImageUrl }, fakeImage1)
+                .intercept({ it == loadingImageUrl2 }, fakeImage2)
                 .build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
         val paragraph =
             Paragraph(
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text 1", title = "smol image"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text 1", title = "smol image"),
                 InlineMarkdown.Text(" and "),
-                InlineMarkdown.Image(source = imageUrl2, alt = "Alt text 2", title = "beeg image"),
+                InlineMarkdown.Image(source = loadingImageUrl2, alt = "Alt text 2", title = "beeg image"),
             )
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
@@ -766,13 +831,13 @@ public class Coil3ImageRendererExtensionImplTest {
         val containerWidth = 100
         val fakeImage = ColorImage(Color.Magenta.toArgb(), width = fakeImageWidth, height = fakeImageHeight)
 
-        val engine = FakeImageLoaderEngine.Builder().intercept({ it == imageUrl }, fakeImage).build()
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
         val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
 
         val paragraph =
             Paragraph(
                 InlineMarkdown.Text("Edge case: "),
-                InlineMarkdown.Image(source = imageUrl, alt = "Alt text", title = "Barely oversized"),
+                InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt text", title = "Barely oversized"),
             )
 
         setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidth)
@@ -789,15 +854,592 @@ public class Coil3ImageRendererExtensionImplTest {
         composeTestRule.onNodeWithTag(DOWNSCALED_INLINE_CONTENT_TAG).assertExists()
     }
 
-    private fun setContent(extension: Coil3ImageRendererExtensionImpl, image: InlineMarkdown.Image) {
+    @Test
+    public fun `failed image without alt text shows URL as link text`() {
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = { ErrorResult(null, it.request, IllegalStateException("Not found")) },
+                )
+                .build()
+
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+        val failingImageMarkdown = InlineMarkdown.Image(source = failingImageUrl, alt = "", title = null)
+
+        setContent(imageLoader, failingImageMarkdown)
+
+        // Failed image without alt text should show URL as link text
+        assertFailedLinkExists(failingImageUrl)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    public fun `previously failed image shows link instead of loading indicator on retry`() {
+        val testDispatcher = StandardTestDispatcher()
+
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = {
+                        delay(100.milliseconds)
+                        ErrorResult(null, it.request, IllegalStateException("Failed"))
+                    },
+                )
+                .build()
+
+        val imageLoader =
+            ImageLoader.Builder(platformContext).components { add(engine) }.coroutineContext(testDispatcher).build()
+        val altText = "Failing image"
+        val failingImageMarkdown = InlineMarkdown.Image(source = failingImageUrl, alt = altText, title = null)
+
+        setContent(imageLoader, failingImageMarkdown)
+
+        // Initially loading indicator should be shown
+        composeTestRule
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertExists()
+
+        // Complete first request - should fail and show link
+        testDispatcher.scheduler.advanceTimeBy(101)
+        testDispatcher.scheduler.runCurrent()
+
+        // Wait for link to appear, then verify loading indicator is gone
+        assertFailedLinkExists(altText)
+        composeTestRule
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    public fun `same source with different alt text renders each occurrence independently`() {
+        val fakeImage = ColorImage(Color.Green.toArgb(), width = 120, height = 80)
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        // Same URL, different alt/title: the two occurrences must not collapse onto a single one.
+        setContent(
+            imageLoader,
+            InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt A", title = "Image A"),
+            InlineMarkdown.Image(source = loadingImageUrl, alt = "Alt B", title = "Image B"),
+        )
+
+        // Rendering the second occurrence must not break the first: both are present.
+        composeTestRule.onNodeWithContentDescription("Image A").assertExists()
+        composeTestRule.onNodeWithContentDescription("Image B").assertExists()
+    }
+
+    @Test
+    public fun `same source with different specified widths sizes each occurrence independently`() {
+        val fakeImage = ColorImage(Color.Red.toArgb(), width = 200, height = 100)
+        val engine = FakeImageLoaderEngine.Builder().intercept({ it == loadingImageUrl }, fakeImage).build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        // Same URL and alt, different specified width: each occurrence keeps its own size.
+        setContent(
+            imageLoader,
+            InlineMarkdown.Image(
+                source = loadingImageUrl,
+                alt = "Alt",
+                title = "Narrow",
+                width = DimensionSize.Pixels(50),
+            ),
+            InlineMarkdown.Image(
+                source = loadingImageUrl,
+                alt = "Alt",
+                title = "Wide",
+                width = DimensionSize.Pixels(99),
+            ),
+        )
+
+        composeTestRule.onNodeWithContentDescription("Narrow").assertExists().assertWidthIsEqualTo(50.dp)
+        composeTestRule.onNodeWithContentDescription("Wide").assertExists().assertWidthIsEqualTo(99.dp)
+    }
+
+    @Test
+    public fun `identical images share the same fate when loading fails`() {
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = { ErrorResult(null, it.request, IllegalStateException("Not found")) },
+                )
+                .build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        // Two byte-for-byte identical occurrences share a content id, so they coalesce and fail together.
+        setContent(
+            imageLoader,
+            InlineMarkdown.Image(source = failingImageUrl, alt = "Shared alt", title = "Shared image"),
+            InlineMarkdown.Image(source = failingImageUrl, alt = "Shared alt", title = "Shared image"),
+        )
+
+        // The fallback link appears once loading fails...
+        assertFailedLinkExists("Shared alt")
+        // ...and neither occurrence rendered as an image: if either had succeeded, its content-description node
+        // would exist. Its absence proves both share the failed fate.
+        composeTestRule.onNodeWithContentDescription("Shared image").assertDoesNotExist()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    public fun `rapid source changes are debounced so only the settled source is loaded`() {
+        val firstImage = ColorImage(Color.Green.toArgb(), width = 40, height = 40)
+        val secondImage = ColorImage(Color.Blue.toArgb(), width = 80, height = 80)
+
+        val firstUrlLoads = AtomicInteger(0)
+        val secondUrlLoads = AtomicInteger(0)
+
+        val testDispatcher = StandardTestDispatcher()
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == loadingImageUrl },
+                    interceptor = {
+                        firstUrlLoads.incrementAndGet()
+                        SuccessResult(firstImage, it.request, DataSource.MEMORY)
+                    },
+                )
+                .intercept(
+                    predicate = { it == loadingImageUrl2 },
+                    interceptor = {
+                        secondUrlLoads.incrementAndGet()
+                        SuccessResult(secondImage, it.request, DataSource.MEMORY)
+                    },
+                )
+                .build()
+        val imageLoader =
+            ImageLoader.Builder(platformContext).components { add(engine) }.coroutineContext(testDispatcher).build()
+
+        val source = mutableStateOf(loadingImageUrl)
+
+        // Drive the debounce clock manually: the delay lives in a LaunchedEffect, so it advances with the
+        // Compose mainClock, while the actual Coil load advances with testDispatcher.
+        composeTestRule.mainClock.autoAdvance = false
+        setContentWithDynamicSource(imageLoader, source)
+
+        // Initial composition: the first source is already settled, so it loads immediately (no debounce).
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.mainClock.advanceTimeBy(16)
+        assertEquals(1, firstUrlLoads.get())
+        assertEquals(0, secondUrlLoads.get())
+
+        // "Type" a new URL; let the recomposition launch the debounce coroutine.
+        source.value = loadingImageUrl2
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Still inside the 300ms window: the new URL must not have been requested yet.
+        composeTestRule.mainClock.advanceTimeBy(200)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("new source must not load during the debounce window", 0, secondUrlLoads.get())
+
+        // Cross the debounce threshold: now the settled source loads, exactly once.
+        composeTestRule.mainClock.advanceTimeBy(150)
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("settled source must load after the debounce window", 1, secondUrlLoads.get())
+        // The first URL was never reloaded while the second was being typed.
+        assertEquals(1, firstUrlLoads.get())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    public fun `intermediate source values typed within the debounce window never load`() {
+        val intermediateUrl = "https://example.com/intermediate.png"
+
+        val initialImage = ColorImage(Color.Green.toArgb(), width = 40, height = 40)
+        val intermediateImage = ColorImage(Color.Yellow.toArgb(), width = 60, height = 60)
+        val finalImage = ColorImage(Color.Blue.toArgb(), width = 80, height = 80)
+
+        val initialLoads = AtomicInteger(0)
+        val intermediateLoads = AtomicInteger(0)
+        val finalLoads = AtomicInteger(0)
+
+        val testDispatcher = StandardTestDispatcher()
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == loadingImageUrl },
+                    interceptor = {
+                        initialLoads.incrementAndGet()
+                        SuccessResult(initialImage, it.request, DataSource.MEMORY)
+                    },
+                )
+                .intercept(
+                    predicate = { it == intermediateUrl },
+                    interceptor = {
+                        intermediateLoads.incrementAndGet()
+                        SuccessResult(intermediateImage, it.request, DataSource.MEMORY)
+                    },
+                )
+                .intercept(
+                    predicate = { it == loadingImageUrl2 },
+                    interceptor = {
+                        finalLoads.incrementAndGet()
+                        SuccessResult(finalImage, it.request, DataSource.MEMORY)
+                    },
+                )
+                .build()
+        val imageLoader =
+            ImageLoader.Builder(platformContext).components { add(engine) }.coroutineContext(testDispatcher).build()
+
+        val source = mutableStateOf(loadingImageUrl)
+
+        composeTestRule.mainClock.autoAdvance = false
+        setContentWithDynamicSource(imageLoader, source)
+
+        // Settle on the initial source.
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.mainClock.advanceTimeBy(16)
+        assertEquals(1, initialLoads.get())
+
+        // Type an intermediate value; its debounce coroutine starts and gets partway through the window...
+        source.value = intermediateUrl
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.mainClock.advanceTimeBy(100)
+
+        // ...then change again before the window elapses. The intermediate coroutine is cancelled mid-delay,
+        // so its assignment (which happens after delay) never runs and its URL is never requested.
+        source.value = loadingImageUrl2
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Still inside the final source's window: neither the intermediate nor the final value has loaded.
+        composeTestRule.mainClock.advanceTimeBy(200)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("intermediate value must never load", 0, intermediateLoads.get())
+        assertEquals(0, finalLoads.get())
+
+        // After the final source settles, only it loads.
+        composeTestRule.mainClock.advanceTimeBy(150)
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("intermediate value must never load", 0, intermediateLoads.get())
+        assertEquals("only the settled final source loads", 1, finalLoads.get())
+        assertEquals(1, initialLoads.get())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    public fun `switching between two valid sources never flashes the loading indicator`() {
+        val firstImage = ColorImage(Color.Green.toArgb(), width = 40, height = 40)
+        val secondImage = ColorImage(Color.Blue.toArgb(), width = 80, height = 80)
+
+        val testDispatcher = StandardTestDispatcher()
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == loadingImageUrl },
+                    interceptor = {
+                        delay(200.milliseconds)
+                        SuccessResult(firstImage, it.request, DataSource.MEMORY)
+                    },
+                )
+                .intercept(
+                    predicate = { it == loadingImageUrl2 },
+                    interceptor = {
+                        delay(200.milliseconds)
+                        SuccessResult(secondImage, it.request, DataSource.MEMORY)
+                    },
+                )
+                .build()
+        val imageLoader =
+            ImageLoader.Builder(platformContext).components { add(engine) }.coroutineContext(testDispatcher).build()
+
+        val source = mutableStateOf(loadingImageUrl)
+
+        composeTestRule.mainClock.autoAdvance = false
+        setContentWithDynamicSource(imageLoader, source)
+
+        // Load the first source fully.
+        composeTestRule.mainClock.advanceTimeBy(16)
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.mainClock.advanceTimeBy(16)
+        composeTestRule.onNodeWithContentDescription("img").assertExists()
+
+        // Switch to the second (also valid) source and let the debounce settle, but do NOT complete its load yet.
+        source.value = loadingImageUrl2
+        composeTestRule.mainClock.advanceTimeBy(16)
+        composeTestRule.mainClock.advanceTimeBy(320)
+
+        // While the new source is loading, the previous image is kept (stale-while-revalidate): the image node
+        // is still present and the loading indicator never appears.
+        composeTestRule
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("img").assertExists()
+
+        // Once the new source finishes loading, it is shown at its own size, still without any spinner.
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.mainClock.advanceTimeBy(16)
+        composeTestRule
+            .onNodeWithContentDescription(Coil3ImageRendererExtensionImpl.LOADING_INDICATOR_DESCRIPTION)
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("img").assertExists().assertWidthIsEqualTo(80.dp)
+    }
+
+    @Test
+    public fun `failed image nested in emphasis keeps the emphasis style in the fallback link`() {
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = { ErrorResult(null, it.request, IllegalStateException("Not found")) },
+                )
+                .build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        // Emphasis is the only source of italics here, so italic in the fallback link can only have come from the
+        // enclosing emphasis - not the base text style or the link style.
+        val inlinesStyling =
+            InlinesStyling(
+                textStyle = TextStyle.Default,
+                inlineCode = SpanStyle(Color.Black),
+                link = SpanStyle(Color.Blue),
+                linkDisabled = SpanStyle(Color.Gray),
+                linkFocused = SpanStyle(Color.Blue),
+                linkHovered = SpanStyle(Color.Blue),
+                linkPressed = SpanStyle(Color.Blue),
+                linkVisited = SpanStyle(Color.Blue),
+                emphasis = SpanStyle(fontStyle = FontStyle.Italic),
+                strongEmphasis = SpanStyle(fontWeight = FontWeight.Bold),
+                inlineHtml = SpanStyle(Color.Black),
+            )
+        val paragraphStyling = MarkdownStyling.Paragraph(inlinesStyling)
+
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Emphasis(
+                    "*",
+                    InlineMarkdown.Image(source = failingImageUrl, alt = "broken", title = null),
+                )
+            )
+
+        var rendered: AnnotatedString? = null
         composeTestRule.setContent {
-            val inlineContent = buildMap { extension.renderImageContent(image)?.let { put("inlineTextContent", it) } }
-            val annotatedString = buildAnnotatedString {
-                append("Rendered inline text image: ")
-                appendInlineContent("inlineTextContent", "[rendered image]")
+            JewelTheme(createMarkdownTestThemeDefinition()) {
+                val imageExtension = Coil3ImageRendererExtension(imageLoader)
+                val renderer =
+                    DefaultMarkdownBlockRenderer(
+                        rootStyling = createMarkdownTestStyling(),
+                        rendererExtensions = listOf(imageExtension),
+                        inlineRenderer = DefaultInlineMarkdownRenderer(listOf(imageExtension)),
+                    )
+                Box(modifier = Modifier.width(Int.MAX_VALUE.dp)) {
+                    renderer.RenderParagraph(
+                        block = paragraph,
+                        styling = paragraphStyling,
+                        enabled = true,
+                        onUrlClick = {},
+                        onTextLayout = { rendered = it.layoutInput.text },
+                        modifier = Modifier,
+                        overflow = TextOverflow.Clip,
+                        softWrap = true,
+                        maxLines = Int.MAX_VALUE,
+                    )
+                }
             }
-            BasicText(text = annotatedString, inlineContent = inlineContent)
         }
+
+        // Wait until the failed image has been rebuilt into a fallback link.
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            rendered?.let { it.getLinkAnnotations(0, it.length).isNotEmpty() } == true
+        }
+
+        val text = rendered!!
+        val link = text.getLinkAnnotations(0, text.length).first().item as LinkAnnotation.Clickable
+        // The fallback link inherits the emphasis it was nested in, matching a real link in the same context.
+        assertEquals(FontStyle.Italic.value, link.styles?.style?.fontStyle?.value)
+    }
+
+    @Test
+    public fun `failed image nested in a link points the fallback link at the outer destination`() {
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = { ErrorResult(null, it.request, IllegalStateException("Not found")) },
+                )
+                .build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val destination = "https://destination.example"
+        // Paragraph with the text: [![broken](failing)](destination)
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Link(
+                    destination,
+                    null,
+                    InlineMarkdown.Image(source = failingImageUrl, alt = "broken", title = null),
+                )
+            )
+
+        var rendered: AnnotatedString? = null
+        composeTestRule.setContent {
+            JewelTheme(createMarkdownTestThemeDefinition()) {
+                val imageExtension = Coil3ImageRendererExtension(imageLoader)
+                val renderer =
+                    DefaultMarkdownBlockRenderer(
+                        rootStyling = createMarkdownTestStyling(),
+                        rendererExtensions = listOf(imageExtension),
+                        inlineRenderer = DefaultInlineMarkdownRenderer(listOf(imageExtension)),
+                    )
+                Box(modifier = Modifier.width(Int.MAX_VALUE.dp)) {
+                    renderer.RenderParagraph(
+                        block = paragraph,
+                        styling = createMarkdownTestStyling().paragraph,
+                        enabled = true,
+                        onUrlClick = {},
+                        onTextLayout = { rendered = it.layoutInput.text },
+                        modifier = Modifier,
+                        overflow = TextOverflow.Clip,
+                        softWrap = true,
+                        maxLines = Int.MAX_VALUE,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            rendered?.let { it.getLinkAnnotations(0, it.length).isNotEmpty() } == true
+        }
+
+        val text = rendered!!
+        val link = text.getLinkAnnotations(0, text.length).first().item as LinkAnnotation.Clickable
+        // The fallback link targets the enclosing link's destination, not the (broken) image source.
+        assertEquals(destination, link.tag)
+    }
+
+    @Test
+    public fun `loading with null content drops a previously loaded image`() {
+        val loading = mutableStateOf(false)
+        val successContent =
+            InlineTextContent(Placeholder(10.sp, 10.sp, PlaceholderVerticalAlign.Bottom)) {
+                Box(Modifier.fillMaxSize().testTag("loaded-image"))
+            }
+        // A custom renderer that shows a loaded image, then "refreshes" it and returns Loading(null).
+        val extension =
+            object : MarkdownRendererExtension {
+                override val imageRendererExtension =
+                    object : ImageRendererExtension {
+                        @Composable
+                        override fun renderImage(image: InlineMarkdown.Image): ImageRenderResult =
+                            if (loading.value) {
+                                ImageRenderResult.Loading(null)
+                            } else {
+                                ImageRenderResult.Success(successContent)
+                            }
+                    }
+            }
+
+        val paragraph = Paragraph(InlineMarkdown.Image(source = loadingImageUrl, alt = "alt", title = null))
+
+        composeTestRule.setContent {
+            JewelTheme(createMarkdownTestThemeDefinition()) {
+                val styling = createMarkdownTestStyling()
+                val renderer =
+                    DefaultMarkdownBlockRenderer(
+                        rootStyling = styling,
+                        rendererExtensions = listOf(extension),
+                        inlineRenderer = DefaultInlineMarkdownRenderer(listOf(extension)),
+                    )
+                Box(modifier = Modifier.width(Int.MAX_VALUE.dp)) {
+                    renderer.RenderParagraph(
+                        block = paragraph,
+                        styling = styling.paragraph,
+                        enabled = true,
+                        onUrlClick = {},
+                        modifier = Modifier,
+                    )
+                }
+            }
+        }
+
+        // The loaded image content is shown.
+        composeTestRule.onNodeWithTag("loaded-image").assertExists()
+
+        // Refreshing into Loading(null) must drop the stale success content instead of keeping it on screen.
+        loading.value = true
+        composeTestRule.onNodeWithTag("loaded-image").assertDoesNotExist()
+    }
+
+    @Test
+    public fun `failed image with no alt in a link shows the destination as the fallback text`() {
+        val engine =
+            FakeImageLoaderEngine.Builder()
+                .intercept(
+                    predicate = { it == failingImageUrl },
+                    interceptor = { ErrorResult(null, it.request, IllegalStateException("Not found")) },
+                )
+                .build()
+        val imageLoader = ImageLoader.Builder(platformContext).components { add(engine) }.build()
+
+        val destination = "https://destination.example"
+        // Paragraph with the text: [![](failing)](destination)
+        val paragraph =
+            Paragraph(
+                InlineMarkdown.Link(
+                    destination,
+                    null,
+                    InlineMarkdown.Image(source = failingImageUrl, alt = "", title = null),
+                )
+            )
+
+        var rendered: AnnotatedString? = null
+        composeTestRule.setContent {
+            JewelTheme(createMarkdownTestThemeDefinition()) {
+                val imageExtension = Coil3ImageRendererExtension(imageLoader)
+                val renderer =
+                    DefaultMarkdownBlockRenderer(
+                        rootStyling = createMarkdownTestStyling(),
+                        rendererExtensions = listOf(imageExtension),
+                        inlineRenderer = DefaultInlineMarkdownRenderer(listOf(imageExtension)),
+                    )
+                Box(modifier = Modifier.width(Int.MAX_VALUE.dp)) {
+                    renderer.RenderParagraph(
+                        block = paragraph,
+                        styling = createMarkdownTestStyling().paragraph,
+                        enabled = true,
+                        onUrlClick = {},
+                        onTextLayout = { rendered = it.layoutInput.text },
+                        modifier = Modifier,
+                        overflow = TextOverflow.Clip,
+                        softWrap = true,
+                        maxLines = Int.MAX_VALUE,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            rendered?.let { it.getLinkAnnotations(0, it.length).isNotEmpty() } == true
+        }
+
+        val text = rendered!!
+        // With no alt, the visible text falls back to the destination (not the broken image source), so it
+        // matches the link's click target.
+        assertTrue(text.text.contains(destination))
+        assertTrue(!text.text.contains(failingImageUrl))
+        val link = text.getLinkAnnotations(0, text.length).first().item as LinkAnnotation.Clickable
+        assertEquals(destination, link.tag)
+    }
+
+    private fun assertFailedLinkExists(altText: String) {
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodes(hasText(altText, substring = true)).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun setContent(imageLoader: ImageLoader, vararg images: InlineMarkdown.Image) {
+        val paragraph = Paragraph(*images)
+        setConstrainedContentWithParagraph(imageLoader, paragraph, containerWidthDp = Int.MAX_VALUE)
     }
 
     private fun setConstrainedContentWithParagraph(
@@ -816,6 +1458,31 @@ public class Coil3ImageRendererExtensionImplTest {
                         inlineRenderer = DefaultInlineMarkdownRenderer(listOf(imageExtension)),
                     )
                 Box(modifier = Modifier.width(containerWidthDp.dp).testTag(PARAGRAPH_WRAPPER_TAG)) {
+                    blockRenderer.RenderParagraph(
+                        block = paragraph,
+                        styling = markdownStyling.paragraph,
+                        enabled = true,
+                        onUrlClick = {},
+                        modifier = Modifier,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun setContentWithDynamicSource(imageLoader: ImageLoader, source: State<String>) {
+        composeTestRule.setContent {
+            JewelTheme(createMarkdownTestThemeDefinition()) {
+                val imageExtension = Coil3ImageRendererExtension(imageLoader)
+                val markdownStyling = createMarkdownTestStyling()
+                val blockRenderer =
+                    DefaultMarkdownBlockRenderer(
+                        rootStyling = markdownStyling,
+                        rendererExtensions = listOf(imageExtension),
+                        inlineRenderer = DefaultInlineMarkdownRenderer(listOf(imageExtension)),
+                    )
+                val paragraph = Paragraph(InlineMarkdown.Image(source = source.value, alt = "Alt", title = "img"))
+                Box(modifier = Modifier.width(Int.MAX_VALUE.dp).testTag(PARAGRAPH_WRAPPER_TAG)) {
                     blockRenderer.RenderParagraph(
                         block = paragraph,
                         styling = markdownStyling.paragraph,


### PR DESCRIPTION
> [!NOTE]
> This PR supersedes #3421 :) 

# Context

Images that fail to load are now rendered as clickable hyperlinks instead of showing raw Markdown syntax or blank placeholders.

## Changes

Failed Image Handling:
  - Images that fail to load are replaced with clickable links showing the alt text (or URL if no alt text)
  - A broken image indicator (🖼) is prepended to the link text
  - Repeated images with the same URL but different alt text render independently

Loading States:
  - Added `ImageRenderResult` sealed interface with `Loading`, `Success`, and `Failed` states
  - A loading indicator is shown while an image is being fetched; when the image specifies
      width/height, the loading placeholder reserves that size so the layout doesn't shift on load
  - Source changes are debounced (~300ms) so editing a URL doesn't fire loads for transient,
      invalid intermediate values and flash the broken-link fallback
  - Switching between valid images keeps the previous one on screen (stale-while-revalidate) rather than flashing the loading indicator (it causes flickering which I do not like at alllll)

API Changes:
  - New `ImageRendererExtension.renderImage` method returning `ImageRenderResult` for explicit state handling
  - `Deprecated renderImageContent` method (preserved for backward compatibility)

## Evidence

| Scenario | Failed image | Debounce while typing | Failed -> Loading -> Success | Swapping Valid Images | Same URL, different alt text | Failed image inside of heading |
|---|---|---|---|---|---|---|
| Screen Recording | <video src="https://github.com/user-attachments/assets/4d936944-1d77-493f-aa80-e8070fb043e6" /> | <video src="https://github.com/user-attachments/assets/4b2142c4-e882-4d26-ac70-69e67577d71d" /> | <video src="https://github.com/user-attachments/assets/3e14c038-1513-4465-822e-319a0aee2b60" /> | <video src="https://github.com/user-attachments/assets/8fe5ceb7-1b27-4066-8520-d418012290ba" /> | <video src="https://github.com/user-attachments/assets/825ca7dd-a069-445f-a73f-4c56d2e2b277" /> | <video src="https://github.com/user-attachments/assets/5c5ec092-5caf-4bea-b81f-fba09c356d12" /> |

| |  Screenshot |
|--------|--------|
| Preserving style applied in a broken link | <img width="797" height="169" alt="image" src="https://github.com/user-attachments/assets/7229de1c-e347-43be-b906-3f8954eafb88" /> |
| Preserving outer link destination URL | <img width="795" height="91" alt="image" src="https://github.com/user-attachments/assets/a8354205-3f1a-46fe-88bf-891790f5d341" /> |
| Using destination as alt if no alt is provided | <img width="797" height="95" alt="image" src="https://github.com/user-attachments/assets/6c60f4b5-5322-418f-ac80-2f5bcbfe2195" /> |

## Release notes

### ⚠️ Important Changes
 - Images that fail to load are now rendered as clickable links instead of showing raw Markdown syntax

### New features
 - In Markdown, images that fail to load are now rendered as hyperlinks

### Deprecated API
- Deprecated `ImageRendererExtension.renderImageContent`; use `renderImage` instead, which provides explicit loading/success/failed states