### PR TITLE
IJPL-252440 Include the scale in SpinningProgressIcon's frame cache key

### DIFF
--- a/platform/ide-core/src/com/intellij/ui/SpinningProgressIcon.kt
+++ b/platform/ide-core/src/com/intellij/ui/SpinningProgressIcon.kt
@@ -68,13 +68,13 @@ class SpinningProgressIcon(
   }
 
   private fun getIconFromCache(i: Int): Icon {
+    val scale = JBUI.pixScale()
+    val cacheKey = 31 * iconColor.hashCode() + scale.toBits()
     val icon = iconCache[i]
-    val cacheKey = iconColor.hashCode()
     if (icon != null && iconCacheKey == cacheKey) {
       return icon
     }
 
-    val scale = JBUI.pixScale()
     val stringBuilder = StringBuilder()
     val header = createRooTag()
     val stroke = ColorUtil.toHex(iconColor)


### PR DESCRIPTION
Fixes [IJPL-252440](https://youtrack.jetbrains.com/issue/IJPL-252440).
Related: [IJPL-241166](https://youtrack.jetbrains.com/issue/IJPL-241166/Support-for-scalable-AnimatedIcon)

`SpinningProgressIcon` rasterizes its animation frames on first paint and caches them under a key that holds
only the icon's colour. `JBUI.pixScale()` is read after the cache check and takes part in the rasterizing
alone, so a change of the IDE scale never invalidates the cache.

The frames are therefore fixed at whatever the zoom was when the first default spinner of the session was
painted — normally 100%, at startup. Zooming the IDE afterwards leaves a 16-pixel spinner among 32-pixel icons
for the rest of the session; switching the theme is what happens to fix it, since the colour is the one thing
the key reacts to.

This reaches every spinner built on `AnimatedIcon.Default`, whose `DEFAULT_FRAMES` is a static array taken from
a single `SpinningProgressIcon` instance — including `SMPoolOfTestIcons.RUNNING_ICON`, the running-test icon of
every test results tree.

## The change

The scale is read before the cache check and folded into the key, so the frames are rebuilt when it moves:

```kotlin
val scale = JBUI.pixScale()
val cacheKey = 31 * iconColor.hashCode() + scale.toBits()
```

Arithmetic rather than `Objects.hash(iconColor, scale)`, which would allocate a varargs array on a path that
runs for every painted frame. `JBUI.pixScale()` itself is two float multiplications, and it was already being
called on every cache miss.

## Steps to reproduce

1. Start the IDE at the default zoom.
2. Let any default spinner be painted at least once — run a test, or open a tool window that loads.
3. `View | Appearance | Zoom IDE In`, up to 200%.
4. Trigger a spinner again: it keeps its 100% size, at half the size of the icons around it.

Verified in PhpStorm 2026.2.0.1 (262.8665.325) and against current `master`; the code is identical in 2025.2.