### PR TITLE
[JEWEL-1399] Read Jewel reviewers from the published maintainers list

### DIFF
--- a/.agents/skills/jewel-pr-preparer/SKILL.md
+++ b/.agents/skills/jewel-pr-preparer/SKILL.md
@@ -349,16 +349,25 @@ gh pr edit <number> --repo JetBrains/intellij-community \
   --add-reviewer "<reviewer3>"
 ```
 
-Add 3 reviewers, mixing external and internal contributors. Known Jewel team reviewer handles:
+Always add 3 reviewers, mixing teams.
 
-- External reviewers (non-JetBrains): `DanielSouzaBertoldi`, `rock3r`
-- Internal reviewers (JetBrains): `DejanMilicic`, `nebojsa-vuksic`, `AlexVanGogen`, `daaria-s`
+The reviewer pool is **not** hardcoded here. It comes from the published Jewel maintainers list at
+<https://jewel-ui.dev/data/maintainers.json>, where every maintainer carries a `team` of either `jetbrains` or `google`. Maintainers from
+Touchlab work on Google's behalf and are recorded as `google`; the only distinction that matters for reviews is whether someone is a
+JetBrains employee. Never hardcode reviewer handles in this skill, in the helper script, or in a PR — if the roster is wrong, fix the
+published list instead.
 
 Do NOT ask for a review from the author of the PR, of course.
 
 For best-effort round-robin assignment, prefer reviewers with the fewest outstanding review requests across currently open Jewel PRs.
-Try to keep at least one external and one internal reviewer in the set whenever possible. This is only a heuristic — it does not know about
+Try to keep at least one reviewer from each team in the set whenever possible. This is only a heuristic — it does not know about
 vacations, availability, or special topic ownership. Ask the user before applying the suggested reviewers.
+
+Requesting 3 reviewers is unrelated to how many approvals the PR needs to merge. Per the
+[approval rules](../../../platform/jewel/docs/jewel-contribution-guide.md#approval-rules), one Jewel team approval is enough for a small or
+simple change, or for one confined to `platform/jewel`; anything else needs two approvals, at least one of them from a JetBrains
+maintainer. Note that "confined to `platform/jewel`" is deliberately narrower than the Jewel-related paths in the contribution guide, so a
+PR touching `libraries/skiko` — or this skill's own files — still needs a JetBrains approval.
 
 Run the helper script from the repository root (or adjust the path accordingly):
 
@@ -369,9 +378,13 @@ python3 .claude/skills/jewel-pr-preparer/scripts/suggest_reviewers.py \
   --exclude <optional-comma-separated-extra-logins>
 ```
 
-The script prints suggested reviewers and an example `gh pr edit ... --add-reviewer ...` command. If the script returns fewer than 3
-reviewers, ask the user how they want to fill the remaining slots. If the user wants a different balance (e.g., 2 internal + 1 external),
-adjust the selection accordingly.
+The script prints the maintainer list it used, the suggested reviewers with their team, and an example `gh pr edit ... --add-reviewer ...`
+command. If the script returns fewer than 3 reviewers, ask the user how they want to fill the remaining slots. If the user wants a different
+balance (e.g., 2 JetBrains + 1 Google), adjust the selection accordingly.
+
+The script fetches the maintainers list at run time. If that fetch fails it warns on stderr and falls back to `maintainers.fallback.json`,
+a snapshot bundled next to the script. When you see that warning, tell the user the suggestions came from a possibly stale copy so they can
+sanity-check the handles. If neither source is usable the script exits with an error and the user should pick reviewers manually.
 
 ### Update YouTrack ticket state
 

--- a/.agents/skills/jewel-pr-preparer/scripts/maintainers.fallback.json
+++ b/.agents/skills/jewel-pr-preparer/scripts/maintainers.fallback.json
@@ -1,0 +1,33 @@
+{
+  "$schema_version": 1,
+  "maintainers": [
+    {
+      "display_name": "Sebastiano Poggi",
+      "github_username": "rock3r",
+      "youtrack_username": "sebp",
+      "role": "lead",
+      "team": "google"
+    },
+    {
+      "display_name": "Nebojsa Vuksic",
+      "github_username": "nebojsa-vuksic",
+      "youtrack_username": "nebojsa.vuksic",
+      "role": "dev",
+      "team": "jetbrains"
+    },
+    {
+      "display_name": "Wellington Pereira",
+      "github_username": "wellingtoncosta",
+      "youtrack_username": "wellington.twpi",
+      "role": "dev",
+      "team": "google"
+    },
+    {
+      "display_name": "Daniel Bertoldi",
+      "github_username": "DanielSouzaBertoldi",
+      "youtrack_username": "daniel.tiwz",
+      "role": "dev",
+      "team": "google"
+    }
+  ]
+}

--- a/.agents/skills/jewel-pr-preparer/scripts/suggest_reviewers.py
+++ b/.agents/skills/jewel-pr-preparer/scripts/suggest_reviewers.py
@@ -1,13 +1,159 @@
 #!/usr/bin/env python3
 
+"""Suggest Jewel PR reviewers from the published Jewel maintainers list.
+
+The reviewer pool is fetched from the Jewel site at run time, so it does not
+need to be kept in sync by hand. If the fetch fails, the bundled snapshot next
+to this script is used instead, so preparing a PR keeps working offline.
+"""
+
+# Keeps the `X | None` annotations below working on Python 3.9.
+from __future__ import annotations
+
 import argparse
 import collections
 import json
+import pathlib
+import re
+import shlex
 import subprocess
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 
-EXTERNAL = ["DanielSouzaBertoldi", "rock3r"]
-INTERNAL = ["DejanMilicic", "nebojsa-vuksic", "AlexVanGogen", "daaria-s"]
+MAINTAINERS_URL = "https://jewel-ui.dev/data/maintainers.json"
+FALLBACK_PATH = pathlib.Path(__file__).with_name("maintainers.fallback.json")
+
+SUPPORTED_SCHEMA_VERSION = 1
+FETCH_TIMEOUT_SECONDS = 10
+MAX_RESPONSE_BYTES = 256 * 1024
+# jewel-ui.dev sits behind Cloudflare, which answers the default urllib
+# User-Agent with 403. Identify the caller properly instead.
+USER_AGENT = "jewel-pr-preparer (+https://github.com/JetBrains/intellij-community)"
+
+# The maintainers list is public, so treat it as untrusted input: everything
+# taken from it is validated before it is used, printed, or put in a command.
+# GitHub logins are 1-39 chars, alphanumeric with single inner hyphens.
+GITHUB_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+# Team names are only used for grouping and display; keep them a short token.
+TEAM_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+Maintainer = collections.namedtuple("Maintainer", ["login", "team"])
+
+
+class MaintainersError(Exception):
+    """The maintainers list could not be read or did not have the expected shape."""
+
+
+class SameHostRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects that leave the expected https origin."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        expected = urllib.parse.urlsplit(MAINTAINERS_URL)
+        target = urllib.parse.urlsplit(newurl)
+        if target.scheme != "https" or target.netloc.lower() != expected.netloc.lower():
+            raise urllib.error.HTTPError(
+                newurl, code, f"refusing redirect off {expected.netloc} to {newurl}", headers, fp
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def describe_invalid(entry) -> str | None:
+    """Return why this entry is unusable, or None if it is fine."""
+    if not isinstance(entry, dict):
+        return "not a JSON object"
+
+    login = entry.get("github_username")
+    if not isinstance(login, str) or not GITHUB_LOGIN_RE.match(login):
+        return f"'github_username' is not a valid GitHub login ({login!r})"
+
+    team = entry.get("team")
+    if not isinstance(team, str) or not TEAM_RE.match(team):
+        return f"'team' is not a valid team name ({team!r})"
+
+    return None
+
+
+def parse_maintainers(raw: str, source: str) -> list[Maintainer]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise MaintainersError(f"{source}: not valid JSON ({error})")
+
+    if not isinstance(payload, dict):
+        raise MaintainersError(f"{source}: expected a JSON object at the top level")
+
+    version = payload.get("$schema_version")
+    if version != SUPPORTED_SCHEMA_VERSION:
+        raise MaintainersError(
+            f"{source}: unsupported $schema_version {version!r}, "
+            f"this script understands {SUPPORTED_SCHEMA_VERSION}"
+        )
+
+    entries = payload.get("maintainers")
+    if not isinstance(entries, list):
+        raise MaintainersError(f"{source}: 'maintainers' is missing or is not a list")
+
+    maintainers: list[Maintainer] = []
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        problem = describe_invalid(entry)
+        if problem:
+            print(f"warning: {source}: skipping maintainers[{index}]: {problem}", file=sys.stderr)
+            continue
+        login = entry["github_username"]
+        if login in seen:
+            print(f"warning: {source}: skipping duplicate entry for {login}", file=sys.stderr)
+            continue
+        seen.add(login)
+        maintainers.append(Maintainer(login=login, team=entry["team"]))
+
+    if not maintainers:
+        raise MaintainersError(f"{source}: no usable maintainer entries")
+
+    return maintainers
+
+
+def fetch_maintainers() -> list[Maintainer]:
+    if urllib.parse.urlsplit(MAINTAINERS_URL).scheme != "https":
+        raise MaintainersError(f"{MAINTAINERS_URL}: refusing to fetch over a non-https URL")
+
+    opener = urllib.request.build_opener(SameHostRedirectHandler)
+    request = urllib.request.Request(
+        MAINTAINERS_URL,
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    with opener.open(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        raw = response.read(MAX_RESPONSE_BYTES + 1)
+
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise MaintainersError(f"{MAINTAINERS_URL}: response is larger than {MAX_RESPONSE_BYTES} bytes")
+
+    return parse_maintainers(raw.decode("utf-8", errors="replace"), MAINTAINERS_URL)
+
+
+def load_maintainers() -> tuple[list[Maintainer], str]:
+    """Return the maintainer pool and a human-readable description of where it came from."""
+    try:
+        return fetch_maintainers(), f"{MAINTAINERS_URL} (live)"
+    except (OSError, MaintainersError) as error:
+        print(f"warning: could not use {MAINTAINERS_URL}: {error}", file=sys.stderr)
+        print(
+            f"warning: falling back to the bundled copy in {FALLBACK_PATH.name}, which may be out of date",
+            file=sys.stderr,
+        )
+
+    try:
+        return parse_maintainers(FALLBACK_PATH.read_text(encoding="utf-8"), str(FALLBACK_PATH)), (
+            f"{FALLBACK_PATH.name} (bundled fallback, may be out of date)"
+        )
+    except (OSError, MaintainersError) as error:
+        raise SystemExit(
+            f"error: no usable maintainer list: {error}\n"
+            "Pick reviewers manually instead, for example:\n"
+            "  gh pr edit <number> --repo JetBrains/intellij-community --add-reviewer <login>"
+        )
 
 
 def run_gh_graphql() -> dict:
@@ -51,11 +197,41 @@ query($searchQuery: String!) {
     return json.loads(raw)
 
 
-def ordered_candidates(candidates: list[str], load: collections.Counter, exclude: set[str]) -> list[str]:
+def ordered_candidates(
+    candidates: list[Maintainer], load: collections.Counter, exclude: set[str]
+) -> list[Maintainer]:
     return sorted(
-        [candidate for candidate in candidates if candidate not in exclude],
-        key=lambda login: (load[login], login.lower()),
+        [candidate for candidate in candidates if candidate.login not in exclude],
+        key=lambda maintainer: (load[maintainer.login], maintainer.login.lower()),
     )
+
+
+def select_reviewers(
+    maintainers: list[Maintainer], load: collections.Counter, exclude: set[str], count: int
+) -> list[Maintainer]:
+    candidates = ordered_candidates(maintainers, load, exclude)
+
+    by_team: dict[str, list[Maintainer]] = {}
+    for candidate in candidates:
+        by_team.setdefault(candidate.team, []).append(candidate)
+
+    selected: list[Maintainer] = []
+
+    # Seed with the least loaded maintainer of each team, so the suggestion
+    # mixes teams whenever the pool allows it.
+    for team in sorted(by_team, key=lambda name: (load[by_team[name][0].login], name)):
+        if len(selected) >= count:
+            break
+        selected.append(by_team[team][0])
+
+    # Fill the remaining slots with whoever has the lightest review load overall.
+    for candidate in candidates:
+        if len(selected) >= count:
+            break
+        if candidate not in selected:
+            selected.append(candidate)
+
+    return selected[:count]
 
 
 def main() -> int:
@@ -77,9 +253,14 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    if args.pr_number and not str(args.pr_number).isdigit():
+        parser.error("--pr-number must be a number")
+
     exclude = {item.strip() for item in args.exclude.split(",") if item.strip()}
     if args.author_login:
         exclude.add(args.author_login.strip())
+
+    maintainers, source = load_maintainers()
 
     data = run_gh_graphql()
     prs = data["data"]["search"]["nodes"]
@@ -94,38 +275,31 @@ def main() -> int:
             if login:
                 load[login] += 1
 
-    external_candidates = ordered_candidates(EXTERNAL, load, exclude)
-    internal_candidates = ordered_candidates(INTERNAL, load, exclude)
+    selected = select_reviewers(maintainers, load, exclude, args.count)
 
-    selected: list[str] = []
-    if args.count > 0 and external_candidates:
-        selected.append(external_candidates[0])
-    if args.count > 1 and internal_candidates:
-        if internal_candidates[0] not in selected:
-            selected.append(internal_candidates[0])
-
-    remaining_pool = ordered_candidates(EXTERNAL + INTERNAL, load, exclude)
-    for login in remaining_pool:
-        if login not in selected:
-            selected.append(login)
-        if len(selected) >= args.count:
-            break
-
-    selected = selected[: args.count]
-
+    print(f"Maintainers source: {source}")
     print("Suggested reviewers (best-effort round robin):")
     if not selected:
         print("- none available after exclusions")
         return 0
 
-    for login in selected:
-        reviewer_type = "external" if login in EXTERNAL else "internal"
-        print(f"- {login} ({reviewer_type}, open Jewel PR review load: {load[login]})")
+    for maintainer in selected:
+        print(f"- {maintainer.login} ({maintainer.team}, open Jewel PR review load: {load[maintainer.login]})")
 
-    reviewer_flags = " ".join(f'--add-reviewer "{login}"' for login in selected)
+    teams = {maintainer.team for maintainer in selected}
+    if len(teams) < 2:
+        print(
+            f"\nNote: every suggestion is from the '{teams.pop()}' team; "
+            "the pool had nobody else available after exclusions."
+        )
+
+    reviewer_flags = " ".join(f"--add-reviewer {shlex.quote(m.login)}" for m in selected)
     if args.pr_number:
         print("\nExample command:")
-        print(f'gh pr edit {args.pr_number} --repo JetBrains/intellij-community {reviewer_flags}')
+        print(
+            f"gh pr edit {shlex.quote(str(args.pr_number))} "
+            f"--repo JetBrains/intellij-community {reviewer_flags}"
+        )
 
     return 0
 

--- a/.claude/skills/jewel-pr-preparer/SKILL.md
+++ b/.claude/skills/jewel-pr-preparer/SKILL.md
@@ -350,16 +350,25 @@ gh pr edit <number> --repo JetBrains/intellij-community \
   --add-reviewer "<reviewer3>"
 ```
 
-Add 3 reviewers, mixing external and internal contributors. Known Jewel team reviewer handles:
+Always add 3 reviewers, mixing teams.
 
-- External reviewers (non-JetBrains): `DanielSouzaBertoldi`, `rock3r`
-- Internal reviewers (JetBrains): `DejanMilicic`, `nebojsa-vuksic`, `AlexVanGogen`, `daaria-s`
+The reviewer pool is **not** hardcoded here. It comes from the published Jewel maintainers list at
+<https://jewel-ui.dev/data/maintainers.json>, where every maintainer carries a `team` of either `jetbrains` or `google`. Maintainers from
+Touchlab work on Google's behalf and are recorded as `google`; the only distinction that matters for reviews is whether someone is a
+JetBrains employee. Never hardcode reviewer handles in this skill, in the helper script, or in a PR — if the roster is wrong, fix the
+published list instead.
 
 Do NOT ask for a review from the author of the PR, of course.
 
 For best-effort round-robin assignment, prefer reviewers with the fewest outstanding review requests across currently open Jewel PRs.
-Try to keep at least one external and one internal reviewer in the set whenever possible. This is only a heuristic — it does not know about
+Try to keep at least one reviewer from each team in the set whenever possible. This is only a heuristic — it does not know about
 vacations, availability, or special topic ownership. Ask the user before applying the suggested reviewers.
+
+Requesting 3 reviewers is unrelated to how many approvals the PR needs to merge. Per the
+[approval rules](../../../platform/jewel/docs/jewel-contribution-guide.md#approval-rules), one Jewel team approval is enough for a small or
+simple change, or for one confined to `platform/jewel`; anything else needs two approvals, at least one of them from a JetBrains
+maintainer. Note that "confined to `platform/jewel`" is deliberately narrower than the Jewel-related paths in the contribution guide, so a
+PR touching `libraries/skiko` — or this skill's own files — still needs a JetBrains approval.
 
 Run the helper script from the repository root (or adjust the path accordingly):
 
@@ -370,9 +379,13 @@ python3 .claude/skills/jewel-pr-preparer/scripts/suggest_reviewers.py \
   --exclude <optional-comma-separated-extra-logins>
 ```
 
-The script prints suggested reviewers and an example `gh pr edit ... --add-reviewer ...` command. If the script returns fewer than 3
-reviewers, ask the user how they want to fill the remaining slots. If the user wants a different balance (e.g., 2 internal + 1 external),
-adjust the selection accordingly.
+The script prints the maintainer list it used, the suggested reviewers with their team, and an example `gh pr edit ... --add-reviewer ...`
+command. If the script returns fewer than 3 reviewers, ask the user how they want to fill the remaining slots. If the user wants a different
+balance (e.g., 2 JetBrains + 1 Google), adjust the selection accordingly.
+
+The script fetches the maintainers list at run time. If that fetch fails it warns on stderr and falls back to `maintainers.fallback.json`,
+a snapshot bundled next to the script. When you see that warning, tell the user the suggestions came from a possibly stale copy so they can
+sanity-check the handles. If neither source is usable the script exits with an error and the user should pick reviewers manually.
 
 ### Update YouTrack ticket state
 

--- a/.claude/skills/jewel-pr-preparer/scripts/maintainers.fallback.json
+++ b/.claude/skills/jewel-pr-preparer/scripts/maintainers.fallback.json
@@ -1,0 +1,33 @@
+{
+  "$schema_version": 1,
+  "maintainers": [
+    {
+      "display_name": "Sebastiano Poggi",
+      "github_username": "rock3r",
+      "youtrack_username": "sebp",
+      "role": "lead",
+      "team": "google"
+    },
+    {
+      "display_name": "Nebojsa Vuksic",
+      "github_username": "nebojsa-vuksic",
+      "youtrack_username": "nebojsa.vuksic",
+      "role": "dev",
+      "team": "jetbrains"
+    },
+    {
+      "display_name": "Wellington Pereira",
+      "github_username": "wellingtoncosta",
+      "youtrack_username": "wellington.twpi",
+      "role": "dev",
+      "team": "google"
+    },
+    {
+      "display_name": "Daniel Bertoldi",
+      "github_username": "DanielSouzaBertoldi",
+      "youtrack_username": "daniel.tiwz",
+      "role": "dev",
+      "team": "google"
+    }
+  ]
+}

--- a/.claude/skills/jewel-pr-preparer/scripts/suggest_reviewers.py
+++ b/.claude/skills/jewel-pr-preparer/scripts/suggest_reviewers.py
@@ -1,13 +1,159 @@
 #!/usr/bin/env python3
 
+"""Suggest Jewel PR reviewers from the published Jewel maintainers list.
+
+The reviewer pool is fetched from the Jewel site at run time, so it does not
+need to be kept in sync by hand. If the fetch fails, the bundled snapshot next
+to this script is used instead, so preparing a PR keeps working offline.
+"""
+
+# Keeps the `X | None` annotations below working on Python 3.9.
+from __future__ import annotations
+
 import argparse
 import collections
 import json
+import pathlib
+import re
+import shlex
 import subprocess
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 
-EXTERNAL = ["DanielSouzaBertoldi", "rock3r"]
-INTERNAL = ["DejanMilicic", "nebojsa-vuksic", "AlexVanGogen", "daaria-s"]
+MAINTAINERS_URL = "https://jewel-ui.dev/data/maintainers.json"
+FALLBACK_PATH = pathlib.Path(__file__).with_name("maintainers.fallback.json")
+
+SUPPORTED_SCHEMA_VERSION = 1
+FETCH_TIMEOUT_SECONDS = 10
+MAX_RESPONSE_BYTES = 256 * 1024
+# jewel-ui.dev sits behind Cloudflare, which answers the default urllib
+# User-Agent with 403. Identify the caller properly instead.
+USER_AGENT = "jewel-pr-preparer (+https://github.com/JetBrains/intellij-community)"
+
+# The maintainers list is public, so treat it as untrusted input: everything
+# taken from it is validated before it is used, printed, or put in a command.
+# GitHub logins are 1-39 chars, alphanumeric with single inner hyphens.
+GITHUB_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+# Team names are only used for grouping and display; keep them a short token.
+TEAM_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+Maintainer = collections.namedtuple("Maintainer", ["login", "team"])
+
+
+class MaintainersError(Exception):
+    """The maintainers list could not be read or did not have the expected shape."""
+
+
+class SameHostRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects that leave the expected https origin."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        expected = urllib.parse.urlsplit(MAINTAINERS_URL)
+        target = urllib.parse.urlsplit(newurl)
+        if target.scheme != "https" or target.netloc.lower() != expected.netloc.lower():
+            raise urllib.error.HTTPError(
+                newurl, code, f"refusing redirect off {expected.netloc} to {newurl}", headers, fp
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def describe_invalid(entry) -> str | None:
+    """Return why this entry is unusable, or None if it is fine."""
+    if not isinstance(entry, dict):
+        return "not a JSON object"
+
+    login = entry.get("github_username")
+    if not isinstance(login, str) or not GITHUB_LOGIN_RE.match(login):
+        return f"'github_username' is not a valid GitHub login ({login!r})"
+
+    team = entry.get("team")
+    if not isinstance(team, str) or not TEAM_RE.match(team):
+        return f"'team' is not a valid team name ({team!r})"
+
+    return None
+
+
+def parse_maintainers(raw: str, source: str) -> list[Maintainer]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise MaintainersError(f"{source}: not valid JSON ({error})")
+
+    if not isinstance(payload, dict):
+        raise MaintainersError(f"{source}: expected a JSON object at the top level")
+
+    version = payload.get("$schema_version")
+    if version != SUPPORTED_SCHEMA_VERSION:
+        raise MaintainersError(
+            f"{source}: unsupported $schema_version {version!r}, "
+            f"this script understands {SUPPORTED_SCHEMA_VERSION}"
+        )
+
+    entries = payload.get("maintainers")
+    if not isinstance(entries, list):
+        raise MaintainersError(f"{source}: 'maintainers' is missing or is not a list")
+
+    maintainers: list[Maintainer] = []
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        problem = describe_invalid(entry)
+        if problem:
+            print(f"warning: {source}: skipping maintainers[{index}]: {problem}", file=sys.stderr)
+            continue
+        login = entry["github_username"]
+        if login in seen:
+            print(f"warning: {source}: skipping duplicate entry for {login}", file=sys.stderr)
+            continue
+        seen.add(login)
+        maintainers.append(Maintainer(login=login, team=entry["team"]))
+
+    if not maintainers:
+        raise MaintainersError(f"{source}: no usable maintainer entries")
+
+    return maintainers
+
+
+def fetch_maintainers() -> list[Maintainer]:
+    if urllib.parse.urlsplit(MAINTAINERS_URL).scheme != "https":
+        raise MaintainersError(f"{MAINTAINERS_URL}: refusing to fetch over a non-https URL")
+
+    opener = urllib.request.build_opener(SameHostRedirectHandler)
+    request = urllib.request.Request(
+        MAINTAINERS_URL,
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    with opener.open(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        raw = response.read(MAX_RESPONSE_BYTES + 1)
+
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise MaintainersError(f"{MAINTAINERS_URL}: response is larger than {MAX_RESPONSE_BYTES} bytes")
+
+    return parse_maintainers(raw.decode("utf-8", errors="replace"), MAINTAINERS_URL)
+
+
+def load_maintainers() -> tuple[list[Maintainer], str]:
+    """Return the maintainer pool and a human-readable description of where it came from."""
+    try:
+        return fetch_maintainers(), f"{MAINTAINERS_URL} (live)"
+    except (OSError, MaintainersError) as error:
+        print(f"warning: could not use {MAINTAINERS_URL}: {error}", file=sys.stderr)
+        print(
+            f"warning: falling back to the bundled copy in {FALLBACK_PATH.name}, which may be out of date",
+            file=sys.stderr,
+        )
+
+    try:
+        return parse_maintainers(FALLBACK_PATH.read_text(encoding="utf-8"), str(FALLBACK_PATH)), (
+            f"{FALLBACK_PATH.name} (bundled fallback, may be out of date)"
+        )
+    except (OSError, MaintainersError) as error:
+        raise SystemExit(
+            f"error: no usable maintainer list: {error}\n"
+            "Pick reviewers manually instead, for example:\n"
+            "  gh pr edit <number> --repo JetBrains/intellij-community --add-reviewer <login>"
+        )
 
 
 def run_gh_graphql() -> dict:
@@ -51,11 +197,41 @@ query($searchQuery: String!) {
     return json.loads(raw)
 
 
-def ordered_candidates(candidates: list[str], load: collections.Counter, exclude: set[str]) -> list[str]:
+def ordered_candidates(
+    candidates: list[Maintainer], load: collections.Counter, exclude: set[str]
+) -> list[Maintainer]:
     return sorted(
-        [candidate for candidate in candidates if candidate not in exclude],
-        key=lambda login: (load[login], login.lower()),
+        [candidate for candidate in candidates if candidate.login not in exclude],
+        key=lambda maintainer: (load[maintainer.login], maintainer.login.lower()),
     )
+
+
+def select_reviewers(
+    maintainers: list[Maintainer], load: collections.Counter, exclude: set[str], count: int
+) -> list[Maintainer]:
+    candidates = ordered_candidates(maintainers, load, exclude)
+
+    by_team: dict[str, list[Maintainer]] = {}
+    for candidate in candidates:
+        by_team.setdefault(candidate.team, []).append(candidate)
+
+    selected: list[Maintainer] = []
+
+    # Seed with the least loaded maintainer of each team, so the suggestion
+    # mixes teams whenever the pool allows it.
+    for team in sorted(by_team, key=lambda name: (load[by_team[name][0].login], name)):
+        if len(selected) >= count:
+            break
+        selected.append(by_team[team][0])
+
+    # Fill the remaining slots with whoever has the lightest review load overall.
+    for candidate in candidates:
+        if len(selected) >= count:
+            break
+        if candidate not in selected:
+            selected.append(candidate)
+
+    return selected[:count]
 
 
 def main() -> int:
@@ -77,9 +253,14 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    if args.pr_number and not str(args.pr_number).isdigit():
+        parser.error("--pr-number must be a number")
+
     exclude = {item.strip() for item in args.exclude.split(",") if item.strip()}
     if args.author_login:
         exclude.add(args.author_login.strip())
+
+    maintainers, source = load_maintainers()
 
     data = run_gh_graphql()
     prs = data["data"]["search"]["nodes"]
@@ -94,38 +275,31 @@ def main() -> int:
             if login:
                 load[login] += 1
 
-    external_candidates = ordered_candidates(EXTERNAL, load, exclude)
-    internal_candidates = ordered_candidates(INTERNAL, load, exclude)
+    selected = select_reviewers(maintainers, load, exclude, args.count)
 
-    selected: list[str] = []
-    if args.count > 0 and external_candidates:
-        selected.append(external_candidates[0])
-    if args.count > 1 and internal_candidates:
-        if internal_candidates[0] not in selected:
-            selected.append(internal_candidates[0])
-
-    remaining_pool = ordered_candidates(EXTERNAL + INTERNAL, load, exclude)
-    for login in remaining_pool:
-        if login not in selected:
-            selected.append(login)
-        if len(selected) >= args.count:
-            break
-
-    selected = selected[: args.count]
-
+    print(f"Maintainers source: {source}")
     print("Suggested reviewers (best-effort round robin):")
     if not selected:
         print("- none available after exclusions")
         return 0
 
-    for login in selected:
-        reviewer_type = "external" if login in EXTERNAL else "internal"
-        print(f"- {login} ({reviewer_type}, open Jewel PR review load: {load[login]})")
+    for maintainer in selected:
+        print(f"- {maintainer.login} ({maintainer.team}, open Jewel PR review load: {load[maintainer.login]})")
 
-    reviewer_flags = " ".join(f'--add-reviewer "{login}"' for login in selected)
+    teams = {maintainer.team for maintainer in selected}
+    if len(teams) < 2:
+        print(
+            f"\nNote: every suggestion is from the '{teams.pop()}' team; "
+            "the pool had nobody else available after exclusions."
+        )
+
+    reviewer_flags = " ".join(f"--add-reviewer {shlex.quote(m.login)}" for m in selected)
     if args.pr_number:
         print("\nExample command:")
-        print(f'gh pr edit {args.pr_number} --repo JetBrains/intellij-community {reviewer_flags}')
+        print(
+            f"gh pr edit {shlex.quote(str(args.pr_number))} "
+            f"--repo JetBrains/intellij-community {reviewer_flags}"
+        )
 
     return 0
 

--- a/platform/jewel/docs/jewel-contribution-guide.md
+++ b/platform/jewel/docs/jewel-contribution-guide.md
@@ -108,10 +108,20 @@ This is the **official flow** for all **external contributions** to Jewel.
 1. **Open a Pull Request** on GitHub against the `intellij-community` repository.
    The change must only affect Jewel-related paths listed above.
 
-2. **Receive one external and one internal approval.**
+2. **Receive the required approvals.** Always request three reviewers from the Jewel team. How many approvals are
+   needed before the change can be merged depends on the change itself:
 
-  - External reviewers are Jewel maintainers working outside of JetBrains (currently Google and Touchlab).
-  - Internal reviewers are JetBrains developers responsible for Jewel.
+  - **One** Jewel team approval is enough for a small or simple change, or for any change confined to `platform/jewel`.
+  - **Two** Jewel team approvals are required otherwise, and at least one of them must be an internal approval.
+
+  An internal approval is only strictly required when the change touches files outside `platform/jewel`. That is
+  deliberately narrower than the Jewel-related paths listed above: a change to `libraries/skiko`, for example, follows
+  the Jewel contribution flow but still needs an internal approval.
+
+  Internal reviewers are JetBrains developers responsible for Jewel; external reviewers are Jewel maintainers working
+  outside of JetBrains (currently Google, and Touchlab on Google's behalf). The current roster is published at
+  [jewel-ui.dev/data/maintainers.json](https://jewel-ui.dev/data/maintainers.json), whose `team` field records
+  `jetbrains` for internal maintainers; every other value is an external maintainer.
 
 3. **Wait for GitHub checks to pass.**
    All Jewel Github Action CI checks must be green before merge can proceed.
@@ -144,15 +154,21 @@ Changes to Jewel code not following the above process, and especially changes ma
 
 | Type | Required Approvals | Merge Trigger | CI Validation | Merge Responsible |
 | :---- | :---- | :---- | :---- | :---- |
-| **External PR (GitHub)** | 2 Jewel team approvals (1 external \+ 1 internal) | “Ready for merge” comment | GitHub \+ Patronus CI | Merge Robot |
-| **Internal PR (touches Jewel)** | 2 Jewel team approvals (1 external \+ 1 internal) | Internal merge request | Patronus CI | Merge Robot |
+| **External PR (GitHub)** | 1 Jewel team approval if the change is small, simple, or confined to `platform/jewel`\*\*; otherwise 2, at least 1 internal | “Ready for merge” comment | GitHub \+ Patronus CI | Merge Robot |
+| **Internal PR (touches Jewel)** | 1 Jewel team approval if the change is small, simple, or confined to `platform/jewel`\*\*; otherwise 2, at least 1 internal | Internal merge request | Patronus CI | Merge Robot |
 | **Internal-only change\*** | Internal approval | Direct merge | Patronus CI | Internal Developer |
+
+Always request three reviewers from the Jewel team when opening a PR, regardless of how many approvals are needed to merge.
 
 \* An example of internal-only change is adding / removing modules from the  `modules.xml` file in the monorepo `.idea` directory.
 
 \* **Internal Jewel team approval** refers to approval provided by a Jewel team developer employed by JetBrains.
 
-\* **External Jewel team approval** refers to approval provided by a Jewel team developer who works outside of JetBrains (currently at Google or Touchlab).
+\* **External Jewel team approval** refers to approval provided by a Jewel team developer who works outside of JetBrains (currently at Google, or at Touchlab on Google's behalf; the published maintainers list records both as `google`).
+
+\*\* For approval purposes, "confined to `platform/jewel`" means every file the PR touches is under `platform/jewel`. This is
+narrower than the Jewel-related paths listed in [Scope of Jewel Contributions](#scope-of-jewel-contributions), and
+deliberately so: touching anything outside `platform/jewel` requires an internal approval, even when it is a Jewel-related path.
 
 ---
 
@@ -189,8 +205,8 @@ When internal developers make changes that affect Jewel-related files, those cha
 
 1. Internal developers commit changes to the internal monorepo on a custom branch following the naming convention `jewel/<jewel-id>`
 2. The Merge Robot (or Mirror Bot) detects Jewel-related modifications on the custom branch and automatically creates a corresponding public PR on GitHub.
-3. External maintainers review the public portion on GitHub. Two approvals from the Jewel team are required, alongside a green GitHub CI status.
-4. Once both internal and external approvals are given, Merge Robot merges internally after Patronus CI validation.
+3. External maintainers review the public portion on GitHub. One Jewel team approval is enough for a small or simple change, or one confined to `platform/jewel`; otherwise two are required, at least one of them internal. A green GitHub CI status is required either way.
+4. Once the required approvals are given, Merge Robot merges internally after Patronus CI validation.
 5. The result is synced automatically to GitHub.
 
 ### Flow (public \+ internal changes)
@@ -198,8 +214,8 @@ When internal developers make changes that affect Jewel-related files, those cha
 1. Internal developers commit changes to the internal monorepo on a custom branch following the naming convention `jewel/<jewel-id>`
 2. The Merge Robot (or Mirror Bot) detects Jewel-related modifications on the custom branch and automatically creates a corresponding public PR on GitHub.
 3. For internal changes, the Merge Robot creates a Space (JetBrains Code) MR
-4. External maintainers review the public portion on GitHub, internal maintainers review internal changes on Space. For the public portion, two approvals from the Jewel team are required, alongside a green GitHub CI status.
-5. Once both internal and external approvals are given, Merge Robot merges internally after Patronus CI validation.
+4. External maintainers review the public portion on GitHub, internal maintainers review internal changes on Space. Because these PRs touch files outside `platform/jewel`, the public portion needs two Jewel team approvals, at least one of them internal, alongside a green GitHub CI status.
+5. Once the required approvals are given, Merge Robot merges internally after Patronus CI validation.
 6. The result is synced automatically to GitHub.
 
 ---
@@ -209,7 +225,7 @@ When internal developers make changes that affect Jewel-related files, those cha
 | Step | Action | System | Result |
 | :---- | :---- | :---- | :---- |
 | 1 | Contributor opens PR on GitHub | GitHub | PR created |
-| 2 | External \+ internal reviewers approve | GitHub | Approvals complete |
+| 2 | The required reviewers approve | GitHub | Approvals complete |
 | 3 | Jewel checks green | GitHub | ✅ Ready for merge |
 | 4 | Contributor adds comment “Ready for merge” | GitHub | Merge Robot triggers |
 | 5 | Merge Robot runs Patronus CI | Internal | Internal validation |
@@ -220,7 +236,8 @@ When internal developers make changes that affect Jewel-related files, those cha
 
 ## Summary
 
-- All Jewel changes must go through **dual approval** (external \+ internal) and have green CI on both GitHub and Patronus.
+- All Jewel changes need at least **one Jewel team approval** and green CI on both GitHub and Patronus. Changes that are not small, simple, or confined to `platform/jewel` need **two approvals, at least one of them internal**.
+- Always **request three reviewers** when opening a PR, regardless of how many approvals are required to merge.
 - Jewel changes must be on separate commits from unrelated changes and follow the commit message format conventions.
 - A **“Ready for merge” comment** triggers internal validation via **Merge Robot** and **Patronus CI**.
 - **Merge Robot** handles all actual merges — contributors never push directly to main.

--- a/platform/jewel/docs/pr-guide.md
+++ b/platform/jewel/docs/pr-guide.md
@@ -8,8 +8,13 @@ these steps:
 
 1. Make sure your commit message first line starts with `[JEWEL-<Jewel YouTrack Id>] `, and squash all the changes in a
    single commit
-2. Prefix the PR title with `[JEWEL-<Jewel YouTrack Id>] `, add the `jewel` label, assign yourself and pick at least two
+2. Prefix the PR title with `[JEWEL-<Jewel YouTrack Id>] `, add the `jewel` label, assign yourself and request three
    reviewers from the Jewel team
+   * The reviewer roster is published at [jewel-ui.dev/data/maintainers.json](https://jewel-ui.dev/data/maintainers.json)
+   * Always request three reviewers, but note that how many approvals are needed to merge depends on the change: one
+     Jewel team approval is enough for a small or simple change, or for one confined to `platform/jewel`; anything else
+     needs two approvals, at least one of them from a JetBrains maintainer
+   * See the [approval rules](jewel-contribution-guide.md#approval-rules) for the details
 3. Avoid creating pull requests from chains of feature branches (branching from feature branches) if at all possible, as
    this can create issues when cherry-picking for a release
    * If this can't be avoided, open the PR as a draft


### PR DESCRIPTION
The `jewel-pr-preparer` skill hardcoded the reviewer list in two places, which had already drifted from the real team. It now reads https://jewel-ui.dev/data/maintainers.json instead. This also relaxes the review policy that was documented alongside those lists.

## Changes

* `suggest_reviewers.py` fetches the maintainers list at run time and groups candidates by `team` (`google`/`jetbrains`) rather than the old external/internal split. Round-robin by open review load, three suggestions, and team mixing are unchanged.
* The list is public input, so it is validated before use: https-only, no cross-host redirects, size-capped, `$schema_version` checked, strict patterns for `github_username` and `team`, bad entries skipped with a warning, handles shell-quoted in the printed `gh` command. A descriptive `User-Agent` is required because Cloudflare 403s the default `urllib` one.
* On fetch failure it falls back to a bundled verbatim snapshot and warns it may be stale; if that is unusable too it exits and asks for manual reviewers. A snapshot works on a fresh checkout (a cache would not) and does not block a PR on a network blip (a hard error would).
* **Review policy:** one Jewel team approval now suffices for a small or simple change, or one confined to `platform/jewel`; an internal approval is only required when a PR touches files outside it. That is deliberately narrower than the guide's Jewel-related paths, and the guide now says so. Requesting three reviewers is unchanged — only the approval bar moved. Updated `jewel-contribution-guide.md` and `pr-guide.md`.

`.agents/skills/jewel-pr-preparer/` is the canonical source; `.claude/…` is its `render-guides.mjs` output, hence the duplicated diff. The renderer needs an Ultimate checkout, so I reproduced its transform and verified it byte-identical against `master` before regenerating.
