### PR TITLE
Invoke ModuleToGradleProjectConnector before DataServices

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/syncAction/impl/bridge/ModuleToGradleProjectConnector.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/syncAction/impl/bridge/ModuleToGradleProjectConnector.kt
@@ -20,7 +20,7 @@ import org.jetbrains.plugins.gradle.model.projectModel.gradleModuleEntity
 @ApiStatus.Internal
 class ModuleToGradleProjectConnector : ProjectDataManager.ProjectDataImportExtension {
 
-  override fun finalizeImportData(projectData: ProjectData?, modelsProvider: IdeModifiableModelsProvider) {
+  override fun prepareImportData(projectData: ProjectData?, modelsProvider: IdeModifiableModelsProvider) {
     val mutableStorage = (modelsProvider as? IdeModifiableModelsProviderImpl)?.actualStorageBuilder ?: return
     if (Registry.`is`("gradle.phased.sync.bridge.disabled")) return
     addGradleModuleEntities(mutableStorage)


### PR DESCRIPTION
So it can properly prepare for data deletion in case when the gradle.phased.sync.disabled isn't set.