### PR TITLE
[JEWEL-1371] Fix the API dump check never running and always passing

### DIFF
--- a/.claude/skills/jewel-pr-preparer/SKILL.md
+++ b/.claude/skills/jewel-pr-preparer/SKILL.md
@@ -116,10 +116,19 @@ parameter, then amend and re-validate.
 
 ### 4e. Bazel build/tests
 
-The IntelliJ Community repo is migrating to Bazel. It's important to make sure the Bazel build is not broken and tests pass:
+The IntelliJ Community repo is migrating to Bazel. It's important to make sure the Bazel build is not broken and tests pass.
+
+Unlike the previous steps, **the commands in this step run from the repository root**, where `tests.cmd` and `bazel.cmd` live.
+`tests.cmd` needs both the JPS module that holds the test class and the test pattern:
 
 ```shell
-./tests.cmd -Dintellij.build.test.patterns=...
+./tests.cmd --module <jps-module> --test <test-class-fqn-or-pattern>
+```
+
+For example, to run the IJP API dump check the way step 4c does under the hood:
+
+```shell
+./tests.cmd --module intellij.platform.testFramework.monorepo.tests --test com.intellij.platform.testFramework.monorepo.api.ApiCheckTest
 ```
 
 If there are no useful tests, at a minimum verify Bazel compilation for the affected Jewel module targets. Common examples:

--- a/.claude/skills/jewel-release-helper/SKILL.md
+++ b/.claude/skills/jewel-release-helper/SKILL.md
@@ -70,7 +70,7 @@ Ask the user:
 - [ ] **1c. IJP target version**: Ask if the IJP target version in `platform/jewel/gradle/libs.versions.toml` needs updating; if so,
   update it.
 - [ ] **1d. Formatting**: Ask the user how they run ktfmt, then format any changed files as needed.
-- [ ] **1e. Bazel checks**: Run Bazel compilation and tests for Jewel (`./tests.cmd -Dintellij.build.test.patterns=org.jetbrains.jewel.*`
+- [ ] **1e. Bazel checks**: Run Bazel compilation and tests for Jewel (`./tests.cmd --module <jps-module> --test org.jetbrains.jewel.*`
   or `./bazel.cmd build //platform/jewel/...`).
 
 **Wait for user confirmation.**
@@ -105,7 +105,8 @@ Repeat for **each target release branch** (ask user which branch to do first):
 - [ ] **3c. Regenerate & Validate**:
   - `./gradlew generateThemes --rerun-tasks`
   - `./gradlew check detekt detektMain detektTest --continue --no-daemon`
-  - Run Bazel compilation and tests for Jewel (`./tests.cmd` or `./bazel.cmd build //platform/jewel/...`)
+  - Run Bazel compilation and tests for Jewel (`./tests.cmd --module <jps-module> --test <pattern>` or
+    `./bazel.cmd build //platform/jewel/...`)
   - run IJ tests as needed
   - verify the standalone sample works
   - verify the IDE samples work

--- a/.github/workflows/jewel-checks.yml
+++ b/.github/workflows/jewel-checks.yml
@@ -162,6 +162,60 @@ jobs:
       - uses: actions/checkout@v7.0.1
         name: Check out repository
 
+      # Bazel reads the whole JPS model, including the android modules, so the subrepo must be present
+      # even though the API check itself only looks at community modules.
+      - uses: actions/checkout@v7.0.1
+        name: Checkout JetBrains/android submodule
+        with:
+          repository: JetBrains/android
+          path: android
+          ref: master
+
+      # The API check compiles every community module, which does not fit a hosted runner's stock
+      # resources. Same preparation as .github/actions/build_ide, which builds the IDE on ubuntu-latest.
+      - name: Free disk space
+        # language=bash
+        run: |
+          echo "Disk space before cleanup:"
+          df -h /
+          # Pre-installed toolchains the API check doesn't need.
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/share/swift \
+            /usr/share/miniconda \
+            /usr/local/lib/android \
+            /usr/local/share/boost \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium \
+            /usr/local/lib/node_modules \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /opt/hostedtoolcache/Ruby \
+            /opt/hostedtoolcache/PyPy \
+            /opt/hostedtoolcache/go \
+            /opt/microsoft \
+            /opt/google \
+            /imagegeneration \
+            /var/cache/apt/archives
+          sudo apt-get -y clean
+          docker image prune --all --force || true
+          docker builder prune --all --force || true
+          echo "Disk space after cleanup:"
+          df -h /
+
+      - name: Expand swap
+        # language=bash
+        run: |
+          # Bazel's JVM workers may hit OOM (exit 137) with the default 16 GB RAM and 4 GB swap.
+          # /mnt on hosted runners has ~70 GB free, so move swap there and grow it.
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile /swapfile
+          sudo fallocate -l 30G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          free -h
+
       - uses: actions/cache@v6.1.0
         name: Cache for jps-bootstrap
         with:

--- a/platform/jewel/scripts/check-api-dumps.main.kts
+++ b/platform/jewel/scripts/check-api-dumps.main.kts
@@ -26,8 +26,7 @@ private class CheckUpdatedCommand : SuspendingCliktCommand(name = "check") {
         val repoRoot = findCommunityRoot() ?: exitWithError("Could not find the repository root directory.")
         println(" DONE: ${repoRoot.canonicalPath}")
 
-        val command =
-            "./tests.cmd -Dintellij.build.test.patterns=com.intellij.platform.testFramework.monorepo.api.ApiCheckTest"
+        val command = "./tests.cmd --module $TEST_MODULE --test $TEST_CLASS"
         if (verbose) println("Running: $command")
 
         // Stream output in real-time and save to a temporary file for later analysis
@@ -36,12 +35,14 @@ private class CheckUpdatedCommand : SuspendingCliktCommand(name = "check") {
         try {
             println("Output will be streamed in real-time and saved to: ${outputFile.absolutePath}")
 
-            // Create a temporary shell script to handle the pipe properly
+            // Create a temporary shell script to handle the pipe properly. The pipeline's exit status must be
+            // tests.cmd's and not tee's, hence the pipefail; errexit makes a failing cd fatal, too.
             scriptFile.writeText(
                 """
                 #!/bin/bash
-                cd "${repoRoot.absolutePath}"
-                $command | tee "${outputFile.absolutePath}"
+                set -e -o pipefail
+                cd ${repoRoot.absolutePath.asShellLiteral()}
+                $command | tee ${outputFile.absolutePath.asShellLiteral()}
                 """
                     .trimIndent()
             )
@@ -66,7 +67,9 @@ private class CheckUpdatedCommand : SuspendingCliktCommand(name = "check") {
                 val moduleList = failingModules.joinToString(", ")
                 exitWithError("❌ API check test failed — failing modules: $moduleList")
             } else if (result.isFailure) {
-                exitWithError("❌ API check test command failed.")
+                // The output scraping only recognises TeamCity test failures; anything else that makes the
+                // command fail (bad invocation, build error, crash) must still be reported as a failure.
+                exitWithError("❌ API check test command failed. See the output above for details.")
             } else {
                 printlnSuccess("✅ API check test passed — no test failures detected.")
             }
@@ -76,11 +79,21 @@ private class CheckUpdatedCommand : SuspendingCliktCommand(name = "check") {
         }
     }
 
+    /**
+     * Renders this string as a single-quoted shell literal. Paths embedded in generated shell source must be quoted
+     * this way: inside double quotes the shell would still expand `$`, backticks and backslashes.
+     */
+    private fun String.asShellLiteral(): String = "'" + replace("'", """'\''""") + "'"
+
     private fun extractFailingModules(output: String): List<String> {
-        val failurePattern =
-            """##teamcity\[testFailed name='com\.intellij\.platform\.testFramework\.monorepo\.api\.ApiCheckTest\.([^']+)'"""
-                .toRegex()
+        val failurePattern = """##teamcity\[testFailed name='${Regex.escape(TEST_CLASS)}\.([^']+)'""".toRegex()
         return failurePattern.findAll(output).map { it.groupValues[1] }.distinct().sorted().toList()
+    }
+
+    private companion object {
+        // tests.cmd needs both the JPS module that holds the test class, and the test pattern itself.
+        const val TEST_MODULE = "intellij.platform.testFramework.monorepo.tests"
+        const val TEST_CLASS = "com.intellij.platform.testFramework.monorepo.api.ApiCheckTest"
     }
 }
 


### PR DESCRIPTION
The `check_ij_api_dumps` CI job ("Check that the IJP API dumps are up-to-date") has been passing unconditionally. Its only step runs `platform/jewel/scripts/check-api-dumps.main.kts`, and that script never actually ran `ApiCheckTest` — it printed `✅ API check test passed — no test failures detected.` and exited 0 on every run. A Jewel PR that changes the public API surface of an IntelliJ Platform module without updating that module's `api-dump.txt` therefore goes green in CI, with no protection at all from this job.

## Context

Two independent defects combined into the false green.

The command line was stale. The script invoked `./tests.cmd -Dintellij.build.test.patterns=com.intellij.platform.testFramework.monorepo.api.ApiCheckTest`, a form `tests.cmd` no longer accepts. It now requires `--module <module> --test <pattern>` and rejects the invocation with `Error: --module is required`, so the test never ran.

Neither failure signal could see that. The generated shell script pipes the command through `tee`, so the pipeline's exit status was `tee`'s and not `tests.cmd`'s, and `result.isFailure` was never true. The only other signal, `extractFailingModules`, scrapes TeamCity `testFailed` service messages out of the captured output, and there were none because no test had run.

Found while working on JEWEL-1370, where an `api-dump.txt` edit had to be verified by running `ApiCheckTest` by hand instead of relying on the script.

## Changes

* `check-api-dumps.main.kts` now invokes `./tests.cmd --module intellij.platform.testFramework.monorepo.tests --test com.intellij.platform.testFramework.monorepo.api.ApiCheckTest`. The module name comes from `platform/testFramework/monorepo/intellij.platform.testFramework.monorepo.tests.iml`.
* The generated shell script sets `-e -o pipefail`, so `tests.cmd`'s own exit status survives the `tee` pipe and a real failure is reported even when the output-scraping heuristic misses it. `errexit` also makes a failing `cd` fatal instead of silently running the test from the wrong directory.
* The module and test class names moved to constants, and the TeamCity failure regex is now derived from the class constant rather than repeating the FQN with hand-escaped dots.
* `.github/workflows/jewel-checks.yml` now prepares the runner in the `check_ij_api_dumps` job by freeing disk space and moving swap to `/mnt` at 30 GB, the same preparation `.github/actions/build_ide` already uses to build the IDE on `ubuntu-latest`. Compiling every community module does not fit a hosted runner's stock 16 GB RAM and 4 GB swap: the first full run was killed at 4,669 of 5,941 targets after 17m43s, with Bazel's JVM workers dying mid-response (`Worker process returned an unparseable WorkResponse!`). The steps are inlined rather than extracted into a shared composite action, to keep this change away from the IDE build path; extracting them is a reasonable follow-up.
* `.github/workflows/jewel-checks.yml` now checks out the `JetBrains/android` subrepo in the `check_ij_api_dumps` job. With the test finally running in CI, the job went red for a second reason the false green had been hiding: Bazel reads the whole JPS model, android `.iml` files included, and that subrepo was absent from this job's checkout — so `bazel run //build:run_tests_build_target` failed with `FileNotFoundException: …/android/android-adb/intellij.android.adb.iml`. The `check_bazel_build` job next to it already checks the subrepo out for exactly this reason.
* The paths interpolated into that generated script are now emitted as single-quoted shell literals. Inside double quotes the shell still expands `$` and backticks, and with `errexit` in place a mis-parsed `cd` is now fatal rather than merely ineffective.
* The `jewel-pr-preparer` and `jewel-release-helper` skills documented the same stale `tests.cmd` invocation in three places, so anyone (or anything) following them would hit the identical wall. All three now show the `--module`/`--test` form, and `jewel-pr-preparer` includes the concrete `ApiCheckTest` command as an example. Its Bazel step also now states that its commands run from the repository root, unlike the steps before it which run from `platform/jewel` — following it literally used to produce `./tests.cmd: No such file or directory`.

The sibling scripts under `platform/jewel/scripts/` were checked for the same two problems and neither applies to them. `metalava-signatures.main.kts` shells out to `./gradlew` without a pipe and already branches on `result.isSuccess`; `annotate-api-dump-changes.main.kts` and `validate-maven-artifacts.main.kts` pass `exitOnError = false` only for `git` calls used as predicates, whose results they do inspect. No other script under `platform/jewel/scripts/` invokes `tests.cmd` or pipes a command through `tee`.

## Verification

Both directions were exercised locally.

**Before the fix**, the script reported success while `tests.cmd` had refused to run anything:

```
Running: ./tests.cmd -Dintellij.build.test.patterns=com.intellij.platform.testFramework.monorepo.api.ApiCheckTest
Error: --module is required

Usage: tests.cmd --module <module> --test <pattern> [options]
...
✅ API check test passed — no test failures detected.
SCRIPT EXIT: 0
```

**After the fix, on a clean tree**, the test actually runs and the script passes:

```
Running: ./tests.cmd --module intellij.platform.testFramework.monorepo.tests --test com.intellij.platform.testFramework.monorepo.api.ApiCheckTest
...
Results: 332 tests, 332 passed, 0 failed, 0 skipped (9829 ms)
*** All tests passed ***
✅ API check test passed — no test failures detected.
SCRIPT EXIT: 0
```

**After the fix, with a genuinely stale dump** — a temporary `public fun apiDumpCheckCanary(): Int` added to `platform/jewel/foundation/.../Compatibility.kt` without touching its `api-dump-experimental.txt` (reverted before committing; the diff in this PR is the script only) — the script fails:

```
com.intellij.platform.testFramework.core.FileComparisonFailedError: 'intellij.platform.jewel.foundation' api-dump-experimental.txt does not match the actual API. ... Simplified diff:
+ - *sf:apiDumpCheckCanary():I

Results: 332 tests, 331 passed, 1 failed, 0 skipped (10579 ms)
❌ API check test command failed. See the output above for details.
SCRIPT EXIT: 1
```

Worth noting: in that run `extractFailingModules` matched nothing, because the local test runner emits no TeamCity service messages. The exit-status fix, not the output scraping, is what caught the failure — the two fixes are both load-bearing.

As a cross-check, `./tests.cmd --module intellij.platform.testFramework.monorepo.tests --test com.intellij.platform.testFramework.monorepo.api.ApiCheckTest` was also run directly on the final tree: 332 tests, 332 passed, exit 0. The clean-tree run was then repeated after the shell-quoting change (332 passed, exit 0), and the quoting itself was checked against a directory whose name contains a `$`, a space and a literal single quote.
