### PR TITLE
IJPL-2176 Support inode aliases in Linux file watcher

### DIFF
--- a/native/fsNotifier/linux/CMakeLists.txt
+++ b/native/fsNotifier/linux/CMakeLists.txt
@@ -16,6 +16,19 @@ target_compile_definitions(fsnotifier PRIVATE VERSION="${VERSION}")
 target_compile_options(fsnotifier PRIVATE "-O2" "-Wall" "-Wextra" "-Wpedantic")
 target_link_options(fsnotifier PRIVATE "-static" "-flto=full")
 
+include(CTest)
+if(BUILD_TESTING)
+    target_compile_definitions(fsnotifier PRIVATE FSNOTIFIER_TESTING)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    add_test(
+        NAME fsnotifier-integration
+        COMMAND Python3::Interpreter ${CMAKE_CURRENT_LIST_DIR}/test_fsnotifier.py
+            --executable $<TARGET_FILE:fsnotifier>
+            --registration-race-hook
+    )
+    set_tests_properties(fsnotifier-integration PROPERTIES TIMEOUT 30)
+endif()
+
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     cmake_path(SET install_dir NORMALIZE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/linux)
     install(TARGETS fsnotifier DESTINATION ${install_dir}/${CMAKE_SYSTEM_PROCESSOR})

--- a/native/fsNotifier/linux/fsnotifier.h
+++ b/native/fsNotifier/linux/fsnotifier.h
@@ -45,6 +45,7 @@ typedef struct table_str table;
 table* table_create(int capacity);
 void* table_put(table* t, int key, void* value);
 void* table_get(table* t, int key);
+void table_set(table* t, int key, void* value);
 void table_delete(table* t);
 
 
@@ -61,7 +62,8 @@ bool init_inotify(void);
 void set_inotify_callback(void (*callback)(const char *, uint32_t));
 int get_inotify_fd(void);
 int watch(const char* root, array* mounts);
-void unwatch(int id);
+void unwatch(int id, const char* path);
+bool watch_tree_matches(int id, const char* path);
 bool process_inotify_input(void);
 void close_inotify(void);
 

--- a/native/fsNotifier/linux/inotify.c
+++ b/native/fsNotifier/linux/inotify.c
@@ -10,18 +10,24 @@
 #include <string.h>
 #include <sys/inotify.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 
 #define WATCH_COUNT_NAME "/proc/sys/fs/inotify/max_user_watches"
 
 #define DEFAULT_SUBDIR_COUNT 5
+#define ADD_WATCH_ATTEMPTS 3
 
 typedef struct watch_node_str {
   int wd;
+  dev_t device;
+  ino_t inode;
   struct watch_node_str* parent;
   array* kids;
   unsigned int path_len;
+  struct watch_node_str* prev;
+  struct watch_node_str* next;
   char path[];
 } watch_node;
 
@@ -39,6 +45,11 @@ static char path_buf[2 * PATH_MAX];
 
 static void read_watch_descriptors_count(void);
 static void watch_limit_reached(void);
+static int path_error_result(int error, bool root);
+static bool watch_node_aliases_match(const watch_node* node);
+#ifdef FSNOTIFIER_TESTING
+static void run_add_watch_test_hook(void);
+#endif
 
 
 bool init_inotify(void) {
@@ -102,57 +113,121 @@ int get_inotify_fd(void) {
 
 #define EVENT_MASK (IN_MODIFY | IN_ATTRIB | IN_CREATE | IN_DELETE | IN_MOVE | IN_DELETE_SELF | IN_MOVE_SELF)
 
-static int add_watch(unsigned int path_len, watch_node* parent) {
-  int wd = inotify_add_watch(inotify_fd, path_buf, EVENT_MASK);
-  if (wd < 0) {
-    if (errno == EACCES || errno == ENOENT) {
-      userlog(LOG_INFO, "inotify_add_watch(%s): %s", path_buf, strerror(errno));
-      return ERR_IGNORE;
-    }
-    else if (errno == ENOSPC) {
-      userlog(LOG_WARNING, "inotify_add_watch(%s): %s", path_buf, strerror(errno));
-      watch_limit_reached();
-      return ERR_CONTINUE;
-    }
-    else {
-      userlog(LOG_ERR, "inotify_add_watch(%s): %s", path_buf, strerror(errno));
-      return ERR_ABORT;
-    }
-  }
-  else {
-    userlog(LOG_INFO, "watching %s: %d", path_buf, wd);
-  }
+static bool is_same_file_system_node(const watch_node* expected, const char* path) {
+  struct stat actual;
+  return stat(path, &actual) == 0 && actual.st_dev == expected->device && actual.st_ino == expected->inode;
+}
 
-  watch_node* node = table_get(watches, wd);
-  if (node != NULL) {
-    if (node->wd != wd) {
-      userlog(LOG_ERR, "table error: corruption at %d:%s / %d:%s / %d", wd, path_buf, node->wd, node->path, watch_count);
-      return ERR_ABORT;
+
+static int add_watch(unsigned int path_len, watch_node* parent, watch_node** result) {
+  int wd = -1;
+  watch_node* existing = NULL;
+  struct stat path_stat;
+  for (int attempt = 0; attempt < ADD_WATCH_ATTEMPTS; attempt++) {
+    struct stat before;
+    if (stat(path_buf, &before) != 0) {
+      int e = errno;
+      userlog(LOG_INFO, "stat(%s): %s", path_buf, strerror(e));
+      return path_error_result(e, parent == NULL);
     }
-    else if (strcmp(node->path, path_buf) != 0) {
-      char buf1[PATH_MAX], buf2[PATH_MAX];
-      const char* normalized1 = realpath(node->path, buf1);
-      const char* normalized2 = realpath(path_buf, buf2);
-      if (normalized1 == NULL || normalized2 == NULL || strcmp(normalized1, normalized2) != 0) {
-        userlog(LOG_ERR, "table error: collision at %d (new %s, existing %s)", wd, path_buf, node->path);
-        return ERR_ABORT;
+
+    wd = inotify_add_watch(inotify_fd, path_buf, EVENT_MASK);
+    if (wd < 0) {
+      int e = errno;
+      if (e == EACCES || e == ENOENT) {
+        userlog(LOG_INFO, "inotify_add_watch(%s): %s", path_buf, strerror(e));
+        return path_error_result(e, parent == NULL);
+      }
+      else if (e == ENOSPC) {
+        userlog(LOG_WARNING, "inotify_add_watch(%s): %s", path_buf, strerror(e));
+        watch_limit_reached();
+        return ERR_CONTINUE;
       }
       else {
-        userlog(LOG_INFO, "intersection at %d: (new %s, existing %s, real %s)", wd, path_buf, node->path, normalized1);
-        return ERR_IGNORE;
+        userlog(LOG_ERR, "inotify_add_watch(%s): %s", path_buf, strerror(e));
+        return ERR_ABORT;
       }
     }
+    else {
+      userlog(LOG_INFO, "watching %s: %d", path_buf, wd);
+    }
 
-    return wd;
+    existing = table_get(watches, wd);
+#ifdef FSNOTIFIER_TESTING
+    run_add_watch_test_hook();
+#endif
+
+    if (stat(path_buf, &path_stat) != 0) {
+      int e = errno;
+      userlog(LOG_INFO, "stat(%s): %s", path_buf, strerror(e));
+      if (existing == NULL && inotify_rm_watch(inotify_fd, wd) < 0) {
+        userlog(LOG_INFO, "inotify_rm_watch(%d:%s): %s", wd, path_buf, strerror(errno));
+      }
+      return path_error_result(e, parent == NULL);
+    }
+
+    if (before.st_dev == path_stat.st_dev && before.st_ino == path_stat.st_ino) {
+      break;
+    }
+
+    userlog(LOG_INFO, "watch path changed during registration, retrying: %s", path_buf);
+    if (existing == NULL && inotify_rm_watch(inotify_fd, wd) < 0) {
+      userlog(LOG_INFO, "inotify_rm_watch(%d:%s): %s", wd, path_buf, strerror(errno));
+    }
+    wd = -1;
   }
 
-  node = malloc(sizeof(watch_node) + path_len + 1);
+  if (wd < 0) {
+    return parent == NULL ? ERR_MISSING : ERR_IGNORE;
+  }
+
+  watch_node* tail = existing;
+  if (existing != NULL) {
+    char normalized_path[PATH_MAX];
+    const char* normalized = realpath(path_buf, normalized_path);
+    bool same_node_found = false;
+
+    for (watch_node* node = existing; node != NULL; node = node->next) {
+      if (node->wd != wd) {
+        userlog(LOG_ERR, "table error: corruption at %d:%s / %d:%s / %d", wd, path_buf, node->wd, node->path, watch_count);
+        return ERR_ABORT;
+      }
+      bool same_node = path_stat.st_dev == node->device && path_stat.st_ino == node->inode;
+      if (same_node && strcmp(node->path, path_buf) == 0) {
+        *result = node;
+        return wd;
+      }
+
+      char normalized_existing_path[PATH_MAX];
+      const char* normalized_existing = realpath(node->path, normalized_existing_path);
+      if (same_node && normalized != NULL && normalized_existing != NULL && strcmp(normalized, normalized_existing) == 0) {
+        userlog(LOG_INFO, "intersection at %d: (new %s, existing %s, real %s)", wd, path_buf, node->path, normalized);
+        return ERR_IGNORE;
+      }
+
+      if (same_node) {
+        same_node_found = true;
+      }
+      tail = node;
+    }
+
+    if (!same_node_found) {
+      userlog(LOG_ERR, "table error: collision at %d (new %s, existing %s)", wd, path_buf, existing->path);
+      return ERR_ABORT;
+    }
+  }
+
+  watch_node* node = malloc(sizeof(watch_node) + path_len + 1);
   CHECK_NULL(node, ERR_ABORT)
   memcpy(node->path, path_buf, path_len + 1);
   node->path_len = path_len;
   node->wd = wd;
+  node->device = path_stat.st_dev;
+  node->inode = path_stat.st_ino;
   node->parent = parent;
   node->kids = NULL;
+  node->prev = tail;
+  node->next = NULL;
 
   if (parent != NULL) {
     if (parent->kids == NULL) {
@@ -162,13 +237,55 @@ static int add_watch(unsigned int path_len, watch_node* parent) {
     CHECK_NULL(array_push(parent->kids, node), ERR_ABORT)
   }
 
-  if (table_put(watches, wd, node) == NULL) {
+  if (tail != NULL) {
+    tail->next = node;
+  }
+  else if (table_put(watches, wd, node) == NULL) {
     userlog(LOG_ERR, "table error: unable to put (%d:%s)", wd, path_buf);
     return ERR_ABORT;
   }
 
+  *result = node;
   return wd;
 }
+
+static int path_error_result(int error, bool root) {
+  if (error == ENOENT) {
+    return root ? ERR_MISSING : ERR_IGNORE;
+  }
+  if (error == EACCES) {
+    return ERR_IGNORE;
+  }
+  return ERR_ABORT;
+}
+
+#ifdef FSNOTIFIER_TESTING
+static void run_add_watch_test_hook(void) {
+  static bool used = false;
+  const char* fds = getenv("FSNOTIFIER_TEST_REGISTRATION_FDS");
+  if (used || fds == NULL) {
+    return;
+  }
+
+  const char* path = getenv("FSNOTIFIER_TEST_REGISTRATION_PATH");
+  if (path != NULL && strcmp(path, path_buf) != 0) {
+    return;
+  }
+
+  int ready_fd;
+  int resume_fd;
+  if (sscanf(fds, "%d:%d", &ready_fd, &resume_fd) != 2) {
+    userlog(LOG_WARNING, "invalid registration test descriptors: %s", fds);
+    return;
+  }
+
+  used = true;
+  char signal = 0;
+  if (write(ready_fd, &signal, 1) != 1 || read(resume_fd, &signal, 1) != 1) {
+    userlog(LOG_WARNING, "registration test synchronization failed: %s", strerror(errno));
+  }
+}
+#endif
 
 static void watch_limit_reached(void) {
   if (!limit_reached) {
@@ -177,22 +294,17 @@ static void watch_limit_reached(void) {
   }
 }
 
-static void rm_watch(int wd, bool update_parent) {
-  watch_node* node = table_get(watches, wd);
+static void rm_watch(watch_node* node, bool update_parent) {
   if (node == NULL) {
     return;
   }
 
   userlog(LOG_INFO, "unwatching %s: %d (%p)", node->path, node->wd, node);
 
-  if (inotify_rm_watch(inotify_fd, node->wd) < 0) {
-    userlog(LOG_INFO, "inotify_rm_watch(%d:%s): %s", node->wd, node->path, strerror(errno));
-  }
-
   for (int i = 0; i < array_size(node->kids); i++) {
     watch_node* kid = array_get(node->kids, i);
     if (kid != NULL) {
-      rm_watch(kid->wd, false);
+      rm_watch(kid, false);
     }
   }
 
@@ -205,9 +317,23 @@ static void rm_watch(int wd, bool update_parent) {
     }
   }
 
+  bool last_alias = node->prev == NULL && node->next == NULL;
+  if (node->prev != NULL) {
+    node->prev->next = node->next;
+  }
+  else {
+    table_set(watches, node->wd, node->next);
+  }
+  if (node->next != NULL) {
+    node->next->prev = node->prev;
+  }
+
+  if (last_alias && inotify_rm_watch(inotify_fd, node->wd) < 0) {
+    userlog(LOG_INFO, "inotify_rm_watch(%d:%s): %s", node->wd, node->path, strerror(errno));
+  }
+
   array_delete(node->kids);
   free(node);
-  table_put(watches, wd, NULL);
 }
 
 
@@ -234,7 +360,8 @@ static int walk_tree(unsigned int path_len, watch_node* parent, bool recursive, 
     }
   }
 
-  int id = add_watch(path_len, parent);
+  watch_node* node;
+  int id = add_watch(path_len, parent, &node);
 
   if (dir == NULL) {
     return id;
@@ -269,9 +396,9 @@ static int walk_tree(unsigned int path_len, watch_node* parent, bool recursive, 
       }
     }
 
-    int subdir_id = walk_tree(path_len + 1 + name_len, table_get(watches, id), recursive, mounts);
+    int subdir_id = walk_tree(path_len + 1 + name_len, node, recursive, mounts);
     if (subdir_id < 0 && subdir_id != ERR_IGNORE) {
-      rm_watch(id, true);
+      rm_watch(node, true);
       id = subdir_id;
       break;
     }
@@ -323,8 +450,37 @@ int watch(const char* root, array* mounts) {
 }
 
 
-void unwatch(int id) {
-  rm_watch(id, true);
+void unwatch(int id, const char* path) {
+  for (watch_node* node = table_get(watches, id); node != NULL; node = node->next) {
+    if (strcmp(node->path, path) == 0) {
+      rm_watch(node, true);
+      return;
+    }
+  }
+}
+
+
+bool watch_tree_matches(int id, const char* path) {
+  for (watch_node* node = table_get(watches, id); node != NULL; node = node->next) {
+    if (strcmp(node->path, path) == 0) {
+      return is_same_file_system_node(node, path) && watch_node_aliases_match(node);
+    }
+  }
+  return false;
+}
+
+
+static bool watch_node_aliases_match(const watch_node* node) {
+  if ((node->prev != NULL || node->next != NULL) && !is_same_file_system_node(node, node->path)) {
+    return false;
+  }
+  for (int i = 0; i < array_size(node->kids); i++) {
+    watch_node* kid = array_get(node->kids, i);
+    if (kid != NULL && !watch_node_aliases_match(kid)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 
@@ -334,38 +490,60 @@ static bool process_inotify_event(struct inotify_event* event) {
     return true;
   }
 
-  bool is_dir = (event->mask & IN_ISDIR) == IN_ISDIR;
-  userlog(LOG_INFO, "inotify: wd=%d mask=%d dir=%d name=%s", event->wd, event->mask & (~IN_ISDIR), is_dir, node->path);
-
-  unsigned int path_len = node->path_len;
-  memcpy(path_buf, node->path, path_len + 1);
-  if (event->len > 0) {
-    path_buf[path_len] = '/';
-    unsigned int name_len = strlen(event->name);
-    memcpy(path_buf + path_len + 1, event->name, name_len + 1);
-    path_len += name_len + 1;
-  }
-
-  if (callback != NULL) {
-    (*callback)(path_buf, event->mask);
-  }
-
-  if (is_dir && event->mask & (IN_CREATE | IN_MOVED_TO)) {
-    int result = walk_tree(path_len, node, true, NULL);
-    if (result < 0 && result != ERR_IGNORE && result != ERR_CONTINUE) {
-      return false;
+  while (node != NULL) {
+    watch_node* next = node->next;
+    if (event->mask & (IN_ATTRIB | IN_DELETE_SELF | IN_MOVE_SELF) &&
+        !is_same_file_system_node(node, node->path)) {
+      memcpy(path_buf, node->path, node->path_len + 1);
+      rm_watch(node, true);
+      if (callback != NULL) {
+        (*callback)(path_buf, IN_DELETE_SELF);
+      }
+      node = next;
+      continue;
     }
-  }
 
-  if (is_dir && event->mask & (IN_DELETE | IN_MOVED_FROM)) {
-    for (int i = 0; i < array_size(node->kids); i++) {
-      watch_node* kid = array_get(node->kids, i);
-      if (kid != NULL && strncmp(path_buf, kid->path, kid->path_len) == 0) {
-        rm_watch(kid->wd, false);
-        array_put(node->kids, i, NULL);
-        break;
+    uint32_t event_mask = event->mask & ~(IN_DELETE_SELF | IN_MOVE_SELF);
+    if (event_mask == 0) {
+      node = next;
+      continue;
+    }
+
+    bool is_dir = (event->mask & IN_ISDIR) == IN_ISDIR;
+    userlog(LOG_INFO, "inotify: wd=%d mask=%d dir=%d name=%s", event->wd, event_mask & (~IN_ISDIR), is_dir, node->path);
+
+    unsigned int path_len = node->path_len;
+    memcpy(path_buf, node->path, path_len + 1);
+    if (event->len > 0) {
+      path_buf[path_len] = '/';
+      unsigned int name_len = strlen(event->name);
+      memcpy(path_buf + path_len + 1, event->name, name_len + 1);
+      path_len += name_len + 1;
+    }
+
+    if (callback != NULL) {
+      (*callback)(path_buf, event_mask);
+    }
+
+    if (is_dir && event_mask & (IN_CREATE | IN_MOVED_TO)) {
+      int result = walk_tree(path_len, node, true, NULL);
+      if (result < 0 && result != ERR_IGNORE && result != ERR_CONTINUE) {
+        return false;
       }
     }
+
+    if (is_dir && event_mask & (IN_DELETE | IN_MOVED_FROM)) {
+      for (int i = 0; i < array_size(node->kids); i++) {
+        watch_node* kid = array_get(node->kids, i);
+        if (kid != NULL && strcmp(path_buf, kid->path) == 0) {
+          rm_watch(kid, false);
+          array_put(node->kids, i, NULL);
+          break;
+        }
+      }
+    }
+
+    node = next;
   }
 
   return true;

--- a/native/fsNotifier/linux/main.c
+++ b/native/fsNotifier/linux/main.c
@@ -12,6 +12,7 @@
 #include <sys/inotify.h>
 #include <sys/select.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 
@@ -22,7 +23,7 @@
 #define HELP_MSG \
     "Try 'fsnotifier --help' for more information.\n"
 
-#define MISSING_ROOT_TIMEOUT 1
+#define ROOT_CHECK_INTERVAL_MS 1000
 
 #define UNFLATTEN(root) (root[0] == '|' ? root + 1 : root)
 
@@ -45,7 +46,8 @@ static array* unwatchable_mounts(void);
 static void inotify_callback(const char* path, uint32_t event);
 static void report_event(const char* event, const char* path);
 static void output(const char* line, bool flush);
-static void check_missing_roots(void);
+static int64_t monotonic_millis(void);
+static bool reconcile_roots(void);
 static void check_root_removal(const char*);
 
 
@@ -139,6 +141,11 @@ static bool main_loop(void) {
   int nfds = (inotify_fd > input_fd ? inotify_fd : input_fd) + 1;
   fd_set rfds;
   struct timeval timeout;
+  int64_t next_root_check = monotonic_millis();
+  if (next_root_check < 0) {
+    return false;
+  }
+  next_root_check += ROOT_CHECK_INTERVAL_MS;
 
   while (true) {
     usleep(50000);
@@ -146,7 +153,7 @@ static bool main_loop(void) {
     FD_ZERO(&rfds);
     FD_SET(input_fd, &rfds);
     FD_SET(inotify_fd, &rfds);
-    timeout = (struct timeval){MISSING_ROOT_TIMEOUT, 0};
+    timeout = (struct timeval){ROOT_CHECK_INTERVAL_MS / 1000, 0};
 
     if (select(nfds, &rfds, NULL, NULL, &timeout) < 0) {
       if (errno != EINTR) {
@@ -162,8 +169,16 @@ static bool main_loop(void) {
     else if (FD_ISSET(inotify_fd, &rfds)) {
       if (!process_inotify_input()) return false;
     }
-    else {
-      check_missing_roots();
+
+    int64_t now = monotonic_millis();
+    if (now < 0) {
+      return false;
+    }
+    if (now >= next_root_check) {
+      if (!reconcile_roots()) {
+        return false;
+      }
+      next_root_check = now + ROOT_CHECK_INTERVAL_MS;
     }
   }
 }
@@ -246,7 +261,7 @@ static void unregister_roots(void) {
   watch_root* root;
   while ((root = array_pop(roots)) != NULL) {
     userlog(LOG_INFO, "unregistering root: %s", root->path);
-    unwatch(root->id);
+    unwatch(root->id, UNFLATTEN(root->path));
     free(root->path);
     free(root);
   }
@@ -399,27 +414,50 @@ static void output(const char* line, bool flush) {
 }
 
 
-static void check_missing_roots(void) {
+static int64_t monotonic_millis(void) {
+  struct timespec time;
+  if (clock_gettime(CLOCK_MONOTONIC, &time) != 0) {
+    userlog(LOG_ERR, "clock_gettime: %s", strerror(errno));
+    return -1;
+  }
+  return time.tv_sec * 1000 + time.tv_nsec / 1000000;
+}
+
+static bool reconcile_roots(void) {
   struct stat st;
   for (int i = 0; i < array_size(roots); i++) {
     watch_root* root = array_get(roots, i);
+    char* unflattened = UNFLATTEN(root->path);
+    if (root->id >= 0 && !watch_tree_matches(root->id, unflattened)) {
+      unwatch(root->id, unflattened);
+      root->id = ERR_MISSING;
+      userlog(LOG_INFO, "root tree identity changed: %s\n", root->path);
+      report_event("DELETE", unflattened);
+    }
+
     if (root->id < 0) {
-      char* unflattened = UNFLATTEN(root->path);
       if (stat(unflattened, &st) == 0) {
-        root->id = watch(root->path, NULL);
-        userlog(LOG_INFO, "root restored: %s\n", root->path);
-        report_event("CREATE", unflattened);
-        report_event("CHANGE", unflattened);
+        int id = watch(root->path, NULL);
+        if (id >= 0) {
+          root->id = id;
+          userlog(LOG_INFO, "root restored: %s\n", root->path);
+          report_event("CREATE", unflattened);
+          report_event("CHANGE", unflattened);
+        }
+        else if (id == ERR_ABORT) {
+          return false;
+        }
       }
     }
   }
+  return true;
 }
 
 static void check_root_removal(const char* path) {
   for (int i = 0; i < array_size(roots); i++) {
     watch_root* root = array_get(roots, i);
     if (root->id >= 0 && strcmp(path, UNFLATTEN(root->path)) == 0) {
-      unwatch(root->id);
+      unwatch(root->id, UNFLATTEN(root->path));
       root->id = -1;
       userlog(LOG_INFO, "root deleted: %s\n", root->path);
       report_event("DELETE", path);

--- a/native/fsNotifier/linux/test_fsnotifier.py
+++ b/native/fsNotifier/linux/test_fsnotifier.py
@@ -1,0 +1,527 @@
+# Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+import argparse
+import os
+import queue
+import select
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--executable", type=Path, required=True)
+parser.add_argument("--bind-mounts", action="store_true")
+parser.add_argument("--registration-race-hook", action="store_true")
+arguments, unittest_arguments = parser.parse_known_args()
+EXECUTABLE = arguments.executable.resolve()
+TEST_BIND_MOUNTS = arguments.bind_mounts
+TEST_REGISTRATION_RACE_HOOK = arguments.registration_race_hook
+sys.argv = [sys.argv[0], *unittest_arguments]
+
+
+class FsNotifier:
+    def __init__(self, executable: Path, *, env=None, pass_fds=()):
+        self._process = subprocess.Popen(
+            [executable],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=env,
+            pass_fds=pass_fds,
+        )
+        self._stdout = queue.Queue()
+        self._stderr = []
+        self._stdout_reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._stderr_reader = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stdout_reader.start()
+        self._stderr_reader.start()
+
+    def _read_stdout(self):
+        for line in self._process.stdout:
+            self._stdout.put(line.rstrip("\n"))
+        self._stdout.put(None)
+
+    def _read_stderr(self):
+        self._stderr.extend(line.rstrip("\n") for line in self._process.stderr)
+
+    def _next_line(self, timeout=5):
+        try:
+            line = self._stdout.get(timeout=timeout)
+        except queue.Empty:
+            self._fail("timed out waiting for output")
+        if line is None:
+            self._fail(f"terminated with exit code {self._process.poll()}")
+        return line
+
+    def _fail(self, message):
+        stderr = "\n".join(self._stderr)
+        raise AssertionError(f"fsnotifier {message}\nstderr:\n{stderr}")
+
+    def set_roots(self, roots):
+        self._write("ROOTS", *roots, "#")
+        if self._next_line() != "UNWATCHEABLE":
+            self._fail("did not acknowledge roots")
+        while self._next_line() != "#":
+            pass
+
+    def expect_events(self, expected, timeout=5, unexpected_paths=()):
+        expected = set(expected)
+        remaining = set(expected)
+        unexpected_paths = set(unexpected_paths)
+        deadline = time.monotonic() + timeout
+        while remaining:
+            operation = self._next_line(max(0.01, deadline - time.monotonic()))
+            path = self._next_line(max(0.01, deadline - time.monotonic()))
+            event = operation, path
+            if path in unexpected_paths and event not in expected:
+                raise AssertionError(f"unexpected {operation} event for {path}")
+            remaining.discard(event)
+
+    def assert_no_event_for(self, path, timeout=0.5):
+        self.assert_no_events_for({path}, timeout)
+
+    def wait_for_quiet(self, timeout=0.5):
+        self.assert_no_events_for(set(), timeout)
+
+    def assert_no_events_for(self, paths, timeout=0.5):
+        paths = set(paths)
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            try:
+                operation = self._next_line(remaining)
+            except AssertionError as error:
+                if "timed out waiting for output" in str(error):
+                    return
+                raise
+            event_path = self._next_line(max(0.01, deadline - time.monotonic()))
+            if event_path in paths:
+                raise AssertionError(f"unexpected {operation} event for {event_path}")
+
+    def stop(self):
+        if self._process.poll() is None:
+            self._write("EXIT")
+        self._process.stdin.close()
+        try:
+            exit_code = self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+            self._stdout_reader.join(timeout=1)
+            self._stderr_reader.join(timeout=1)
+            self._process.stdout.close()
+            self._process.stderr.close()
+            self._fail("did not exit")
+        self._stdout_reader.join(timeout=1)
+        self._stderr_reader.join(timeout=1)
+        self._process.stdout.close()
+        self._process.stderr.close()
+        if exit_code != 0:
+            self._fail(f"exited with code {exit_code}")
+        if any("table error" in line for line in self._stderr):
+            self._fail("reported a table error")
+
+    def _write(self, *lines):
+        try:
+            self._process.stdin.write("".join(f"{line}\n" for line in lines))
+            self._process.stdin.flush()
+        except BrokenPipeError:
+            self._fail(f"terminated with exit code {self._process.poll()}")
+
+
+class FsNotifierTest(unittest.TestCase):
+    @unittest.skipUnless(TEST_REGISTRATION_RACE_HOOK, "requires --registration-race-hook")
+    def test_replaced_during_registration(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            file = root / "file.txt"
+            replacement = root / "replacement.txt"
+            file.write_text("old inode")
+            replacement.write_text("replacement inode")
+
+            ready_read, ready_write = os.pipe()
+            resume_read, resume_write = os.pipe()
+            env = os.environ.copy()
+            env["FSNOTIFIER_TEST_REGISTRATION_FDS"] = f"{ready_write}:{resume_read}"
+            watcher = FsNotifier(EXECUTABLE, env=env, pass_fds=(ready_write, resume_read))
+            os.close(ready_write)
+            os.close(resume_read)
+
+            errors = []
+
+            def register_root():
+                try:
+                    watcher.set_roots([f"|{file}"])
+                except BaseException as error:
+                    errors.append(error)
+
+            registration = threading.Thread(target=register_root)
+            resumed = False
+            try:
+                registration.start()
+                readable, _, _ = select.select([ready_read], [], [], 5)
+                self.assertTrue(readable, "fsnotifier did not pause during registration")
+                self.assertEqual(b"\0", os.read(ready_read, 1))
+
+                os.replace(replacement, file)
+                self.assertEqual(1, os.write(resume_write, b"\0"))
+                resumed = True
+
+                registration.join(timeout=5)
+                self.assertFalse(registration.is_alive(), "root registration did not finish")
+                if errors:
+                    raise errors[0]
+
+                file.write_text("replacement updated")
+                watcher.expect_events({("CHANGE", str(file))})
+            finally:
+                if registration.is_alive():
+                    if not resumed:
+                        os.write(resume_write, b"\0")
+                    registration.join(timeout=5)
+                watcher.stop()
+                os.close(ready_read)
+                os.close(resume_write)
+
+    @unittest.skipUnless(TEST_REGISTRATION_RACE_HOOK, "requires --registration-race-hook")
+    def test_descendant_removed_during_registration(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            disappearing = root / "disappearing"
+            disappearing.mkdir()
+            survivor = root / "survivor.txt"
+            survivor.write_text("initial")
+
+            ready_read, ready_write = os.pipe()
+            resume_read, resume_write = os.pipe()
+            env = os.environ.copy()
+            env["FSNOTIFIER_TEST_REGISTRATION_FDS"] = f"{ready_write}:{resume_read}"
+            env["FSNOTIFIER_TEST_REGISTRATION_PATH"] = str(disappearing)
+            watcher = FsNotifier(EXECUTABLE, env=env, pass_fds=(ready_write, resume_read))
+            os.close(ready_write)
+            os.close(resume_read)
+
+            errors = []
+
+            def register_root():
+                try:
+                    watcher.set_roots([str(root)])
+                except BaseException as error:
+                    errors.append(error)
+
+            registration = threading.Thread(target=register_root)
+            resumed = False
+            try:
+                registration.start()
+                readable, _, _ = select.select([ready_read], [], [], 5)
+                self.assertTrue(readable, "fsnotifier did not pause at the descendant")
+                self.assertEqual(b"\0", os.read(ready_read, 1))
+
+                disappearing.rmdir()
+                self.assertEqual(1, os.write(resume_write, b"\0"))
+                resumed = True
+
+                registration.join(timeout=5)
+                self.assertFalse(registration.is_alive(), "root registration did not finish")
+                if errors:
+                    raise errors[0]
+
+                survivor.write_text("updated")
+                watcher.expect_events(
+                    {("CHANGE", str(survivor))},
+                    unexpected_paths={str(root)},
+                )
+            finally:
+                if registration.is_alive():
+                    if not resumed:
+                        os.write(resume_write, b"\0")
+                    registration.join(timeout=5)
+                watcher.stop()
+                os.close(ready_read)
+                os.close(resume_write)
+
+    def test_hard_link_roots(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file, link = create_hard_link_roots(Path(temp_dir))
+
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([f"|{file}", f"|{link}"])
+                file.write_text("updated")
+                watcher.expect_events({("CHANGE", str(file)), ("CHANGE", str(link))})
+
+                watcher.set_roots([f"|{file}"])
+                file.write_text("updated again")
+                watcher.expect_events({("CHANGE", str(file))})
+                watcher.assert_no_event_for(str(link))
+            finally:
+                watcher.stop()
+
+    def test_unlinked_hard_link_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file, link = create_hard_link_roots(Path(temp_dir))
+
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([f"|{file}", f"|{link}"])
+                file.unlink()
+                watcher.expect_events({("DELETE", str(file))})
+
+                link.write_text("survivor updated")
+                watcher.expect_events({("CHANGE", str(link))})
+                watcher.assert_no_event_for(str(file))
+
+                file.write_text("recreated")
+                watcher.expect_events({("CREATE", str(file)), ("CHANGE", str(file))})
+                file.write_text("recreated updated")
+                watcher.expect_events({("CHANGE", str(file))})
+                watcher.assert_no_event_for(str(link))
+            finally:
+                watcher.stop()
+
+    def test_renamed_hard_link_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            file = root / "head.txt"
+            link = root / "tail.txt"
+            file.write_text("initial")
+            os.link(file, link)
+
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([f"|{file}", f"|{link}"])
+                file.rename(file.with_name("renamed.txt"))
+                watcher.expect_events({("DELETE", str(file))})
+                watcher.assert_no_event_for(str(link))
+
+                link.write_text("survivor updated")
+                watcher.expect_events({("CHANGE", str(link))})
+                watcher.assert_no_event_for(str(file))
+
+                file.write_text("recreated")
+                watcher.expect_events({("CREATE", str(file)), ("CHANGE", str(file))})
+                file.write_text("recreated updated")
+                watcher.expect_events({("CHANGE", str(file))})
+                watcher.assert_no_event_for(str(link))
+            finally:
+                watcher.stop()
+
+    def test_distinct_file_roots_become_hard_links(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file, other = create_file_root_paths(Path(temp_dir))
+            file.write_text("old inode")
+            other.write_text("shared inode")
+            old_inode_link = file.with_name("old-inode.txt")
+            replacement = file.with_name("replacement.txt")
+            os.link(file, old_inode_link)
+            os.link(other, replacement)
+
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([f"|{file}", f"|{other}"])
+                os.replace(replacement, file)
+                watcher.expect_events({
+                    ("DELETE", str(file)),
+                    ("CREATE", str(file)),
+                    ("CHANGE", str(file)),
+                }, unexpected_paths={str(other)})
+                watcher.assert_no_event_for(str(other))
+
+                other.write_text("shared inode updated")
+                watcher.expect_events({("CHANGE", str(file)), ("CHANGE", str(other))})
+                watcher.wait_for_quiet()
+
+                old_inode_link.write_text("old inode updated")
+                watcher.assert_no_events_for({str(file), str(other)})
+            finally:
+                watcher.stop()
+
+    def test_hard_link_root_becomes_unique_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file, link = create_hard_link_roots(Path(temp_dir))
+            replacement = file.with_name("replacement.txt")
+            replacement.write_text("unique replacement")
+
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([f"|{file}", f"|{link}"])
+                os.replace(replacement, file)
+                watcher.expect_events({
+                    ("DELETE", str(file)),
+                    ("CREATE", str(file)),
+                    ("CHANGE", str(file)),
+                })
+
+                file.write_text("unique replacement updated")
+                watcher.expect_events({("CHANGE", str(file))}, unexpected_paths={str(link)})
+                watcher.assert_no_event_for(str(link))
+
+                link.write_text("surviving old inode updated")
+                watcher.expect_events({("CHANGE", str(link))}, unexpected_paths={str(file)})
+                watcher.assert_no_event_for(str(file))
+            finally:
+                watcher.stop()
+
+    def test_symlink_intersection(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / "target"
+            target.mkdir()
+            file = target / "file.txt"
+            file.write_text("initial")
+            first_link = root / "first"
+            second_link = root / "second"
+            first_link.symlink_to(target, target_is_directory=True)
+            second_link.symlink_to(target, target_is_directory=True)
+
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([str(first_link), str(second_link)])
+                file.write_text("updated")
+                watcher.expect_events({("CHANGE", str(first_link / file.name))})
+            finally:
+                watcher.stop()
+
+    @unittest.skipUnless(os.geteuid() == 0 and TEST_BIND_MOUNTS, "requires root and --bind-mounts")
+    def test_bind_mount_roots(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            alias = root / "alias"
+            nested = source / "nested"
+            nested.mkdir(parents=True)
+            alias.mkdir()
+            file = nested / "file.txt"
+            file.write_text("initial")
+            subprocess.run(["mount", "--bind", source, alias], check=True)
+            try:
+                watcher = FsNotifier(EXECUTABLE)
+                try:
+                    watcher.set_roots([str(source), str(alias)])
+                    file.write_text("updated")
+                    watcher.expect_events({
+                        ("CHANGE", str(file)),
+                        ("CHANGE", str(alias / "nested" / file.name)),
+                    })
+
+                    watcher.set_roots([str(source)])
+                    file.write_text("updated again")
+                    watcher.expect_events({("CHANGE", str(file))})
+                    watcher.assert_no_event_for(str(alias / "nested" / file.name))
+                finally:
+                    watcher.stop()
+            finally:
+                subprocess.run(["umount", alias], check=True)
+
+    @unittest.skipUnless(os.geteuid() == 0 and TEST_BIND_MOUNTS, "requires root and --bind-mounts")
+    def test_unmounted_bind_mount_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            alias = root / "alias"
+            nested = source / "nested"
+            nested.mkdir(parents=True)
+            alias.mkdir()
+            source_file = nested / "file.txt"
+            source_file.write_text("initial")
+            subprocess.run(["mount", "--bind", source, alias], check=True)
+            mounted = True
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([str(source), str(alias)])
+                subprocess.run(["umount", alias], check=True)
+                mounted = False
+                watcher.expect_events({
+                    ("DELETE", str(alias)),
+                    ("CREATE", str(alias)),
+                    ("CHANGE", str(alias)),
+                }, unexpected_paths={str(source)})
+
+                source_file.write_text("source updated")
+                watcher.expect_events(
+                    {("CHANGE", str(source_file))},
+                    unexpected_paths={str(alias / "nested" / source_file.name)},
+                )
+                watcher.assert_no_event_for(str(alias / "nested" / source_file.name))
+
+                exposed_file = alias / "exposed.txt"
+                exposed_file.write_text("exposed mountpoint updated")
+                watcher.expect_events({
+                    ("CREATE", str(exposed_file)),
+                    ("CHANGE", str(exposed_file)),
+                })
+            finally:
+                watcher.stop()
+                if mounted:
+                    subprocess.run(["umount", alias], check=True)
+
+    @unittest.skipUnless(os.geteuid() == 0 and TEST_BIND_MOUNTS, "requires root and --bind-mounts")
+    def test_unmounted_nested_bind_mount(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            alias = root / "alias"
+            nested = source / "nested"
+            nested.mkdir(parents=True)
+            alias.mkdir()
+            source_file = nested / "source.txt"
+            source_file.write_text("initial")
+            exposed_file = alias / "exposed.txt"
+            exposed_file.write_text("hidden by bind mount")
+            stale_alias_file = alias / "nested" / source_file.name
+            subprocess.run(["mount", "--bind", source, alias], check=True)
+            mounted = True
+            watcher = FsNotifier(EXECUTABLE)
+            try:
+                watcher.set_roots([str(root)])
+                subprocess.run(["umount", alias], check=True)
+                mounted = False
+                watcher.expect_events({
+                    ("DELETE", str(root)),
+                    ("CREATE", str(root)),
+                    ("CHANGE", str(root)),
+                })
+
+                source_file.write_text("source updated")
+                watcher.expect_events(
+                    {("CHANGE", str(source_file))},
+                    unexpected_paths={str(stale_alias_file)},
+                )
+                watcher.assert_no_event_for(str(stale_alias_file))
+
+                exposed_file.write_text("exposed mountpoint updated")
+                watcher.expect_events({("CHANGE", str(exposed_file))})
+            finally:
+                watcher.stop()
+                if mounted:
+                    subprocess.run(["umount", alias], check=True)
+
+
+def create_file_root_paths(root: Path):
+    first = root / "first"
+    second = root / "second"
+    first.mkdir()
+    second.mkdir()
+    file = first / "file.txt"
+    link = second / "link.txt"
+    return file, link
+
+
+def create_hard_link_roots(root: Path):
+    file, link = create_file_root_paths(root)
+    file.write_text("initial")
+    os.link(file, link)
+    return file, link
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/native/fsNotifier/linux/util.c
+++ b/native/fsNotifier/linux/util.c
@@ -158,6 +158,13 @@ void* table_get(table* t, int key) {
   }
 }
 
+void table_set(table* t, int key, void* value) {
+  int k = wrap(key, t);
+  if (k >= 0) {
+    t->data[k] = value;
+  }
+}
+
 void table_delete(table* t) {
   if (t != NULL) {
     free(t->data);

--- a/platform/platform-tests/testSrc/com/intellij/openapi/vfs/local/FileWatcherTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/vfs/local/FileWatcherTest.kt
@@ -42,6 +42,7 @@ import com.intellij.util.TimeoutUtil
 import com.intellij.util.concurrency.Semaphore
 import com.intellij.util.io.copyRecursively
 import com.intellij.util.io.delete
+import com.intellij.util.system.LowLevelLocalMachineAccess
 import com.intellij.util.system.OS
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -58,11 +59,15 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createFile
 import kotlin.io.path.writeText
 
+@OptIn(LowLevelLocalMachineAccess::class)
 class FileWatcherTest : BareTestFixtureTestCase() {
   //<editor-fold desc="Set up / tear down">
   private val LOG = logger<FileWatcherTest>()
@@ -75,6 +80,7 @@ class FileWatcherTest : BareTestFixtureTestCase() {
   private lateinit var alarm: Alarm
 
   private val watchedPaths = mutableListOf<String>()
+  private val watcherEventLatches = ConcurrentHashMap<String, CountDownLatch>()
   private val watcherEvents = Semaphore()
   private val resetHappened = AtomicBoolean()
 
@@ -94,6 +100,7 @@ class FileWatcherTest : BareTestFixtureTestCase() {
     assertFalse(watcher.isOperational)
     watchedPaths += tempDir.rootPath.toString()
     startup(watcher) { path ->
+      watcherEventLatches[path]?.countDown()
       if (path === FileWatcher.RESET || path !== FileWatcher.OTHER && watchedPaths.any { path.startsWith(it) }) {
         alarm.cancelAllRequests()
         alarm.addRequest({ watcherEvents.up() }, INTER_RESPONSE_DELAY)
@@ -136,6 +143,96 @@ class FileWatcherTest : BareTestFixtureTestCase() {
     assertEvents({ files.forEach { it.writeText("new content") } }, files.associateWith { 'U' })
     assertEvents({ files.forEach { it.delete() } }, files.associateWith { 'D' })
     assertEvents({ files.forEach { it.writeText("re-creation") } }, files.associateWith { 'C' })
+  }
+
+  @Test fun testHardLinkedFileRoots() {
+    assumeTrue("Linux-only", OS.CURRENT == OS.Linux)
+
+    val (file, link) = createHardLinkedFileRoots()
+    refresh(file)
+    refresh(link)
+
+    watch(file, false)
+    watch(link, false)
+    assertEvents({ file.writeText("new content") }, mapOf(file to 'U', link to 'U'))
+  }
+
+  @Test fun testUnlinkedHardLinkedFileRoot() {
+    assumeTrue("Linux-only", OS.CURRENT == OS.Linux)
+
+    val (file, link) = createHardLinkedFileRoots()
+    refresh(file)
+    refresh(link)
+
+    watch(file, false)
+    watch(link, false)
+    assertEvents({ file.delete() }, mapOf(file to 'D'))
+    assertEvents({ link.writeText("survivor updated") }, mapOf(link to 'U'))
+    assertEvents({ file.writeText("recreated") }, mapOf(file to 'C'))
+    assertEvents({ file.writeText("recreated updated") }, mapOf(file to 'U'))
+  }
+
+  @Test fun testRenamedHardLinkedFileRoot() {
+    assumeTrue("Linux-only", OS.CURRENT == OS.Linux)
+
+    val (file, link) = createHardLinkedFileRoots()
+    refresh(file)
+    refresh(link)
+
+    watch(file, false)
+    watch(link, false)
+    assertEvents({ Files.move(file, file.resolveSibling("renamed.txt")) }, mapOf(file to 'D'))
+    assertEvents({ link.writeText("survivor updated") }, mapOf(link to 'U'))
+    assertEvents({ file.writeText("recreated") }, mapOf(file to 'C'))
+    assertEvents({ file.writeText("recreated updated") }, mapOf(file to 'U'))
+  }
+
+  @Test fun testDistinctFileRootsBecomeHardLinks() {
+    assumeTrue("Linux-only", OS.CURRENT == OS.Linux)
+
+    val (file, other) = createFileRootPaths()
+    file.writeText("old inode")
+    other.writeText("shared inode")
+    val oldInodeLink = Files.createLink(file.resolveSibling("old-inode.txt"), file)
+    val replacement = Files.createLink(file.resolveSibling("replacement.txt"), other)
+    refresh(file)
+    refresh(other)
+
+    watch(file, false)
+    watch(other, false)
+    assertEvents(
+      {
+        awaitRootReRegistration(file) {
+          Files.move(replacement, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        }
+      },
+      mapOf(file to 'U'),
+    )
+    assertEvents({ other.writeText("shared inode updated") }, mapOf(file to 'U', other to 'U'))
+    assertEvents({ oldInodeLink.writeText("old inode updated") }, emptyMap(), SHORT_PROCESS_DELAY)
+  }
+
+  @Test fun testHardLinkedFileRootBecomesUniqueFile() {
+    assumeTrue("Linux-only", OS.CURRENT == OS.Linux)
+
+    val (file, link) = createHardLinkedFileRoots()
+    val replacement = file.resolveSibling("replacement.txt")
+    replacement.writeText("unique replacement")
+    refresh(file)
+    refresh(link)
+
+    watch(file, false)
+    watch(link, false)
+    assertEvents(
+      {
+        awaitRootReRegistration(file) {
+          Files.move(replacement, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        }
+      },
+      mapOf(file to 'U'),
+    )
+    assertEvents({ file.writeText("unique replacement updated") }, mapOf(file to 'U'))
+    assertEvents({ link.writeText("surviving old inode updated") }, mapOf(link to 'U'))
   }
 
   @Test fun testFileRootRecursive() {
@@ -699,6 +796,35 @@ class FileWatcherTest : BareTestFixtureTestCase() {
   private fun unwatch(request: LocalFileSystem.WatchRequest) {
     unwatch(watcher, request)
     fs.refresh(false)
+  }
+
+  private fun createFileRootPaths(): Pair<Path, Path> {
+    val first = tempDir.newDirectoryPath("first")
+    val second = tempDir.newDirectoryPath("second")
+    val file = first.resolve("file.txt")
+    val link = second.resolve("link.txt")
+    return file to link
+  }
+
+  private fun createHardLinkedFileRoots(): Pair<Path, Path> {
+    val (file, link) = createFileRootPaths()
+    file.createFile()
+    Files.createLink(link, file)
+    return file to link
+  }
+
+  private fun awaitRootReRegistration(path: Path, action: () -> Unit) {
+    val pathString = path.toString()
+    // A missing root is reported as deleted, then re-registered with create and change notifications.
+    val latch = CountDownLatch(3)
+    check(watcherEventLatches.put(pathString, latch) == null)
+    try {
+      action()
+      assertTrue("root was not re-registered: $path", latch.await(NATIVE_PROCESS_DELAY, TimeUnit.MILLISECONDS))
+    }
+    finally {
+      watcherEventLatches.remove(pathString, latch)
+    }
   }
 
   private fun assertEvents(action: () -> Unit, expectedOps: Map<Path, Char>, timeout: Long = NATIVE_PROCESS_DELAY) {


### PR DESCRIPTION
## Issue

[IJPL-2176 – File watcher failed to start ("table error: collision" messages in the log)](https://youtrack.jetbrains.com/issue/IJPL-2176/File-watcher-failed-to-start-table-error-collision-messages-in-the-log)

## Summary

- allow Linux inotify watches to represent multiple path aliases for the same filesystem inode instead of terminating on a watch-descriptor collision
- revalidate aliases during self-events and periodic reconciliation so unlink, rename, atomic replacement, descendant removal, and mount-topology changes retain or rebuild the correct watches
- add native and IDE regression coverage for hard-link lifecycle transitions, registration races, disappearing descendants, and detached bind mounts

## Testing

- Clang CMake build: passed
- CTest: 1/1 passed
- privileged native suite with registration-race and bind-mount coverage: 11/11 passed
- Bazel `com.intellij.openapi.vfs.local.FileWatcherTest`: 45 discovered, 36 passed, 9 platform-specific assumption skips
- `git diff --check`: passed
