### PR TITLE
[IJPL-252958] Fix Compose Resources string fold/preview.

### DIFF
--- a/plugins/compose/intellij.compose.ide.plugin.resources/src/com/intellij/compose/ide/plugin/resources/folding/ComposeResourcesFoldingBuilder.kt
+++ b/plugins/compose/intellij.compose.ide.plugin.resources/src/com/intellij/compose/ide/plugin/resources/folding/ComposeResourcesFoldingBuilder.kt
@@ -62,19 +62,37 @@ private fun KtSimpleNameExpression.getFoldingDescriptor(): FoldingDescriptor? {
 }
 
 private fun getResourcePlaceholderText(psiElements: List<PsiElement>): String? {
-  for (psiElement in psiElements) {
-    val xmlTag = psiElement.parent.parent as? XmlTag ?: continue
-    val textValue = when (xmlTag.name) {
-      ResourceType.STRING.typeName -> xmlTag.value.text.trim()
-      ResourceType.PLURAL_STRING.typeName -> {
-        val itemTag = xmlTag.childrenSequence.filterIsInstance<XmlTag>().firstOrNull() ?: continue
-        itemTag.value.text.trim()
-      }
-      else -> continue
+  for (element in psiElements) {
+    if (isValuesDirectory(element)) {
+      extractPlaceholderText(element)?.let { return it }
     }
-    if (textValue.isEmpty()) continue
-    return "\"" + StringUtil.shortenTextWithEllipsis(textValue, FOLD_MAX_LENGTH - 2, 0) + "\""
+  }
+
+  for (element in psiElements) {
+    if (!isValuesDirectory(element)) {
+      extractPlaceholderText(element)?.let { return it }
+    }
   }
 
   return null
+}
+
+private fun isValuesDirectory(element: PsiElement): Boolean {
+  return element.containingFile?.parent?.name == "values"
+}
+
+private fun extractPlaceholderText(psiElement: PsiElement): String? {
+  val xmlTag = psiElement.parent?.parent as? XmlTag ?: return null
+
+  val rawText = when (xmlTag.name) {
+                  ResourceType.STRING.typeName -> xmlTag.value.text
+                  ResourceType.PLURAL_STRING.typeName -> xmlTag.subTags.firstOrNull()?.value?.text
+                  else -> null
+                } ?: return null
+
+  val trimmed = rawText.trim()
+  if (trimmed.isEmpty()) return null
+
+  val shortened = StringUtil.shortenTextWithEllipsis(trimmed, FOLD_MAX_LENGTH - 2, 0)
+  return "\"$shortened\""
 }


### PR DESCRIPTION
When a Compose Multiplatform string resource (`Res.string.xxx`) is referenced in Kotlin code, the IDE folds the reference and shows a preview of its resolved text. 

This preview is generated by `ComposeResourcesFoldingBuilder.getResourcePlaceholderText()`, which iterates `psiElements` (one per locale variant of the resource) and returns the text of the *first* non-empty match with no preference for the base/default (unqualified `values/`) resource. 

In practice, this list is not ordered with the base `values/strings.xml` first, so the folded preview ends up showing whatever locale-qualified variant happens to sort first (e.g. `values-ar` before `values` in the resource item list), even when the base `values/strings.xml` holds the actual default text.


**Steps to reproduce**
1. Create a Compose Multiplatform project with composeResources.
2. Add `res/values/strings.xml` with a string key, e.g. `<string name="foo">Hello</string>`.
3. Add `res/values-ar/strings.xml` with the same key translated, e.g. `<string name="foo">مرحبا</string>`.
4. In Kotlin code, reference `stringResource(Res.string.foo)`.
5. Observe the folded inline preview shows the Arabic text instead of "Hello".

**Expected behavior**
The folded preview should prefer the text from the unqualified `values/` (default) resource folder when one exists, falling back to whatever is available otherwise.

***I verified this locally by compiling and patching the code, the patch resolves the issue and the fold now correctly shows the default locale's text.***

**Environment**
- IDE: IntelliJ IDEA 2026.2.1
- Compose Multiplatform plugin version: 263.20260731.0
- OS: macOS 26
- Project uses composeResources with 16 locale folders (values, values-ar, values-de, ...)
<img width="1140" height="1736" alt="Screenshot 2026-08-14 at 11 02 51 AM" src="https://github.com/user-attachments/assets/2af27cdb-a26b-430e-961b-1fc8f00b5069" />
<img width="1110" height="314" alt="Screenshot 2026-08-14 at 10 59 51 AM" src="https://github.com/user-attachments/assets/0a761d6a-f9d3-47f4-8daf-47f2d4f48824" />
