### PR TITLE
[KTIJ-26108] Kotlin: Add Leaking This Inspection

### DIFF
--- a/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
+++ b/plugins/kotlin/base/resources/resources-en/messages/KotlinBundle.properties
@@ -1552,6 +1552,7 @@ optimize.imports=Optimize imports
 remove.unused.imports.quickfix.text=Remove unused imports
 unused.import.directive=Unused import directive
 title.lateinit.var.overrides.lateinit.var='lateinit var' overrides super 'lateinit var'
+inspection.leaking.this.display.message=Leaking this
 leaking.this.in.constructor.of.non.final.class.0=Leaking ''this'' in constructor of non-final class {0}
 leaking.this.in.constructor.of.enum.class.0.with.overridable.members=Leaking ''this'' in constructor of enum class {0} (with overridable members)
 accessing.non.final.property.0.in.constructor=Accessing non-final property {0} in constructor

--- a/plugins/kotlin/code-insight/inspections-k2/resources/intellij.kotlin.codeInsight.inspections.xml
+++ b/plugins/kotlin/code-insight/inspections-k2/resources/intellij.kotlin.codeInsight.inspections.xml
@@ -2318,6 +2318,14 @@
                      cleanupTool="true"
                      language="kotlin"
                      key="inspection.setter.backing.field.assignment.display.name" bundle="messages.KotlinBundle"/>
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.codeInsight.inspections.LeakingThisInspection"
+                     groupPath="Kotlin"
+                     groupBundle="messages.KotlinBundle" groupKey="group.names.probable.bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     cleanupTool="true"
+                     language="kotlin"
+                     key="inspection.leaking.this.display.name" bundle="messages.KotlinBundle"/>
 
     <localInspection implementationClass="org.jetbrains.kotlin.idea.codeInsight.inspections.JavaCollectionsStaticMethodOnImmutableListInspection"
                      groupPath="Kotlin"

--- a/plugins/kotlin/code-insight/inspections-k2/src/org/jetbrains/kotlin/idea/codeInsight/inspections/LeakingThisInspection.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/src/org/jetbrains/kotlin/idea/codeInsight/inspections/LeakingThisInspection.kt
@@ -1,0 +1,109 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.kotlin.idea.codeInsight.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.idea.base.resources.KotlinBundle
+import org.jetbrains.kotlin.idea.codeinsight.api.applicators.ApplicabilityRange
+import org.jetbrains.kotlin.idea.codeinsight.api.classic.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtClassInitializer
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtVisitor
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+
+internal class LeakingThisInspection : AbstractKotlinInspection() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitor<*, *> =
+        object : KtVisitorVoid() {
+            override fun visitProperty(property: KtProperty) {
+                property.initializer?.let { findThisUsages(it, holder, isOnTheFly) }
+            }
+
+            override fun visitClassInitializer(initializer: KtClassInitializer) {
+                findThisUsages(initializer, holder, isOnTheFly)
+            }
+
+            override fun visitConstructor(constructor: KtConstructor<*>) {
+                findThisUsages(constructor, holder, isOnTheFly)
+            }
+        }
+
+    private fun findThisUsages(
+        initializer: KtElement,
+        holder: ProblemsHolder,
+        isOnTheFly: Boolean
+    ) {
+        initializer.accept(object : KtTreeVisitorVoid() {
+            override fun visitThisExpression(expression: KtThisExpression) {
+                visitTargetElement(expression, holder, isOnTheFly)
+            }
+
+            override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {}
+        })
+    }
+
+    private fun visitTargetElement(
+        expression: KtThisExpression,
+        holder: ProblemsHolder,
+        @Suppress("UNUSED_PARAMETER") isOnTheFly: Boolean
+    ) {
+        isLeaking(expression) ?: return
+        ApplicabilityRange.self(expression).forEach {
+            holder.registerProblem(
+                expression,
+                it,
+                KotlinBundle.message("inspection.leaking.this.display.message")
+            )
+        }
+    }
+
+    fun isLeaking(element: PsiElement): LeakingThisContext? {
+        return when (element) {
+            // `this.foo` / `this.method()` — the dot access itself is not a leak;
+            // the result may still escape, but that is tracked via the outer expression.
+            /*
+            *           var c: A? = null
+                        class A {
+                            var b: Int = 42
+                                set(value) { field = value; foo(); c = this}
+                            init {
+                                this.foo()
+                                this.b = 10
+                            }
+                            fun foo() { c = this }
+                        }*/
+            is KtDotQualifiedExpression -> null
+            // Transparent wrapper — check what the parenthesised expression is used for.
+            is KtParenthesizedExpression -> isLeaking(element.parent)
+            // `foo(this)`, `obj.bar(this)`, collection.add(this), etc.
+            is KtValueArgument -> LeakingThisContext.LeakingThis
+            // `field = this` (EQ) or `list += this` (PLUSEQ — appends to a collection).
+            is KtBinaryExpression -> when (element.operationToken) {
+                KtTokens.EQ, KtTokens.PLUSEQ -> LeakingThisContext.LeakingThis
+                else -> null
+            }
+            // `this::method` — bound callable reference captures `this`.
+            is KtCallableReferenceExpression -> LeakingThisContext.LeakingThis
+            is KtThisExpression -> isLeaking(element.parent)
+            else -> null
+        }
+    }
+
+    sealed interface LeakingThisContext {
+        object LeakingThis : LeakingThisContext
+        //object CallLeakingThisFunction : LeakingThisContext
+    }
+}
+

--- a/plugins/kotlin/code-insight/inspections-k2/tests/test/org/jetbrains/kotlin/idea/inspections/tests/K2LocalInspectionTestGenerated.java
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/test/org/jetbrains/kotlin/idea/inspections/tests/K2LocalInspectionTestGenerated.java
@@ -17471,6 +17471,74 @@ public abstract class K2LocalInspectionTestGenerated extends AbstractK2LocalInsp
         }
 
         @RunWith(JUnit3RunnerWithInners.class)
+        @TestMetadata("testData/inspectionsLocal/leakingThis")
+        public static class LeakingThis extends AbstractK2LocalInspectionTest {
+            private void runTest(String testDataFilePath) throws Exception {
+                KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
+            }
+
+            @TestMetadata("callMethod.kt")
+            public void testCallMethod() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/callMethod.kt");
+            }
+
+            @TestMetadata("leakingThisAssign.kt")
+            public void testLeakingThisAssign() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/leakingThisAssign.kt");
+            }
+
+            @TestMetadata("leakingThisInAnonymOblect.kt")
+            public void testLeakingThisInAnonymOblect() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/leakingThisInAnonymOblect.kt");
+            }
+
+            @TestMetadata("leakingThisInConstructor.kt")
+            public void testLeakingThisInConstructor() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/leakingThisInConstructor.kt");
+            }
+
+            @TestMetadata("leakingThisInNestedClasses.kt")
+            public void testLeakingThisInNestedClasses() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/leakingThisInNestedClasses.kt");
+            }
+
+            @TestMetadata("leakingThisInPropertyInit.kt")
+            public void testLeakingThisInPropertyInit() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/leakingThisInPropertyInit.kt");
+            }
+
+            @TestMetadata("leakingThisViaParameter.kt")
+            public void testLeakingThisViaParameter() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/leakingThisViaParameter.kt");
+            }
+
+            @TestMetadata("noLeakingInDelegate.kt")
+            public void testNoLeakingInDelegate() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/noLeakingInDelegate.kt");
+            }
+
+            @TestMetadata("noLeakingInGetter.kt")
+            public void testNoLeakingInGetter() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/noLeakingInGetter.kt");
+            }
+
+            @TestMetadata("noLeakingInMethods.kt")
+            public void testNoLeakingInMethods() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/noLeakingInMethods.kt");
+            }
+
+            @TestMetadata("noLeakingInSetter.kt")
+            public void testNoLeakingInSetter() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/noLeakingInSetter.kt");
+            }
+
+            @TestMetadata("propertyAssign.kt")
+            public void testPropertyAssign() throws Exception {
+                runTest("testData/inspectionsLocal/leakingThis/propertyAssign.kt");
+            }
+        }
+
+        @RunWith(JUnit3RunnerWithInners.class)
         @TestMetadata("testData/inspectionsLocal/liftOut")
         public abstract static class LiftOut extends AbstractK2LocalInspectionTest {
             @RunWith(JUnit3RunnerWithInners.class)

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/.inspection
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.codeInsight.inspections.LeakingThisInspection

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/callMethod.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/callMethod.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+class Foo {
+    init {
+        <caret>onInit()
+    }
+
+    fun onInit() {
+        println("initialized")
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisAssign.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisAssign.kt
@@ -1,0 +1,9 @@
+// PROBLEM: Leaking this
+// FIX: none
+class Foo {
+    init {
+        global = <caret>this
+    }
+}
+
+var global: Foo? = null

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInAnonymOblect.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInAnonymOblect.kt
@@ -1,0 +1,14 @@
+// PROBLEM: Leaking this
+// FIX: none
+class Foo1 {
+    class Foo2 {
+        init {
+            var a = Any()
+            val c = object {
+                init {
+                    a = <caret>this
+                }
+            }
+        }
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInConstructor.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInConstructor.kt
@@ -1,0 +1,11 @@
+// PROBLEM: Leaking this
+// FIX: none
+class Foo(val bar: Bar) {
+    constructor(bar: Bar, int: Int) : this(bar) {
+        bar.take(<caret>this)
+    }
+}
+
+class Bar {
+    fun take(foo: Foo) {}
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInNestedClasses.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInNestedClasses.kt
@@ -1,0 +1,13 @@
+// PROBLEM: Leaking this
+// FIX: none
+class Foo1(val bar: Bar) {
+    class Foo2(val bar: Bar) {
+        init {
+            bar.take(<caret>this)
+        }
+    }
+}
+
+class Bar {
+    fun take(foo: Foo1.Foo2) {}
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInPropertyInit.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisInPropertyInit.kt
@@ -1,0 +1,12 @@
+// PROBLEM: Leaking this
+// FIX: none
+
+class Foo(val bar: Bar) {
+    val i = 10.also {
+        bar.take(<caret>this)
+    }
+}
+
+class Bar {
+    fun take(foo: Foo) {}
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisViaParameter.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/leakingThisViaParameter.kt
@@ -1,0 +1,11 @@
+// PROBLEM: Leaking this
+// FIX: none
+class Foo(val bar: Bar) {
+    init {
+        bar.take(<caret>this)
+    }
+}
+
+class Bar {
+    fun take(foo: Foo) {}
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInDelegate.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInDelegate.kt
@@ -1,0 +1,14 @@
+import kotlin.reflect.KProperty
+// PROBLEM: none
+class Foo {
+    var d by Delegate(<caret>this)
+}
+
+class Delegate<T : Any>(var value: T){
+    public operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return value
+    }
+    public operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        this.value = value
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInGetter.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInGetter.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+class Foo {
+    var instance: Foo get() = <caret>this
+        set(value) {}
+}
+

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInMethods.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInMethods.kt
@@ -1,0 +1,6 @@
+// PROBLEM: none
+class Foo {
+    fun getInstance() : Foo {
+        return <caret>this
+    }
+}

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInSetter.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/noLeakingInSetter.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+class Foo {
+    var instance: Foo get() = <caret>this
+    set(value) {
+        local = this
+    }
+}
+
+var local: Foo? = null
+

--- a/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/propertyAssign.kt
+++ b/plugins/kotlin/code-insight/inspections-k2/tests/testData/inspectionsLocal/leakingThis/propertyAssign.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+class Foo {
+    var value: Int = 42
+    init {
+        <caret>this.value = 42
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-26108
<img width="445" height="533" alt="Screenshot 2026-08-11 010643" src="https://github.com/user-attachments/assets/af8af908-ba9a-4af5-9e22-d3ae9fe27c88" />
I want to ask about https://github.com/JetBrains/intellij-community/plugins/kotlin/code-insight/descriptions/resources-en/inspectionDescriptions/LeakingThis.html that still exist should I modify it?