### PR TITLE
[JEWEL-1363] Fix missing slf4j-api in standalone sample Bazel build 

### DIFF
--- a/platform/jewel/samples/standalone/BUILD.bazel
+++ b/platform/jewel/samples/standalone/BUILD.bazel
@@ -41,6 +41,7 @@ jvm_library(
     visibility = ["//visibility:public"],
     runtime_deps = [
         # do not sort,
+        "@lib//:slf4j-api",
         "@lib//:platform-jewel-samples-standalone-org-lwjgl-lwjgl-tinyfd",
         "@lib//:platform-jewel-samples-standalone-org-nibor-autolink-autolink",
         "@lib//:jna",

--- a/platform/jewel/samples/standalone/intellij.platform.jewel.samples.standalone.iml
+++ b/platform/jewel/samples/standalone/intellij.platform.jewel.samples.standalone.iml
@@ -35,6 +35,7 @@
     <orderEntry type="library" name="kotlin-stdlib" level="project" />
     <orderEntry type="module" module-name="intellij.libraries.kotlinx.coroutines.core" />
     <orderEntry type="library" name="jetbrains-annotations" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="slf4j-api" level="project" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="intellij.platform.jewel.markdown.extensions.autolink" />
     <orderEntry type="module" module-name="intellij.platform.jewel.ui" />


### PR DESCRIPTION
# Context

Running the standalone sample through Bazel (`bazel run //platform/jewel/samples/standalone:standalone_sample`) broke Markdown image loading: every request from Coil's Ktor network fetcher crashed with
`java.lang.NoClassDefFoundError: Could not initialize class io.ktor.client.plugins.HttpRequestLifecycleKt`, whose root cause is `NoClassDefFoundError: org/slf4j/LoggerFactory`. The same sample ran fine through
Gradle (`./gradlew :samples:standalone:run`).

Check out the entire stacktrace below:

<details><summary>Stacktrace</summary>
<p>

```
WARNING: AsyncImage loading failed.
  java.lang.NoClassDefFoundError: Could not initialize class io.ktor.client.plugins.HttpRequestLifecycleKt
      at io.ktor.client.HttpClient.<init>(HttpClient.kt:1373)
      at io.ktor.client.HttpClient.<init>(HttpClient.kt:1293)
      at io.ktor.client.HttpClientKt.HttpClient(HttpClient.kt:650)
      at io.ktor.client.HttpClientJvmKt.HttpClient(HttpClientJvm.kt:25)
      at io.ktor.client.HttpClientJvmKt.HttpClient$default(HttpClientJvm.kt:23)
      at coil3.network.ktor3.KtorNetworkFetcher.KtorNetworkFetcherFactory$lambda$0(KtorNetworkFetcher.kt:16)
      at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:86)
      at coil3.network.NetworkFetcher.executeNetworkRequest(NetworkFetcher.kt:201)
      at coil3.network.NetworkFetcher.fetch(NetworkFetcher.kt:74)
      at coil3.intercept.EngineInterceptor.fetch(EngineInterceptor.kt:169)
      at coil3.intercept.EngineInterceptor.execute(EngineInterceptor.kt:126)
      at coil3.intercept.EngineInterceptor.access$execute(EngineInterceptor.kt:43)
      at coil3.intercept.EngineInterceptor$intercept$2.invokeSuspend(EngineInterceptor.kt:77)
      at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
      at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
      at kotlinx.coroutines.internal.SoftLimitedDispatcher$Worker.run(SoftLimitedDispatcher.kt:130)
      at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
      at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:610)
      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:1188)
      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:775)
      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:762)
  Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory [in thread "DefaultDispatcher-worker-7"]
      at io.ktor.util.logging.KtorSimpleLoggerJvmKt.KtorSimpleLogger(KtorSimpleLoggerJvm.kt:10)
      at io.ktor.client.plugins.HttpRequestLifecycleKt.<clinit>(HttpRequestLifecycle.kt:13)
```

</p>
</details> 

## Investigation

Ktor's JVM logger (`KtorSimpleLogger`) calls `org.slf4j.LoggerFactory` directly, so `slf4j-api` has to be on the runtime classpath. The two build systems get it there in different ways, and only one of them actually did.

### Gradle and its sneaky transitive dependency
Gradle reads Maven POMs and resolves transitive dependencies, so `coil3-network-ktor3` pulls in `ktor-client-core-jvm`, whose POM declares `org.slf4j:slf4j-api` at compile scope, so the jar lands on the classpath without anyone writing it down. With no slf4j binding present, slf4j 2.x falls back to its NOP logger and images load fine.


### The JPS to Bazel Script
The JPS model, and the Bazel build generated from it, imports every Maven jar with `include-transitive-deps="false"`. The POM's dependency list is ignored, and every transitive dependency has to be re-declared by hand in some module. The sample's runtime classpath is the closure of hand-written module edges:

intellij.platform.jewel.samples.standalone
  └─ intellij.libraries.coil
      └─ intellij.libraries.ktor.client
          └─ ktor-client-core, ktor-client-java, ... (jars)

Every hop in that chain was declared, which is why all the Ktor jars are present. The one thing nobody ever mirrored over from the POMs is Ktor's own dependency on `slf4j-api`. The omission stayed invisible because every other consumer of `intellij.libraries.ktor.client` runs inside the IDE, where the platform packs `slf4j-api` and `slf4j-jdk14` into `lib/util-8.jar` (see `PlatformModules.kt`). The standalone sample's `java_binary` is the first consumer whose classpath is only the declared Bazel closure, with no platform underneath to hide the gap.

# Changes

- Added `slf4j-api` as a RUNTIME project-library dependency to `intellij.platform.jewel.samples.standalone.iml`.
- Regenerated the Bazel files with `jpsModelToBazelCommunityOnly.cmd`, which adds `@lib//:slf4j-api` to the `runtime_deps` of the standalone target.

The result matches the Gradle run's behavior: `slf4j-api` with no binding, so Ktor logs go to the NOP logger.

> [!NOTE]
>  We kept the fix at the Jewel sample level on purpose. The dependency arguably belongs in `intellij.libraries.ktor.client`, since that module owns the jars that need it, but adding it there changes the runtime classpath of every `ktor.client` consumer in the monorepo for a problem that only affects standalone `java_binary` targets. If more standalone Bazel binaries run into this, moving the declaration into `intellij.libraries.ktor.client` is the natural follow-up.

# Screenshots

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/c4c7e19d-bfa5-42a9-9c7b-37ded97bccf5" /> | <video src="https://github.com/user-attachments/assets/051c3129-0613-47c5-9f62-51d9d38bc24d" /> | 