### PR TITLE
[JEWEL-1288] Run PR formalities from the base branch

### DIFF
--- a/.github/workflows/jewel-checks.yml
+++ b/.github/workflows/jewel-checks.yml
@@ -105,12 +105,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_paths
     if: needs.check_paths.outputs.run_formalities == 'true'
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
+      # These scripts only need the PR number via the GitHub API. Checkout the
+      # base SHA so a PR cannot replace the validators that receive GH_TOKEN
+      # and JEWEL_YT_TOKEN (JEWEL-1288).
       - uses: actions/checkout@v7.0.1
+        name: Check out base branch scripts only
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-        name: Check out repository
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            platform/jewel/scripts/
 
       - name: Grant execute permission to validation scripts
         run: chmod +x ./scripts/validate-commit-message.sh && chmod +x ./scripts/validate-pr-commits.sh
@@ -131,6 +139,9 @@ jobs:
   annotate_breaking_api_changes:
     name: Annotate breaking API changes with IJP dumps
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -138,6 +149,22 @@ jobs:
           # We need fetch-depth: '2' so we get HEAD~1 in case this is missing the PR token
           fetch-depth: '2'
         name: Check out repository
+
+      # The job needs the PR's API dumps, but must run the trusted annotator
+      # with GH_TOKEN, not a replacement from the PR (JEWEL-1288).
+      - uses: actions/checkout@v7.0.1
+        name: Check out trusted CI scripts from the base branch
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            platform/jewel/scripts/
+          path: .trusted-base-scripts
+
+      - name: Overlay trusted CI scripts
+        working-directory: .
+        run: |
+          rm -rf platform/jewel/scripts
+          cp -a .trusted-base-scripts/platform/jewel/scripts platform/jewel/scripts
 
       - name: Set up Kotlin ${{ env.KOTLIN_VERSION }}
         id: kotlin


### PR DESCRIPTION
The `formalities` job still checked out `${{ github.event.pull_request.head.sha }}` and then ran the validation scripts with `GH_TOKEN` and `JEWEL_YT_TOKEN`. A pull request can replace those scripts. [JEWEL-1288](https://youtrack.jetbrains.com/issue/JEWEL-1288).

[#3456](https://github.com/JetBrains/intellij-community/pull/3456) switched that ref to `base.sha` and was the right call, but it never landed. Master on 2026-08-20 still used `head.sha`.

The formalities job does not need the PR tree. It only talks to the GitHub API with the PR number. This change checks out `github.event.pull_request.base.sha` and only `platform/jewel/scripts/`.

The API-dump annotator does need the PR dumps, so it still checks out the PR, then overlays the scripts from the same base SHA before running them with `GH_TOKEN`.

## Changes

* `formalities`: checkout `base.sha` with a sparse checkout of `platform/jewel/scripts/`, and pin token permissions to `contents: read` / `pull-requests: read`
* `annotate_breaking_api_changes`: overlay trusted scripts from `base.sha` before running the annotator