### PR TITLE
[gradle-maven] don't suppress completion for non-coordinate literals in dependencies blocks

### DIFF
--- a/plugins/gradle-maven/resources/intellij.gradle.java.maven.xml
+++ b/plugins/gradle-maven/resources/intellij.gradle.java.maven.xml
@@ -35,7 +35,7 @@
     <postStartupActivity implementation="org.jetbrains.plugins.gradle.integrations.maven.GradleProjectStartupActivity"/>
     <externalSystemTaskNotificationListener
         implementation="org.jetbrains.plugins.gradle.integrations.maven.GradleMavenProjectImportNotificationListener"/>
-    <completion.contributor language="Groovy" order="first"
+    <completion.contributor id="gradleMavenDependencies" language="Groovy" order="first"
                             implementationClass="org.jetbrains.plugins.gradle.integrations.maven.codeInsight.completion.MavenDependenciesGradleCompletionContributor"/>
     <projectService serviceImplementation="org.jetbrains.plugins.gradle.integrations.maven.MavenRepositoriesHolder"/>
   </extensions>

--- a/plugins/gradle-maven/src/org/jetbrains/plugins/gradle/integrations/maven/codeInsight/completion/MavenDependenciesGradleCompletionContributor.kt
+++ b/plugins/gradle-maven/src/org/jetbrains/plugins/gradle/integrations/maven/codeInsight/completion/MavenDependenciesGradleCompletionContributor.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.patterns.PatternCondition
 import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.repository.search.completion.api.DependencyArtifactCompletionRequest
 import com.intellij.repository.search.completion.api.DependencyCompletionEvent
@@ -33,6 +34,8 @@ import org.jetbrains.idea.maven.model.MavenRepoArtifactInfo
 import org.jetbrains.plugins.groovy.lang.completion.GrDummyIdentifierProvider.DUMMY_IDENTIFIER_DECAPITALIZED
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.arguments.GrArgumentList
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.arguments.GrNamedArgument
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrMethodCall
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrReferenceExpression
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.literals.GrLiteral
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.path.GrMethodCallExpression
 import org.jetbrains.plugins.groovy.lang.psi.api.util.GrNamedArgumentsOwner
@@ -53,16 +56,20 @@ class MavenDependenciesGradleCompletionContributor : AbstractGradleGroovyComplet
         context: ProcessingContext,
         result: CompletionResultSet,
       ) {
-        val parent = params.position.parent?.parent
-        if (parent !is GrNamedArgument || parent.parent !is GrNamedArgumentsOwner) {
-          return
-        }
+        val namedArgument = params.position.parent?.parent
+        if (namedArgument !is GrNamedArgument) return
+        val argumentsOwner = namedArgument.parent
+        if (argumentsOwner !is GrNamedArgumentsOwner) return
+        // Named arguments of nested calls like project(path: ':path') are not
+        // dependency coordinates; leave them to other completion contributors.
+        if (isNonCoordinateNotation(argumentsOwner.parent)) return
+
         result.stopHere()
         result.restartCompletionOnAnyPrefixChange()
 
         val completionContext = params.getCompletionContext()
-        if (GROUP_LABEL == parent.labelName) {
-          val groupId = trimDummy(findNamedArgumentValue(parent.parent as GrNamedArgumentsOwner, GROUP_LABEL))
+        if (GROUP_LABEL == namedArgument.labelName) {
+          val groupId = trimDummy(findNamedArgumentValue(argumentsOwner, GROUP_LABEL))
           runBlockingCancellable {
             val seen = mutableSetOf<String>()
             service<DependencyCompletionService>()
@@ -80,9 +87,9 @@ class MavenDependenciesGradleCompletionContributor : AbstractGradleGroovyComplet
               }
           }
         }
-        else if (NAME_LABEL == parent.labelName) {
-          val groupId = trimDummy(findNamedArgumentValue(parent.parent as GrNamedArgumentsOwner, GROUP_LABEL))
-          val artifactId = trimDummy(findNamedArgumentValue(parent.parent as GrNamedArgumentsOwner, NAME_LABEL))
+        else if (NAME_LABEL == namedArgument.labelName) {
+          val groupId = trimDummy(findNamedArgumentValue(argumentsOwner, GROUP_LABEL))
+          val artifactId = trimDummy(findNamedArgumentValue(argumentsOwner, NAME_LABEL))
           runBlockingCancellable {
             if (groupId.isBlank()) {
               service<DependencyCompletionService>()
@@ -112,9 +119,9 @@ class MavenDependenciesGradleCompletionContributor : AbstractGradleGroovyComplet
             }
           }
         }
-        else if (VERSION_LABEL == parent.labelName) {
-          val groupId = trimDummy(findNamedArgumentValue(parent.parent as GrNamedArgumentsOwner, GROUP_LABEL))
-          val artifactId = trimDummy(findNamedArgumentValue(parent.parent as GrNamedArgumentsOwner, NAME_LABEL))
+        else if (VERSION_LABEL == namedArgument.labelName) {
+          val groupId = trimDummy(findNamedArgumentValue(argumentsOwner, GROUP_LABEL))
+          val artifactId = trimDummy(findNamedArgumentValue(argumentsOwner, NAME_LABEL))
           val newResult = result.withRelevanceSorter(CompletionService.getCompletionService().emptySorter().weigh(MavenVersionNegatingWeigher()))
           runBlockingCancellable {
             service<DependencyCompletionService>()
@@ -139,11 +146,17 @@ class MavenDependenciesGradleCompletionContributor : AbstractGradleGroovyComplet
         result: CompletionResultSet,
       ) {
         val element = params.position.parent
-        if (element !is GrLiteral || element.parent !is GrArgumentList) {
-          //try
+        val literal = if (element is GrLiteral && element.parent is GrArgumentList) {
+          element
+        }
+        else {
           val parent = element?.parent
           if (parent !is GrLiteral || parent.parent !is GrArgumentList) return
+          parent
         }
+        // Arguments of nested calls like project(':path') or files('libs/dep.jar') are not
+        // dependency coordinates; leave them to other completion contributors.
+        if (isNonCoordinateNotation(literal.parent.parent)) return
 
         result.stopHere()
 
@@ -230,6 +243,19 @@ class MavenDependenciesGradleCompletionContributor : AbstractGradleGroovyComplet
     private val IN_METHOD_DEPENDENCY_NOTATION = psiElement()
       .and(GRADLE_FILE_PATTERN)
       .and(DEPENDENCIES_CALL_PATTERN)
+
+    /**
+     * Method calls nested inside a dependencies block whose arguments are project paths or
+     * file paths rather than maven coordinates, e.g. `project(':path')` or `files('libs/dep.jar')`.
+     */
+    private val NON_COORDINATE_NOTATION_METHODS = setOf("project", "files", "fileTree", "file")
+
+    private fun isNonCoordinateNotation(call: PsiElement?): Boolean {
+      if (call !is GrMethodCall) return false
+      val invoked = call.invokedExpression
+      val methodName = (invoked as? GrReferenceExpression)?.referenceName ?: invoked.text
+      return methodName in NON_COORDINATE_NOTATION_METHODS
+    }
 
     private fun trimDummy(value: String?): String {
       return if (value == null) {

--- a/plugins/gradle-maven/testSources/integrations/maven/codeInsight/completion/MavenDependenciesGradleCompletionContributorTest.kt
+++ b/plugins/gradle-maven/testSources/integrations/maven/codeInsight/completion/MavenDependenciesGradleCompletionContributorTest.kt
@@ -1,0 +1,132 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gradle.integrations.maven.codeInsight.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionContributorEP
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.extensions.DefaultPluginDescriptor
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.extensions.LoadingOrder
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Verifies that [MavenDependenciesGradleCompletionContributor] does not suppress other
+ * completion contributors (via stopHere) for string literals inside a dependencies block
+ * that are not maven coordinates, such as project(':path') arguments.
+ *
+ * The plugin descriptor registering the contributor is not loaded in this test environment,
+ * so the contributor is registered manually with order="first", as in production, followed
+ * by a marker contributor standing in for any later contributor.
+ */
+class MavenDependenciesGradleCompletionContributorTest : BasePlatformTestCase() {
+
+  override fun setUp() {
+    super.setUp()
+    val ep = ExtensionPointName<CompletionContributorEP>("com.intellij.completion.contributor")
+    val descriptor = DefaultPluginDescriptor("MavenDependenciesGradleCompletionContributorTest")
+    val maven = CompletionContributorEP(
+      "Groovy", MavenDependenciesGradleCompletionContributor::class.java.name, descriptor
+    )
+    val marker = CompletionContributorEP("Groovy", MarkerContributor::class.java.name, descriptor)
+    ep.point.registerExtension(maven, LoadingOrder.FIRST, testRootDisposable)
+    ep.point.registerExtension(marker, testRootDisposable)
+  }
+
+  fun `test project path argument is not claimed as a dependency coordinate`() {
+    doTestMarkerPresent(
+      """
+      dependencies {
+        implementation project(':<caret>')
+      }
+      """.trimIndent()
+    )
+  }
+
+  fun `test parenthesized project path argument is not claimed as a dependency coordinate`() {
+    doTestMarkerPresent(
+      """
+      dependencies {
+        implementation(project(':<caret>'))
+      }
+      """.trimIndent()
+    )
+  }
+
+  fun `test project path named argument is not claimed as a dependency coordinate`() {
+    doTestMarkerPresent(
+      """
+      dependencies {
+        implementation project(path: ':<caret>')
+      }
+      """.trimIndent()
+    )
+  }
+
+  fun `test files argument is not claimed as a dependency coordinate`() {
+    doTestMarkerPresent(
+      """
+      dependencies {
+        implementation files('libs/<caret>')
+      }
+      """.trimIndent()
+    )
+  }
+
+  fun `test file argument is not claimed as a dependency coordinate`() {
+    doTestMarkerPresent(
+      """
+      dependencies {
+        implementation files(file('libs/<caret>'))
+      }
+      """.trimIndent()
+    )
+  }
+
+  fun `test qualified files argument is not claimed as a dependency coordinate`() {
+    doTestMarkerPresent(
+      """
+      dependencies {
+        implementation rootProject.files('libs/<caret>')
+      }
+      """.trimIndent()
+    )
+  }
+
+  fun `test map dependency notation is still claimed`() {
+    myFixture.configureByText(
+      "build.gradle",
+      """
+      dependencies {
+        implementation group: 'junit', name: 'junit', classifier: '<caret>'
+      }
+      """.trimIndent()
+    )
+    myFixture.completeBasic()
+    val lookups = myFixture.lookupElementStrings ?: emptyList()
+    assertDoesntContain(lookups, MARKER_1, MARKER_2)
+  }
+
+  private fun doTestMarkerPresent(text: String) {
+    myFixture.configureByText("build.gradle", text)
+    myFixture.completeBasic()
+    val lookups = myFixture.lookupElementStrings ?: emptyList()
+    assertContainsElements(lookups, MARKER_1, MARKER_2)
+  }
+
+  internal class MarkerContributor : CompletionContributor() {
+    override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+      // Match any prefix, and add two elements so completion shows a popup
+      // instead of auto-inserting a sole match
+      val anyPrefix = result.withPrefixMatcher("")
+      anyPrefix.addElement(LookupElementBuilder.create(MARKER_1))
+      anyPrefix.addElement(LookupElementBuilder.create(MARKER_2))
+    }
+  }
+
+  companion object {
+    private const val MARKER_1 = "marker.lookup.element.1"
+    private const val MARKER_2 = "marker.lookup.element.2"
+  }
+}


### PR DESCRIPTION
`MavenDependenciesGradleCompletionContributor` called `stopHere()` for any string literal inside a dependencies block, including arguments of nested calls like `project(':path')` and `files('libs/dep.jar')` that are not maven coordinates. This suppressed completion from all other contributors for those literals. Skip such literals instead, and give the contributor registration an id so plugins can order relative to it.

My [spotlight plugin](https://github.com/joshfriend/spotlight) offers autocomplete contributions for `project(...)` and the gradle-maven plugin has broken that in 2026.2+