### PR TITLE
    Use safer regex for end of line patterns

### DIFF
--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/GradleIssueFailureImpl.kt
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/issue/GradleIssueFailureImpl.kt
@@ -83,8 +83,7 @@ private object GradleIssueFailureLocationResolver {
 
   private val ERROR_LOCATION_IN_FILE_PATTERN = Pattern.compile("(?:Build|Settings) file '([^']*)' line: (\\d+)")
   private val ERROR_IN_FILE_PATTERN = Pattern.compile("(?:Build|Settings) file '([^']*)'")
-  private val STACK_TRACE_SCRIPT_LOCATION_PATTERN = Pattern.compile("\\((.*?\\.(?:gradle\\.kts|gradle)):(\\d+)\\)")
-
+  private val STACK_TRACE_SCRIPT_LOCATION_PATTERN = Pattern.compile("\\(([^()]*?\\.(?:gradle\\.kts|gradle)):(\\d+)\\)")
   fun getFilePositionFromText(text: String?): FilePosition? {
     if (text.isNullOrEmpty()) return null
     for (line in StringUtil.splitByLines(text)) {

--- a/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionErrorHandler.java
+++ b/plugins/gradle/src/org/jetbrains/plugins/gradle/service/execution/GradleExecutionErrorHandler.java
@@ -30,7 +30,7 @@ public class GradleExecutionErrorHandler {
     UNSUPPORTED_GRADLE_VERSION_ERROR_PATTERN = Pattern.compile("Gradle version .* is required.*");
     DOWNLOAD_GRADLE_DISTIBUTION_ERROR_PATTERN = Pattern.compile("The specified Gradle distribution .* does not exist.");
     MISSING_METHOD_PATTERN = Pattern.compile("org.gradle.api.internal.MissingMethodException: Could not find method (.*?) .*");
-    ERROR_LOCATION_IN_FILE_PATTERN = Pattern.compile("(?:Build|Settings) file '(.*)' line: (\\d+)");
+    ERROR_LOCATION_IN_FILE_PATTERN = Pattern.compile("(?:Build|Settings) file '([^']*)' line: (\\d+)");
     ERROR_IN_FILE_PATTERN = Pattern.compile("(?:Build|Settings) file '(.*)'");
   }
 


### PR DESCRIPTION
In order to avoid ending up with unnecessary branching logic that is very unoptimal for longer stacktraces.
this impacts Windows specifically that has \r\n as EOL, so for each line, we would have 2 patterns to evaluate against that would match the previous regex.
This blows the complexity to an exponential level.
    
Fixes IDEA-392543