### PR TITLE
[KTIJ-8733]: Add Closeable Inspection

### DIFF
--- a/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
@@ -2585,6 +2585,7 @@ inspection.convert.sealed.interface.to.class.display.name=Sealed interface can b
 inspection.convert.sealed.interface.to.class.fix.text=Convert to sealed class
 inspection.duplicate.arguments.in.setof.mapof.functions.display.name=Duplicate arguments in 'setOf' and 'mapOf' functions
 inspection.duplicate.arguments.in.setof.mapof.functions.display.message=Duplicate element in collection: ''{0}''
+inspection.closeable.display.name=Closeable
 popup.title.choose.supertype=Choose Supertype
 fix.remove.argument.text=Remove argument
 fix.remove.redundant.star.text=Remove redundant *
@@ -3018,6 +3019,11 @@ inspection.coroutine.context.with.job.description.non.cancellable=''NonCancellab
 inspection.suspend.coroutine.lacks.cancellation.guarantees.display.name='suspendCoroutine' lacks cancellation guarantees
 inspection.suspend.coroutine.lacks.cancellation.guarantees.description='suspendCoroutine' lacks cancellation guarantees; prefer 'kotlinx.coroutines.suspendCancellableCoroutine' for proper cancellation support
 inspection.suspend.coroutine.lacks.cancellation.guarantees.fix=Replace with more cancellation-friendly 'suspendCancellableCoroutine'
+
+inspection.closeable.expression.description=Resource opened here is not closed via ''use''
+inspection.closeable.variable.description=Resource opened here is not closed via ''use''
+inspection.closeable.variable.fix.name=Replace with 'use'
+inspection.closeable.no.close.description=No close operation found
 
 fix.replace.run.blocking.with.inline=Replace 'runBlocking' with inline code
 fix.replace.run.blocking.with.run=Replace 'runBlocking' with 'run'

--- a/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/Closeable.html
+++ b/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/Closeable.html
@@ -1,0 +1,76 @@
+<html>
+<body>
+Reports <code>Closeable</code> or <code>AutoCloseable</code> resources that are not managed with the <code>use { }</code> function.
+<p>
+    Resources that implement <code>Closeable</code> or <code>AutoCloseable</code> must be properly closed after use.
+    The idiomatic Kotlin way is to call <code>use { }</code>, which automatically closes the resource even if an exception is thrown.
+    Explicit <code>close()</code> calls are not exception-safe and should be replaced with <code>use { }</code>.
+</p>
+<!-- tooltip end -->
+<p>The inspection covers the following cases:</p>
+<ul>
+    <li>A closeable resource assigned to a local variable without being wrapped in <code>use { }</code>.</li>
+    <li>A closeable expression used directly (e.g. method call, <code>also</code> chain) without <code>use { }</code>.</li>
+    <li>A closeable expression returned as the last expression of a lambda block, without <code>use { }</code>.</li>
+    <li>A result of <code>use { }</code> that is itself a closeable resource not wrapped in another <code>use { }</code>.</li>
+</ul>
+<p>Example (variable):</p>
+<pre><code>
+val stream = FileInputStream("file.txt") // resource is never closed safely
+stream.read()
+</code></pre>
+<p>After the quick-fix:</p>
+<pre><code>
+FileInputStream("file.txt").use { stream ->
+    stream.read()
+}
+</code></pre>
+<p>Example (variable, last statement produces a value):</p>
+<pre><code>
+val stream = FileInputStream("file.txt")
+val result = stream.read()
+</code></pre>
+<p>After the quick-fix:</p>
+<pre><code>
+val result = FileInputStream("file.txt").use { stream -> stream.read() }
+</code></pre>
+<p>Example (variable with explicit close — not exception-safe):</p>
+<pre><code>
+val stream = FileInputStream("file.txt")
+stream.read()
+stream.close()
+</code></pre>
+<p>After the quick-fix:</p>
+<pre><code>
+FileInputStream("file.txt").use { stream ->
+    stream.read()
+}
+</code></pre>
+<p>Example (expression):</p>
+<pre><code>
+getStream().also { it.read() }.read() // resource is never closed
+</code></pre>
+<p>After the quick-fix:</p>
+<pre><code>
+getStream().use { it.also { it.read() }.read() }
+</code></pre>
+<p>Example (lambda block returning a closeable):</p>
+<pre><code>
+run {
+    AC() // returned but never closed
+}
+</code></pre>
+<p>After the quick-fix:</p>
+<pre><code>
+run {
+    AC()
+}.use { }
+</code></pre>
+<p>The following cases are <b>not</b> reported:</p>
+<ul>
+    <li>Resources already wrapped in <code>use { }</code>, or chained with <code>also { ... }</code> before <code>use { }</code>.</li>
+    <li>Types that declare a <code>close()</code> method but do not implement <code>Closeable</code> or <code>AutoCloseable</code>.</li>
+    <li>Resources that are explicitly closed with <code>close()</code> before their derived values escape the enclosing scope.</li>
+</ul>
+</body>
+</html>

--- a/plugins/kotlin/code-insight/inspections-k2/resources/intellij.kotlin.codeInsight.inspections.xml
+++ b/plugins/kotlin/code-insight/inspections-k2/resources/intellij.kotlin.codeInsight.inspections.xml
@@ -1435,6 +1435,15 @@
                      bundle="messages.KotlinBundle"
                      key="inspection.duplicate.arguments.in.setof.mapof.functions.display.name"/>
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.codeInsight.inspections.CloseableInspection"
+                     groupPath="Kotlin"
+                     groupBundle="messages.KotlinBundle" groupKey="group.names.probable.bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+                     bundle="messages.KotlinBundle"
+                     key="inspection.closable.display.name"/>
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.codeInsight.inspections.RemoveExplicitSuperQualifierInspection"
                      groupPath="Kotlin"
                      groupBundle="messages.KotlinBundle" groupKey="group.names.redundant.constructs"

--- a/plugins/kotlin/code-insight/inspections-k2/src/org/jetbrains/kotlin/idea/codeInsight/inspections/CloseableInspection.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/src/org/jetbrains/kotlin/idea/codeInsight/inspections/CloseableInspection.kt
@@ -1,0 +1,317 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.codeInsight.inspections
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.modcommand.ModPsiUpdater
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
+import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.components.isSubtypeOf
+import org.jetbrains.kotlin.analysis.api.components.resolveToCall
+import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.idea.base.analysis.api.utils.allOverriddenSymbolsWithSelf
+import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
+import org.jetbrains.kotlin.idea.codeinsight.api.applicable.inspections.KotlinApplicableInspectionBase
+import org.jetbrains.kotlin.idea.codeinsight.api.applicable.inspections.KotlinModCommandQuickFix
+import org.jetbrains.kotlin.idea.codeinsight.utils.StandardKotlinNames
+import org.jetbrains.kotlin.idea.codeinsight.utils.callExpression
+import org.jetbrains.kotlin.idea.codeinsight.utils.isCallingAnyOf
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
+/**
+ * Detects `Closeable`/`AutoCloseable` resources that are not properly closed via `.use { }`:
+ *
+ * **Case 1 – variable assignment**: warns when closeable is stored in a local variable
+ * instead of being consumed by `use { }`.
+ * ```kotlin
+ * val stream = FileInputStream("file.txt")  // ← warned
+ * ```
+ *
+ * **Case 2 – inline expression**: warns when closeable is consumed by a scope function
+ * (`also`, `apply`) that does not close it.
+ * ```kotlin
+ * getStream().also { it.read() }  // ← warned; replace 'also' with 'use'
+ * ```
+ */
+internal class CloseableInspection : KotlinApplicableInspectionBase<KtCallExpression, CloseableInspection.Context>() {
+    override fun InspectionManager.createProblemDescriptor(
+        element: KtCallExpression,
+        context: Context,
+        rangeInElement: TextRange?,
+        onTheFly: Boolean
+    ): ProblemDescriptor = createProblemDescriptor(
+        element,
+        rangeInElement,
+        getProblemDescription(context),
+        ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+        onTheFly,
+        *if (context == Context.NoCloseContext) emptyArray() else arrayOf(createQuickFix(context)),
+    )
+
+    internal sealed interface Context {
+        data class VariableContext(val start: Int, val end: Int, val escaped: Map<String, PropertyUsage>) : Context
+        data class ExpressionContext(val deep: Int) : Context
+
+        object NoCloseContext : Context
+
+    }
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : KtVisitorVoid() {
+        override fun visitCallExpression(expression: KtCallExpression) {
+            visitTargetElement(expression, holder, isOnTheFly)
+            super.visitCallExpression(expression)
+        }
+    }
+
+    @OptIn(KaExperimentalApi::class)
+    override fun KaSession.prepareContext(element: KtCallExpression): Context? {
+        val type = element.expressionType ?: return null
+        if (!type.isCloseable || element.isAlsoOrApply) {
+            return null
+        }
+
+        return prepareContextLocal(element)
+    }
+
+    @OptIn(KaExperimentalApi::class)
+    private fun KaSession.prepareContextLocal(element: KtExpression, deep: Int = 0): Context? {
+        val parent = element.parent
+        if (parent is KtDotQualifiedExpression) {
+            if (parent.callExpression == element || parent.callExpression?.isAlsoOrApply == true) {
+                return prepareContextLocal(parent, deep + 1)
+            }
+            if (parent.callExpression?.isCallingAnyOf(StandardKotlinNames.use) == true) {
+                return null
+            }
+
+            return Context.ExpressionContext(deep + 1)
+        } else if (parent is KtProperty && parent.initializer?.expressionType?.isCloseable == true) {
+            val scope = parent.parent
+
+            if (scope is KtBlockExpression) {
+                val parentName = parent.name ?: return null
+                val statements = scope.statements
+                var firstDeclaration = -1
+                var closed = false
+                val propertyIndex = statements.indexOf(parent)
+                val declarations = hashMapOf(parentName to PropertyUsage(parent, propertyIndex, propertyIndex))
+                val offset = propertyIndex + 1
+                for (i in offset until statements.size) {
+                    val statement = statements[i]
+                    if (firstDeclaration == -1 && statement is KtDeclaration && statement !is KtProperty) {
+                        firstDeclaration = i
+                    }
+                    if (statement.collectUsagesAndCheckClose(declarations, i, parent)) {
+                        closed = true
+                    }
+                    if (statement is KtProperty) {
+                        val name = statement.name ?: continue
+                        declarations[name] = PropertyUsage(statement, i, i)
+                    }
+                }
+                val mainProperty = declarations.remove(parentName)!!
+                val escaped = declarations
+                    .filter { it.value.index >= mainProperty.index && it.value.declare <= mainProperty.index}
+                if (escaped.size < 2 && firstDeclaration == -1) {
+                    return Context.VariableContext(propertyIndex, mainProperty.index, escaped)
+                } else if (!closed) {
+                    return Context.NoCloseContext
+                }
+            }
+        } else if (parent is KtBlockExpression) {
+            val statements = parent.statements
+            if (statements.lastOrNull() == element &&
+                parent.expressionType?.isCloseable == true &&
+                parent.parent !is KtNamedFunction) {
+                return null
+            }
+            return Context.ExpressionContext(deep)
+        }
+
+        return null
+    }
+
+    private fun getProblemDescription(context: Context): String = when (context) {
+        is Context.VariableContext ->
+            KotlinBundle.message("inspection.closeable.variable.description")
+
+        is Context.ExpressionContext ->
+            KotlinBundle.message("inspection.closeable.expression.description")
+
+        is Context.NoCloseContext ->
+            KotlinBundle.message("inspection.closeable.no.close.description")
+    }
+
+    override fun getApplicableRanges(element: KtCallExpression): List<TextRange> {
+        val parent = element.parent
+        if (parent is KtDotQualifiedExpression && parent.selectorExpression == element) {
+            val calleeExpr = element.calleeExpression
+                ?: return listOf(TextRange(0, element.textLength))
+            return listOf(
+                TextRange(
+                    calleeExpr.startOffset - element.startOffset,
+                    calleeExpr.endOffset - element.startOffset,
+                )
+            )
+        }
+        return listOf(TextRange(0, element.textLength))
+    }
+
+    private fun createQuickFix(
+        context: Context,
+    ): KotlinModCommandQuickFix<KtCallExpression> = object : KotlinModCommandQuickFix<KtCallExpression>() {
+
+        override fun getFamilyName(): String =
+            KotlinBundle.message("inspection.closeable.variable.fix.name")
+
+        override fun applyFix(project: Project, element: KtCallExpression, updater: ModPsiUpdater) {
+            val psiFactory = KtPsiFactory(project)
+            when (context) {
+                is Context.VariableContext -> {
+                    val property = element.getStrictParentOfType<KtProperty>() ?: return
+                    val varName = property.name ?: return
+                    val scope = property.parent as? KtBlockExpression ?: return
+                    val statements = scope.statements
+                    val escapedProperties = context.escaped.values.map { it.property }.toSet()
+                    val statementsAfter = statements.subList(context.start + 1, context.end + 1).toList()
+                    val bodyStatements = statementsAfter.filterNot { stmt ->
+                        if (stmt in escapedProperties) return@filterNot true
+                        val dotExpr = stmt as? KtDotQualifiedExpression ?: return@filterNot false
+                        val receiver = dotExpr.receiverExpression as? KtNameReferenceExpression ?: return@filterNot false
+                        val call = dotExpr.selectorExpression as? KtCallExpression ?: return@filterNot false
+                        receiver.text == varName && call.calleeExpression?.text == "close" && call.valueArguments.isEmpty()
+                    }
+                    val receiverText = property.initializer?.text ?: return
+                    val newNode: PsiElement = when (context.escaped.size) {
+                        0 -> {
+                            val bodyText = bodyStatements.joinToString("\n") { it.text }
+                            psiFactory.createExpression("$receiverText.use { $varName ->\n$bodyText\n}")
+                        }
+
+                        1 -> {
+                            val escapedProp = context.escaped.values.first().property
+                            val name = escapedProp.name ?: return
+                            val lastStatement = bodyStatements.lastOrNull()
+                            val bodyText = if (lastStatement is KtProperty && lastStatement.name == escapedProp.name) {
+                                val initText = escapedProp.initializer?.text ?: return
+                                (bodyStatements.dropLast(1).map { it.text } + initText)
+                            } else {
+                                (bodyStatements.map { it.text } + name)
+                            }.joinToString("\n")
+                            val keyword = escapedProp.valOrVarKeyword.text
+                            psiFactory.createProperty("$keyword $name = $receiverText.use { $varName ->\n$bodyText\n}")
+                        }
+
+                        else -> error("Unexpected number of escaped variables: ${context.escaped.size}")
+                    }
+                    for (stmt in statementsAfter) {
+                        stmt.delete()
+                    }
+                    property.replace(newNode)
+                }
+
+                is Context.ExpressionContext -> {
+                    var e: PsiElement = element
+                    repeat(context.deep) {
+                        e = e.parent
+                    }
+                    val expression1 = e as? KtDotQualifiedExpression
+                    val newElement = if (expression1 != null && expression1.callExpression != element) {
+                        expression1.receiverExpression.text?.let {
+                            psiFactory.createExpression("$it.use { it${e.text.substring(it.length)}}")
+                        }
+                    } else {
+                        null
+                    } ?: psiFactory.createExpression("${e.text}.use { }")
+                    e.replace(newElement)
+                }
+
+                is Context.NoCloseContext -> {}
+            }
+        }
+    }
+}
+
+context(_: KaSession)
+private val KtCallExpression.isAlsoOrApply: Boolean
+    get() =
+        isCallingAnyOf(StandardKotlinNames.also, StandardKotlinNames.apply)
+
+private val CLOSEABLE_ID = ClassId.fromString("java.io/Closeable")
+private val AUTO_CLOSEABLE_ID = ClassId.fromString("kotlin/AutoCloseable")
+private val JAVA_AUTO_CLOSEABLE_ID = ClassId.fromString("java.lang/AutoCloseable")
+
+private val CLOSEABLE_CLOSE_ID = CallableId(CLOSEABLE_ID, Name.identifier("close"))
+private val AUTO_CLOSEABLE_CLOSE_ID =
+    CallableId(AUTO_CLOSEABLE_ID, Name.identifier("close"))
+private val JAVA_AUTO_CLOSEABLE_CLOSE_ID =
+    CallableId(JAVA_AUTO_CLOSEABLE_ID, Name.identifier("close"))
+
+context(_: KaSession)
+private val KaType.isCloseable: Boolean
+    get() =
+        isSubtypeOf(CLOSEABLE_ID) || isSubtypeOf(AUTO_CLOSEABLE_ID)
+
+context(_: KaSession)
+private fun KtCallExpression.isCloseableClose(): Boolean {
+    if (calleeExpression?.text != "close" || valueArguments.isNotEmpty()) return false
+    val symbol = resolveToCall()?.singleFunctionCallOrNull()?.symbol ?: return false
+    return symbol.allOverriddenSymbolsWithSelf.any { sym ->
+        val id = sym.callableId
+        id == CLOSEABLE_CLOSE_ID || id == AUTO_CLOSEABLE_CLOSE_ID || id == JAVA_AUTO_CLOSEABLE_CLOSE_ID
+    }
+}
+
+context(_: KaSession)
+private fun KtExpression.collectUsagesAndCheckClose(map: MutableMap<String, PropertyUsage>, index: Int, property: KtProperty): Boolean {
+    var result = false
+    this.accept(object : KtTreeVisitorVoid() {
+        override fun visitReferenceExpression(expression: KtReferenceExpression) {
+            super.visitReferenceExpression(expression)
+            val property = map[expression.text]
+            if (property != null && expression.mainReference.isReferenceTo(property.property)) {
+                property.index = index
+            }
+        }
+
+        override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+            val callee = expression.callExpression
+            val receiver = expression.receiverExpression
+            if (receiver.mainReference?.isReferenceTo(property) == true &&
+                callee?.isCloseableClose() == true
+            ) {
+                result = true
+            }
+            super.visitDotQualifiedExpression(expression)
+        }
+    })
+
+    return result
+}
+
+internal data class PropertyUsage(val property: KtProperty, val declare: Int, var index: Int)

--- a/plugins/kotlin/code-insight/inspections-k2/tests/test/org/jetbrains/kotlin/idea/inspections/tests/K2LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/test/org/jetbrains/kotlin/idea/inspections/tests/K2LocalInspectionTestGenerated.java
@@ -13338,6 +13338,114 @@ public abstract class K2LocalInspectionTestGenerated extends AbstractK2LocalInsp
         }
 
         @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/inspectionsLocal/closeable")
+        public static class Closeable extends AbstractK2LocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("alreadyUse.kt")
+            public void testAlreadyUse() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/alreadyUse.kt");
+            }
+
+            @TestMetadata("alreadyUseWithAlso.kt")
+            public void testAlreadyUseWithAlso() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/alreadyUseWithAlso.kt");
+            }
+
+            @TestMetadata("alreadyUseWithUseResult.kt")
+            public void testAlreadyUseWithUseResult() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/alreadyUseWithUseResult.kt");
+            }
+
+            @TestMetadata("closeWithArgs.kt")
+            public void testCloseWithArgs() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/closeWithArgs.kt");
+            }
+
+            @TestMetadata("escapedCannotWrap.kt")
+            public void testEscapedCannotWrap() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/escapedCannotWrap.kt");
+            }
+
+            @TestMetadata("escapedWithClose.kt")
+            public void testEscapedWithClose() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/escapedWithClose.kt");
+            }
+
+            @TestMetadata("expression.kt")
+            public void testExpression() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/expression.kt");
+            }
+
+            @TestMetadata("expressionInBlock.kt")
+            public void testExpressionInBlock() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/expressionInBlock.kt");
+            }
+
+            @TestMetadata("expressionWithAlso.kt")
+            public void testExpressionWithAlso() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/expressionWithAlso.kt");
+            }
+
+            @TestMetadata("lambdaInBlock.kt")
+            public void testLambdaInBlock() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/lambdaInBlock.kt");
+            }
+
+            @TestMetadata("lambdaInBlock2.kt")
+            public void testLambdaInBlock2() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/lambdaInBlock2.kt");
+            }
+
+            @TestMetadata("notCloseable.kt")
+            public void testNotCloseable() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/notCloseable.kt");
+            }
+
+            @TestMetadata("property.kt")
+            public void testProperty() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/property.kt");
+            }
+
+            @TestMetadata("propertyWithDeclaration.kt")
+            public void testPropertyWithDeclaration() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/propertyWithDeclaration.kt");
+            }
+
+            @TestMetadata("propertyWithLastProperty.kt")
+            public void testPropertyWithLastProperty() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/propertyWithLastProperty.kt");
+            }
+
+            @TestMetadata("propertyWithStatement.kt")
+            public void testPropertyWithStatement() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/propertyWithStatement.kt");
+            }
+
+            @TestMetadata("singleProperty.kt")
+            public void testSingleProperty() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/singleProperty.kt");
+            }
+
+            @TestMetadata("statementInBlock.kt")
+            public void testStatementInBlock() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/statementInBlock.kt");
+            }
+
+            @TestMetadata("useReturnsClosable.kt")
+            public void testUseReturnsClosable() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/useReturnsClosable.kt");
+            }
+
+            @TestMetadata("withClose.kt")
+            public void testWithClose() throws Exception {
+                runTest("testData/inspectionsLocal/closeable/withClose.kt");
+            }
+        }
+
+        @RunWith(JUnit3RunnerWithInners.class)
         @TestMetadata("testData/inspectionsLocal/collapseCollectionLiteralChainCall")
         public static class CollapseCollectionLiteralChainCall extends AbstractK2LocalInspectionTest {
             private void runTest(String testDataFilePath) throws Exception {

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/.inspection
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.codeInsight.inspections.CloseableInspection

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUse.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUse.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    <caret>AC().use { it.read() }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUseWithAlso.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUseWithAlso.kt
@@ -1,0 +1,15 @@
+// PROBLEM: none
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    <caret>AC().also {
+        it.read()
+    }.use { it.read() }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUseWithUseResult.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUseWithUseResult.kt
@@ -1,0 +1,13 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val ac = AC().<caret>use { it.read(); AC() }
+    ac.read()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUseWithUseResult.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/alreadyUseWithUseResult.kt.after
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { it.read(); AC() }.use { ac ->
+        ac.read()
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/closeWithArgs.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/closeWithArgs.kt
@@ -1,0 +1,17 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+    fun close(times: Int) {
+        repeat(times) { print("close") }
+    }
+}
+
+fun c() {
+    val s = <caret>AC()
+    s.read()
+    s.close(2)
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/closeWithArgs.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/closeWithArgs.kt.after
@@ -1,0 +1,18 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+    fun close(times: Int) {
+        repeat(times) { print("close") }
+    }
+}
+
+fun c() {
+    AC().use { s ->
+        s.read()
+        s.close(2)
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/escapedCannotWrap.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/escapedCannotWrap.kt
@@ -1,0 +1,16 @@
+// PROOBLEM: No close operation found
+// FIX: none
+class AC : AutoCloseable {
+    fun getA(): String = "a"
+    fun getB(): String = "b"
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c(): Pair<String, String> {
+    val s = <caret>AC()
+    val a = s.getA()
+    val b = s.getB()
+    return a to b
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/escapedWithClose.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/escapedWithClose.kt
@@ -1,0 +1,16 @@
+// PROBLEM: none
+class AC : AutoCloseable {
+    fun getA(): String = "a"
+    fun getB(): String = "b"
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c(): Pair<String, String> {
+    val s = <caret>AC()
+    val a = s.getA()
+    val b = s.getB()
+    s.close()
+    return a to b
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expression.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expression.kt
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    <caret>AC().read()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expression.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expression.kt.after
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { it.read() }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionInBlock.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionInBlock.kt
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    run {
+        <caret>AC().read()
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionInBlock.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionInBlock.kt.after
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    run {
+        AC().use { it.read() }
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionWithAlso.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionWithAlso.kt
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    <caret>AC().also { it.read() }.read()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionWithAlso.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/expressionWithAlso.kt.after
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().also { it.read() }.use { it.read() }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock.kt
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    run {
+        <caret>AC()
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock.kt.after
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    run {
+        AC()
+    }.use { }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock2.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock2.kt
@@ -1,0 +1,18 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    <caret>run {
+        run {
+            AC().also {
+                it.read()
+            }
+        }
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock2.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/lambdaInBlock2.kt.after
@@ -1,0 +1,18 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    run {
+        run {
+            AC().also {
+                it.read()
+            }
+        }
+    }.use { }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/notCloseable.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/notCloseable.kt
@@ -1,0 +1,15 @@
+// PROBLEM: none
+class NotCloseable {
+    fun read() {
+        print("read")
+    }
+    fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val s = <caret>NotCloseable()
+    s.read()
+    s.close()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/property.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/property.kt
@@ -1,0 +1,13 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val s = <caret>AC()
+    s.read()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/property.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/property.kt.after
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { s ->
+        s.read()
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithDeclaration.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithDeclaration.kt
@@ -1,0 +1,16 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val s = <caret>AC()
+    var string = "string"
+    s.read()
+    s.close()
+    println(string)
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithDeclaration.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithDeclaration.kt.after
@@ -1,0 +1,17 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    var string = AC().use { s ->
+        var string = "string"
+        s.read()
+        string
+    }
+    println(string)
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithLastProperty.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithLastProperty.kt
@@ -1,0 +1,15 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    fun getResult(): String = "result"
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val s = <caret>AC()
+    s.read()
+    val result = s.getResult()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithLastProperty.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithLastProperty.kt.after
@@ -1,0 +1,16 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    fun getResult(): String = "result"
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val result = AC().use { s ->
+        s.read()
+        s.getResult()
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithStatement.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithStatement.kt
@@ -1,0 +1,13 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val s = <caret>AC()
+    s.read()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithStatement.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/propertyWithStatement.kt.after
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { s ->
+        s.read()
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/singleProperty.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/singleProperty.kt
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val s = <caret>AC()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/singleProperty.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/singleProperty.kt.after
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { s ->
+
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/statementInBlock.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/statementInBlock.kt
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    <caret>AC()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/statementInBlock.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/statementInBlock.kt.after
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/useReturnsClosable.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/useReturnsClosable.kt
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().<caret>use { it.let { AC() } }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/useReturnsClosable.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/useReturnsClosable.kt.after
@@ -1,0 +1,12 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { it.let { AC() } }.use { }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/withClose.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/withClose.kt
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    val s = <caret>AC()
+    s.read()
+    s.close()
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/withClose.kt.after
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/closeable/withClose.kt.after
@@ -1,0 +1,14 @@
+class AC : AutoCloseable {
+    fun read() {
+        print("read")
+    }
+    override fun close() {
+        print("close")
+    }
+}
+
+fun c() {
+    AC().use { s ->
+        s.read()
+    }
+}

--- a/plugins/kotlin/code-insight/utils/src/org/jetbrains/kotlin/idea/codeinsight/utils/StandardKotlinNames.kt
+++ b/plugins/kotlin/code-insight/utils/src/org/jetbrains/kotlin/idea/codeinsight/utils/StandardKotlinNames.kt
@@ -156,6 +156,8 @@ object StandardKotlinNames {
 
     @JvmField val context: FqName = BUILT_INS_PACKAGE_FQ_NAME + "context"
 
+    @JvmField val use: FqName = BUILT_INS_PACKAGE_FQ_NAME + "use"
+
     private val collectionTransformationFunctionNames = listOf(
         "chunked",
         "distinct",


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-8733/Add-inspection-for-unclosed-AutoCloseable-with-quickfix-to-wrap-usage-in-use
I implemented what I have found and tried to improve it. The purpose of improvements was to do not suggest invaild options that cause errors
https://github.com/user-attachments/assets/95cc1c57-c69d-4583-b2c3-e6820c41a329

