### PR TITLE
[JEWEL-1369] Fix stroked icons rendering incorrectly across frontends

### DIFF
--- a/platform/icons-impl/intellij/src/com/intellij/platform/icons/impl/intellij/rendering/Convertors.kt
+++ b/platform/icons-impl/intellij/src/com/intellij/platform/icons/impl/intellij/rendering/Convertors.kt
@@ -55,8 +55,7 @@ private class ProxySvgAttributePatcher(
         }
         SvgPatchOperation.Operation.Replace -> {
           if (operation.conditional) {
-            val matches = attributes[operation.attributeName] == operation.expectedValue
-            if (matches == !operation.negatedCondition) {
+            if (operation.matches(attributes[operation.attributeName]) != operation.negatedCondition) {
               attributes.replace(operation.attributeName, operation.value!!)
             }
           } else {
@@ -65,8 +64,7 @@ private class ProxySvgAttributePatcher(
         }
         SvgPatchOperation.Operation.Remove -> {
           if (operation.conditional) {
-            val matches = attributes[operation.attributeName] == operation.expectedValue
-            if (matches == !operation.negatedCondition) {
+            if (operation.matches(attributes[operation.attributeName]) != operation.negatedCondition) {
               attributes.remove(operation.attributeName)
             }
           } else {

--- a/platform/icons-impl/intellij/src/com/intellij/platform/icons/impl/intellij/rendering/images/SwingImageResourceHolder.kt
+++ b/platform/icons-impl/intellij/src/com/intellij/platform/icons/impl/intellij/rendering/images/SwingImageResourceHolder.kt
@@ -7,8 +7,8 @@ import com.intellij.ui.scale.ScaleContext
 import com.intellij.platform.icons.impl.intellij.rendering.toAwtFilter
 import com.intellij.platform.icons.impl.intellij.rendering.toIJPatcher
 import com.intellij.platform.icons.impl.patchers.DefaultSvgPatcher
+import com.intellij.platform.icons.impl.patchers.strokeSvgPatcher
 import com.intellij.platform.icons.impl.rendering.DefaultImageModifiers
-import com.intellij.platform.icons.patchers.svgPatcher
 import com.intellij.platform.icons.rendering.Dimensions
 import com.intellij.platform.icons.rendering.ImageModifiers
 import java.awt.Image
@@ -26,18 +26,22 @@ internal fun ImageModifiers?.toLoadParameters(): LoadIconParameters {
     filters.add(colorFilter.toAwtFilter())
   }
   val knownModifiers = this as? DefaultImageModifiers
-  val strokePatcher = knownModifiers?.stroke?.let { stroke ->
-    svgPatcher {
-      replace("fill", "transparent")
-      add("stroke", stroke.toHex())
-    }
-  }
+  val strokePatcher = knownModifiers?.stroke?.let { strokeSvgPatcher(it) }
   val ijModifiers = this as? IntelliJImageModifiers
-  val colorPatcher = ((this?.svgPatcher?.combineWith(strokePatcher)) as? DefaultSvgPatcher)?.toIJPatcher(ijModifiers?.legacyPatcherProvider)
+  // The icon's own patcher runs first and the stroke substitution after it, so an icon that explicitly recolors a
+  // palette color keeps that color: the stroke operation no longer matches what the explicit one already replaced.
+  // The elvis is what keeps a stroke-only icon patched at all — `svgPatcher` is null whenever an icon carries no
+  // explicit patcher, and combining outwards from null would discard the stroke patcher entirely.
+  val combinedPatcher = this?.svgPatcher?.combineWith(strokePatcher) ?: strokePatcher
+  val colorPatcher = (combinedPatcher as? DefaultSvgPatcher)?.toIJPatcher(ijModifiers?.legacyPatcherProvider)
+  val isStroke = knownModifiers?.stroke != null
   return LoadIconParameters(
     filters = filters,
-    isDark = knownModifiers?.isDark ?: false,
+    // A stroked icon loads its light artwork even in a dark theme. The palette describes the light variants, so
+    // resolving `_dark` first would hand the patcher colors it does not know and the icon would keep its authored
+    // ones — and the artwork is about to be recolored wholesale anyway, so which variant it started from is moot.
+    isDark = !isStroke && knownModifiers?.isDark == true,
     colorPatcher = colorPatcher,
-    isStroke = knownModifiers?.stroke != null
+    isStroke = isStroke
   )
 }

--- a/platform/icons-impl/intellij/tests/test/com/intellij/platform/icons/impl/intellij/StrokePatcherTest.kt
+++ b/platform/icons-impl/intellij/tests/test/com/intellij/platform/icons/impl/intellij/StrokePatcherTest.kt
@@ -1,0 +1,117 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.platform.icons.impl.intellij
+
+import com.intellij.platform.icons.impl.design.DefaultSRGB
+import com.intellij.platform.icons.impl.patchers.DefaultSvgPatcher
+import com.intellij.platform.icons.impl.patchers.SvgPatchOperation
+import com.intellij.platform.icons.impl.patchers.strokeSvgPatcher
+import com.intellij.testFramework.junit5.TestApplication
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+
+/**
+ * Pins the shape of the stroke patch itself: which colors it covers, which attributes it touches, and how selectively.
+ *
+ * New UI icons are authored in two styles — `<path fill="#6C707E">` and `<path fill="none" stroke="#6C707E">` — so a
+ * substitution that touches only one attribute silently leaves every icon of the other style in its authored gray. It
+ * also has to stay a palette substitution rather than a blanket one, since replacing every `fill` outright erases
+ * icons drawn from filled shapes. Palette colors can be spelled as hex or as a keyword, and both have to match.
+ *
+ * The expected colors are spelled out here rather than read back from the patcher's own palette, so that dropping one
+ * fails the test instead of quietly shrinking what it checks. They mirror the legacy Swing stroke patcher in
+ * `com.intellij.ui.icons`, which is the palette both are expected to agree on.
+ */
+@TestApplication
+class StrokePatcherTest {
+  // Built directly, not via sRGB(), which would need the IconManager before it is activated.
+  private val red = DefaultSRGB.fromHex("#FF0000")
+
+  @BeforeEach
+  fun activateIconManager() {
+    // strokeSvgPatcher builds its patcher through the IconManager, so this class cannot rely on some other test
+    // having activated it first.
+    IntelliJIconManager.activate()
+  }
+
+  @Test
+  fun `stroking recolors every foreground palette color, on both attributes`() {
+    for (color in FOREGROUND) {
+      assertRecolored(color, "foreground palette color")
+    }
+  }
+
+  @Test
+  fun `stroking recolors colors spelled as keywords`() {
+    // fill="black" and fill="#000000" are the same color to a renderer, but only one of them matches a hex palette.
+    for (keyword in FOREGROUND_KEYWORDS) {
+      assertRecolored(keyword, "color keyword")
+    }
+  }
+
+  @Test
+  fun `stroking drops every background palette color, on both attributes`() {
+    for (color in BACKGROUND) {
+      for (attribute in ATTRIBUTES) {
+        val match = conditionalReplacement(attribute, color)
+        assertNotNull(match) { "no $attribute replacement for background palette color $color" }
+        assert(match.value == "transparent") { "$attribute for $color became ${match.value}, wanted transparent" }
+      }
+    }
+  }
+
+  @Test
+  fun `stroking patches nothing beyond the palette`() {
+    // Every operation has to be accounted for: a stray one is a substitution nobody asked for.
+    val expected = (FOREGROUND.size + FOREGROUND_KEYWORDS.size + BACKGROUND.size) * ATTRIBUTES.size
+    val actual = operations().size
+    assert(actual == expected) { "expected $expected operations for the palette, got $actual: ${operations()}" }
+  }
+
+  @Test
+  fun `stroking never blanks an attribute unconditionally`() {
+    // An unconditional replace is what erases icons: it drops every fill, palette color or not.
+    val unconditional = operations().filter { !it.conditional }
+    assert(unconditional.isEmpty()) { "unconditional operations would erase off-palette artwork: $unconditional" }
+  }
+
+  private fun assertRecolored(value: String, what: String) {
+    for (attribute in ATTRIBUTES) {
+      val match = conditionalReplacement(attribute, value)
+      assertNotNull(match) { "no $attribute replacement for $what $value" }
+      assert(match.value == red.toHex()) { "$attribute for $value became ${match.value}, wanted red" }
+    }
+  }
+
+  private fun conditionalReplacement(attribute: String, expectedValue: String): SvgPatchOperation? =
+    operations().singleOrNull {
+      it.attributeName == attribute &&
+      it.operation == SvgPatchOperation.Operation.Replace &&
+      it.conditional &&
+      it.expectedValue == expectedValue
+    }
+
+  private fun operations(): List<SvgPatchOperation> {
+    val patcher = strokeSvgPatcher(red) as? DefaultSvgPatcher
+    assertNotNull(patcher)
+    return patcher.operations
+  }
+
+  private companion object {
+    private val ATTRIBUTES = listOf("fill", "stroke")
+
+    // Lowercase, because that is what Color.toHex() produces and therefore what the conditions are built from.
+    private val FOREGROUND =
+      listOf(
+        "#000000", "#ffffff", "#818594", "#6c707e", "#3574f0", "#5fb865", "#e35252",
+        "#eb7171", "#e3ae4d", "#fcc75b", "#f28c35", "#955ae0", "#a8adbd", "#ced0d6",
+      )
+
+    private val FOREGROUND_KEYWORDS = listOf("black", "white")
+
+    private val BACKGROUND =
+      listOf(
+        "#ebecf0", "#e7effd", "#dff2e0", "#f2fcf3", "#ffe8e8", "#fff5f5", "#fff8e3", "#fff4eb", "#eee0ff",
+      )
+  }
+}

--- a/platform/icons-impl/intellij/tests/test/com/intellij/platform/icons/impl/intellij/StrokeRenderTest.kt
+++ b/platform/icons-impl/intellij/tests/test/com/intellij/platform/icons/impl/intellij/StrokeRenderTest.kt
@@ -1,0 +1,181 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.platform.icons.impl.intellij
+
+import com.intellij.platform.icons.imageIcon
+import com.intellij.platform.icons.impl.design.DefaultSRGB
+import com.intellij.platform.icons.modifiers.IconModifier
+import com.intellij.platform.icons.modifiers.patchSvg
+import com.intellij.platform.icons.modifiers.stroke
+import com.intellij.platform.icons.patchers.svgPatcher
+import com.intellij.platform.icons.swing.toSwingIcon
+import com.intellij.testFramework.junit5.TestApplication
+import java.awt.image.BufferedImage
+import javax.swing.UIManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Renders real New UI icons through the actual Swing path — `imageIcon(...).toSwingIcon().paintIcon(...)`, the same one
+ * a Swing toolbar takes — and inspects the resulting pixels.
+ *
+ * Stroking only holds end to end if every stage agrees: the patcher has to be built, survive being combined with
+ * whatever else patches the icon, reach the renderer, and match the color values the SVG was actually authored with.
+ * Asserting over the patch description alone sees none of that, so this asserts on the rasterized output.
+ *
+ * Both authoring styles New UI icons come in are covered, since a substitution that handles one can silently miss the
+ * other: fill-authored (`<path fill="#6C707E">`, e.g. softWrap) and stroke-authored
+ * (`<path fill="none" stroke="#6C707E">`, e.g. save and inlaySettings). Each is checked in both states — unstroked it
+ * keeps its authored gray, stroked it is fully recolored with none of that gray left behind.
+ */
+@TestApplication
+class StrokeRenderTest {
+  // Built directly, not via sRGB(), which would need the IconManager before it is activated.
+  private val red = DefaultSRGB.fromHex("#FF0000")
+
+  @BeforeEach
+  fun activateIconManager() {
+    // Building a patcher goes through the IconManager (svgPatcher {} included), so no test here can rely on some other
+    // test having activated it first: JUnit runs `an icon's own patcher wins...` before anything calls render().
+    IntelliJIconManager.activate()
+  }
+
+  @Test
+  fun `fill-authored icon strokes red`() {
+    assertStrokedRed("expui/general/softWrap.svg")
+  }
+
+  @Test
+  fun `stroke-authored icon strokes red`() {
+    assertStrokedRed("expui/general/save.svg")
+  }
+
+  @Test
+  fun `another stroke-authored icon strokes red`() {
+    assertStrokedRed("expui/codeInsight/inlaySettings.svg")
+  }
+
+  @Test
+  fun `icons stroke red in a dark theme too`() {
+    // A dark variant is authored in its own grays (inlaySettings_dark.svg is #9DA0A8), which are not stroke palette
+    // colors. Resolving it while stroking would leave the icon in those grays, so stroking must take the light artwork.
+    val path = "expui/codeInsight/inlaySettings.svg"
+    val light = render(path, IconModifier)
+
+    withDarkTheme {
+      // Guard: without this the theme override could silently not reach the loader and the test would prove nothing.
+      val dark = render(path, IconModifier)
+      assertTrue(!sameImage(light, dark)) { "$path rendered identically in both themes, so the dark theme never applied" }
+
+      // Assert on "every opaque pixel is red" rather than on the absence of a specific gray: which gray an unstroked
+      // icon shows is theme-dependent, but a fully recolored glyph is not.
+      assertFullyRed(path)
+      assertFullyRed("expui/general/softWrap.svg")
+    }
+  }
+
+  private fun assertFullyRed(path: String) {
+    val stroked = count(render(path, IconModifier.stroke(red)))
+    println("[stroke-render/dark] $path  stroked=[$stroked]")
+    assertTrue(stroked.opaque > 0) { "$path: the stroked icon rendered nothing at all" }
+    assertEquals(stroked.opaque, stroked.red, "$path: stroking left non-red pixels behind, got $stroked")
+  }
+
+  @Test
+  fun `an icon's own patcher wins over the stroke substitution`() {
+    // Both target #6C707E. The icon's patcher runs first, so the stroke operation finds green and no longer matches;
+    // reversing the order would silently override whatever an icon deliberately recolors.
+    val path = "expui/general/softWrap.svg"
+    val green = DefaultSRGB.fromHex("#00FF00")
+    val ownPatcher = svgPatcher { replaceIfMatches("fill", "#6c707e", green.toHex()) }
+    val counts = count(render(path, IconModifier.patchSvg(ownPatcher).stroke(red)))
+
+    println("[stroke-render/order] $path  $counts")
+    // Both halves matter: green proves the icon's own patcher ran at all, and no red proves stroking did not
+    // override it. Asserting only the absence of red would also pass on a blank or unpatched render.
+    assertTrue(counts.green > 0) { "$path: the icon's own patcher did not take effect, got $counts" }
+    assertEquals(0, counts.red, "$path: the stroke color overrode the icon's own patcher, got $counts")
+  }
+
+  private fun assertStrokedRed(path: String) {
+    val plain = count(render(path, IconModifier))
+    val stroked = count(render(path, IconModifier.stroke(red)))
+    println("[stroke-render] $path  plain=[$plain]  stroked=[$stroked]")
+
+    // Control: the unstroked icon renders in its authored gray, never red.
+    assertTrue(plain.gray > 0) { "$path: expected the unstroked icon to render gray pixels, got $plain" }
+    assertEquals(0, plain.red, "$path: the unstroked icon must not contain red pixels, got $plain")
+
+    // Stroking recolors the whole glyph: red appears, and none of the authored gray survives.
+    assertTrue(stroked.red > 0) { "$path: expected stroking to produce red pixels, got $stroked" }
+    assertEquals(0, stroked.gray, "$path: stroking must replace the authored gray, but gray pixels remain: $stroked")
+  }
+
+  private fun render(path: String, modifier: IconModifier): BufferedImage {
+    IntelliJIconManager.activate()
+    val swingIcon = imageIcon(path, StrokeRenderTest::class.java.classLoader, modifier).toSwingIcon()
+    val image = BufferedImage(swingIcon.iconWidth, swingIcon.iconHeight, BufferedImage.TYPE_INT_ARGB)
+    val g = image.createGraphics()
+    try {
+      swingIcon.paintIcon(null, g, 0, 0)
+    } finally {
+      g.dispose()
+    }
+    return image
+  }
+
+  private fun count(image: BufferedImage): Counts {
+    var red = 0
+    var green = 0
+    var gray = 0
+    var opaque = 0
+    for (y in 0 until image.height) {
+      for (x in 0 until image.width) {
+        val argb = image.getRGB(x, y)
+        val a = argb ushr 24 and 0xFF
+        if (a < 128) continue
+        opaque++
+        val r = argb ushr 16 and 0xFF
+        val g = argb ushr 8 and 0xFF
+        val b = argb and 0xFF
+        // Strongly red: the stroke color took over the glyph.
+        if (r > 140 && g < 110 && b < 110) red++
+        // Strongly green: the icon's own patcher took over the glyph.
+        if (g > 140 && r < 110 && b < 110) green++
+        // The authored New UI gray (#6C707E ~ 108,112,126): near-equal channels in the mid range.
+        if (r in 70..190 && kotlin.math.abs(r - g) < 24 && kotlin.math.abs(g - b) < 28) gray++
+      }
+    }
+    return Counts(red, green, gray, opaque)
+  }
+
+  private fun withDarkTheme(action: () -> Unit) {
+    val defaults = UIManager.getLookAndFeelDefaults()
+    val previous = defaults.get(DARK_THEME_KEY)
+    defaults.put(DARK_THEME_KEY, true)
+    try {
+      action()
+    } finally {
+      defaults.put(DARK_THEME_KEY, previous)
+    }
+  }
+
+  private fun sameImage(a: BufferedImage, b: BufferedImage): Boolean {
+    if (a.width != b.width || a.height != b.height) return false
+    for (y in 0 until a.height) {
+      for (x in 0 until a.width) {
+        if (a.getRGB(x, y) != b.getRGB(x, y)) return false
+      }
+    }
+    return true
+  }
+
+  private class Counts(val red: Int, val green: Int, val gray: Int, val opaque: Int) {
+    override fun toString(): String = "red=$red green=$green gray=$gray opaque=$opaque"
+  }
+
+  private companion object {
+    private const val DARK_THEME_KEY = "ui.theme.is.dark"
+  }
+}

--- a/platform/icons-impl/intellij/tests/test/com/intellij/platform/icons/impl/intellij/SvgPatchOperationMatchesTest.kt
+++ b/platform/icons-impl/intellij/tests/test/com/intellij/platform/icons/impl/intellij/SvgPatchOperationMatchesTest.kt
@@ -1,0 +1,77 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.platform.icons.impl.intellij
+
+import com.intellij.platform.icons.impl.patchers.SvgPatchOperation
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins how a patch operation decides whether its condition holds.
+ *
+ * Every frontend resolves operations through this one method, so its answer is what makes the same icon render the same
+ * way everywhere. The rule is narrow on purpose: case folding is correct for a color literal and wrong for anything
+ * that carries an identifier.
+ */
+class SvgPatchOperationMatchesTest {
+  @Test
+  fun `hex colors match regardless of case`() {
+    assertTrue(condition("fill", "#6c707e").matches("#6C707E"))
+    assertTrue(condition("stroke", "#6C707E").matches("#6c707e"))
+  }
+
+  @Test
+  fun `color keywords match regardless of case`() {
+    assertTrue(condition("fill", "white").matches("WHITE"))
+    assertTrue(condition("fill", "none").matches("None"))
+  }
+
+  @Test
+  fun `hyphenated paint keywords match regardless of case`() {
+    assertTrue(condition("fill", "context-fill").matches("CONTEXT-FILL"))
+    assertTrue(condition("stroke", "context-stroke").matches("Context-Stroke"))
+  }
+
+  @Test
+  fun `every color-valued attribute folds case`() {
+    // `color` feeds `currentColor`, and the gradient and filter attributes are colors just as much as fill is.
+    for (attribute in listOf("color", "solid-color", "stop-color", "flood-color", "lighting-color")) {
+      assertTrue(condition(attribute, "#aabbcc").matches("#AABBCC")) { "$attribute did not fold case" }
+    }
+  }
+
+  @Test
+  fun `different colors do not match`() {
+    assertFalse(condition("fill", "#6c707e").matches("#818594"))
+    assertFalse(condition("fill", "white").matches("black"))
+  }
+
+  @Test
+  fun `paint references keep their case`() {
+    // The fragment in url(#id) names an element, and element ids are case-sensitive: folding case here would
+    // repaint whichever gradient happened to differ only in capitalisation.
+    assertFalse(condition("fill", "url(#gradient)").matches("url(#Gradient)"))
+    assertTrue(condition("fill", "url(#gradient)").matches("url(#gradient)"))
+  }
+
+  @Test
+  fun `non-color attributes keep their case`() {
+    assertFalse(condition("id", "gradient").matches("Gradient"))
+    assertTrue(condition("id", "gradient").matches("gradient"))
+  }
+
+  @Test
+  fun `an absent attribute matches nothing`() {
+    assertFalse(condition("fill", "#6c707e").matches(null))
+  }
+
+  private fun condition(attribute: String, expected: String): SvgPatchOperation =
+    SvgPatchOperation(
+      attributeName = attribute,
+      value = "#ff0000",
+      conditional = true,
+      negatedCondition = false,
+      expectedValue = expected,
+      operation = SvgPatchOperation.Operation.Replace,
+    )
+}

--- a/platform/icons-impl/src/com/intellij/platform/icons/impl/patchers/StrokePatcher.kt
+++ b/platform/icons-impl/src/com/intellij/platform/icons/impl/patchers/StrokePatcher.kt
@@ -1,0 +1,80 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.platform.icons.impl.patchers
+
+import com.intellij.platform.icons.design.Color
+import com.intellij.platform.icons.impl.design.DefaultSRGB
+import com.intellij.platform.icons.patchers.SvgPatcher
+import com.intellij.platform.icons.patchers.svgPatcher
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * The SVG patch that renders an icon as a monochrome outline in [stroke].
+ *
+ * Stroking is a *palette* substitution, not a blanket one: IntelliJ icons are authored from a fixed set of design
+ * colors, so the background tints become transparent and the foreground tints become [stroke], while anything painted
+ * in a color outside those two sets is deliberately left alone. Blanking every `fill` instead would erase icons drawn
+ * entirely from filled shapes.
+ *
+ * Both the `fill` and the `stroke` attribute carry the substitution, because New UI icons come in two authoring
+ * styles — `<path fill="#6C707E">` and `<path fill="none" stroke="#6C707E">` — and patching only one of them leaves
+ * every icon of the other style in its authored gray.
+ *
+ * Every rendering backend has to stroke the same way, or one icon renders differently in a Swing toolbar than in a
+ * Compose one; this is the single definition they are all expected to use.
+ */
+@ApiStatus.Internal
+fun strokeSvgPatcher(stroke: Color): SvgPatcher = svgPatcher {
+    for (color in strokeBackgroundPalette) {
+        replaceIfMatches("fill", color.toHex(), "transparent")
+        replaceIfMatches("stroke", color.toHex(), "transparent")
+    }
+    for (color in strokeForegroundPalette) {
+        replaceIfMatches("fill", color.toHex(), stroke.toHex())
+        replaceIfMatches("stroke", color.toHex(), stroke.toHex())
+    }
+    for (keyword in strokeForegroundKeywords) {
+        replaceIfMatches("fill", keyword, stroke.toHex())
+        replaceIfMatches("stroke", keyword, stroke.toHex())
+    }
+}
+
+/**
+ * Foreground palette entries an SVG may spell as a color keyword rather than as hex.
+ *
+ * `fill="black"` and `fill="#000000"` are the same color to a renderer but not to an attribute-value comparison, so a
+ * palette expressed only in hex silently misses the keyword spelling.
+ */
+private val strokeForegroundKeywords: List<String> = listOf("black", "white")
+
+/** The design palette's background tints: the fills a stroked icon drops. */
+private val strokeBackgroundPalette: List<Color> =
+    listOf(
+        DefaultSRGB.fromHex("#EBECF0"),
+        DefaultSRGB.fromHex("#E7EFFD"),
+        DefaultSRGB.fromHex("#DFF2E0"),
+        DefaultSRGB.fromHex("#F2FCF3"),
+        DefaultSRGB.fromHex("#FFE8E8"),
+        DefaultSRGB.fromHex("#FFF5F5"),
+        DefaultSRGB.fromHex("#FFF8E3"),
+        DefaultSRGB.fromHex("#FFF4EB"),
+        DefaultSRGB.fromHex("#EEE0FF"),
+    )
+
+/** The design palette's foreground tints: the fills a stroked icon recolors. */
+private val strokeForegroundPalette: List<Color> =
+    listOf(
+        DefaultSRGB.fromHex("#000000"),
+        DefaultSRGB.fromHex("#FFFFFF"),
+        DefaultSRGB.fromHex("#818594"),
+        DefaultSRGB.fromHex("#6C707E"),
+        DefaultSRGB.fromHex("#3574F0"),
+        DefaultSRGB.fromHex("#5FB865"),
+        DefaultSRGB.fromHex("#E35252"),
+        DefaultSRGB.fromHex("#EB7171"),
+        DefaultSRGB.fromHex("#E3AE4D"),
+        DefaultSRGB.fromHex("#FCC75B"),
+        DefaultSRGB.fromHex("#F28C35"),
+        DefaultSRGB.fromHex("#955AE0"),
+        DefaultSRGB.fromHex("#A8ADBD"),
+        DefaultSRGB.fromHex("#CED0D6"),
+    )

--- a/platform/icons-impl/src/com/intellij/platform/icons/impl/patchers/SvgPatcher.kt
+++ b/platform/icons-impl/src/com/intellij/platform/icons/impl/patchers/SvgPatcher.kt
@@ -3,6 +3,7 @@ package com.intellij.platform.icons.impl.patchers
 
 import com.intellij.platform.icons.patchers.SvgPatcher
 import kotlinx.serialization.Serializable
+import org.jetbrains.annotations.ApiStatus
 
 @Serializable
 class DefaultSvgPatcher(
@@ -75,6 +76,25 @@ class SvgPatchOperation(
         Set,
     }
 
+    /**
+     * Whether [actualValue], the attribute's current value, satisfies this operation's condition.
+     *
+     * A plain color compares case-insensitively, because hex colors and keywords are case-insensitive in SVG:
+     * `#6C707E` and `#6c707e` are the same color, and which one a document uses is an authoring accident. Everything
+     * else compares exactly — an `id`, and equally the fragment in a `fill="url(#Gradient)"` paint reference, is
+     * case-sensitive, so folding case there would match a different paint server.
+     *
+     * Condition evaluation lives here rather than in each renderer so that every frontend resolves the same operation
+     * the same way; a renderer that compared differently would draw the same icon differently.
+     */
+    @ApiStatus.Internal
+    fun matches(actualValue: String?): Boolean =
+        if (attributeName in COLOR_ATTRIBUTES && isPlainColor(expectedValue) && isPlainColor(actualValue)) {
+            actualValue.equals(expectedValue, ignoreCase = true)
+        } else {
+            actualValue == expectedValue
+        }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -104,3 +124,28 @@ class SvgPatchOperation(
     override fun toString(): String =
         "SvgPatchOperation(attributeName='$attributeName', value=$value, conditional=$conditional, negatedCondition=$negatedCondition, expectedValue=$expectedValue, operation=$operation)"
 }
+
+/**
+ * The attributes whose values are colors, and so compare case-insensitively.
+ *
+ * Top-level rather than a companion: this class is `@Serializable`, and declaring a companion here would displace the
+ * one the serialization plugin generates, taking `SvgPatchOperation.serializer()` out of the public API with it.
+ */
+private val COLOR_ATTRIBUTES =
+    setOf("fill", "stroke", "color", "solid-color", "stop-color", "flood-color", "lighting-color")
+
+/** A hex triplet, with or without alpha. */
+private val HEX_COLOR = Regex("#[0-9a-fA-F]{3,8}")
+
+/**
+ * A bare word, hyphens allowed: a color keyword such as `white`, `none`, `transparent` or `context-fill`. Never a
+ * function like `url(...)`, which is the case-sensitive form this must not swallow.
+ */
+private val COLOR_KEYWORD = Regex("[a-zA-Z]+(-[a-zA-Z]+)*")
+
+/**
+ * Whether [value] is a plain color literal, as opposed to a paint reference such as `url(#Gradient)` whose fragment id
+ * is case-sensitive.
+ */
+private fun isPlainColor(value: String?): Boolean =
+    value != null && (HEX_COLOR.matches(value) || COLOR_KEYWORD.matches(value))

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/icon/ComposeImageResourceProvider.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/icon/ComposeImageResourceProvider.kt
@@ -1,14 +1,13 @@
 // Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package org.jetbrains.jewel.ui.icon
 
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.decodeToImageBitmap
 import androidx.compose.ui.unit.Density
 import com.intellij.platform.icons.ImageResourceLocation
 import com.intellij.platform.icons.impl.patchers.DefaultSvgPatcher
 import com.intellij.platform.icons.impl.patchers.SvgPatchOperation
+import com.intellij.platform.icons.impl.patchers.strokeSvgPatcher
 import com.intellij.platform.icons.impl.rendering.DefaultImageModifiers
-import com.intellij.platform.icons.patchers.svgPatcher
 import com.intellij.platform.icons.rendering.ImageModifiers
 import com.intellij.platform.icons.rendering.ImageResource
 import com.intellij.platform.icons.rendering.ImageResourceProvider
@@ -54,52 +53,18 @@ private fun patchSvg(modifiers: ImageModifiers?, inputStream: InputStream): Byte
     val document = builder.parse(inputStream)
 
     val knownModifiers = modifiers as? DefaultImageModifiers
-    val patcher =
-        knownModifiers
-            ?.stroke
-            ?.let { stroke ->
-                svgPatcher {
-                    for (color in backgroundPalette) {
-                        replaceIfMatches("fill", color.toIconsColor().toHex(), "transparent")
-                    }
-                    for (color in strokeColors) {
-                        replaceIfMatches("fill", color.toIconsColor().toHex(), stroke.toHex())
-                    }
-                }
-            }
-            ?.combineWith(modifiers.svgPatcher)
+    // The palette substitution lives in the platform, so this frontend and the Swing one cannot drift into stroking
+    // the same icon differently.
+    val strokePatcher = knownModifiers?.stroke?.let { strokeSvgPatcher(it) }
+    // Same order as the Swing frontend: the icon's own patcher first, the stroke substitution after it. The elvis
+    // keeps a stroke-only icon patched, since `svgPatcher` is null whenever an icon carries no explicit patcher.
+    val patcher = modifiers?.svgPatcher?.combineWith(strokePatcher) ?: strokePatcher
     (patcher as? DefaultSvgPatcher)?.patch(document.documentElement)
     return document.writeToString().toByteArray()
 }
 
-private val backgroundPalette =
-    listOf(
-        Color(0xFFEBECF0),
-        Color(0xFFE7EFFD),
-        Color(0xFFDFF2E0),
-        Color(0xFFF2FCF3),
-        Color(0xFFFFE8E8),
-        Color(0xFFFFF5F5),
-        Color(0xFFFFF8E3),
-        Color(0xFFFFF4EB),
-        Color(0xFFEEE0FF),
-    )
-
-private val strokeColors =
-    listOf(
-        Color(0xFF000000),
-        Color(0xFFFFFFFF),
-        Color(0xFF818594),
-        Color(0xFF6C707E),
-        Color(0xFF3574F0),
-        Color(0xFF5FB865),
-        Color(0xFFE35252),
-        Color(0xFFEB7171),
-        Color(0xFFE3AE4D),
-        Color(0xFFFCC75B),
-        Color(0xFFF28C35),
-        Color(0xFF955AE0),
-    )
+/** The attribute's value, or `null` when the element does not carry it — DOM reports both as an empty string. */
+private fun Element.attributeOrNull(name: String): String? = if (hasAttribute(name)) getAttribute(name) else null
 
 @Suppress("NestedBlockDepth", "UnsafeCallOnNullableType")
 private fun DefaultSvgPatcher.patch(element: Element) {
@@ -111,20 +76,23 @@ private fun DefaultSvgPatcher.patch(element: Element) {
                 }
             }
             SvgPatchOperation.Operation.Replace -> {
-                if (operation.conditional) {
-                    val matches =
-                        element.getAttribute(operation.attributeName).equals(operation.expectedValue, ignoreCase = true)
-                    if (matches == !operation.negatedCondition) {
-                        element.setAttribute(operation.attributeName, operation.value!!)
-                    }
-                } else if (element.hasAttribute(operation.attributeName)) {
+                // Replace never creates an attribute, conditionally or not: an element that does not carry the
+                // attribute inherits it, and adding one here would override that inheritance. Add exists for that.
+                if (
+                    element.hasAttribute(operation.attributeName) &&
+                        (!operation.conditional ||
+                            operation.matches(element.attributeOrNull(operation.attributeName)) !=
+                                operation.negatedCondition)
+                ) {
                     element.setAttribute(operation.attributeName, operation.value!!)
                 }
             }
             SvgPatchOperation.Operation.Remove -> {
                 if (operation.conditional) {
-                    val matches = element.getAttribute(operation.attributeName) == operation.expectedValue
-                    if (matches == !operation.negatedCondition) {
+                    if (
+                        operation.matches(element.attributeOrNull(operation.attributeName)) !=
+                            operation.negatedCondition
+                    ) {
                         element.removeAttribute(operation.attributeName)
                     }
                 } else {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/icon/PathImageResourceLocation.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/icon/PathImageResourceLocation.kt
@@ -38,7 +38,10 @@ public class PathImageResourceLocation(public val path: String, public val class
             append(path.substringBeforeLast('/', ""))
             append('/')
             append(path.substringBeforeLast('.').substringAfterLast('/'))
-            if (modifiers.isDark) {
+            // A stroked icon loads its light artwork even in a dark theme, matching the Swing frontend: the stroke
+            // palette describes the light variants, so a `_dark` variant would come back with colors it does not know
+            // and would be left in its authored color instead of being recolored.
+            if (modifiers.isDark && modifiers.stroke == null) {
                 append("_dark")
             }
             append('.')


### PR DESCRIPTION
> [!IMPORTANT]
> **This is about the new cross-frontend icons API** — `com.intellij.platform.icons`, in `platform/icons-api` / `platform/icons-impl` — the one designed to render the same icon through multiple frontends (Swing, Compose) and the one Jewel's Compose standalone frontend draws through. **The legacy icon path (`IconLoader`, `SVGLoader` and its colour patchers) is not touched by this PR** and none of the defects below apply to it.

Stroking an icon — the palette substitution that turns an icon into a monochrome outline in a given color — rendered differently depending on which frontend drew it. The Swing frontend and Jewel's Compose standalone frontend each carried their own copy of the same substitution, and each copy was wrong in a different way, so the same icon could come out blanked in a Swing toolbar, gray in a Compose one, and correct in neither. That is precisely the failure the new API exists to prevent: one icon, one appearance, whichever frontend renders it.

Fixes [JEWEL-1369](https://youtrack.jetbrains.com/issue/JEWEL-1369) / IJPL-176416.

Six distinct defects were behind that:

* **The Swing frontend blanked every fill.** It replaced `fill` unconditionally with `transparent` and added a `stroke` attribute. An icon drawn from filled shapes — which is most of them — became invisible rather than stroked.
* **The stroke patcher was silently dropped.** The patchers were combined outwards from `svgPatcher`, which is `null` whenever an icon carries no explicit patcher (the common case), so the null-safe call discarded the stroke patcher entirely — while `isStroke` still forced the stroke variant to load, leaving the icon in its authored gray.
* **Only `fill` was patched, never `stroke`, in both frontends.** New UI icons come in two authoring styles, `<path fill="#6C707E">` and `<path fill="none" stroke="#6C707E">`; patching one attribute leaves every icon of the other style untouched.
* **The palette was incomplete.** It was missing two colours the legacy Swing stroke patcher (`com.intellij.ui.icons.stroke`) has — `#A8ADBD` and `#CED0D6` — plus the keyword spellings `black` and `white`, which an SVG may use in place of `#000000` / `#FFFFFF`. Icons painted in any of those were left un-stroked.
* **Stroking resolved dark artwork in a dark theme.** A `_dark` variant is authored in its own grays (`inlaySettings_dark.svg` is `#9DA0A8`), which are not stroke palette colours, so a stroked icon in a dark theme kept them. The legacy path avoids this by loading the light variant; both frontends now do the same.
* **The Swing frontend compared color values case-sensitively.** SVGs are authored uppercase (`#6C707E`) while the palette is built from `Color.toHex()`, which is lowercase. Every palette color containing a hex letter silently failed to match and was left un-stroked; colors that happen to be all digits (`#818594`) worked by accident. SVG hex colors are case-insensitive per spec, and the Compose frontend already compared that way.

## Changes

* Adds `strokeSvgPatcher(stroke)` in `platform/icons-impl` as the single definition of the stroke substitution. Both frontends now call it, which is what stops them drifting apart again. It is the only new public declaration — the design palettes it is built from stay private.
* The substitution is *palette-only*, never blanket: background tints become `transparent`, foreground tints become the stroke color, and anything painted outside those two sets is deliberately left alone — so filled artwork survives instead of being erased.
* The substitution applies to both the `fill` and the `stroke` attribute, covering both New UI authoring styles. The foreground palette also gains the two colours and the two keyword spellings it was missing relative to the legacy patcher, so the two agree on what counts as a palette colour.
* Condition evaluation moved onto `SvgPatchOperation.matches`, so both frontends resolve an operation identically rather than each deciding for itself. It folds case only for a plain colour literal on a colour-valued attribute — a `url(#Id)` paint reference and an `id` are case-sensitive and must not be conflated.
* The combine starts from the icon's own `svgPatcher` and falls back to the stroke patcher. That fixes the dropped-patcher bug while keeping the icon's own patcher running *first*, so an icon that deliberately recolours a palette colour keeps it.
* Jewel’s `ComposeImageResourceProvider` (the Compose frontend) drops its duplicate palette and its `fill -> transparent` blanket replacement, and delegates to the shared patcher.
* Adds no public platform API: `strokeSvgPatcher` and `SvgPatchOperation.matches` are both `@ApiStatus.Internal`, and `api-dump.txt` is unchanged.
* `StrokeRenderTest` pins the behavior at the pixel level through the *real* Swing path — `imageIcon(...).toSwingIcon().paintIcon(...)` — rasterizing real New UI icons and counting red vs. authored-gray pixels: `softWrap` (fill-authored), `save` and `inlaySettings` (stroke-authored) all recolor fully, with none of the authored gray left behind. `StrokePatcherTest` pins the patch shape itself, spelling out the colours it expects rather than reading them back from the patcher's own palette, so dropping an entry fails the test instead of quietly shrinking what it checks. `SvgPatchOperationMatchesTest` pins the comparison rule directly. The render tests also cover a dark theme and patcher ordering; each was mutation-checked to fail when the behaviour it describes is reverted.

## Screenshots

Real New UI icons rendered through the Swing frontend — `imageIcon(...).toSwingIcon().paintIcon(...)` — asked to stroke in `#3574F0`, at master vs. this branch. Before the fix, stroking is a no-op: the "before" row is pixel-identical to the unstroked reference.

![Icon stroking before and after](https://static.sebastiano.dev/private/567f1686-5385-4ff1-a62c-7ad3ef6f44ee.png)

## Release notes

### Bug fixes

* Fixed icon stroking rendering incorrectly: icons drawn from filled shapes were blanked out entirely, icons authored with `stroke` rather than `fill` were left in their authored gray, and stroking was silently skipped for icons that carry no explicit SVG patcher. Stroking now recolors both the `fill` and the `stroke` attribute, matches palette colors case-insensitively (including keyword spellings such as `black`), and renders identically in the Swing and Compose frontends.
