### PR TITLE
Use --repo_env instead of --action_env for cpp toolchain flags

### DIFF
--- a/build/jvm-rules/.bazelrc
+++ b/build/jvm-rules/.bazelrc
@@ -45,8 +45,8 @@ common --symlink_prefix=/
 common --incompatible_enable_proto_toolchain_resolution
 
 # Do not depend on external environment
-common --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-common --action_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 startup --noautodetect_server_javabase
 
 # Remote-caches related

--- a/build/jvm-rules/jvm-inc-builder-tests/testData/.bazelrc
+++ b/build/jvm-rules/jvm-inc-builder-tests/testData/.bazelrc
@@ -36,6 +36,6 @@ common --@protobuf//bazel/toolchains:prefer_prebuilt_protoc=true
 common --experimental_platform_in_output_dir
 
 # Do not depend on external environment
-common --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-common --action_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 startup --noautodetect_server_javabase

--- a/common.bazelrc
+++ b/common.bazelrc
@@ -145,8 +145,8 @@ common --incompatible_strict_action_env=true
 common --experimental_platform_in_output_dir
 
 # Do not depend on external environment
-common --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-common --action_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 startup --noautodetect_server_javabase
 
 # Clear PATH environment variable to enable remote cache hits on Windows

--- a/platform/build-scripts/bazel/.bazelrc
+++ b/platform/build-scripts/bazel/.bazelrc
@@ -96,8 +96,8 @@ common --enable_platform_specific_config
 common --incompatible_enable_proto_toolchain_resolution
 
 # Do not depend on external environment
-common --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-common --action_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common --repo_env BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 startup --noautodetect_server_javabase
 
 # Remote-caches related


### PR DESCRIPTION
These env vars should be set with --repo_env since they are consumed by a repository rule. Using --action_env no longer works because Bazel 9+ sets --incompatible_repo_env_ignores_action_env by default.

cc @shalupov 

See also the example in https://github.com/bazelbuild/rules_cc/blob/main/README.md#default-autoconfigured-toolchain.