### PR TITLE
IDEA-254862 Gradle: accept transformed auxiliary artifacts

### DIFF
--- a/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/auxiliary/AuxiliaryArtifactResolverImpl.java
+++ b/plugins/gradle/tooling-extension-impl/src/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/auxiliary/AuxiliaryArtifactResolverImpl.java
@@ -13,10 +13,10 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.intellij.lang.annotations.MagicConstant;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.File;
 import java.util.Collections;
@@ -67,13 +67,15 @@ public class AuxiliaryArtifactResolverImpl implements AuxiliaryArtifactResolver 
     return new AuxiliaryConfigurationArtifacts(sources, javadocs);
   }
 
-  private static @NotNull Map<ComponentIdentifier, Set<File>> classify(@NotNull Set<ResolvedArtifactResult> artifacts) {
+  @VisibleForTesting
+  static @NotNull Map<ComponentIdentifier, Set<File>> classify(@NotNull Set<ResolvedArtifactResult> artifacts) {
     Map<ComponentIdentifier, Set<File>> result = new HashMap<>();
     for (ResolvedArtifactResult artifact : artifacts) {
       ComponentArtifactIdentifier identifier = artifact.getId();
-      if (identifier instanceof ModuleComponentArtifactIdentifier) {
+      ComponentIdentifier componentIdentifier = identifier.getComponentIdentifier();
+      if (componentIdentifier instanceof ModuleComponentIdentifier) {
         File file = artifact.getFile();
-        result.computeIfAbsent(identifier.getComponentIdentifier(), __ -> new HashSet<>())
+        result.computeIfAbsent(componentIdentifier, __ -> new HashSet<>())
           .add(file);
       }
     }

--- a/plugins/gradle/tooling-extension-impl/testSources/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/auxiliary/AuxiliaryArtifactResolverImplTest.kt
+++ b/plugins/gradle/tooling-extension-impl/testSources/com/intellij/gradle/toolingExtension/impl/model/dependencyModel/auxiliary/AuxiliaryArtifactResolverImplTest.kt
@@ -1,0 +1,55 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.intellij.gradle.toolingExtension.impl.model.dependencyModel.auxiliary
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class AuxiliaryArtifactResolverImplTest {
+
+  @field:TempDir
+  lateinit var tempDir: File
+
+  @Test
+  fun `classify accepts public artifact identifier implementations`() {
+    val componentIdentifier = proxy<ModuleComponentIdentifier> { method ->
+      error("Unexpected call to ${method.name}")
+    }
+    val artifactIdentifier = proxy<ComponentArtifactIdentifier> { method ->
+      when (method.name) {
+        "getComponentIdentifier" -> componentIdentifier
+        "getDisplayName" -> "generated sources"
+        else -> error("Unexpected call to ${method.name}")
+      }
+    }
+    val sources = File(tempDir, "library-sources.jar")
+    val artifact = proxy<ResolvedArtifactResult> { method ->
+      when (method.name) {
+        "getId" -> artifactIdentifier
+        "getFile" -> sources
+        else -> error("Unexpected call to ${method.name}")
+      }
+    }
+
+    assertThat(AuxiliaryArtifactResolverImpl.classify(setOf(artifact)))
+      .containsEntry(componentIdentifier, setOf(sources))
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private inline fun <reified T> proxy(crossinline invocation: (Method) -> Any?): T {
+    return Proxy.newProxyInstance(T::class.java.classLoader, arrayOf(T::class.java)) { proxy, method, arguments ->
+      when (method.name) {
+        "equals" -> proxy === arguments?.single()
+        "hashCode" -> System.identityHashCode(proxy)
+        "toString" -> T::class.java.simpleName
+        else -> invocation(method)
+      }
+    } as T
+  }
+}


### PR DESCRIPTION
This PR allows transformed source and javadoc artifacts to be attached during project import.

Currently, `AuxiliaryArtifactResolverImpl.classify()` checks for Gradle's internal `ModuleComponentArtifactIdentifier`. Transform outputs use `TransformedComponentFileArtifactIdentifier`, so valid artifacts are discarded.

This PR uses `ModuleComponentIdentifier` instead, which works with transformed artifacts. Additionally, it's also not internal Gradle API.

This fixes the first problem that I mentioned in my [youtrack comment](https://youtrack.jetbrains.com/issue/IDEA-254862/Gradle-import-and-auto-download-of-sources-does-not-respect-artifact-transformers#focus=Comments-27-14232476.0-0) on [IDEA-254862](https://youtrack.jetbrains.com/issue/IDEA-254862) and passes the `transformed-source-artifact-id.zip` reproducer attached there.

I've also added a unit test for this. It currently uses `java.lang.reflect.Proxy` instead of mockito because mockito is not on the test classpath for this module, but I can change it to use mockito if that is required.