### PR TITLE
IDEA: detect AI coding CLIs for plugin suggestions

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/pluginsAdvertisement/EnvironmentDependencyCollector.kt
@@ -14,6 +14,11 @@ internal class EnvironmentDependencyCollector : DependencyCollector {
     "podman",
     "terraform",
 
+    // AI coding CLIs
+    "copilot",
+    "codex",
+    "claude",
+
     // Reserved for Cloud vendors only
     "az",
     "gcloud",


### PR DESCRIPTION
## Summary

Add the executable basenames for three AI coding CLIs to `EnvironmentDependencyCollector`:

- `copilot` — GitHub Copilot CLI
- `codex` — OpenAI Codex CLI
- `claude` — Claude Code

This lets IntelliJ detect the commands from `PATH` and resolve Marketplace plugins that declare matching `dependencySupport` features such as `executable:copilot`.

## Motivation

GitHub Copilot for IntelliJ plans to declare these executable mappings in its main plugin descriptor so users of AI coding CLIs can discover the IDE integration through the existing **Plugins | Suggested** experience.

## Testing

- `git diff --check`
- reviewed the existing cross-platform `EnvironmentScannerTest`, which covers executable suffix handling and executable-file checks used by this collector
- no scanner behavior is changed; this patch only extends the collector's data list