### PR TITLE
[JEWEL-1384] Fix coroutines NoSuchMethodError in standalone artifacts

### DIFF
--- a/build/src/org/jetbrains/intellij/build/IdeaCommunityProperties.kt
+++ b/build/src/org/jetbrains/intellij/build/IdeaCommunityProperties.kt
@@ -91,6 +91,8 @@ open class IdeaCommunityProperties(private val communityHomeDir: Path) : JetBrai
     mavenArtifacts.patchDependencies = { module, dependencies ->
       when {
         JewelMavenArtifacts.isPublishedJewelModule(module) -> JewelMavenArtifacts.patchDependencies(module, dependencies)
+        JewelMavenArtifacts.isPublishedPlatformDependency(module) ->
+          JewelMavenArtifacts.patchPlatformDependencies(module, dependencies)
         else -> dependencies
       }
     }

--- a/build/src/org/jetbrains/intellij/build/JewelMavenArtifacts.kt
+++ b/build/src/org/jetbrains/intellij/build/JewelMavenArtifacts.kt
@@ -21,8 +21,34 @@ import org.jetbrains.jps.model.module.JpsDependencyElement
 import org.jetbrains.jps.model.module.JpsModule
 import org.jetbrains.jps.model.module.JpsModuleDependency
 import kotlin.io.path.exists
+import kotlin.io.path.name
+import kotlin.io.path.readText
 
 private const val GROUP_ID: String = "org.jetbrains.jewel"
+
+/**
+ * The IJP fork of kotlinx.coroutines, and the stock artifact it is forked from.
+ *
+ * The fork shares the `kotlinx.coroutines.*` packages with the stock artifact but has a different groupId, so
+ * neither Gradle nor Maven can conflict-resolve the two. Consumers get both jars, and whichever one sorts first
+ * on the classpath wins. The fork lags upstream, so when it wins, anything stock added since the fork point is
+ * missing: stock 1.11.0 compiles `runBlocking` to `BuildersKt.runBlockingK` via `@JvmName`, the fork has no such
+ * method, and every `runBlocking` call in a consumer throws `NoSuchMethodError`.
+ *
+ * The fork must never reach standalone consumers. See [JewelMavenArtifacts.patchPlatformDependencies].
+ */
+private const val IJP_COROUTINES_FORK_GROUP: String = "org.jetbrains.intellij.deps.kotlinx"
+private const val STOCK_COROUTINES_GROUP: String = "org.jetbrains.kotlinx"
+
+/** The fork appends this to the stock version it is based on, e.g. `1.10.2-intellij-1` for stock `1.10.2`. */
+private const val IJP_COROUTINES_FORK_VERSION_SUFFIX: String = "-intellij"
+
+/**
+ * Artifact ID prefix used by the upstream coroutines artifacts and by the IJP fork. Matching on it rather than on
+ * [IJP_COROUTINES_FORK_GROUP] also covers a fork that moves to another groupId. This is a best-effort guard: a fork
+ * published under an unrelated artifact ID would still get through.
+ */
+private const val COROUTINES_ARTIFACT_PREFIX: String = "kotlinx-coroutines"
 
 /**
  * Each entry represents a prefix for Platform dependencies which are being published to Maven Central.
@@ -180,6 +206,55 @@ internal object JewelMavenArtifacts {
   private fun MavenArtifactDependency.withTransitiveDependencies(scope: DependencyScope) =
     copy(scope = scope, excludedDependencies = emptyList(), includeTransitiveDeps = true)
 
+  /**
+   * Patches the dependencies of the [isPublishedPlatformDependency] modules, which are consumed outside the IDE
+   * once published to Maven Central.
+   *
+   * These modules depend on the IJP coroutines fork. That is fine in the IDE, where the fork is already on the
+   * platform classpath, but it breaks standalone consumers (see [IJP_COROUTINES_FORK_GROUP]). They only use stock
+   * coroutines API, so the dependency is repointed at the stock artifact: the artifactId is the same in both
+   * groups, and dropping the [IJP_COROUTINES_FORK_VERSION_SUFFIX] suffix gives the stock version the fork is based
+   * on.
+   */
+  fun patchPlatformDependencies(
+    module: JpsModule,
+    dependencies: List<MavenArtifactDependency>,
+  ): List<MavenArtifactDependency> {
+    check(isPublishedPlatformDependency(module))
+    return dependencies.map { dependency ->
+      val coordinates = dependency.coordinates
+      val patched = if (coordinates.groupId == IJP_COROUTINES_FORK_GROUP) {
+        check(coordinates.version.contains(IJP_COROUTINES_FORK_VERSION_SUFFIX)) {
+          "Cannot derive the stock coroutines version from $coordinates: the version does not contain " +
+          "'$IJP_COROUTINES_FORK_VERSION_SUFFIX'. The fork's versioning scheme has changed, so this mapping needs " +
+          "updating; publishing it as-is would point consumers at a $STOCK_COROUTINES_GROUP version that " +
+          "does not exist."
+        }
+        dependency.copy(
+          coordinates = coordinates.copy(
+            groupId = STOCK_COROUTINES_GROUP,
+            version = coordinates.version.substringBefore(IJP_COROUTINES_FORK_VERSION_SUFFIX),
+          )
+        )
+      }
+      else {
+        dependency
+      }
+      checkCoroutinesAreStock(module, patched.coordinates)
+      patched
+    }
+  }
+
+  // Fails the build if [coordinates] is a coroutines artifact from anywhere other than [STOCK_COROUTINES_GROUP].
+  private fun checkCoroutinesAreStock(module: JpsModule, coordinates: MavenCoordinates) {
+    if (!coordinates.artifactId.startsWith(COROUTINES_ARTIFACT_PREFIX)) return
+    check(coordinates.groupId == STOCK_COROUTINES_GROUP) {
+      "The POM for ${module.name} would declare $coordinates, but only $STOCK_COROUTINES_GROUP may provide " +
+      "$COROUTINES_ARTIFACT_PREFIX artifacts. A fork published under any other groupId cannot be conflict-resolved " +
+      "against the stock artifact, so consumers would end up with both jars on the classpath."
+    }
+  }
+
   private fun JpsModule.isTransitiveJewelDependency(coordinates: MavenCoordinates): Boolean {
     val moduleArtifactId = ALL[name] ?: error("Unknown Jewel module: $name")
     val artifactId = coordinates.artifactId
@@ -257,6 +332,28 @@ internal object JewelMavenArtifacts {
       }) {
         "The module $jewelModuleName is expected to have groupId=$GROUP_ID and artifactId=$artifactId: " +
         "${mavenArtifacts.filter { (module) -> module.name == jewelModuleName }}"
+      }
+    }
+    checkNoCoroutinesForkIsPublished(mavenArtifacts)
+  }
+
+  /**
+   * Fails the build if the IJP coroutines fork leaks into a published POM (see [IJP_COROUTINES_FORK_GROUP]).
+   * Consumers only hit that once they package an app, so it is easy to ship by accident.
+   *
+   * This checks the generated POMs rather than the patched dependency lists, so it also catches the fork arriving
+   * transitively through a dependency republished as-is.
+   */
+  private fun checkNoCoroutinesForkIsPublished(mavenArtifacts: Collection<GeneratedMavenArtifacts>) {
+    for ((module, coordinates, files) in mavenArtifacts) {
+      val pomFileName = coordinates.getFileName(packaging = "pom")
+      val pom = files.singleOrNull { it.name == pomFileName }
+      checkNotNull(pom) { "No $pomFileName is generated for the module ${module.name}" }
+      check(!pom.readText().contains(IJP_COROUTINES_FORK_GROUP)) {
+        "The POM of $coordinates declares a dependency on $IJP_COROUTINES_FORK_GROUP. " +
+        "The IJP coroutines fork must not be published to Maven Central: it shares the kotlinx.coroutines.* " +
+        "packages with the stock artifact but uses a different groupId, so consumers get both jars on their " +
+        "classpath and the fork can shadow stock API. See patchPlatformDependencies."
       }
     }
   }

--- a/platform/build-scripts/tests/testSrc/org/jetbrains/intellij/build/MavenArtifactsBuilderTest.kt
+++ b/platform/build-scripts/tests/testSrc/org/jetbrains/intellij/build/MavenArtifactsBuilderTest.kt
@@ -10,20 +10,21 @@ import org.jetbrains.intellij.build.impl.maven.MavenArtifactDependency
 import org.jetbrains.intellij.build.impl.maven.MavenArtifactsBuilder
 import org.jetbrains.intellij.build.impl.maven.MavenCoordinates
 import org.junit.Assert
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class MavenArtifactsBuilderTest {
-  private val builder by lazy {
+  private val context by lazy {
     runBlocking {
-      MavenArtifactsBuilder(
-        createBuildContext(
-          projectHome = ULTIMATE_HOME,
-          productProperties = IdeaCommunityProperties(COMMUNITY_ROOT.communityRoot),
-          setupTracer = false,
-        )
+      createBuildContext(
+        projectHome = ULTIMATE_HOME,
+        productProperties = IdeaCommunityProperties(COMMUNITY_ROOT.communityRoot),
+        setupTracer = false,
       )
     }
   }
+
+  private val builder by lazy { MavenArtifactsBuilder(context) }
 
   @Test
   fun `maven coordinates`() {
@@ -107,4 +108,77 @@ class MavenArtifactsBuilderTest {
       Assert.assertTrue("${dependency.coordinates} must include transitive dependencies", dependency.includeTransitiveDeps)
     }
   }
+
+  /**
+   * The Icons API modules depend on the IJP fork of coroutines, which shares the `kotlinx.coroutines.*` packages
+   * with the stock artifact but uses a different groupId. Neither Gradle nor Maven can conflict-resolve the two, so
+   * publishing the fork leaves standalone consumers with both jars on the classpath, and the fork can shadow API
+   * that only stock has. The published POMs must therefore point at the stock artifact instead. See JEWEL-1384.
+   */
+  @Test
+  fun `icons poms declare stock coroutines instead of the ijp fork`() {
+    val iconsImpl = context.outputProvider.findRequiredModule("intellij.platform.icons.impl")
+    val dependencies = listOf(
+      forkDependency("1.10.2-intellij-1"),
+      MavenArtifactDependency(
+        coordinates = MavenCoordinates("org.jetbrains.kotlinx", "kotlinx-serialization-core-jvm", "1.9.0"),
+        includeTransitiveDeps = false,
+        excludedDependencies = emptyList(),
+        scope = null,
+      ),
+    )
+
+    val patched = context.productProperties.mavenArtifacts.patchDependencies(iconsImpl, dependencies)
+
+    val coroutines = patched.single { it.coordinates.artifactId == "kotlinx-coroutines-core-jvm" }.coordinates
+    Assert.assertEquals("The IJP coroutines fork must not be published", "org.jetbrains.kotlinx", coroutines.groupId)
+    Assert.assertEquals("The stock version the fork is based on must be used", "1.10.2", coroutines.version)
+
+    Assert.assertEquals(
+      "Dependencies that are not the coroutines fork must be left untouched",
+      dependencies.filterNot { it.coordinates.groupId == "org.jetbrains.intellij.deps.kotlinx" },
+      patched.filterNot { it.coordinates.artifactId == "kotlinx-coroutines-core-jvm" },
+    )
+  }
+
+  @Test
+  fun `unexpected coroutines fork version fails the build`() {
+    val iconsImpl = context.outputProvider.findRequiredModule("intellij.platform.icons.impl")
+
+    val exception = assertThrows(IllegalStateException::class.java) {
+      context.productProperties.mavenArtifacts.patchDependencies(iconsImpl, listOf(forkDependency("1.10.2-ij-1")))
+    }
+
+    Assert.assertTrue(
+      "The failure must explain that the fork's versioning scheme changed, but was: ${exception.message}",
+      exception.message!!.contains("-intellij"),
+    )
+  }
+
+  @Test
+  fun `coroutines from an unknown group fail the build`() {
+    val iconsImpl = context.outputProvider.findRequiredModule("intellij.platform.icons.impl")
+    val renamedFork = MavenArtifactDependency(
+      coordinates = MavenCoordinates("com.example.repackaged", "kotlinx-coroutines-core-jvm", "1.10.2"),
+      includeTransitiveDeps = false,
+      excludedDependencies = emptyList(),
+      scope = null,
+    )
+
+    val exception = assertThrows(IllegalStateException::class.java) {
+      context.productProperties.mavenArtifacts.patchDependencies(iconsImpl, listOf(renamedFork))
+    }
+
+    Assert.assertTrue(
+      "The failure must name the offending coordinates, but was: ${exception.message}",
+      exception.message!!.contains("com.example.repackaged"),
+    )
+  }
+
+  private fun forkDependency(version: String) = MavenArtifactDependency(
+    coordinates = MavenCoordinates("org.jetbrains.intellij.deps.kotlinx", "kotlinx-coroutines-core-jvm", version),
+    includeTransitiveDeps = false,
+    excludedDependencies = emptyList(),
+    scope = null,
+  )
 }


### PR DESCRIPTION
We got a [crash report](https://youtrack.jetbrains.com/issue/JEWEL-1374) that happens when users targets Jewel `0.38.*` or `0.39.*` versions and explicitly targets coroutines 1.11.0+. The crash only happens on packaged standalone apps that call `runBlocking`:

```
- Exception in thread "main" `java.lang.NoSuchMethodError: 'java.lang.Object kotlinx.coroutines.BuildersKt.runBlockingK$default(kotlin.coroutines.CoroutineContext, kotlin.jvm.functions.Function2, int,
  java.lang.Object)'`
```

## Context

### TL;DR:
Stock coroutines 1.11.0 [reestructured the runBlocking function](https://github.com/Kotlin/kotlinx.coroutines//blob/1.11.0/kotlinx-coroutines-core/concurrent/src/Builders.concurrent.kt#L156) so Kotlin call sites compile to `BuildersKt.runBlockingK` rather than `runBlocking`, while Java callers get a separate overload that keeps the old name.

After we updated our standalone library POM file to also depend on the new icons api, we also inadvertently added the transitive dependencies from the new icons API. One of the transitive dependency is the IJP's fork of coroutines (`org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm`).

So, effectively we have two `kotlinx-coroutines-core-jvm` libraries. Gradle doesn't get rid of one over the other because their group id is different so it assumes they are completely different libraries.

Except they are not, so when we package the distribution of our code, the coroutines fork wins the classpath race (looks like jpackage writes the classpath alphabetically, so `1.10.2-intellij-1` lands before `1.11.0`), the bytecode tries to call `runBlockingK` function which does not exist in the fork and bang. Crash.

---
  
`icons-api`, `icons-api-rendering` and `icons-impl` all declare a dependency on the IntelliJ Platform fork of coroutines (`org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm`). The fork uses a different `groupId` than the stock artifact, so Gradle and Maven do not see the two as the same module. No conflict resolution happens and consumers get both jars. Both contain the `kotlinx.coroutines.*` packages, so whichever jar comes first on the classpath shadows the other. jpackage writes the classpath alphabetically, and `1.10.2-intellij-1` sorts before stock `1.11.0`, so the fork wins.

The fork lags upstream. Stock 1.11.0 declares `runBlocking` with `@JvmName("runBlockingK")`, so Kotlin call sites compile to `BuildersKt.runBlockingK`. The fork has no such method and every `runBlocking` call fails to link.

This does not reproduce under `./gradlew run`, because Gradle orders the runtime classpath by dependency graph rather than alphabetically, and stock happens to come first there. It only appears in the packaged artifact, so it passes CI and reaches users.

The icons POMs have declared the fork since MRI-4371 made those modules publishable to Maven Central. Nothing consumed them from outside the IDE until [JEWEL-1374] declared them in the Jewel POMs, which is why this surfaced in 0.38.1 and 0.39.1.

None of the three modules use anything the fork adds: `IntellijCoroutines`, `ParallelismCompensation`, `softLimitedParallelism`, `runBlockingWithParallelismCompensation`, `SoftLimitedDispatcher`, `FlowValueWrapperInternal` and `probeJobCreated` have zero hits in their bytecode. `icons-api` references no coroutines at all, `icons-api-rendering` only uses `CoroutineScope`, and `icons-impl` only uses stock API. Stock coroutines is a safe substitute.

## Changes

* Add `JewelMavenArtifacts.patchPlatformDependencies`, which repoints the coroutines dependency of the published Icons API modules from the fork to the stock artifact. The `artifactId` is the same in both groups, and dropping the `-intellij-N` suffix gives the stock version the fork is based on (`1.10.2-intellij-1` becomes `1.10.2`), so normal conflict resolution can pick a single version.
* Wire `patchPlatformDependencies` into `IdeaCommunityProperties.mavenArtifacts.patchDependencies` for `isPublishedPlatformDependency` modules, which previously fell through unpatched.
* Add `checkNoCoroutinesForkIsPublished` to `JewelMavenArtifacts.validate`, failing the build if any generated POM declares the fork `groupId`. It reads the generated POMs rather than the patched dependency lists, so it also catches the fork arriving transitively.
* Fix the "Testing publishing locally" section of the releasing guide. The `BuildContextImpl`/`ULTIMATE_HOME` workaround it describes no longer exists, since `JewelMavenArtifactsBuildTarget` already passes the community root. The publish script path was also wrong, the build number is optional, and the tolerated exit code 1 was undocumented.

The dependency is repointed rather than dropped because `icons-impl` declares no Compose dependency and uses `BuildersKt`, `Job`, `channels`, `flow` and friends at runtime. Dropping it would leave anyone depending on `icons-impl` directly with no coroutines provider at all.

## Verification

Published locally with `../scripts/publishJewelStandaloneToMavenLocal.cmd`. All three icons POMs now declare `org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2`, and no generated POM mentions the fork `groupId`.

A standalone reproducer that calls `runBlocking` and compiles against stock coroutines 1.11.0 now packages with a single coroutines jar and launches. Its call site still compiles to `runBlockingK$default`, so the fix is not hiding the problem by falling back to an older API.

<details><summary>Want to test this yourself? Check the steps here</summary>
<p>

1. Check out this branch
2. Run the script in `platform/jewel/scripts/publishJewelStandaloneToMavenLocal.cmd`
3. Clone the reproducer here: https://github.com/DanielSouzaBertoldi/JewelIconsApiRunBlockingCrashReproducer
4. Run `./gradlew packageDistributionForCurrentOS`
5. Open the generated app in `build/compose/binaries/main/app/JewelStandaloneReproducer`
    * The crash should not happen if the root `build.gradle` file targets Jewel `0.40.0-263.SNAPSHOT` (if it can't find the version, check what version was locally generated in step 2)
    * Change it to `0.39.1-262.9437.29`, rerun the app, and it should crash

</p>
</details> 

## Screen Recordings

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/353e2741-72c5-406a-9ee9-4f8079012c9a"/> | <video src="https://github.com/user-attachments/assets/1b69c15e-f008-48aa-9916-9dabc48f3e28" /> |

## Release notes

### Bug fixes

 * Fixed a `NoSuchMethodError` crash on startup in packaged Jewel Standalone apps, caused by the IntelliJ Platform fork of `kotlinx-coroutines-core` being published as a transitive dependency of the Icons API modules alongside the stock artifact. Projects that worked around this with a `replacedBy` module rule can now remove it.