### PR TITLE
[JEWEL-1360] Gradle Scripts to Bazel Migration - Part 3

### DIFF
--- a/platform/jewel/build-scripts/bazel/BUILD.bazel
+++ b/platform/jewel/build-scripts/bazel/BUILD.bazel
@@ -1,5 +1,15 @@
-load("@rules_java//java:defs.bzl", "java_binary")
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_import", "kt_jvm_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_import", "kt_jvm_library", "kt_jvm_test")
+
+java_library(
+    name = "clikt-dependencies",
+    exports = [
+        "@lib//:fleet-clikt",
+        "@lib//:fleet-clikt-core",
+        "@lib//:kotlinx-coroutines-core",
+    ],
+    visibility = ["//visibility:public"],
+)
 
 kt_jvm_import(
     name = "kotlinpoet",
@@ -20,6 +30,15 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "clikt-utils",
+    srcs = ["src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CliktUtils.kt"],
+    deps = [
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+    ],
+)
+
+kt_jvm_library(
     name = "ktfmt-runner-lib",
     srcs = ["src/main/kotlin/org/jetbrains/jewel/scripts/bazel/KtfmtRunner.kt"],
     deps = [
@@ -34,6 +53,45 @@ kt_jvm_library(
     deps = [
         ":jewel-bazel-scripts-utils",
         "@lib//:kotlinx-coroutines-core",
+    ],
+)
+
+kt_jvm_library(
+    name = "annotate-api-dumps",
+    srcs = ["src/main/kotlin/org/jetbrains/jewel/scripts/bazel/AnnotateApiDumpChanges.kt"],
+    deps = [
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+        ":clikt-utils",
+    ],
+)
+
+kt_jvm_library(
+    name = "check-api-dumps",
+    srcs = ["src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CheckApiDumps.kt"],
+    deps = [
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+        ":clikt-utils",
+    ],
+)
+
+kt_jvm_library(
+    name = "compare-branches",
+    srcs = ["src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CompareBranches.kt"],
+    deps = [
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+    ],
+)
+
+kt_jvm_library(
+    name = "validate-maven-artifacts",
+    srcs = ["src/main/kotlin/org/jetbrains/jewel/scripts/bazel/ValidateMavenArtifacts.kt"],
+    deps = [
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+        ":clikt-utils",
     ],
 )
 
@@ -55,4 +113,123 @@ java_binary(
     name = "jewelVersionUpdater",
     main_class = "org.jetbrains.jewel.scripts.bazel.JewelVersionUpdaterKt",
     runtime_deps = [":jewel-version-updater"],
+)
+
+java_binary(
+    name = "annotateApiDumpChanges",
+    runtime_deps = [":annotate-api-dumps"],
+    main_class = "org.jetbrains.jewel.scripts.bazel.AnnotateApiDumpChangesKt",
+)
+
+java_binary(
+    name = "checkApiDumps",
+    runtime_deps = [":check-api-dumps"],
+    main_class = "org.jetbrains.jewel.scripts.bazel.CheckApiDumpsKt",
+)
+
+# Run this on CLI like: bazel run //platform/jewel/build-scripts/bazel:compareBranches -- branch1 branch2
+java_binary(
+    name = "compareBranches",
+    runtime_deps = [":compare-branches"],
+    main_class = "org.jetbrains.jewel.scripts.bazel.CompareBranchesKt",
+)
+
+# Run this on CLI like: bazel run //platform/jewel/build-scripts/bazel:validateMavenArtifacts -- branch1 branch2
+java_binary(
+    name = "validateMavenArtifacts",
+    runtime_deps = [":validate-maven-artifacts"],
+    main_class = "org.jetbrains.jewel.scripts.bazel.ValidateMavenArtifactsKt",
+)
+
+# Tests
+kt_jvm_test(
+    name = "bazel-test-utils",
+    srcs = ["src/test/kotlin/org/jetbrains/jewel/scripts/bazel/BazelTestUtils.kt"],
+)
+
+kt_jvm_test(
+    name = "jewelBazelScriptsUtilsTest",
+    srcs = [
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/JewelBazelScriptsUtilsTest.kt",
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/FakeCommandRunner.kt",
+    ],
+    associates = [":jewel-bazel-scripts-utils"],
+    deps = [
+        "@rules_kotlin//kotlin/compiler:kotlin-test",
+        "@lib//:junit4",
+        "@lib//:kotlinx-coroutines-test",
+    ],
+    test_class = "org.jetbrains.jewel.scripts.bazel.JewelBazelScriptsUtilsTest",
+)
+
+kt_jvm_test(
+    name = "annotateApiDumpChangesTest",
+    srcs = [
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/AnnotateApiDumpChangesTest.kt",
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/FakeCommandRunner.kt",
+    ],
+    associates = [":annotate-api-dumps"],
+    deps = [
+        "@rules_kotlin//kotlin/compiler:kotlin-test",
+        "@lib//:junit4",
+        "@lib//:kotlinx-coroutines-test",
+        ":jewel-bazel-scripts-utils",
+        ":bazel-test-utils",
+    ],
+    test_class = "org.jetbrains.jewel.scripts.bazel.AnnotateApiDumpChangesTest",
+)
+
+kt_jvm_test(
+    name = "checkApiDumpsTest",
+    srcs = [
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/CheckApiDumpsTest.kt",
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/FakeCommandRunner.kt",
+    ],
+    associates = [":check-api-dumps"],
+    deps = [
+        "@rules_kotlin//kotlin/compiler:kotlin-test",
+        "@lib//:junit4",
+        "@lib//:kotlinx-coroutines-test",
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+    ],
+    test_class = "org.jetbrains.jewel.scripts.bazel.CheckApiDumpsTest",
+)
+
+kt_jvm_test(
+    name = "compareBranchesTest",
+    srcs = [
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/CompareBranchesTest.kt",
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/FakeCommandRunner.kt",
+    ],
+    # Tests don't need a real workspace root (git calls go through FakeCommandRunner, path-existence checks go
+    # through the injected pathExists), just some valid directory to pass the isDirectory check.
+    env = {"BUILD_WORKSPACE_DIRECTORY": "."},
+    associates = [":compare-branches"],
+    deps = [
+        "@rules_kotlin//kotlin/compiler:kotlin-test",
+        "@lib//:junit4",
+        "@lib//:kotlinx-coroutines-test",
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+    ],
+    test_class = "org.jetbrains.jewel.scripts.bazel.CompareBranchesTest",
+)
+
+kt_jvm_test(
+    name = "validateMavenArtifactsTest",
+    srcs = [
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/ValidateMavenArtifactsTest.kt",
+        "src/test/kotlin/org/jetbrains/jewel/scripts/bazel/FakeCommandRunner.kt",
+    ],
+    associates = [":validate-maven-artifacts"],
+    deps = [
+        "@rules_kotlin//kotlin/compiler:kotlin-test",
+        "@lib//:junit4",
+        "@lib//:kotlinx-coroutines-test",
+        ":jewel-bazel-scripts-utils",
+        ":clikt-dependencies",
+        ":bazel-test-utils",
+    ],
+    test_class = "org.jetbrains.jewel.scripts.bazel.ValidateMavenArtifactsTest",
 )

--- a/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/AnnotateApiDumpChanges.kt
+++ b/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/AnnotateApiDumpChanges.kt
@@ -1,0 +1,272 @@
+@file:Suppress("RAW_RUN_BLOCKING", "SSBasedInspection")
+package org.jetbrains.jewel.scripts.bazel
+
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
+import com.github.ajalt.clikt.command.main
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import java.io.File
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+
+private val chunkHeaderRegex = "^@@ \\-([0-9]+)(?:,[0-9]+)? \\+([0-9]+)".toRegex()
+
+fun main(args: Array<String>) {
+    runBlocking { AnnotateApiDumpChangesCommand().main(args) }
+}
+
+internal class AnnotateApiDumpChangesCommand(private val commandRunner: CommandRunner = DefaultCommandRunner) :
+    SuspendingCliktCommand(name = "annotate") {
+    private val verbose: Boolean by option("--verbose", "-v", help = "Enable verbose output.").flag(default = false)
+
+    override fun help(context: Context): String = "Annotates API dump files for breaking changes against a base commit."
+
+    override suspend fun run() {
+        print("⏳ Locating Jewel root...")
+        val jewelRoot = getJewelRoot() ?: exitWithError("Could not find the Jewel root directory.")
+        println(" DONE: ${jewelRoot.canonicalPath}")
+
+        val baseCommit = determineBaseCommit(jewelRoot)
+        println("Checking against base commit: $baseCommit")
+
+        println("\nValidating stable API dumps...")
+        val stableViolations =
+            validateDumps(verbose, experimental = false, baseCommit, jewelRoot, commandRunner) {
+                it.name == "api-dump.txt"
+            }
+
+        println("\nValidating experimental API dumps...")
+        val experimentalViolations =
+            validateDumps(verbose, experimental = true, baseCommit, jewelRoot, commandRunner) {
+                it.name == "api-dump-experimental.txt"
+            }
+
+        println("\nCreating summary...")
+        val summary = buildSummary(stableViolations, experimentalViolations)
+        println(summary.prependIndent())
+
+        println("\nWriting summary to GitHub Job...")
+        writeSummary(summary)
+
+        println("\nDone processing API dumps")
+
+        if (stableViolations) {
+            exitWithError("Stable API breakages found.")
+        } else {
+            printlnSuccess("✅ No stable API breakages found.")
+        }
+    }
+
+    private suspend fun determineBaseCommit(jewelRoot: File) =
+        if (checkPrNumber()) {
+            requireGhTool()
+            commandRunner("gh pr view ${getPrNumber()} --json baseRefOid -q .baseRefOid", jewelRoot).getOrThrow()
+        } else {
+            printlnWarn("GitHub PR number not found, falling back to checking against HEAD~1 instead")
+            commandRunner("git rev-parse HEAD~1", jewelRoot).getOrThrow()
+        }
+
+    private fun buildSummary(stableViolations: Boolean, experimentalViolations: Boolean) = buildString {
+        appendLine("## Binary check result")
+        if (!stableViolations && !experimentalViolations) {
+            appendLine("✅ No API breakages found.")
+        } else {
+            if (stableViolations) {
+                appendLine("❌ Stable API breakages found.")
+            }
+            if (experimentalViolations) {
+                appendLine("⚠️ Experimental API breakages found.")
+            }
+        }
+    }
+
+    private fun writeSummary(summary: String) {
+        // Write the summary to the magical GITHUB_STEP_SUMMARY file
+        // See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+        val summaryFile = System.getenv("GITHUB_STEP_SUMMARY")?.takeIf { !it.isBlank() }?.let { File(it) }
+        if (summaryFile != null) {
+            summaryFile.writeText(summary)
+            println("Summary written to ${summaryFile.absolutePath}")
+        } else {
+            printlnWarn("GITHUB_STEP_SUMMARY environment variable not set")
+        }
+    }
+
+    /**
+     * Requires the GitHub CLI tool (`gh`) to be present on the system's PATH. Exits the process with an error code if
+     * the tool is not found.
+     */
+    private suspend fun requireGhTool() {
+        if (checkGhTool()) return
+
+        exitWithError("ERROR: the GitHub CLI tool must be present on the PATH.")
+    }
+
+    /**
+     * Checks if the GitHub CLI tool (`gh`) is present on the system's PATH.
+     *
+     * @return `true` if the `gh` tool is found, `false` otherwise.
+     */
+    private suspend fun checkGhTool() = commandRunner("which gh", null, exitOnError = false).isSuccess
+}
+
+/**
+ * Checks if the PR number environment variable (`PR_NUMBER`) is set and is a valid integer.
+ *
+ * @return `true` if `PR_NUMBER` is set and is an integer, `false` otherwise.
+ */
+private fun checkPrNumber() = System.getenv("PR_NUMBER")?.trim()?.toIntOrNull() != null
+
+/**
+ * Gets the value of the PR number environment variable (`PR_NUMBER`).
+ *
+ * @return The PR number as a string.
+ * @throws IllegalStateException if the `PR_NUMBER` environment variable is not set.
+ */
+private fun getPrNumber() = checkNotNull(System.getenv("PR_NUMBER")?.trim()) { "PR number not set" }
+
+internal fun processDiff(diff: String, file: File, experimental: Boolean): List<BreakingChange> {
+    val breakingChanges = mutableListOf<BreakingChange>()
+    var oldLineNum = 0
+    var newLineNum = 0
+    var lastLineWasRemoval = false
+
+    diff.lines().forEach { line ->
+        when {
+            line.startsWith("@@") -> {
+                val match = chunkHeaderRegex.find(line)
+                if (match != null) {
+                    oldLineNum = match.groupValues[1].toInt()
+                    newLineNum = match.groupValues[2].toInt()
+                }
+                lastLineWasRemoval = false
+            }
+
+            line.startsWith("-") && !line.startsWith("---") -> {
+                breakingChanges.add(
+                    BreakingChange(
+                        file,
+                        line
+                            .substring(1) // Skip the first character (either + or -)
+                            .replace("%", "%25"), // Escape the % character
+                        experimental,
+                        oldLineNum,
+                        newLineNum,
+                        !lastLineWasRemoval,
+                    )
+                )
+                oldLineNum++
+                lastLineWasRemoval = true
+            }
+
+            line.startsWith("+") && !line.startsWith("+++") -> {
+                newLineNum++
+                lastLineWasRemoval = false
+            }
+
+            line.startsWith(" ") -> {
+                oldLineNum++
+                newLineNum++
+                lastLineWasRemoval = false
+            }
+        }
+    }
+
+    return breakingChanges
+}
+
+internal suspend fun validateDumps(
+    verbose: Boolean,
+    experimental: Boolean,
+    baseCommit: String,
+    jewelRoot: File,
+    commandRunner: CommandRunner,
+    dumpsFilter: (File) -> Boolean,
+): Boolean {
+    val samplesDir = File(jewelRoot, "samples").absolutePath
+    val apiDumpFiles =
+        jewelRoot.walkTopDown().filter { dumpsFilter(it) && !it.absolutePath.startsWith(samplesDir) }.toList()
+
+    println()
+    println("Detected API dumps:\n${apiDumpFiles.joinToString("\n") { " * ${it.toRelativeString(jewelRoot)}" }}")
+
+    val results = coroutineScope {
+        apiDumpFiles
+            .map { file ->
+                async {
+                    val breakingChanges = mutableListOf<BreakingChange>()
+                    val log = buildString {
+                        appendLine("\n  Checking ${file.toRelativeString(jewelRoot)}")
+
+                        val isModifiedResult =
+                            commandRunner(
+                                "git diff --quiet $baseCommit -- ${file.absolutePath}",
+                                jewelRoot,
+                                exitOnError = false,
+                            )
+
+                        if (verbose) {
+                            appendLine("    First diff result:\n${isModifiedResult.output}")
+                        }
+
+                        if (isModifiedResult.isFailure) {
+                            appendLine("    Detected changes, investigating...")
+
+                            val command = "git --no-pager diff --unified=0 $baseCommit -- ${file.absolutePath}"
+                            if (verbose) {
+                                appendLine("      Running: $command...")
+                            }
+
+                            val diffResult = commandRunner(command, jewelRoot)
+                            if (verbose) {
+                                appendLine("      Second diff result:\n${diffResult.output}")
+                            }
+
+                            breakingChanges.addAll(processDiff(diffResult.output, file, experimental))
+                        }
+                        breakingChanges.forEach { it.formatLog(this, jewelRoot) }
+                    }
+                    ValidationResult(file, log, breakingChanges)
+                }
+            }
+            .awaitAll()
+    }
+
+    results.forEach { result -> print(result.log) }
+    return results.any { it.breakingChanges.isNotEmpty() }
+}
+
+internal data class BreakingChange(
+    val file: File,
+    val lineContent: String,
+    val experimental: Boolean,
+    val oldLineNum: Int,
+    val newLineNum: Int,
+    val annotate: Boolean,
+) {
+    fun formatLog(log: StringBuilder, jewelRoot: File) {
+        val type = if (experimental) "experimental" else "stable"
+        val message = "⚠️ Breaking $type API change:\n       line $oldLineNum removed: $lineContent"
+        log.appendLine("    " + if (experimental) message.asWarning() else message.asError())
+
+        if (!annotate) return
+
+        // Use the magic log format that GitHub workflows accept to annotate code
+        // See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+        val severity = if (experimental) "warning" else "error"
+        log.append("::$severity ")
+
+        val repoRoot = jewelRoot.parentFile.parentFile
+        log.append("file=${file.toRelativeString(repoRoot)},")
+
+        log.append("line=$newLineNum,")
+
+        val title = if (experimental) "Breaking experimental API change" else "Breaking API change"
+        log.appendLine("title=$title::This looks like a breaking API change, make sure it's intended.")
+    }
+}
+
+internal data class ValidationResult(val file: File, val log: String, val breakingChanges: List<BreakingChange>)

--- a/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CheckApiDumps.kt
+++ b/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CheckApiDumps.kt
@@ -1,0 +1,105 @@
+@file:Suppress("RAW_RUN_BLOCKING", "SSBasedInspection")
+package org.jetbrains.jewel.scripts.bazel
+
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
+import com.github.ajalt.clikt.command.main
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import java.io.File
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+// tests.cmd needs both the JPS module that holds the test class, and the test pattern itself.
+private const val TEST_MODULE = "intellij.platform.testFramework.monorepo.tests"
+private const val TEST_CLASS = "com.intellij.platform.testFramework.monorepo.api.ApiCheckTest"
+
+fun main(args: Array<String>) {
+    runBlocking { CheckUpdatedCommand().main(args) }
+}
+
+/**
+ * Renders this string as a single-quoted shell literal. Paths embedded in generated shell source must be quoted this
+ * way: inside double quotes the shell would still expand `$`, backticks and backslashes.
+ */
+internal fun String.asShellLiteral(): String = "'" + replace("'", """'\''""") + "'"
+
+internal fun buildApiCheckCommand(): String = "./tests.cmd --module $TEST_MODULE --test $TEST_CLASS"
+
+/**
+ * Builds the shell script that runs [command] and tees its output to [outputFile], from [repoRoot].
+ *
+ * The pipeline's exit status must be [command]'s and not tee's, hence `pipefail`; `errexit` makes a failing `cd`
+ * fatal, too.
+ */
+internal fun buildApiCheckScript(repoRoot: File, outputFile: File, command: String): String =
+    """
+    #!/bin/bash
+    set -e -o pipefail
+    cd ${repoRoot.absolutePath.asShellLiteral()}
+    $command | tee ${outputFile.absolutePath.asShellLiteral()}
+    """
+        .trimIndent()
+
+internal class CheckUpdatedCommand(private val commandRunner: CommandRunner = DefaultCommandRunner) :
+    SuspendingCliktCommand("check") {
+    private val verbose: Boolean by option("--verbose", "-v", help = "Enable verbose output.").flag(default = false)
+
+    override fun help(context: Context): String = "Runs APICheckTest and fails if test failures are detected."
+
+    override suspend fun run() =
+        withContext(Dispatchers.IO) {
+            print("⏳ Locating repository root...")
+            val repoRoot = getBuildWorkspaceDirectory()
+            println(" DONE: ${repoRoot.canonicalPath}")
+
+            val command = buildApiCheckCommand()
+            if (verbose) println("Running: $command")
+
+            val outputFile = File.createTempFile("api-check-output", ".log")
+            val scriptFile = File.createTempFile("api-check-script", ".sh")
+
+            try {
+                println("Output will be streamed in real-time and saved to: ${outputFile.absolutePath}")
+
+                scriptFile.writeText(buildApiCheckScript(repoRoot, outputFile, command))
+                scriptFile.setExecutable(true)
+
+                val result =
+                    commandRunner(
+                        command = scriptFile.absolutePath,
+                        workingDir = repoRoot,
+                        exitOnError = false,
+                        timeoutAmount = 60.minutes,
+                        streamOutput = true,
+                    )
+
+                // Read the captured output for analysis
+                val output = outputFile.readText()
+
+                // Extract failing module names from TeamCity test failure messages
+                val failingModules = extractFailingModules(output)
+
+                if (failingModules.isNotEmpty()) {
+                    val moduleList = failingModules.joinToString(", ")
+                    exitWithError("❌ API check test failed — failing modules: $moduleList")
+                } else if (result.isFailure) {
+                    // The output scraping only recognises TeamCity test failures; anything else that makes the
+                    // command fail (bad invocation, build error, crash) must still be reported as a failure.
+                    exitWithError("❌ API check test command failed. See the output above for details.")
+                } else {
+                    printlnSuccess("✅ API check test passed — no test failures detected.")
+                }
+            } finally {
+                outputFile.delete()
+                scriptFile.delete()
+            }
+        }
+
+    internal fun extractFailingModules(output: String): List<String> {
+        val failurePattern = """##teamcity\[testFailed name='${Regex.escape(TEST_CLASS)}\.([^']+)'""".toRegex()
+        return failurePattern.findAll(output).map { it.groupValues[1] }.distinct().sorted().toList()
+    }
+}

--- a/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CliktUtils.kt
+++ b/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CliktUtils.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import com.github.ajalt.clikt.core.PrintMessage
+
+fun exitWithError(message: String): Nothing {
+    throw PrintMessage(message.asError(), statusCode = 1, printError = true)
+}

--- a/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CompareBranches.kt
+++ b/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/CompareBranches.kt
@@ -1,0 +1,378 @@
+@file:Suppress("RAW_RUN_BLOCKING", "SSBasedInspection")
+package org.jetbrains.jewel.scripts.bazel
+
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
+import com.github.ajalt.clikt.command.main
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.defaultLazy
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import java.io.File
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
+
+// Run it like: bazel run //platform/jewel/build-scripts/bazel:compareBranches -- branch1 branch2
+fun main(args: Array<String>) {
+    runBlocking { CompareBranchesCommand().main(args) }
+}
+
+internal class CompareBranchesCommand(
+    private val commandRunner: CommandRunner = DefaultCommandRunner,
+    private val pathExists: (File) -> Boolean = File::exists,
+) : SuspendingCliktCommand() {
+    private val verbose: Boolean by
+        option("--verbose", help = "Prints the normalized commit subjects being compared.").flag(default = false)
+    private val jewelOnly: Boolean by
+        option("--jewel-only", help = "Only prints commits whose subject contains the word 'jewel' (case insensitive).")
+            .flag(default = false)
+    private val showHashes: Boolean by
+        option("--hash", help = "Show commit hashes in the output.").flag(default = false)
+    private val noBuildChanges: Boolean by
+        option(
+                "--no-build-changes",
+                help = "Exclude commits that only affect the build/ directory. Mutually exclusive with --build-only.",
+            )
+            .flag(default = false)
+    private val buildOnly: Boolean by
+        option(
+                "--build-only",
+                help =
+                    "Only check commits that affect the build/ directory. Mutually exclusive with --no-build-changes.",
+            )
+            .flag(default = false)
+    private val branch1: String by argument(help = "The first branch to compare.")
+    private val branch2: String by argument(help = "The second branch to compare.")
+    private val sinceDate: String by
+        option(
+                "--since",
+                help =
+                    "The start date for the commit range (yyyy-mm-dd). " +
+                        "If omitted, it will be inferred from the latest release in RELEASE NOTES.md.",
+            )
+            .defaultLazy {
+                val since = getLatestReleaseDate(getJewelRoot() ?: File(".").canonicalFile)
+                if (since.isNullOrBlank()) {
+                    throw UsageError(
+                        "Error: --since is required if RELEASE NOTES.md does not exist or contain a release date."
+                    )
+                }
+                since
+            }
+
+    override fun help(context: Context): String =
+        "Compares commits affecting specific paths between two branches by commit message."
+
+    override suspend fun run() {
+        // Validate mutually exclusive flags
+        if (noBuildChanges && buildOnly) {
+            throw UsageError("Error: --no-build-changes and --build-only are mutually exclusive.")
+        }
+
+        val pathsToCheck = validateEnvironment()
+        val commits1 = fetchCommits(branch1, pathsToCheck)
+        val commits2 = fetchCommits(branch2, pathsToCheck)
+
+        if (verbose) {
+            println(
+                "📊 Found ${commits1.size} commits in '${branch1}' and ${commits2.size} commits in '${branch2}' since ${sinceDate}"
+            )
+
+            if (commits1.isNotEmpty()) {
+                println("\n--- Commits for '${branch1}' ---")
+                commits1.forEach(::printCommitInfoLine)
+                println()
+            }
+
+            if (commits2.isNotEmpty()) {
+                println("\n--- Commits for '${branch2}' ---")
+                commits2.forEach(::printCommitInfoLine)
+                println()
+            }
+        }
+
+        compareAndDisplayResults(commits1, commits2)
+    }
+
+    /** Validates the environment and prerequisites, returning the paths to check. */
+    private suspend fun validateEnvironment(): List<String> {
+        print("⏳ Locating IntelliJ Community root...")
+
+        val communityRoot = getBuildWorkspaceDirectory()
+        if (!communityRoot.isDirectory) {
+            println()
+            printlnErr(
+                "    Could not find the IntelliJ Community root directory. " +
+                    "Please make sure you're running the script from somewhere inside it."
+            )
+            exitProcess(1)
+        }
+
+        println(" DONE: ${communityRoot.absolutePath}")
+
+        // Validate git repository
+        if (!isDirectoryGitRepo(communityRoot, commandRunner)) {
+            printlnErr("Error: Not a git repository.")
+            exitProcess(1)
+        }
+
+        // Validate branches exist
+        if (!branchExists(branch1, communityRoot, commandRunner)) {
+            printlnErr("Error: Branch '$branch1' not found.")
+            exitProcess(1)
+        }
+
+        if (!branchExists(branch2, communityRoot, commandRunner)) {
+            printlnErr("Error: Branch '$branch2' not found.")
+            exitProcess(1)
+        }
+
+        // Determine which paths to check based on flags
+        val pathsToCheck =
+            when {
+                noBuildChanges -> Config.PATHS_TO_CHECK.filterNot { it.startsWith("build") }
+                buildOnly -> Config.PATHS_TO_CHECK.filter { it.startsWith("build") }
+                else -> Config.PATHS_TO_CHECK
+            }
+
+        // Validate paths exist
+        var anyPathMissing = false
+        for (path in pathsToCheck) {
+            val file = File(communityRoot, path)
+            if (!pathExists(file)) {
+                printlnErr("Error: Path to check does not exist: $path")
+                anyPathMissing = true
+            }
+        }
+        if (anyPathMissing) exitProcess(1)
+
+        // Display comparison parameters
+        println("🔍 Comparing commits between '$branch1' and '$branch2' since $sinceDate for paths:")
+        pathsToCheck.forEach { println("  - $it") }
+        if (jewelOnly) println("[Only including commits explicitly tagged as Jewel]")
+        if (noBuildChanges) println("[Excluding build/ directory changes]")
+        if (buildOnly) println("[Only including build/ directory changes]")
+        println()
+        return pathsToCheck
+    }
+
+    /**
+     * Fetches commits for a given branch, filtering by author date.
+     *
+     * Uses the author date instead of the commit date to properly handle cherry-picks.
+     */
+    internal suspend fun fetchCommits(branch: String, pathsToCheck: List<String>): List<CommitInfo> {
+        val communityRoot = getBuildWorkspaceDirectory()
+        val pathsArg = pathsToCheck.joinToString(separator = " ") { "-- $it" }
+
+        println("📋 Fetching commits from '$branch'...")
+
+        val result =
+            commandRunner("git log $branch --pretty=format:'${Config.GIT_LOG_FORMAT},%ai' $pathsArg", communityRoot)
+        val allLines = result.output.lines()
+        val nonBlankLines = allLines.filter { it.isNotBlank() }
+
+        if (verbose) {
+            println("  📊 Raw output: ${allLines.size} lines total, ${nonBlankLines.size} non-blank")
+        }
+
+        // Parse commit messages and filter by author date
+        val commits = mutableListOf<CommitInfo>()
+        val unparseable = mutableListOf<String>()
+        var dateFilteredCount = 0
+
+        nonBlankLines.forEach { line ->
+            when (val result = parseCommitWithDateResult(line)) {
+                is ParseResult.Success -> commits.add(result.commit)
+                is ParseResult.DateFiltered -> dateFilteredCount++
+                is ParseResult.ParseError -> unparseable.add(line)
+            }
+        }
+
+        if (verbose) {
+            println("  ✅ Parsed ${commits.size} commits, filtered out $dateFilteredCount commits by date")
+        }
+
+        // Report truly unparseable commits only
+        if (unparseable.isNotEmpty()) {
+            printlnWarn(
+                "  ⚠️  Warning: ${unparseable.size} commits from '$branch' could not be parsed due to format issues:"
+            )
+            for (line in unparseable.take(5)) { // Only show the first 5 to avoid spam
+                println("    • ${line.take(100)}${if (line.length > 100) "..." else ""}")
+            }
+            if (unparseable.size > 5) {
+                println("    ... and ${unparseable.size - 5} more")
+            }
+        }
+
+        return commits
+    }
+
+    /** Parses a git log line and returns a ParseResult indicating success, date filtering, or parse error */
+    internal fun parseCommitWithDateResult(line: String): ParseResult {
+        // Remove surrounding quotes first
+        val cleanLine = line.trim().removeSurrounding("'")
+
+        // Author dates have a consistent format: YYYY-MM-DD HH:MM:SS +ZZZZ
+        // Use regex to find the author date at the end of the line
+        val authorDateRegex = Regex("""^(.+),(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+\-]\d{4})$""")
+        val matchResult = authorDateRegex.find(cleanLine) ?: return ParseResult.ParseError
+
+        val commitPart = matchResult.groupValues[1]
+        val authorDatePart = matchResult.groupValues[2]
+
+        val commit = parseCommitLine(commitPart)
+
+        // Filter by author date (handles cherry-picks correctly) using proper date parsing
+        return if (isCommitAfterDate(authorDatePart, sinceDate)) {
+            ParseResult.Success(commit)
+        } else {
+            ParseResult.DateFiltered
+        }
+    }
+
+    /**
+     * Compares author date with since date using proper datetime parsing. Handles timezone-aware comparison properly.
+     */
+    internal fun isCommitAfterDate(authorDateStr: String, sinceDateStr: String): Boolean {
+        return try {
+            // Parse the git author date (format: "2025-09-25 12:37:32 +0200")
+            val authorDate = ZonedDateTime.parse(authorDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z"))
+
+            // Parse the "since" date (format: "2025-08-25" -> start of day in local timezone)
+            val sinceDate =
+                LocalDate.parse(sinceDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+                    .atStartOfDay()
+                    .atZone(authorDate.zone) // Use same timezone as author for fair comparison
+
+            authorDate.isAfter(sinceDate) || authorDate.isEqual(sinceDate)
+        } catch (e: Exception) {
+            printlnWarn(
+                "    Warning: Failed to parse dates - author: '$authorDateStr', since: '$sinceDateStr' (${e.message})"
+            )
+            // Fallback to string comparison if parsing fails
+            authorDateStr >= sinceDateStr
+        }
+    }
+
+    /**
+     * Compares commits between branches and displays results. Cherry-picked commits with identical subjects are
+     * considered the same.
+     */
+    private fun compareAndDisplayResults(commits1: List<CommitInfo>, commits2: List<CommitInfo>) {
+        val horizontalLine = "------------------------------------------------------------------"
+        println(horizontalLine)
+
+        // Find commits unique to branch1 (by comparing normalized subjects)
+        val branch2Subjects = commits2.map { it.subject }.toSet()
+        val commitsInBranch1Only = commits1.filter { (_, subject) -> subject !in branch2Subjects }
+
+        if (verbose) {
+            println("Analyzing commits in '$branch1' but not '$branch2':")
+            println("  Raw list: ${commitsInBranch1Only.joinToString { it.subject }}")
+            println()
+        }
+
+        if (commitsInBranch1Only.isNotEmpty()) {
+            println("Commits in '$branch1' but not '$branch2':")
+            commitsInBranch1Only.forEach(::printCommitInfoLine)
+        } else {
+            println("✅ No unique commits found in '$branch1'.")
+        }
+
+        println()
+        println(horizontalLine)
+
+        // Find commits unique to branch2
+        val branch1Subjects = commits1.map { it.subject }.toSet()
+        val commitsInBranch2Only = commits2.filter { (_, subject) -> subject !in branch1Subjects }
+
+        if (verbose) {
+            println("Analyzing commits in '$branch2' but not '$branch1':")
+            println("  Raw list: ${commitsInBranch2Only.joinToString { it.subject }}")
+            println()
+        }
+
+        if (commitsInBranch2Only.isNotEmpty()) {
+            println("Commits in '$branch2' but not '$branch1':")
+            commitsInBranch2Only.forEach(::printCommitInfoLine)
+        } else {
+            println("✅ No unique commits found in '$branch2'.")
+        }
+
+        println()
+        println(horizontalLine)
+    }
+
+    /** Parses a git log line to extract commit hash and subject */
+    internal fun parseCommitLine(commitLine: String): CommitInfo {
+        val (hash, subject) = commitLine.split(Config.DELIMITER)
+        if (subject.isBlank()) {
+            printlnWarn("  Warning: Empty commit subject found for commit $hash.")
+        }
+        return CommitInfo(hash.trim('\''), normalizeSubject(subject.trim('\'')))
+    }
+
+    /** Prints a formatted commit line with hash and subject, highlighting Jewel commits */
+    private fun printCommitInfoLine(commitInfo: CommitInfo) {
+        val isJewelCommit = commitInfo.subject.contains("jewel", ignoreCase = true)
+        if (jewelOnly && !isJewelCommit) return
+
+        val output = buildString {
+            append("  - ")
+            if (showHashes) {
+                append(commitInfo.hash.take(7))
+                append(" | ")
+            }
+            append(commitInfo.subject)
+        }
+
+        if (isJewelCommit) {
+            println(output.asBold())
+        } else {
+            println(output)
+        }
+    }
+
+    /**
+     * Normalizes commit subjects by removing cherry-pick prefixes. This ensures cherry-picked commits match their
+     * original counterparts.
+     */
+    internal fun normalizeSubject(subject: String): String =
+        subject.replaceFirst(Regex("""^(cherry picked from commit [0-9a-f]+):? """, RegexOption.IGNORE_CASE), "").trim()
+}
+
+/** Configuration for the branch comparison script. Defines paths to check and git log formatting options. */
+private object Config {
+    /** Paths to monitor for changes - platform components and build files */
+    val PATHS_TO_CHECK =
+        listOf(
+            "platform/jewel",
+            "libraries/skiko",
+            "libraries/compose-runtime-desktop",
+            "libraries/compose-foundation-desktop",
+            "libraries/compose-foundation-desktop-junit",
+            "libraries/detekt-compose-rules",
+            "build/src/org/jetbrains/intellij/build/JewelMavenArtifacts.kt",
+            "build/src/JewelMavenArtifactsBuildTarget.kt",
+        )
+    const val DELIMITER = "::COMMIT::"
+    const val GIT_LOG_FORMAT = "%H${DELIMITER}%s"
+}
+
+/** Represents a git commit with its hash and subject line. */
+internal data class CommitInfo(val hash: String, val subject: String)
+
+/** Result of parsing a git log line */
+internal sealed class ParseResult {
+    data class Success(val commit: CommitInfo) : ParseResult()
+
+    object DateFiltered : ParseResult()
+
+    object ParseError : ParseResult()
+}

--- a/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/JewelBazelScriptsUtils.kt
+++ b/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/JewelBazelScriptsUtils.kt
@@ -137,7 +137,7 @@ suspend fun isDirectoryGitRepo(directory: File, runner: CommandRunner = DefaultC
  * @return true if the branch exists, false otherwise.
  */
 suspend fun branchExists(branch: String, directory: File, runner: CommandRunner = DefaultCommandRunner): Boolean =
-    runner("git rev-parse --verify $branch", directory).isSuccess
+    runner("git rev-parse --verify $branch", directory, exitOnError = false).isSuccess
 
 /**
  * Gets the date of the latest release from the "RELEASE NOTES.md" file.
@@ -215,7 +215,14 @@ private suspend fun runCommand(
             if (!streamOutput) {
                 CompletableFuture.supplyAsync { process.inputStream.bufferedReader().readText() }
             } else null
-        val exitCode = process.waitFor()
+
+        val finishedInTime = process.waitFor(timeoutAmount.inWholeSeconds, TimeUnit.SECONDS)
+        if (!finishedInTime) {
+            process.destroyForcibly()
+            error("Command '$command' timed out after $timeoutAmount".asError())
+        }
+
+        val exitCode = process.exitValue()
         val output = outputFuture?.get(timeoutAmount.inWholeSeconds, TimeUnit.SECONDS) ?: ""
 
         if (exitCode == 0) {

--- a/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/ValidateMavenArtifacts.kt
+++ b/platform/jewel/build-scripts/bazel/src/main/kotlin/org/jetbrains/jewel/scripts/bazel/ValidateMavenArtifacts.kt
@@ -1,0 +1,603 @@
+@file:Suppress("RAW_RUN_BLOCKING", "SSBasedInspection")
+package org.jetbrains.jewel.scripts.bazel
+
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
+import com.github.ajalt.clikt.command.main
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.terminal
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.file
+import com.github.ajalt.mordant.terminal.YesNoPrompt
+import java.io.File
+import java.nio.file.Files
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+
+// Run this on CLI like: bazel run //platform/jewel/build-scripts/bazel:validateMavenArtifacts -- branch1 branch2
+fun main(args: Array<String>) {
+    runBlocking { ValidateMavenArtifactsCommand().main(args) }
+}
+
+internal class ValidateMavenArtifactsCommand(
+    private val commandRunner: CommandRunner = DefaultCommandRunner,
+    private val isDirectory: (File) -> Boolean = File::isDirectory,
+    private val isFile: (File) -> Boolean = File::isFile,
+) : SuspendingCliktCommand() {
+    private val branches: List<String> by
+        argument(help = "Branches to build and compare artifacts from (at least two).").multiple(required = true)
+
+    private val forcePull: Boolean by
+        option("--force-pull", help = "Force pull untracked branches before building.").flag(default = false)
+
+    private val verbose: Boolean by option("--verbose", "-v", help = "Enable verbose output.").flag(default = false)
+
+    private val artifactsDir: File? by
+        option(
+                "--artifacts-dir",
+                "-a",
+                "--out-dir",
+                "-o",
+                help =
+                    "Directory to store the built artifacts. " +
+                        "If not specified, it will create a temp dir in the system temp dir.",
+            )
+            .file(mustExist = false, canBeFile = false)
+
+    private val preserveTemp: Boolean by
+        option(
+                "--preserve-temp",
+                "-p",
+                help = "Do not clean up the temporary directory after execution. Implicit when --no-build is specified.",
+            )
+            .flag(default = false)
+
+    private val noBuild: Boolean by
+        option(
+                "--no-build",
+                "-n",
+                help =
+                    "Skip building artifacts, only validate the artifacts in --artifacts-dir. " +
+                        "Requires passing --artifacts-dir, implies --preserve-temp.",
+            )
+            .flag(default = false)
+
+    private val mavenArtifactsOutputDirName = "maven-artifacts" // Matches JewelMavenArtifactsBuildTarget
+
+    override fun help(context: Context): String = "Validates Jewel Maven artifacts across specified branches."
+
+    override suspend fun run() =
+        withContext(Dispatchers.IO) {
+            if (branches.size < 2) {
+                exitWithError("Please specify at least two branches to compare.")
+            }
+
+            print("⏳ Locating IntelliJ Community root...")
+            val communityRoot = getBuildWorkspaceDirectory()
+
+            println(" DONE: ${communityRoot.canonicalPath}")
+
+            print("⏳ Checking git status...")
+            if (!isDirectoryGitRepo(communityRoot, commandRunner)) {
+                println()
+                exitWithError("Not a git repository at ${communityRoot.canonicalPath}.")
+            }
+
+            // Check if the repo has pending changes, which can cause issues when switching branches.
+            // If --no-build is specified, we don't switch branches to build, so this is not needed.
+            if (!noBuild) {
+                val gitStatus = commandRunner("git status --porcelain", communityRoot, exitOnError = true).output.trim()
+                if (gitStatus.isNotEmpty()) {
+                    println()
+                    exitWithError(
+                        "Local changes detected in the git repository at ${communityRoot.canonicalPath}. " +
+                            "Please commit or stash them."
+                    )
+                }
+            }
+
+            // Store the original branch to return to later
+            val originalBranch = getCurrentBranchName(communityRoot, commandRunner)
+            printlnSuccess(" DONE")
+
+            if (verbose) println("  Original branch: $originalBranch")
+
+            val mavenArtifactsDir = communityRoot.resolve("out/idea-ce/artifacts/$mavenArtifactsOutputDirName")
+            val artifactsDirectory = artifactsDir ?: Files.createTempDirectory("jewel-artifacts").toFile()
+
+            if (noBuild) {
+                if (artifactsDirectory == null || !isDirectory(artifactsDirectory)) {
+                    exitWithError(
+                        "When --no-build is specified, --artifacts-dir must be " +
+                            "provided and point to an existing directory."
+                    )
+                }
+
+                println("ℹ️ Skipping build and validating from ${artifactsDirectory.canonicalPath}")
+
+                val hasDiscrepancies = validateMavenArtifacts(artifactsDirectory)
+                if (!hasDiscrepancies) {
+                    println("✅ No discrepancies found in artifact presence or dependencies.")
+                } else {
+                    exitWithError("❌ Discrepancies found. Please review the output.")
+                }
+            } else {
+                validateAndBuildArtifacts(mavenArtifactsDir, artifactsDirectory, communityRoot, originalBranch)
+
+                if (!preserveTemp && isDirectory(artifactsDirectory) && artifactsDir == null) {
+                    println("🧹 Cleaning temporary artifacts directory: ${artifactsDirectory.canonicalPath}")
+                    artifactsDirectory.deleteRecursively()
+                }
+            }
+        }
+
+    private suspend fun validateAndBuildArtifacts(
+        mavenArtifactsDir: File,
+        artifactsRoot: File,
+        communityRoot: File,
+        originalBranch: String,
+    ) {
+        try {
+            checkJewelMavenArtifactsFileConsistency(communityRoot)
+
+            print("🧹 Cleaning output directory: $mavenArtifactsDir...")
+            if (isDirectory(mavenArtifactsDir)) {
+                mavenArtifactsDir.deleteRecursively()
+            }
+            mavenArtifactsDir.mkdirs()
+            printlnSuccess(" DONE")
+
+            if (isDirectory(artifactsRoot)) {
+                print("🧹 Cleaning artifacts directory: $artifactsRoot...")
+                artifactsRoot.deleteRecursively()
+                printlnSuccess(" DONE")
+            }
+            artifactsRoot.mkdirs()
+
+            for (branch in branches) {
+                println("\n--- Building artifacts for branch ${branch.asBold()} ---")
+                checkoutBranch(branch, communityRoot)
+
+                val buildTargetFile = communityRoot.resolve("build/src/JewelMavenArtifactsBuildTarget.kt")
+                if (!isFile(buildTargetFile)) {
+                    exitWithError("Build target file not found at ${buildTargetFile.canonicalPath}")
+                }
+
+                println("🩹 Patching ${buildTargetFile.relativeTo(communityRoot).toString().asBold()}")
+                val patchedBuildTargetContent =
+                    buildTargetFile
+                        .readText()
+                        .replace("projectHome = ULTIMATE_HOME", "projectHome = COMMUNITY_ROOT.communityRoot")
+                buildTargetFile.writeText(patchedBuildTargetContent)
+
+                pullBranchIfNeeded(branch, communityRoot)
+
+                buildArtifactsOnBranch(communityRoot, branch)
+
+                // Copy artifacts to the temp directory
+                println("📦 Copying artifacts for branch ${branch.asBold()} to ${artifactsRoot.canonicalPath}")
+                mavenArtifactsDir.copyRecursively(artifactsRoot, true)
+            }
+
+            println()
+
+            val hasDiscrepancies = validateMavenArtifacts(artifactsRoot)
+            if (!hasDiscrepancies) {
+                println("✅ No discrepancies found in artifact presence or dependencies.")
+            } else {
+                exitWithError("❌ Discrepancies found. Please review the output.")
+            }
+        } finally {
+            cleanup(communityRoot, originalBranch, artifactsRoot, preserveTemp)
+        }
+    }
+
+    private suspend fun checkJewelMavenArtifactsFileConsistency(communityRoot: File) {
+        println("\n🔍 Verifying JewelMavenArtifacts.kt consistency across branches...")
+
+        val filePath = "build/src/org/jetbrains/intellij/build/JewelMavenArtifacts.kt"
+        val contentsByBranch =
+            branches.associateWith { branch ->
+                println("    Checking branch $branch...")
+                commandRunner("git show $branch:$filePath", communityRoot, exitOnError = false)
+            }
+
+        val failedBranches = contentsByBranch.filterValues { it.isFailure }.map { it.key }
+        if (failedBranches.isNotEmpty()) {
+            exitWithError("Could not read $filePath from branches: ${failedBranches.joinToString()}.")
+        }
+
+        val contents = contentsByBranch.mapValues { it.value.getOrThrow() }
+        val referenceBranch = branches.first()
+        val referenceContent = contents[referenceBranch]
+
+        val differingBranches = branches.drop(1).filter { contents[it] != referenceContent }
+
+        if (differingBranches.isEmpty()) {
+            printlnSuccess("✅ JewelMavenArtifacts.kt is consistent across all branches.")
+            return
+        }
+
+        printlnWarn(
+            "Found differences in build/src/org/jetbrains/intellij/build/JewelMavenArtifacts.kt between branches."
+        )
+        printlnWarn("This is likely to produce inconsistent build results.")
+
+        for (branch in differingBranches) {
+            println("\n--- Diff between ${referenceBranch.asBold()} and ${branch.asBold()} ---")
+            val diffResult =
+                commandRunner("git diff $referenceBranch $branch -- $filePath", communityRoot, exitOnError = false)
+            if (diffResult.isSuccess && diffResult.output.isNotBlank()) {
+                println(diffResult.output)
+            } else {
+                printlnErr("Could not compute diff for $filePath between branches '$referenceBranch' and '$branch'.")
+            }
+        }
+
+        if (YesNoPrompt("Do you want to proceed with the build anyway?", terminal, default = true).ask() == false) {
+            exitWithError("Build cancelled by user due to file inconsistencies.")
+        }
+    }
+
+    private suspend fun checkoutBranch(branch: String, communityRoot: File) {
+        print("Checking out branch '$branch'...")
+        val checkoutResult = commandRunner("git checkout $branch", communityRoot)
+        if (checkoutResult.isFailure) {
+            // Attempt to stash and retry checkout
+            printlnWarn("Checkout failed, attempting to stash changes and retry...")
+            commandRunner("git stash", communityRoot, exitOnError = false)
+            val retryCheckoutResult = commandRunner("git checkout $branch", communityRoot)
+            if (retryCheckoutResult.isFailure) {
+                println()
+                exitWithError("Failed to checkout branch '$branch' even after stashing. Aborting.")
+            } else {
+                println("  Checkout successful after stashing.")
+            }
+        } else {
+            printlnSuccess(" DONE")
+        }
+    }
+
+    private suspend fun pullBranchIfNeeded(branch: String, communityRoot: File) {
+        val remoteInfo =
+            commandRunner(
+                    command = "git for-each-ref --format='%(upstream:remotename)' refs/heads/$branch",
+                    workingDir = communityRoot,
+                    exitOnError = false,
+                )
+                .output
+                .trim()
+
+        val trackingBranch =
+            commandRunner(
+                    command = "git for-each-ref --format='%(upstream:short)' refs/heads/$branch",
+                    workingDir = communityRoot,
+                    exitOnError = false,
+                )
+                .output
+                .trim()
+
+        if (remoteInfo.isNotEmpty() && trackingBranch.isNotEmpty()) {
+            val pullNeeded =
+                commandRunner("git status -uno", communityRoot, exitOnError = false).output.let {
+                    it.contains("Your branch is behind") || it.contains("Your branch and") // Covers divergence
+                }
+
+            if (pullNeeded || forcePull) {
+                pullBranch(branch, trackingBranch, communityRoot)
+            } else if (verbose) {
+                println("Branch '$branch' is up-to-date or doesn't need pulling.")
+            }
+        } else if (verbose) {
+            println("Branch '$branch' does not track a remote branch.")
+        }
+    }
+
+    private suspend fun pullBranch(branch: String, trackingBranch: String, communityRoot: File) {
+        val shouldPull =
+            if (forcePull) {
+                true
+            } else {
+                print("Branch '$branch' tracks '$trackingBranch'. Do you want to pull? (y/n): ")
+                readlnOrNull()?.trim()?.lowercase() == "y"
+            }
+
+        if (shouldPull) {
+            println("Pulling from '$trackingBranch'...")
+            val pullResult = commandRunner("git pull --rebase", communityRoot, exitOnError = false)
+
+            if (pullResult.isFailure) {
+                val statusAfterPull = commandRunner("git status", communityRoot).output
+                if (
+                    statusAfterPull.contains("Unmerged paths") || statusAfterPull.contains("You have unstaged changes")
+                ) {
+                    printlnErr("Conflicts detected after pull. Please resolve manually and re-run the script.")
+                }
+                exitWithError("Failed to pull branch '$branch'. Aborting...")
+            }
+            println("Pull successful.")
+        } else {
+            println("Skipping pull for branch '$branch'.")
+        }
+    }
+
+    private suspend fun buildArtifactsOnBranch(communityRoot: File, branch: String) {
+        println("🚀 Building artifacts...")
+
+        val buildCommand = buildString {
+            append("platform/jps-bootstrap/jps-bootstrap")
+            append(if (isWindows) ".cmd" else ".sh")
+            append(" ")
+            append(communityRoot.absolutePath)
+            append(" intellij.idea.community.build JewelMavenArtifactsBuildTarget")
+        }
+
+        if (verbose) println("Build command: $buildCommand")
+
+        val buildResult =
+            commandRunner(
+                buildCommand,
+                communityRoot,
+                timeoutAmount = 30.minutes, // Allow more time for build
+                streamOutput = verbose,
+            )
+
+        if (buildResult.isFailure) {
+            println(buildResult.output)
+            exitWithError("Build failed for branch '$branch'. Aborting...")
+        }
+        println("Build successful for branch ${branch.asBold()}.")
+    }
+
+    private fun validateMavenArtifacts(artifactsDir: File): Boolean {
+        println("\n--- Comparing built artifacts ---")
+
+        val pomFiles =
+            artifactsDir
+                .walkTopDown()
+                .onFail { file, ioException -> printlnErr("Error accessing $file: $ioException") }
+                .filter { it.extension.lowercase() == "pom" }
+                .toList()
+
+        if (verbose) {
+            println("Found ${pomFiles.size} POM files. Computing distinct groupId:artifactId coordinates...")
+        }
+
+        if (pomFiles.isEmpty()) {
+            exitWithError("No POM files found in the temporary output directory.")
+        }
+
+        val artifactNames = pomFiles.map { getArtifactNameFromPom(it) }.toSortedSet()
+
+        println("Found ${artifactNames.size} unique artifacts.")
+
+        if (verbose) {
+            println("Artifact coordinates:")
+            artifactNames.sorted().forEach { println("  - $it") }
+        }
+
+        return checkForDiscrepancies(artifactNames, pomFiles)
+    }
+
+    private fun checkForDiscrepancies(allFoundArtifactNames: MutableSet<String>, pomFiles: List<File>): Boolean {
+        println("\nVerifying artifact presence across branches...")
+
+        var hasDiscrepancies = false
+
+        // First, check that we have all versions for each artifact
+        for (artifactName in allFoundArtifactNames) {
+            val pomsForArtifact = pomFiles.filter { pomFile -> getArtifactNameFromPom(pomFile) == artifactName }
+
+            if (pomsForArtifact.size != branches.size) {
+                printlnErr(
+                    buildString {
+                        append("  * Artifact ")
+                        append(artifactName.asBold())
+                        append(" is missing in one or more branches.".asError())
+                        append(" (")
+                        append(branches.size)
+                        append(" expected, ")
+                        append(pomsForArtifact.size)
+                        append(" found).")
+                    }
+                )
+                printlnErr("    Found versions:")
+                pomsForArtifact.forEach { println("     - " + getVersionFromPom(it).asBold()) }
+                hasDiscrepancies = true
+            }
+        }
+
+        // Then, compare dependencies for each artifact across versions
+        return checkForDependencyDiscrepancies(allFoundArtifactNames, pomFiles) || hasDiscrepancies
+    }
+
+    private fun checkForDependencyDiscrepancies(artifactNames: MutableSet<String>, pomFiles: List<File>): Boolean {
+        println("\nVerifying dependencies across branches...")
+
+        var hasDiscrepancies = false
+        for (artifactName in artifactNames) {
+            val pomsForArtifact = pomFiles.filter { pomFile -> getArtifactNameFromPom(pomFile) == artifactName }
+
+            if (pomsForArtifact.size < 2) {
+                printlnWarn(
+                    "Skipping dependency comparison for ${artifactName.asBold()}: " +
+                        "only ${pomsForArtifact.size} POMs found."
+                )
+                continue
+            }
+
+            val dependencySets = pomsForArtifact.associateWith { pomFile -> getDependenciesFromPom(pomFile) }
+
+            hasDiscrepancies =
+                crossValidateDependencies(pomsForArtifact, dependencySets, artifactName) || hasDiscrepancies
+        }
+        return hasDiscrepancies
+    }
+
+    internal fun getArtifactNameFromPom(pomFile: File): String =
+        try {
+            val factory = DocumentBuilderFactory.newInstance()
+            val builder = factory.newDocumentBuilder()
+            val doc = builder.parse(pomFile)
+            doc.documentElement.normalize()
+
+            val groupId =
+                checkNotNull(doc.getElementsByTagName("groupId").item(0).textContent) { "groupId not found" }.trim()
+            val artifactId =
+                checkNotNull(doc.getElementsByTagName("artifactId").item(0).textContent) { "artifactId not found" }
+                    .trim()
+
+            "$groupId:$artifactId"
+        } catch (e: Exception) {
+            exitWithError("Error parsing POM file ${pomFile.name}: ${e.message}")
+        }
+
+    internal fun getDependenciesFromPom(pomFile: File): Set<String> {
+        return try {
+            val factory = DocumentBuilderFactory.newInstance()
+            val builder = factory.newDocumentBuilder()
+            val doc = builder.parse(pomFile)
+            doc.documentElement.normalize()
+
+            val dependencies = mutableSetOf<String>()
+            val dependencyNodes: NodeList = doc.getElementsByTagName("dependency")
+
+            for (i in 0 until dependencyNodes.length) {
+                val dependencyNode: Node = dependencyNodes.item(i)
+                val coordinates = processDependencyNode(dependencyNode, pomFile.name, i)
+                if (coordinates != null) dependencies.add(coordinates)
+            }
+            dependencies
+        } catch (e: Exception) {
+            printlnErr("Error parsing dependencies in POM file ${pomFile.name}: ${e.message}")
+            emptySet()
+        }
+    }
+
+    private fun processDependencyNode(dependencyNode: Node, fileName: String, position: Int): String? {
+        if (dependencyNode.nodeType != Node.ELEMENT_NODE) return null
+        val element = dependencyNode as Element
+        val groupId = element.getElementsByTagName("groupId").item(0)?.textContent?.trim()
+        val artifactId = element.getElementsByTagName("artifactId").item(0)?.textContent?.trim()
+
+        return if (groupId != null && artifactId != null) {
+            "$groupId:$artifactId"
+        } else {
+            printlnWarn("Skipping incomplete dependency in $fileName at position #$position")
+            null
+        }
+    }
+
+    internal fun crossValidateDependencies(
+        poms: List<File>,
+        dependencySets: Map<File, Set<String>>,
+        artifactName: String,
+    ): Boolean {
+        var hasDiscrepancies = false
+
+        for ((i, element) in poms.withIndex()) {
+            for (j in i + 1 until poms.size) {
+                val file1 = element
+                val file2 = poms[j]
+                val deps1 = dependencySets[file1] ?: emptySet()
+                val deps2 = dependencySets[file2] ?: emptySet()
+
+                hasDiscrepancies =
+                    crossValidateDependencies(artifactName, file1, file2, deps1, deps2) || hasDiscrepancies
+            }
+        }
+
+        println()
+
+        return hasDiscrepancies
+    }
+
+    internal fun crossValidateDependencies(
+        artifactName: String,
+        file1: File,
+        file2: File,
+        deps1: Set<String>,
+        deps2: Set<String>,
+    ): Boolean {
+        var hasDiscrepancies = false
+        val discrepancies = (deps1 union deps2) - (deps1 intersect deps2)
+
+        if (discrepancies.isNotEmpty()) {
+            printlnErr(
+                buildString {
+                    append("  * Dependencies DIFFER for ")
+                    append(artifactName.asBold())
+                    append(" between ")
+                    append(file1.name.asBold().asLink(file1.absolutePath))
+                    append(" and ")
+                    append(file2.name.asBold().asLink(file2.absolutePath))
+                    append(".")
+                }
+            )
+
+            println("    Unique dependencies:")
+            discrepancies.sorted().forEach { println("      - ${it.asBold()}") }
+            hasDiscrepancies = true
+        } else {
+            printlnSuccess(
+                buildString {
+                    append("  * Dependencies MATCH for ")
+                    append(artifactName.asBold())
+                    append(" between ")
+                    append(file1.name.asBold().asLink(file1.absolutePath))
+                    append(" and ")
+                    append(file2.name.asBold().asLink(file2.absolutePath))
+                    append(".")
+                }
+            )
+        }
+
+        return hasDiscrepancies
+    }
+
+    internal suspend fun cleanup(
+        communityRoot: File,
+        originalBranch: String,
+        artifactsRoot: File,
+        preserveTemp: Boolean,
+    ) {
+        println("\n--- Cleaning up ---")
+
+        print("🔄 Reverting local changes...")
+        commandRunner("git reset --hard", communityRoot)
+        printlnSuccess(" DONE")
+
+        print("🔄 Returning to original branch '$originalBranch'...")
+        commandRunner("git checkout $originalBranch", communityRoot)
+        printlnSuccess(" DONE")
+
+        if (!preserveTemp) {
+            println("🧹 Cleaning artifacts directory: ${artifactsRoot.canonicalPath}")
+            if (isDirectory(artifactsRoot)) {
+                artifactsRoot.deleteRecursively()
+            }
+        } else {
+            println("ℹ️ Skipping cleanup of artifacts directory: ${artifactsRoot.canonicalPath}")
+        }
+    }
+
+    internal fun getVersionFromPom(pomFile: File): String =
+        try {
+            val factory = DocumentBuilderFactory.newInstance()
+            val builder = factory.newDocumentBuilder()
+            val doc = builder.parse(pomFile)
+            doc.documentElement.normalize()
+
+            checkNotNull(doc.getElementsByTagName("version").item(0)?.textContent?.trim()) { "version not found" }
+        } catch (e: Exception) {
+            exitWithError("Error parsing POM file ${pomFile.name}: ${e.message}")
+        }
+}

--- a/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/AnnotateApiDumpChangesTest.kt
+++ b/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/AnnotateApiDumpChangesTest.kt
@@ -1,0 +1,513 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import java.io.File
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+
+private val testFile = File("api-dump-test.txt")
+
+class AnnotateApiDumpChangesTest {
+    private val tmpDir = createSafeTempDir("annotate-api-dump-changes-test")
+
+    private fun apiDumpFile(dir: File, name: String = "api-dump.txt"): File =
+        dir.resolve(name).also { it.writeText("") }
+
+    @After
+    fun tearDown() {
+        tmpDir.deleteRecursively()
+    }
+
+    @Test
+    fun `processDiff with empty string should return an empty list`() {
+        val result = processDiff("", testFile, true)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `processDiff only addition diff should not raise breaking changes`() {
+        val apiDiff =
+            """
+            --- a/additionTest.kt
+            +++ b/additionTest.kt
+            @@ -5,0 +6 @@
+            +   println("Hi developer! This print statement was the only thing added!")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `processDiff only removal diff should raise one breaking change`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5 +4,0 @@
+            -   println("Hi developer! This print statement was straight up removed for good.")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `processDiff only replace diff should raise one breaking change`() {
+        val apiDiff =
+            """
+            --- a/replaceTest.kt
+            +++ b/replaceTest.kt
+            @@ -5 +5 @@
+            -   println("Hi developer! This print statement will be replaced.")
+            +   println("Hi developer! Just got replaced.") 
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `processDiff multiple removals in one file should raise the correct number of BreakingChanges`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5,3 +4,0 @@
+            -   println("Hi developer! This line was removed.")
+            -   println("This one also got removed.")
+            -   println("And this one :(")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        assertEquals(3, result.size)
+    }
+
+    @Test
+    fun `processDiff multiple removals scattered in the same file should raise more than one BreakingChange`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5,3 +4,0 @@
+            -   println("Hi developer! This line was removed.")
+            -   println("This one also got removed.")
+            -   println("And this one :(")
+            @@ -10,1 +9,0 @@
+            -   println("This line was removed in the same file, but later on the file.")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        assertEquals(4, result.size)
+    }
+
+    @Test
+    fun `processDiff multiple removals in different files should the correct number of BreakingChange`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5 +4,0 @@
+            -   println("Hi developer! This line was removed.")
+            
+            --- a/removalTestTwo.kt
+            +++ b/removalTestTwo.kt
+            @@ -8,2 +7,0 @@
+            -   println("Why are we deleting so many lines?")
+            -   println("Guess this one also got deleted...")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        assertEquals(3, result.size)
+    }
+
+    @Test
+    fun `processDiff removals and replaces should count as breaking changes`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5,3 +4,0 @@
+            -   println("Hi developer! This line was removed.")
+            -   println("This one also got removed.")
+            -   println("And this one :(")
+            @@ -14 +14 @@
+            -   println("This text got replaced...")
+            +   println("...by this text :)")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        assertEquals(4, result.size)
+    }
+
+    @Test
+    fun `processDiff breaking change found should have correct data`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5 +4,0 @@
+            -   println("Hi developer! We need to check the data in this line")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, false).first()
+
+        val expected =
+            BreakingChange(
+                file = testFile,
+                "   println(\"Hi developer! We need to check the data in this line\")",
+                false,
+                5,
+                4,
+                true,
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `processDiff consecutive removals should have annotate false if in the same hunk header`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5,3 +4,0 @@
+            -   println("Hi developer! This line was removed.")
+            -   println("This one also got removed.")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        val expected =
+            listOf(
+                BreakingChange(
+                    file = testFile,
+                    "   println(\"Hi developer! This line was removed.\")",
+                    true,
+                    5,
+                    4,
+                    true,
+                ),
+                BreakingChange(file = testFile, "   println(\"This one also got removed.\")", true, 6, 4, false),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `processDiff removals in different hunks should have annotate true`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5 +4,0 @@
+            -   println("Hi developer! This line was removed.")
+            @@ -13 +12,0 @@
+            -   println("This one also got removed.")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        val expected =
+            listOf(
+                BreakingChange(
+                    file = testFile,
+                    "   println(\"Hi developer! This line was removed.\")",
+                    true,
+                    5,
+                    4,
+                    true,
+                ),
+                BreakingChange(file = testFile, "   println(\"This one also got removed.\")", true, 13, 12, true),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `processDiff removals separated by an addition should both have annotate true`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5,2 +5 @@
+            -   println("Hi developer! This line was removed.")
+            +   println("And this line was added")
+            -   println("But this one also got removed.")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true)
+
+        val expected =
+            listOf(
+                BreakingChange(
+                    file = testFile,
+                    "   println(\"Hi developer! This line was removed.\")",
+                    true,
+                    5,
+                    5,
+                    true,
+                ),
+                BreakingChange(file = testFile, "   println(\"But this one also got removed.\")", true, 6, 6, true),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `processDiff removal with percentage symbol should be escaped`() {
+        val apiDiff =
+            """
+            --- a/removalTest.kt
+            +++ b/removalTest.kt
+            @@ -5 +4,0 @@
+            -   println("This line has a character '%' that should be escaped.")
+            """
+                .trimIndent()
+
+        val result = processDiff(apiDiff, testFile, true).first().lineContent
+
+        val expected = "   println(\"This line has a character '%25' that should be escaped.\")"
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `validateDumps returns false when no files changed`() = runTest {
+        val dir = tmpDir.resolve("no-change").also { it.mkdirs() }
+        apiDumpFile(dir)
+        val runner = FakeCommandRunner { CmdResult.Success("") }
+
+        val result = validateDumps(false, false, "abc123", dir, runner) { it.name == "api-dump.txt" }
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `validateDumps returns true when breaking change found`() = runTest {
+        val dir = tmpDir.resolve("with-change").also { it.mkdirs() }
+        dir.resolve("api-dump.txt").also { it.writeText("") }
+        val fakeDiff =
+            """
+            --- a/api-dump.txt
+            +++ b/api-dump.txt
+            @@ -5 +4,0 @@
+            -   fun deletedFunction()
+        """
+                .trimIndent()
+
+        val runner = FakeCommandRunner { command ->
+            when {
+                command.contains("--quiet") -> CmdResult.Failure("") // `isModifiedResult` fails
+                else -> CmdResult.Success(fakeDiff)
+            }
+        }
+
+        val result = validateDumps(false, false, "baseCommit", dir, runner) { it.name == "api-dump.txt" }
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `validateDumps breaking changes in samples folder are ignored`() = runTest {
+        val samplesDir = tmpDir.resolve("samples").also { it.mkdirs() }
+        samplesDir.resolve("api-dump.txt").also { it.writeText("") }
+        val fakeDiff =
+            """
+            --- a/api-dump.txt
+            +++ b/api-dump.txt
+            @@ -5 +4,0 @@
+            -   fun deletedFunction()
+        """
+                .trimIndent()
+
+        val runner = FakeCommandRunner { command ->
+            when {
+                command.contains("--quiet") -> CmdResult.Failure("") // `isModifiedResult` fails
+                else -> CmdResult.Success(fakeDiff)
+            }
+        }
+
+        val result = validateDumps(false, false, "baseCommit", tmpDir, runner) { it.name == "api-dump.txt" }
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `validateDumps with only additions in dump should return false`() = runTest {
+        val dir = tmpDir.resolve("with-change").also { it.mkdirs() }
+        dir.resolve("api-dump.txt").also { it.writeText("") }
+        val fakeDiff =
+            """
+            --- a/api-dump.txt
+            +++ b/api-dump.txt
+            @@ -5,0 +6 @@
+            +   fun addedFunction()
+        """
+                .trimIndent()
+
+        val runner = FakeCommandRunner { command ->
+            when {
+                command.contains("--quiet") -> CmdResult.Failure("") // `isModifiedResult` fails
+                else -> CmdResult.Success(fakeDiff)
+            }
+        }
+
+        val result = validateDumps(false, false, "baseCommit", dir, runner) { it.name == "api-dump.txt" }
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `validateDumps two files but only one has a breaking change should return true`() = runTest {
+        val noChangeDir = tmpDir.resolve("no-change").also { it.mkdirs() }
+        val withChangeDir = tmpDir.resolve("with-change").also { it.mkdirs() }
+        noChangeDir.resolve("api-dump.txt").also { it.writeText("") }
+        withChangeDir.resolve("api-dump.txt").also { it.writeText("") }
+        val fakeDiff =
+            """
+            --- a/api-dump.txt
+            +++ b/api-dump.txt
+            @@ -5,0 +6 @@
+            -   fun deletedFunction()
+        """
+                .trimIndent()
+
+        val runner = FakeCommandRunner { command ->
+            when {
+                command.contains("--quiet") && command.contains("no-change") -> CmdResult.Success("")
+                command.contains("--quiet") && command.contains("with-change") -> CmdResult.Failure("")
+                else -> CmdResult.Success(fakeDiff)
+            }
+        }
+
+        val result = validateDumps(false, false, "baseCommit", tmpDir, runner) { it.name == "api-dump.txt" }
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `validateDumps returns false when filter matches no files`() = runTest {
+        val dir = tmpDir.resolve("with-change").also { it.mkdirs() }
+        dir.resolve("api-dump.txt").also { it.writeText("") }
+        val fakeDiff =
+            """
+            --- a/api-dump.txt
+            +++ b/api-dump.txt
+            @@ -5 +4,0 @@
+            -   fun deletedFunction()
+        """
+                .trimIndent()
+
+        val runner = FakeCommandRunner { command ->
+            when {
+                command.contains("--quiet") -> CmdResult.Failure("") // `isModifiedResult` fails
+                else -> CmdResult.Success(fakeDiff)
+            }
+        }
+
+        val result = validateDumps(false, false, "baseCommit", dir, runner) { it.name == "non-existing-file.txt" }
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `assert stable breaking change formatLog result is correct`() {
+        val lineContent = "this is a breaking change"
+        val oldLineNum = 0
+        val newLineNum = 0
+        val breakingChange =
+            BreakingChange(
+                file = tmpDir,
+                lineContent = "this is a breaking change",
+                experimental = false,
+                oldLineNum = oldLineNum,
+                newLineNum = newLineNum,
+                annotate = true,
+            )
+        val log = StringBuilder()
+        breakingChange.formatLog(log, tmpDir)
+        val result = log.toString()
+
+        assertContains(result, "⚠️ Breaking stable API change:\n       line $oldLineNum removed: $lineContent")
+        assertContains(result, "::error")
+        assertContains(result, "line=$newLineNum")
+        assertContains(
+            result,
+            "title=Breaking API change::This looks like a breaking API change, make sure it's intended",
+        )
+    }
+
+    @Test
+    fun `assert experimental breaking change formatLog result is correct`() {
+        val lineContent = "this is a breaking change"
+        val oldLineNum = 0
+        val newLineNum = 0
+        val breakingChange =
+            BreakingChange(
+                file = tmpDir,
+                lineContent = "this is a breaking change",
+                experimental = true,
+                oldLineNum = oldLineNum,
+                newLineNum = newLineNum,
+                annotate = true,
+            )
+        val log = StringBuilder()
+        breakingChange.formatLog(log, tmpDir)
+        val result = log.toString()
+
+        assertContains(result, "⚠️ Breaking experimental API change:\n       line $oldLineNum removed: $lineContent")
+        assertContains(result, "::warning")
+        assertContains(result, "line=$newLineNum")
+        assertContains(
+            result,
+            "title=Breaking experimental API change::This looks like a breaking API change, make sure it's intended",
+        )
+    }
+
+    @Test
+    fun `assert breaking change formatLog with annotate false only appends first line`() {
+        val lineContent = "this is a breaking change"
+        val oldLineNum = 0
+        val newLineNum = 0
+        val breakingChange =
+            BreakingChange(
+                file = tmpDir,
+                lineContent = "this is a breaking change",
+                experimental = false,
+                oldLineNum = oldLineNum,
+                newLineNum = newLineNum,
+                annotate = false,
+            )
+        val log = StringBuilder()
+        breakingChange.formatLog(log, tmpDir)
+        val result = log.toString()
+
+        assertContains(result, "⚠️ Breaking stable API change:\n       line $oldLineNum removed: $lineContent")
+        assertFalse(result.contains("::error"))
+        assertFalse(result.contains("::warning"))
+    }
+}

--- a/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/BazelTestUtils.kt
+++ b/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/BazelTestUtils.kt
@@ -1,0 +1,6 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import java.io.File
+
+fun createSafeTempDir(subDirectory: String) = File(System.getenv("TEST_TMPDIR") ?: System.getProperty("java.io.tmpdir"))
+    .resolve(subDirectory).apply { mkdirs() }

--- a/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/CheckApiDumpsTest.kt
+++ b/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/CheckApiDumpsTest.kt
@@ -1,0 +1,106 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class CheckApiDumpsTest {
+    private val fakeRunner = FakeCommandRunner { CmdResult.Success("") }
+    private val testClass = CheckUpdatedCommand(fakeRunner)
+
+    @Test
+    fun `buildApiCheckCommand passes both the module and the test pattern`() {
+        val result = buildApiCheckCommand()
+
+        assertEquals(
+            "./tests.cmd --module intellij.platform.testFramework.monorepo.tests " +
+                "--test com.intellij.platform.testFramework.monorepo.api.ApiCheckTest",
+            result,
+        )
+    }
+
+    @Test
+    fun `buildApiCheckScript enables errexit and pipefail so a real failure survives the tee pipe`() {
+        val result = buildApiCheckScript(File("/repo"), File("/tmp/out.log"), "./tests.cmd")
+
+        assertTrue(result.lines().contains("set -e -o pipefail"))
+    }
+
+    @Test
+    fun `buildApiCheckScript quotes the repo root and output paths as single-quoted shell literals`() {
+        // A path containing a $, a space and a literal single quote — exactly the case the shell-quoting
+        // fix targets: unquoted or double-quoted, the shell would still expand '$(evil)' as a command.
+        val dangerousRoot = File("/repo/weird '$(evil)' dir")
+
+        val result = buildApiCheckScript(dangerousRoot, File("/tmp/out.log"), "./tests.cmd")
+
+        assertTrue(result.contains("cd '/repo/weird '\\''\$(evil)'\\'' dir'"))
+    }
+
+    @Test
+    fun `buildApiCheckScript pipes the command through tee to both the console and the output file`() {
+        val result = buildApiCheckScript(File("/repo"), File("/tmp/out.log"), "./tests.cmd --module m --test t")
+
+        assertTrue(result.contains("./tests.cmd --module m --test t | tee '/tmp/out.log'"))
+    }
+
+    @Test
+    fun `extractFailingModules returns module name from single failure`() {
+        val output = "##teamcity[testFailed name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.Fail'"
+
+        val result = testClass.extractFailingModules(output)
+
+        assertEquals(listOf("Fail"), result)
+    }
+
+    @Test
+    fun `extractFailingModules returns modules sorted alphabetically`() {
+        val output =
+            """"
+            ##teamcity[testFailed name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.Z'
+            ##teamcity[testFailed name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.A'
+            ##teamcity[testFailed name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.G'
+            """
+                .trimIndent()
+
+        val result = testClass.extractFailingModules(output)
+
+        assertEquals(listOf("A", "G", "Z"), result)
+    }
+
+    @Test
+    fun `extractFailingModules deduplicates repeated failures`() {
+        val output =
+            """
+            ##teamcity[testFailed name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.Fail'
+            ##teamcity[testFailed name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.Fail'
+            """
+                .trimIndent()
+
+        val result = testClass.extractFailingModules(output)
+
+        assertEquals(listOf("Fail"), result)
+    }
+
+    @Test
+    fun `extractFailingModules returns empty list when no failures found`() {
+        val output =
+            """
+            ##teamcity[testSuccess name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.Cool'
+            ##teamcity[testSuccess name='com.intellij.platform.testFramework.monorepo.api.ApiCheckTest.Yeah'
+            """
+                .trimIndent()
+
+        val result = testClass.extractFailingModules(output)
+
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `extractFailingModules empty output should return an empty list`() {
+        val result = testClass.extractFailingModules("")
+
+        assertEquals(emptyList(), result)
+    }
+}

--- a/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/CompareBranchesTest.kt
+++ b/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/CompareBranchesTest.kt
@@ -1,0 +1,296 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import com.github.ajalt.clikt.command.test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class CompareBranchesTest {
+    private val fakeRunner = FakeCommandRunner { CmdResult.Success("") }
+    private val testClass = CompareBranchesCommand(fakeRunner, pathExists = { true })
+
+    @Test
+    fun `normalizeSubject subject with cherry pick prefix should ignore it`() {
+        val subject = "cherry picked from commit 123: cool cherry-pick"
+
+        val result = testClass.normalizeSubject(subject)
+
+        val expected = "cool cherry-pick"
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `normalizeSubject without cherry-pick prefix should be returned unchanged`() {
+        val subject = "this was not a cherry-pick"
+
+        val result = testClass.normalizeSubject(subject)
+
+        assertEquals(subject, result)
+    }
+
+    @Test
+    fun `isCommitAfterDate with valid dates and authorDate after sinceDate returns true`() {
+        val authorDateStr = "2026-05-13 12:37:32 +0300"
+        val sinceDateStr = "2026-05-10"
+
+        val result = testClass.isCommitAfterDate(authorDateStr, sinceDateStr)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isCommitAfterDate with valid dates and authorDate equals sinceDate returns true`() {
+        val authorDateStr = "2026-05-13 12:37:32 +0300"
+        val sinceDateStr = "2026-05-13"
+
+        val result = testClass.isCommitAfterDate(authorDateStr, sinceDateStr)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isCommitAfterDate with valid dates and authorDate before sinceDate returns false`() {
+        val authorDateStr = "2026-05-13 12:37:32 +0300"
+        val sinceDateStr = "2026-05-15"
+
+        val result = testClass.isCommitAfterDate(authorDateStr, sinceDateStr)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isCommitAfterDate unparseable dates and authorDate after sinceDate returns true`() {
+        val authorDateStr = "2026-05-13 invalid date"
+        val sinceDateStr = "2026-05-10"
+
+        val result = testClass.isCommitAfterDate(authorDateStr, sinceDateStr)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isCommitAfterDate unparseable dates and authorDate equals sinceDate returns true`() {
+        val authorDateStr = "2026-05-13 invalid date"
+        val sinceDateStr = "2026-05-13"
+
+        val result = testClass.isCommitAfterDate(authorDateStr, sinceDateStr)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isCommitAfterDate unparseable dates and authorDate before sinceDate returns false`() {
+        val authorDateStr = "2026-05-13 invalid date"
+        val sinceDateStr = "2026-05-15"
+
+        val result = testClass.isCommitAfterDate(authorDateStr, sinceDateStr)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `parseCommitLine correctly parses commit line`() {
+        val commitLine = "5f4c0c6c9476::COMMIT::[JEWEL-007] Casino Royale Easter Egg"
+
+        val result = testClass.parseCommitLine(commitLine)
+
+        val expected = CommitInfo(hash = "5f4c0c6c9476", subject = "[JEWEL-007] Casino Royale Easter Egg")
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parseCommitLine trims apostrophe from hash and subject`() {
+        val commitLine = "'5f4c0c6c9476'::COMMIT::'[JEWEL-007] Casino Royale Easter Egg'"
+
+        val result = testClass.parseCommitLine(commitLine)
+
+        val expected = CommitInfo(hash = "5f4c0c6c9476", subject = "[JEWEL-007] Casino Royale Easter Egg")
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parseCommitWithDateResult with commit after sinceDate return ParseResult Success`() = runTest {
+        val line = "408c5::COMMIT::[JEWEL-007] Casino Royale Easter Egg,2026-05-13 22:27:38 +0300"
+
+        // initializing command with sinceDate
+        testClass.test(listOf("branch1", "branch2", "--since", "2026-05-10"))
+        val result = testClass.parseCommitWithDateResult(line)
+
+        val expected = ParseResult.Success(CommitInfo(hash = "408c5", subject = "[JEWEL-007] Casino Royale Easter Egg"))
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parseCommitWithDateResult with commit before sinceDate return ParseResult DateFiltered`() = runTest {
+        val line = "408c5::COMMIT::[JEWEL-007] Casino Royale Easter Egg,2026-05-13 22:27:38 +0300"
+
+        // initializing command with sinceDate
+        testClass.test(listOf("branch1", "branch2", "--since", "2026-05-15"))
+        val result = testClass.parseCommitWithDateResult(line)
+
+        assertEquals(ParseResult.DateFiltered, result)
+    }
+
+    @Test
+    fun `parseCommitWithDateResult with invalid line date returns ParseError`() = runTest {
+        val line = "408c5::COMMIT::[JEWEL-007] Casino Royale Easter Egg,this date is invalid"
+
+        // initializing command with sinceDate
+        testClass.test(listOf("branch1", "branch2"))
+        val result = testClass.parseCommitWithDateResult(line)
+
+        assertEquals(ParseResult.ParseError, result)
+    }
+
+    @Test
+    fun `parseCommitWithDateResult commit message with surrounding quotes should remove them`() = runTest {
+        val line = "408c5::COMMIT::'[JEWEL-007] Casino Royale Easter Egg',2026-05-13 10:10:10 +0300"
+
+        // initializing command with sinceDate
+        testClass.test(listOf("branch1", "branch2", "--since", "2026-05-10"))
+        val result = testClass.parseCommitWithDateResult(line) as ParseResult.Success
+
+        assertEquals("[JEWEL-007] Casino Royale Easter Egg", result.commit.subject)
+    }
+
+    @Test
+    fun `fetchCommits returns all commits when all are valid`() = runTest {
+        val fakeRunner = FakeCommandRunner { command ->
+            when {
+                command.contains("--pretty=format:") -> {
+                    CmdResult.Success(
+                        """
+                            408c5::COMMIT::[JEWEL-007] Casino Royale Easter Egg,2026-05-13 13:13:13 +0300
+                            be0b1::COMMIT::[JEWEL-101] Adding README,2026-05-13 22:27:38 +0200
+                            """
+                            .trimIndent()
+                    )
+                }
+                else -> CmdResult.Success("")
+            }
+        }
+        val testClass = CompareBranchesCommand(fakeRunner, pathExists = { true })
+        testClass.test(listOf("branch1", "branch2", "--since", "2026-05-10")) // populate Clikt delegates
+
+        val result = testClass.fetchCommits("branch1", emptyList())
+
+        val expected =
+            listOf(
+                CommitInfo(hash = "408c5", subject = "[JEWEL-007] Casino Royale Easter Egg"),
+                CommitInfo(hash = "be0b1", subject = "[JEWEL-101] Adding README"),
+            )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `fetchCommits skips unparseable commit`() = runTest {
+        val fakeRunner = FakeCommandRunner { command ->
+            when {
+                command.contains("--pretty=format:") -> {
+                    CmdResult.Success(
+                        """
+                            408c5::COMMIT::[JEWEL-007] Casino Royale Easter Egg,2026-05-13 13:13:13 +0300
+                            be0b1::COMMIT::[JEWEL-101] Adding README,invalid date
+                            """
+                            .trimIndent()
+                    )
+                }
+                else -> CmdResult.Success("")
+            }
+        }
+        val testClass = CompareBranchesCommand(fakeRunner, pathExists = { true })
+        testClass.test(listOf("branch1", "branch2", "--since", "2026-05-10")) // populate Clikt delegates
+
+        val result = testClass.fetchCommits("branch1", emptyList())
+
+        val expected = listOf(CommitInfo(hash = "408c5", subject = "[JEWEL-007] Casino Royale Easter Egg"))
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `fetchCommits filters out commits before sinceDate`() = runTest {
+        val fakeRunner = FakeCommandRunner { command ->
+            when {
+                command.contains("--pretty=format:") -> {
+                    CmdResult.Success(
+                        """
+                            408c5::COMMIT::[JEWEL-007] Casino Royale Easter Egg,2026-05-13 13:13:13 +0300
+                            be0b1::COMMIT::[JEWEL-101] Adding README,2026-05-15 22:27:38 +0200
+                            """
+                            .trimIndent()
+                    )
+                }
+                else -> CmdResult.Success("")
+            }
+        }
+        val testClass = CompareBranchesCommand(fakeRunner, pathExists = { true })
+        testClass.test(listOf("branch1", "branch2", "--since", "2026-05-14"))
+
+        val result = testClass.fetchCommits("branch1", emptyList())
+
+        val expected = listOf(CommitInfo(hash = "be0b1", subject = "[JEWEL-101] Adding README"))
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `fetchCommits with empty git output should return an empty list`() = runTest {
+        val fakeRunner = FakeCommandRunner { command ->
+            when {
+                command.contains("--pretty=format:") -> {
+                    CmdResult.Success(
+                        """
+                            408c5::COMMIT::[JEWEL-007] Casino Royale Easter Egg,2026-05-13 13:13:13 +0300
+                            be0b1::COMMIT::[JEWEL-101] Adding README,invalid date
+                            """
+                            .trimIndent()
+                    )
+                }
+                else -> CmdResult.Success("")
+            }
+        }
+        val testClass = CompareBranchesCommand(fakeRunner, pathExists = { true })
+        testClass.test(listOf("branch1", "branch2", "--since", "2026-05-30"))
+
+        val result = testClass.fetchCommits("branch1", emptyList())
+
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `fetchCommits with all commits filtered out should return an empty list`() = runTest {
+        val fakeGitHubRunner = FakeCommandRunner { command ->
+            when {
+                command.contains("--pretty=format:") -> {
+                    CmdResult.Success("")
+                }
+                else -> CmdResult.Success("")
+            }
+        }
+        val testClass = CompareBranchesCommand(fakeGitHubRunner, pathExists = { true })
+        testClass.test(listOf("branch1", "branch2"))
+
+        val result = testClass.fetchCommits("branch1", emptyList())
+
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `run throws usage error when --no-build-changes and --build-only are both set`() = runTest {
+        val result =
+            testClass.test(
+                listOf("branch1", "branch2", "--no-build-changes", "--build-only", "--since", "2026-05-10")
+            )
+
+        assertContains(result.output, "Error: --no-build-changes and --build-only are mutually exclusive.")
+    }
+}

--- a/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/FakeCommandRunner.kt
+++ b/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/FakeCommandRunner.kt
@@ -1,0 +1,36 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import java.io.File
+import kotlin.time.Duration
+
+class FakeCommandRunner(private val handler: (command: String) -> CmdResult = { CmdResult.Success("") }) :
+    CommandRunner {
+    val calls = mutableListOf<String>()
+
+    override suspend fun invoke(
+        command: String,
+        workingDir: File?,
+        timeoutAmount: Duration,
+        exitOnError: Boolean,
+        streamOutput: Boolean,
+    ): CmdResult {
+        calls.add(command)
+
+        val result = handler(command)
+        if (result.isFailure && exitOnError) {
+            error(
+                buildString {
+                    appendLine()
+                    append("Command '$command' failed")
+                    if (result.output.isNotBlank()) {
+                        appendLine(":")
+                        appendLine(result.output)
+                    } else {
+                        appendLine()
+                    }
+                }
+            )
+        }
+        return result
+    }
+}

--- a/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/JewelBazelScriptsUtilsTest.kt
+++ b/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/JewelBazelScriptsUtilsTest.kt
@@ -1,0 +1,68 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import java.io.File
+import kotlin.system.measureTimeMillis
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.test.runTest
+import org.junit.Assume
+import org.junit.Test
+
+class JewelBazelScriptsUtilsTest {
+    @Test
+    fun `DefaultCommandRunner aborts a command that exceeds timeoutAmount instead of blocking until it exits`() =
+        runTest {
+            // JUnit4 equivalent of @DisabledOnOs from JUnit5
+            Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
+            
+            var elapsed = 0L
+
+            assertFailsWith<IllegalStateException> {
+                elapsed = measureTimeMillis {
+                    DefaultCommandRunner("sleep 10", workingDir = null, timeoutAmount = 1.seconds)
+                }
+            }
+
+            // The underlying process sleeps for 10s; if the timeout weren't enforced, this call would
+            // block for the full 10s (or longer). Give it generous headroom over the 1s bound to absorb
+            // process-startup/scheduling overhead, while still failing if the old unbounded waitFor() regresses.
+            assertTrue(elapsed < 5_000, "expected the command to be aborted around the 1s timeout, took ${elapsed}ms")
+        }
+
+    @Test
+    fun `branchExists returns false instead of throwing when the branch does not exist`() = runTest {
+        // git rev-parse --verify exits non-zero for exactly this case — the one branchExists exists to detect.
+        val fakeRunner = FakeCommandRunner { CmdResult.Failure("fatal: Needed a single revision") }
+
+        val result = branchExists("nonexistent-branch", File("."), fakeRunner)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `branchExists returns true when git rev-parse succeeds`() = runTest {
+        val fakeRunner = FakeCommandRunner { CmdResult.Success("abc123") }
+
+        val result = branchExists("main", File("."), fakeRunner)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isDirectoryGitRepo returns false instead of throwing when the directory is not a git repo`() = runTest {
+        val fakeRunner = FakeCommandRunner { CmdResult.Failure("fatal: not a git repository") }
+
+        val result = isDirectoryGitRepo(File("."), fakeRunner)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `getCurrentBranchName propagates a failing git command`() = runTest {
+        val fakeRunner = FakeCommandRunner { CmdResult.Failure("fatal: not a git repository") }
+
+        assertFailsWith<IllegalStateException> { getCurrentBranchName(File("."), fakeRunner) }
+    }
+}

--- a/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/ValidateMavenArtifactsTest.kt
+++ b/platform/jewel/build-scripts/bazel/src/test/kotlin/org/jetbrains/jewel/scripts/bazel/ValidateMavenArtifactsTest.kt
@@ -1,0 +1,270 @@
+package org.jetbrains.jewel.scripts.bazel
+
+import com.github.ajalt.clikt.core.PrintMessage
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+
+class ValidateMavenArtifactsTest {
+    private val fakeRunner = FakeCommandRunner { CmdResult.Success("") }
+    private val command = ValidateMavenArtifactsCommand(fakeRunner)
+    private val tmpDir = createSafeTempDir("validate-maven-artifacts-test")
+    private val basicPom = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project>
+          <groupId>org.jetbrains.jewel</groupId>
+          <artifactId>jewel-ui</artifactId>
+          <version>1.0.0</version>
+          <dependencies>
+              <dependency>
+                  <groupId>org.jetbrains.kotlin</groupId>
+                  <artifactId>kotlin-stdlib</artifactId>
+              </dependency>
+          </dependencies>
+      </project>
+    """.trimIndent()
+    private fun createPomFile(content: String = basicPom, name: String = "test.pom") = tmpDir.resolve(name).also { 
+        it.writeText(content)
+    }
+    
+    @After
+    fun tearDown() {
+        tmpDir.deleteRecursively()
+    }
+
+    @Test
+    fun `getArtifactNameFromPom with groupId and artifactId should not throw an error`() {
+        val result = command.getArtifactNameFromPom(createPomFile())
+
+        assertEquals("org.jetbrains.jewel:jewel-ui", result)
+    }
+
+    @Test
+    fun `getArtifactNameFromPom with missing groupId throws`() {
+        val pomFileWithoutGroupId = createPomFile(
+            content = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <artifactId>wheres-my-group-id</artifactId>
+                </project>
+            """.trimIndent()
+        )
+
+        assertFailsWith<PrintMessage> { 
+            command.getArtifactNameFromPom(pomFileWithoutGroupId)
+        }
+    }
+
+    @Test
+    fun `getArtifactNameFromPom with missing artifactId throws`() {
+        val pomFileWithoutArtifactId = createPomFile(
+            content = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <groupId>wheres-my-artifact-id</groupId>
+                </project>
+            """.trimIndent()
+        )
+
+        assertFailsWith<PrintMessage> {
+            command.getArtifactNameFromPom(pomFileWithoutArtifactId)
+        }
+    }
+    
+    @Test
+    fun `getDependenciesFromPom with one dependency assert expected result`() {
+        val result = command.getDependenciesFromPom(createPomFile())
+        
+        val expected = setOf("org.jetbrains.kotlin:kotlin-stdlib")
+        
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `getDependenciesFromPom skips dependency with missing groupId`() {
+        val unresolvedDependencyPom = createPomFile(
+            content = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <groupId>org.jetbrains.jewel</groupId>
+                    <artifactId>jewel-ui</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <artifactId>incomplete-dependency</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jetbrains.kotlin</groupId>
+                            <artifactId>kotlin-stdlib</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """.trimIndent()
+        )
+        val result = command.getDependenciesFromPom(unresolvedDependencyPom)
+
+        val expected = setOf("org.jetbrains.kotlin:kotlin-stdlib")
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `getDependenciesFromPom skips dependency with missing artifactId`() {
+        val unresolvedDependencyPom = createPomFile(
+            content = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <groupId>org.jetbrains.jewel</groupId>
+                    <artifactId>jewel-ui</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>incomplete-dependency</groupId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jetbrains.kotlin</groupId>
+                            <artifactId>kotlin-stdlib</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """.trimIndent()
+        )
+        val result = command.getDependenciesFromPom(unresolvedDependencyPom)
+
+        val expected = setOf("org.jetbrains.kotlin:kotlin-stdlib")
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `getDependenciesFromPom with no dependencies returns empty set`() {
+        val pomWithNoDeps = createPomFile(
+            content = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <groupId>org.jetbrains.jewel</groupId>
+                    <artifactId>jewel-ui</artifactId>
+                </project>
+            """.trimIndent()
+        )
+
+        val result = command.getDependenciesFromPom(pomWithNoDeps)
+
+        assertEquals(emptySet(), result)
+    }
+
+    @Test
+    fun `getVersionFromPom returns version string`() {
+        val result = command.getVersionFromPom(createPomFile())
+
+        assertEquals("1.0.0", result)
+    }
+
+    @Test
+    fun `getVersionFromPom with missing version throws`() {
+        val pomWithoutVersion = createPomFile(
+            content = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <groupId>org.jetbrains.jewel</groupId>
+                    <artifactId>jewel-ui</artifactId>
+                </project>
+            """.trimIndent()
+        )
+
+        assertFailsWith<PrintMessage> {
+            command.getVersionFromPom(pomWithoutVersion)
+        }
+    }
+
+    @Test
+    fun `crossValidateDependencies with identical deps returns false`() {
+        val deps = setOf("org.jetbrains.kotlin:kotlin-stdlib", "org.jetbrains.compose:compose-ui")
+
+        val result = command.crossValidateDependencies(
+            "org.jetbrains.jewel:jewel-ui",
+            File("branch1.pom"),
+            File("branch2.pom"),
+            deps,
+            deps,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `crossValidateDependencies with differing deps returns true`() {
+        val deps1 = setOf("org.jetbrains.kotlin:kotlin-stdlib", "org.jetbrains.compose:compose-ui")
+        val deps2 = setOf("org.jetbrains.kotlin:kotlin-stdlib")
+
+        val result = command.crossValidateDependencies(
+            "org.jetbrains.jewel:jewel-ui",
+            File("branch1.pom"),
+            File("branch2.pom"),
+            deps1,
+            deps2,
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `crossValidateDependencies with both empty deps returns false`() {
+        val result = command.crossValidateDependencies(
+            "org.jetbrains.jewel:jewel-ui",
+            File("branch1.pom"),
+            File("branch2.pom"),
+            emptySet(),
+            emptySet(),
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `cleanup reverts local changes and returns to the original branch`() = runTest {
+        val artifactsDir = tmpDir.resolve("cleanup-git-only")
+
+        command.cleanup(tmpDir, "main", artifactsDir, preserveTemp = true)
+
+        assertEquals(listOf("git reset --hard", "git checkout main"), fakeRunner.calls)
+    }
+
+    @Test
+    fun `cleanup deletes an existing artifacts directory when preserveTemp is false`() = runTest {
+        val commandWithFakeDirectoryCheck = ValidateMavenArtifactsCommand(fakeRunner, isDirectory = { true })
+        val artifactsDir = tmpDir.resolve("cleanup-target").also { it.mkdirs() }
+        File(artifactsDir, "dummy.txt").writeText("x")
+
+        commandWithFakeDirectoryCheck.cleanup(tmpDir, "main", artifactsDir, preserveTemp = false)
+
+        assertFalse(artifactsDir.exists())
+    }
+
+    @Test
+    fun `cleanup preserves the artifacts directory when preserveTemp is true`() = runTest {
+        val commandWithFakeDirectoryCheck = ValidateMavenArtifactsCommand(fakeRunner, isDirectory = { true })
+        val artifactsDir = tmpDir.resolve("preserved-target").also { it.mkdirs() }
+        File(artifactsDir, "dummy.txt").writeText("x")
+
+        commandWithFakeDirectoryCheck.cleanup(tmpDir, "main", artifactsDir, preserveTemp = true)
+
+        assertTrue(artifactsDir.exists())
+    }
+
+    @Test
+    fun `cleanup does not attempt deletion when isDirectory reports false, even if the real directory exists`() =
+        runTest {
+            val commandWithFakeDirectoryCheck = ValidateMavenArtifactsCommand(fakeRunner, isDirectory = { false })
+            val artifactsDir = tmpDir.resolve("not-recognized-as-directory").also { it.mkdirs() }
+            File(artifactsDir, "dummy.txt").writeText("x")
+
+            commandWithFakeDirectoryCheck.cleanup(tmpDir, "main", artifactsDir, preserveTemp = false)
+
+            // The real directory is untouched because isDirectory (the injected seam) said it wasn't one.
+            assertTrue(artifactsDir.exists())
+        }
+}

--- a/platform/jewel/scripts/utils.main.kts
+++ b/platform/jewel/scripts/utils.main.kts
@@ -388,7 +388,7 @@ suspend fun isDirectoryGitRepo(directory: File): Boolean =
  * @return true if the branch exists, false otherwise.
  */
 suspend fun branchExists(branch: String, directory: File): Boolean =
-    runCommand("git rev-parse --verify $branch", directory).isSuccess
+    runCommand("git rev-parse --verify $branch", directory, exitOnError = false).isSuccess
 
 val isWindows = "windows" in System.getProperty("os.name").lowercase()
 


### PR DESCRIPTION
## Context

Part 3 of the Jewel Bazel migration: ports `annotate-api-dump-changes.main.kts`, `check-api-dumps.main.kts`, `compare-branches.main.kts`, and `validate-maven-artifacts.main.kts` to Bazel-buildable Kotlin, alongside their `.main.kts` originals under `platform/jewel/scripts/`. Each ported command takes an injected `CommandRunner` instead of shelling out directly — a real `DefaultCommandRunner` in production, a `FakeCommandRunner` in tests — and `CompareBranches`/`ValidateMavenArtifacts` take a couple of small injectable filesystem lambdas (`pathExists`, `isDirectory`, `isFile`) for the same reason.

Every script got built and tested for real via `bazel build`/`bazel test`, and checked line-by-line against its live `.main.kts` original. That turned up a few real bugs along the way, fixed here instead of left to rot further:

* `JewelBazelScriptsUtils.kt`'s `runCommand` never actually enforced `timeoutAmount` — `process.waitFor()` had no timeout argument, so a hung subprocess would block forever instead of aborting. It now uses the timed `waitFor` overload and kills the process on timeout.
* `CheckApiDumps.kt` had the exact "false green" bug a recent Jewel PR just fixed in `check-api-dumps.main.kts`. A stale `tests.cmd` invocation (which `tests.cmd` now rejects) combined with a missing `set -e` meant the check reported success without the test ever running. Restored `--module`/`--test`, `set -e -o pipefail`, and single-quoted shell-literal path escaping, and pulled the command/script-building logic out into testable functions while at it.
* `branchExists`, in both `JewelBazelScriptsUtils.kt` and the original `utils.main.kts`, was missing `exitOnError = false` — unlike `isDirectoryGitRepo` sitting right next to it. Since `git rev-parse --verify` exits non-zero for exactly the case `branchExists` exists to catch, `compare-branches`' own "Branch not found" message was dead code in both scripts. Fixed in both, not just the port.

A few smaller things got cleaned up too: a "Checking aginst base commit" typo, `requireGhTool` not going through the shared `exitWithError` helper like every other error path in the file, and a dropped trailing period in `CheckApiDumps`' `--verbose` help text.

## Changes

* Ports `AnnotateApiDumpChanges.kt`, `CheckApiDumps.kt`, `CompareBranches.kt`, and `ValidateMavenArtifacts.kt`, plus a shared `CliktUtils.kt` (`exitWithError`) used by all four Clikt-based commands.
* Adds a full test suite: `FakeCommandRunner` plus one test file per script, exercising the extracted pure/testable functions (`processDiff`, `buildApiCheckCommand`/`buildApiCheckScript`, `fetchCommits`, `crossValidateDependencies`, `cleanup`).
* Fixes the three bugs above (subprocess timeout, `CheckApiDumps` false green, `branchExists`), plus the minor typo/consistency fixes.
