### PR TITLE
IJPL-245730: Make startup error text selectable

### DIFF
--- a/platform/platform-impl/src/com/intellij/platform/ide/bootstrap/StartupErrorReporter.java
+++ b/platform/platform-impl/src/com/intellij/platform/ide/bootstrap/StartupErrorReporter.java
@@ -273,7 +273,7 @@ public final class StartupErrorReporter {
     try {
       var reportId = worker.get();
       var message = prepareMessage(message("bootstrap.error.message.submitted", reportId));
-      JOptionPane.showMessageDialog(JOptionPane.getRootFrame(), message, message("bootstrap.error.title.submitted"), JOptionPane.INFORMATION_MESSAGE);
+      JOptionPane.showMessageDialog(JOptionPane.getRootFrame(), prepareMessage(message), message("bootstrap.error.title.submitted"), JOptionPane.INFORMATION_MESSAGE);
     }
     catch (Throwable t) {
       var buf = new StringWriter();


### PR DESCRIPTION
Wrap the success message in prepareMessage() so the text can be selected and copied by the user.