### PR TITLE
IDEA-347862 Lombok: Fix false-negative for redundant slf4j definition inspection

### DIFF
--- a/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/inspection/RedundantSlf4jDefinitionInspection.java
+++ b/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/inspection/RedundantSlf4jDefinitionInspection.java
@@ -4,20 +4,21 @@ import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.JavaElementVisitor;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiClassObjectAccessExpression;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiExpression;
 import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.util.PsiUtil;
+import com.siyeh.ig.callMatcher.CallMatcher;
 import de.plushnikov.intellij.plugin.LombokBundle;
 import de.plushnikov.intellij.plugin.processor.clazz.log.Slf4jProcessor;
 import de.plushnikov.intellij.plugin.quickfix.UseSlf4jAnnotationQuickFix;
 import org.jetbrains.annotations.NotNull;
 
-import static java.lang.String.format;
-
 public final class RedundantSlf4jDefinitionInspection extends LombokJavaInspectionBase {
 
   private static final String LOGGER_SLF4J_FQCN = Slf4jProcessor.LOGGER_TYPE;
-  private static final String LOGGER_INITIALIZATION = "LoggerFactory.getLogger(%s.class)";
 
   @Override
   protected @NotNull PsiElementVisitor createVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
@@ -38,12 +39,30 @@ public final class RedundantSlf4jDefinitionInspection extends LombokJavaInspecti
       findRedundantDefinition(field);
     }
 
+    private static final CallMatcher LOGGER_FACTORY_GET_LOGGER = CallMatcher.staticCall("org.slf4j.LoggerFactory", "getLogger")
+      .parameterTypes("java.lang.Class");
+
+    private static boolean isLoggerInitCall(PsiExpression initializer, PsiClass containingClass) {
+      initializer = PsiUtil.skipParenthesizedExprDown(initializer);
+      if (!(initializer instanceof PsiMethodCallExpression call) || !LOGGER_FACTORY_GET_LOGGER.test(call)) {
+        return false;
+      }
+
+      PsiExpression argument = PsiUtil.skipParenthesizedExprDown(call.getArgumentList().getExpressions()[0]);
+      if (!(argument instanceof PsiClassObjectAccessExpression classLiteral)) {
+        return false;
+      }
+
+      PsiClass referencedClass = PsiUtil.resolveClassInClassTypeOnly(classLiteral.getOperand().getType());
+      return referencedClass != null && containingClass.getManager().areElementsEquivalent(referencedClass, containingClass);
+    }
+
     private void findRedundantDefinition(@NotNull PsiField field) {
       if (field.getType().equalsToText(LOGGER_SLF4J_FQCN)) {
         final PsiExpression initializer = field.getInitializer();
         final PsiClass containingClass = field.getContainingClass();
         if (initializer != null && containingClass != null) {
-          if (initializer.getText().contains(format(LOGGER_INITIALIZATION, containingClass.getQualifiedName()))) {
+          if (isLoggerInitCall(initializer, containingClass)) {
             holder.registerProblem(field, LombokBundle.message("inspection.message.slf4j.logger.defined.explicitly"),
                                    LocalQuickFix.from(new UseSlf4jAnnotationQuickFix(field, containingClass)));
           }

--- a/plugins/lombok/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantSlf4jDefinitionInspectionTest.java
+++ b/plugins/lombok/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantSlf4jDefinitionInspectionTest.java
@@ -19,4 +19,8 @@ public class RedundantSlf4jDefinitionInspectionTest extends LombokInspectionTest
     checkQuickFix("Replace logger field with @Slf4j annotation");
   }
 
+  public void testRedundantSlf4jDefinitionInPackage() {
+    doTest();
+    checkQuickFix("Replace logger field with @Slf4j annotation");
+  }
 }

--- a/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinition.after.java
+++ b/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinition.after.java
@@ -1,6 +1,7 @@
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static org.slf4j.LoggerFactory.getLogger;
 
 @Slf4j
 class RedundantSlf4jDefinition {
@@ -8,6 +9,8 @@ class RedundantSlf4jDefinition {
     org.slf4j.Logger LOG2 = org.slf4j.LoggerFactory.getLogger(RedundantSlf4jDefinition.class);
 
   Logger LOG3 = LoggerFactory.getLogger(RedundantSlf4jDefinition.class);
+
+  Logger LOG4 = getLogger(RedundantSlf4jDefinition.class);
 
   void foo() {
     log.info("foo() called");

--- a/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinition.java
+++ b/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinition.java
@@ -1,5 +1,6 @@
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static org.slf4j.LoggerFactory.getLogger;
 
 class RedundantSlf4jDefinition {
   <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">private static final org.slf4j.Logger LOG1<caret> = org.slf4j.LoggerFactory.getLogger(RedundantSlf4jDefinition.class);</warning>
@@ -7,6 +8,8 @@ class RedundantSlf4jDefinition {
   <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">org.slf4j.Logger LOG2 = org.slf4j.LoggerFactory.getLogger(RedundantSlf4jDefinition.class);</warning>
 
   <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">Logger LOG3 = LoggerFactory.getLogger(RedundantSlf4jDefinition.class);</warning>
+
+  <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">Logger LOG4 = getLogger(RedundantSlf4jDefinition.class);</warning>
 
   void foo() {
     LOG1.info("foo() called");

--- a/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinitionInPackage.after.java
+++ b/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinitionInPackage.after.java
@@ -1,0 +1,24 @@
+package foo;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Slf4j
+class RedundantSlf4jDefinitionInPackage {
+
+    org.slf4j.Logger LOG2 = org.slf4j.LoggerFactory.getLogger(RedundantSlf4jDefinitionInPackage.class);
+
+  Logger LOG3 = LoggerFactory.getLogger(RedundantSlf4jDefinitionInPackage.class);
+
+  Logger LOG4 = getLogger(RedundantSlf4jDefinitionInPackage.class);
+
+  void foo() {
+    log.info("foo() called");
+  }
+
+  public static void main(String[] args) {
+    log.info("Using LOG1 Logger");
+  }
+}

--- a/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinitionInPackage.java
+++ b/plugins/lombok/testData/inspection/redundantSlf4jDeclaration/RedundantSlf4jDefinitionInPackage.java
@@ -1,0 +1,23 @@
+package foo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.slf4j.LoggerFactory.getLogger;
+
+class RedundantSlf4jDefinitionInPackage {
+  <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">private static final org.slf4j.Logger LOG1<caret> = org.slf4j.LoggerFactory.getLogger(RedundantSlf4jDefinitionInPackage.class);</warning>
+
+  <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">org.slf4j.Logger LOG2 = org.slf4j.LoggerFactory.getLogger(RedundantSlf4jDefinitionInPackage.class);</warning>
+
+  <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">Logger LOG3 = LoggerFactory.getLogger(RedundantSlf4jDefinitionInPackage.class);</warning>
+
+  <warning descr="Slf4j Logger is defined explicitly. Use Lombok @Slf4j annotation instead.">Logger LOG4 = getLogger(RedundantSlf4jDefinitionInPackage.class);</warning>
+
+  void foo() {
+    LOG1.info("foo() called");
+  }
+
+  public static void main(String[] args) {
+    LOG1.info("Using LOG1 Logger");
+  }
+}


### PR DESCRIPTION
The inspection only worked on classes without a package (or if the getLogger call used the fully qualified class name) because `PsiClass.getQualifiedName` returns the whole name.

```java
initializer.getText() // LoggerFactory.getLogger(org.example.Test.class)
  .contains(format(LOGGER_INITIALIZATION, containingClass.getQualifiedName())) // LoggerFactory.getLogger(Test.class)
```

The fix swaps the simple text-based comparison to a `CallMatcher` with some further validation. Also added some tests to verify that it's working correctly.

cc @mikosik (assigned to the issue in YouTrack)