### PR TITLE
[JEWEL-1372] Bump GitHub Actions in the Jewel checks workflow to Node 24 runtimes

### DIFF
--- a/.github/actions/setup-kotlin/action.yml
+++ b/.github/actions/setup-kotlin/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Restore cached Kotlin ${{ inputs.version }}
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6.1.0
       with:
         key: kotlin-${{ runner.os }}-${{ inputs.version }}
         path: ${{ runner.temp }}/kotlin-${{ inputs.version }}

--- a/.github/workflows/jewel-checks.yml
+++ b/.github/workflows/jewel-checks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - "platform/jewel/**"
+      # This workflow and the actions it depends on must run on changes to themselves, so that a change to the
+      # checks is validated by the checks it changes rather than by the next unrelated Jewel PR.
+      - ".github/workflows/jewel-checks.yml"
+      - ".github/actions/setup-kotlin/**"
 
 defaults:
   run:
@@ -24,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         name: Check out repository
 
       - name: Set up JBR 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: 21
           distribution: jetbrains
@@ -42,14 +46,14 @@ jobs:
         run: ./gradlew check -x detekt --continue --no-daemon
 
       - name: Annotate JUnit test failures
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: failure()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           annotate_only: true # A forked repo cannot write comments, so just do annotations
 
       - name: Upload JUnit test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: failure()
         with:
           name: junit-test-results
@@ -85,10 +89,10 @@ jobs:
       run_formalities: ${{ steps.filter.outputs.run_formalities }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         name: Check out repository
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         name: Check which files are changed
         id: filter
         with:
@@ -103,7 +107,7 @@ jobs:
     if: needs.check_paths.outputs.run_formalities == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
         name: Check out repository
@@ -129,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           # We need fetch-depth: '2' so we get HEAD~1 in case this is missing the PR token
           fetch-depth: '2'
@@ -155,10 +159,10 @@ jobs:
         working-directory: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         name: Check out repository
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6.1.0
         name: Cache for jps-bootstrap
         with:
           key: ${{ runner.os }}-jps-bootstrap-${{ hashFiles('platform/jps-bootstrap/**') }}
@@ -185,10 +189,10 @@ jobs:
         working-directory: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         name: Check out repository
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         name: Checkout JetBrains/android submodule
         with:
           repository: JetBrains/android
@@ -196,7 +200,7 @@ jobs:
           ref: master
 
       - name: Set up JBR 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: 21
           distribution: jetbrains
@@ -235,11 +239,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         name: Check out repository
 
       - name: Set up JBR 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: 21
           distribution: jetbrains


### PR DESCRIPTION
Every job in the Jewel checks workflow emits a GitHub Actions deprecation warning: `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4.` GitHub is already forcing these onto Node 24, so the warning is advance notice — once the compatibility shim goes away, the pinned versions stop working.

The warning names only two actions, but every action this workflow uses was still on a `node20` release, as was the `actions/cache` inside the `setup-kotlin` composite action. This bumps all of them to the latest major, each of which declares `runs.using: node24`.

## Changes

* `actions/checkout` `v4` → `v7.0.1` (8 occurrences)
* `actions/setup-java` `v4` → `v5.6.0` (3 occurrences)
* `actions/cache` `v4` → `v6.1.0` (1 in the workflow, 1 in `.github/actions/setup-kotlin`)
* `actions/upload-artifact` `v4` → `v7.0.1`
* `dorny/paths-filter` `v3` → `v4`
* `mikepenz/action-junit-report` `v5` → `v6`
* Added `.github/workflows/jewel-checks.yml` and `.github/actions/setup-kotlin/**` to the workflow's trigger paths

The `setup-kotlin` action stays on `using: composite`, which needs no runtime change; only its inner `actions/cache` pin moves.

## Trigger paths

The workflow only triggered on `platform/jewel/**` changes. Since it is the only workflow in the repository with a `pull_request` trigger, a PR that changed only the checks — like the first revision of this one — got no CI at all: not the bumped actions, not even the `formalities` job that validates the commit message. The change would first be exercised on whatever unrelated Jewel PR happened to land next, which is a poor place to discover that an action bump misbehaves.

Adding the workflow and the `setup-kotlin` action to the trigger paths makes changes to the checks validate themselves. The trade-off is that CI-only PRs now pay the full `check_ij_api_dumps` cost, which currently runs about 30 minutes because it compiles every community module.

## Compatibility

None of the majors being crossed change the inputs these steps use.

* `actions/setup-java@v5` additionally stops defaulting to pre-release JBRs, which matters here because the workflow requests `distribution: jetbrains`.
* `actions/checkout@v7` adds a guard against checking out a fork PR head, but it applies only to the `pull_request_target` and `workflow_run` events. This workflow triggers on `pull_request`, so the `formalities` job's checkout of `github.event.pull_request.head.sha` is unaffected.
* `actions/upload-artifact@v7` adds an opt-in `archive` input and migrates to ESM; the existing step's inputs are unchanged.
* `actions/cache@v6` is a runtime bump plus an internal ESM migration.
* `dorny/paths-filter@v4` and `mikepenz/action-junit-report@v6` are runtime-only bumps for how this workflow uses them.

This leaves the repository with two pins for `actions/checkout` and `actions/upload-artifact`, since `ide_build_and_upload.yml` and `build_ide/action.yml` sit on v6. Those files are out of scope here.
