### PR TITLE
[JEWEL-1415] Fix InlineBanner Crash and Layout Bug

### DIFF
--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/banners/InlineBannerTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/banners/InlineBannerTest.kt
@@ -1,18 +1,111 @@
 package org.jetbrains.jewel.ui.component.banners
 
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.InlineInformationBanner
 import org.jetbrains.jewel.ui.component.banner.BannerIconActionScope
 import org.jetbrains.jewel.ui.component.banner.BannerLinkActionScope
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+import org.junit.Assert.assertTrue
 import org.junit.Rule
+import org.junit.Test
 
 class InlineBannerTest : SharedBannerTest() {
     @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun `when the incoming width is unbounded, wrap the content`() {
+        rule.setContent {
+            IntUiTheme {
+                Box(Modifier.horizontalScroll(rememberScrollState())) {
+                    InlineInformationBanner(
+                        text = "Lipsum.",
+                        linkActions = { action("Action") {} },
+                        iconActions = {
+                            iconAction(AllIconsKeys.General.Gear, "Settings") {}
+                            iconAction(AllIconsKeys.Actions.Close, "Close") {}
+                        },
+                    )
+                }
+            }
+        }
+
+        rule.onNodeWithText("Lipsum.").assertIsDisplayed()
+        rule.onNodeWithText("Action").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Settings").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Close").assertIsDisplayed()
+
+        val bounds = rule.onNodeWithTag("InlineBanner").getBoundsInRoot()
+        assertTrue("The banner collapsed to a zero width", bounds.right - bounds.left > 0.dp)
+    }
+
+    @Test
+    fun `when the banner is taller than its content, keep the link actions inside it`() {
+        rule.setContent {
+            IntUiTheme {
+                InlineInformationBanner(
+                    text = "Lipsum.",
+                    linkActions = { action("Action") {} },
+                    modifier = Modifier.width(720.dp).height(120.dp),
+                )
+            }
+        }
+
+        val bannerBounds = rule.onNodeWithTag("InlineBanner").getBoundsInRoot()
+        val textBounds = rule.onNodeWithText("Lipsum.").getBoundsInRoot()
+        val linkBounds = rule.onNodeWithText("Action").getBoundsInRoot()
+
+        assertTrue(
+            "The link actions were pushed outside the banner (${linkBounds.bottom} > ${bannerBounds.bottom})",
+            linkBounds.bottom <= bannerBounds.bottom,
+        )
+        assertTrue(
+            "The link actions were not placed right below the text (gap of ${linkBounds.top - textBounds.bottom})",
+            linkBounds.top - textBounds.bottom < 16.dp,
+        )
+    }
+
+    @Test
+    fun `when there are action icons, the title and content must not extend under them`() {
+        rule.setContent {
+            IntUiTheme {
+                InlineInformationBanner(
+                    title = "A title",
+                    iconActions = {
+                        iconAction(AllIconsKeys.General.Gear, "Settings") {}
+                        iconAction(AllIconsKeys.Actions.Close, "Close") {}
+                    },
+                    modifier = Modifier.width(720.dp),
+                ) {
+                    Box(Modifier.fillMaxWidth().height(16.dp).testTag("bannerTextArea"))
+                }
+            }
+        }
+
+        val textArea = rule.onNodeWithTag("bannerTextArea").getBoundsInRoot()
+        val leftmostIcon = rule.onNodeWithContentDescription("Settings").getBoundsInRoot()
+
+        assertTrue(
+            "The text area runs under the action icons " +
+                "(it ends at ${textArea.right}, the icons start at ${leftmostIcon.left})",
+            textArea.right <= leftmostIcon.left,
+        )
+    }
 
     override fun runBannerTest(
         text: String,

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/InlineBanner.kt
@@ -33,8 +33,10 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastCoerceAtLeast
 import org.jetbrains.annotations.Nls
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
@@ -620,7 +622,7 @@ private fun InlineBannerImpl(
         SubcomposeLayout { constraints ->
             val spacingPx = BANNER_CONTENT_SPACING.dp.roundToPx()
 
-            val unconstrained = constraints.copy(minWidth = 0)
+            val unconstrained = constraints.copy(minWidth = 0, minHeight = 0)
             val actionIconsPlaceables =
                 subcompose("actionIcons") {
                         if (actionIcons != null) {
@@ -643,11 +645,26 @@ private fun InlineBannerImpl(
             // Calculate width available for the main content column
             // Total - Icon - Spacing
             val startOffset = if (iconWidth > 0) iconWidth + spacingPx else 0
-            val contentAvailableWidth = (constraints.maxWidth - startOffset).coerceAtLeast(0)
+
+            // When the incoming width is unbounded there is no space to distribute, so children are measured at
+            // their natural width and the banner reports the width it wants to occupy via naturalWidth below.
+            val hasBoundedWidth = constraints.hasBoundedWidth
+            val contentAvailableWidth =
+                if (hasBoundedWidth) (constraints.maxWidth - startOffset).fastCoerceAtLeast(0) else Constraints.Infinity
+
+            val halfPaddingEnd = (originalPadding.calculateEndPadding(layoutDirection).toPx() / 2).toInt()
+            // width of all icons + the background padding when hovering the icons + an extra of 8.dp
+            val actionIconsReservedWidth =
+                if (actionIconsWidth > 0) actionIconsWidth + halfPaddingEnd + spacingPx else 0
 
             // Text MUST respect Action Icons (i.e, subtract their width)
-            val textConstraints =
-                constraints.copy(minWidth = 0, maxWidth = (contentAvailableWidth - actionIconsWidth).coerceAtLeast(0))
+            val textMaxWidth =
+                if (hasBoundedWidth) {
+                    (contentAvailableWidth - actionIconsReservedWidth).fastCoerceAtLeast(0)
+                } else {
+                    Constraints.Infinity
+                }
+            val textConstraints = constraints.copy(minWidth = 0, minHeight = 0, maxWidth = textMaxWidth)
             val textPlaceables =
                 subcompose("text") {
                         Column {
@@ -664,7 +681,7 @@ private fun InlineBannerImpl(
 
             // Link Actions must IGNORE Action Icons (use full available width)
             // This allows buttons to render underneath the top-right icons
-            val linkConstraints = constraints.copy(minWidth = 0, maxWidth = contentAvailableWidth)
+            val linkConstraints = constraints.copy(minWidth = 0, minHeight = 0, maxWidth = contentAvailableWidth)
             val linkPlaceables =
                 subcompose("links") {
                         if (actions != null) {
@@ -681,7 +698,7 @@ private fun InlineBannerImpl(
             // calculating the width the banner actually wants to occupy, coerced to
             // fit within the incoming minWidth/maxWidth constraints
             val naturalWidth =
-                (startOffset + maxOf(textWidth + actionIconsWidth, linksWidth)).coerceIn(
+                (startOffset + maxOf(textWidth + actionIconsReservedWidth, linksWidth)).coerceIn(
                     constraints.minWidth,
                     constraints.maxWidth,
                 )
@@ -700,7 +717,6 @@ private fun InlineBannerImpl(
                     // We always offset the action icon to half the padding
                     val topPaddingPx = adjustedPadding.calculateTopPadding().roundToPx()
                     val halfPaddingTop = (originalPadding.calculateTopPadding().toPx() / 2).toInt()
-                    val halfPaddingEnd = (originalPadding.calculateEndPadding(layoutDirection).toPx() / 2).toInt()
 
                     // Offset Logic:
                     val yPos = halfPaddingTop - topPaddingPx

--- a/plugins/devkit/intellij.devkit.compose/src/demo/SwingComparisonTabPanel.kt
+++ b/plugins/devkit/intellij.devkit.compose/src/demo/SwingComparisonTabPanel.kt
@@ -187,7 +187,6 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
       compose {
         Box {
           InlineInformationBanner(
-            modifier = Modifier.width(300.dp), // TODO: this is a hack. A proper fix will come in JEWEL-1415
             text = DevkitComposeBundle.message("jewel.compose.inline.banners"),
             iconActions = {
               iconAction(


### PR DESCRIPTION
# Context

We currently have this crash happening in our `SwingComparisonTabPanel`:

<details><summary>Crash stacktrace</summary>
<p>

```
java.lang.IllegalStateException: Unable to actualize size of Compose content. Provide a specific value instead
	at androidx.compose.ui.scene.ComposeContainer.actualizeSize(ComposeContainer.desktop.kt:278)
	at androidx.compose.ui.awt.ComposePanel.actualize(ComposePanel.desktop.kt:225)
	at androidx.compose.ui.awt.ComposePanel.getPreferredSize(ComposePanel.desktop.kt:262)
	at java.desktop/java.awt.BorderLayout.preferredLayoutSize(BorderLayout.java:732)
	at java.desktop/java.awt.Container.preferredSize(Container.java:1820)
	at java.desktop/java.awt.Container.getPreferredSize(Container.java:1804)
	at java.desktop/javax.swing.JComponent.getPreferredSize(JComponent.java:1732)
	at com.intellij.ui.components.JBPanel.getPreferredSize(JBPanel.java:137)
	at com.intellij.ui.dsl.gridLayout.impl.GridImpl.collectPreCalculationData(GridImpl.kt:154)
	at com.intellij.ui.dsl.gridLayout.impl.GridImpl.collectPreCalculationData(GridImpl.kt:129)
	at com.intellij.ui.dsl.gridLayout.impl.GridImpl.calculatePreferredLayoutData(GridImpl.kt:169)
	at com.intellij.ui.dsl.gridLayout.impl.GridImpl.getSizeConstrainsData(GridImpl.kt:82)
	at com.intellij.ui.dsl.gridLayout.GridLayout.getPreferredSizeData$intellij_platform_ide(GridLayout.kt:128)
	at com.intellij.ui.dsl.gridLayout.GridLayout.preferredLayoutSize(GridLayout.kt:80)
	at java.desktop/java.awt.Container.preferredSize(Container.java:1820)
	at java.desktop/java.awt.Container.getPreferredSize(Container.java:1804)
	at java.desktop/javax.swing.JComponent.getPreferredSize(JComponent.java:1732)
	at com.intellij.ui.components.JBPanel.getPreferredSize(JBPanel.java:137)
	at com.intellij.ui.components.JBScrollPane$Layout.layoutContainer(JBScrollPane.java:630)
	at java.desktop/java.awt.Container.layout(Container.java:1537)
	at java.desktop/java.awt.Container.doLayout(Container.java:1526)
	at java.desktop/java.awt.Container.validateTree(Container.java:1719)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validateTree(Container.java:1728)
	at java.desktop/java.awt.Container.validate(Container.java:1654)
	at java.desktop/javax.swing.RepaintManager.validateInvalidComponents(RepaintManager.java:715)
	at java.desktop/javax.swing.RepaintManager$ProcessingRunnable.run(RepaintManager.java:1865)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:193)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:193)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:199)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:193)
	at com.intellij.util.concurrency.ContextRunnable.lambda$run$0(ContextRunnable.java:26)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:295)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:25)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:323)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:732)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:711)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:728)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:581)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0$0$0$0(IdeEventQueue.kt:385)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:962)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0$0$0(IdeEventQueue.kt:384)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$0(IdeEventQueue.kt:1115)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:106)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1115)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0(IdeEventQueue.kt:379)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:411)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
Caused by: java.lang.IllegalArgumentException: Can't represent a width of 2147483499 and height of 0 in Constraints
	at androidx.compose.ui.unit.ConstraintsKt.throwInvalidConstraintException(Constraints.kt:401)
	at androidx.compose.ui.unit.ConstraintsKt.createConstraints(Constraints.kt:425)
	at androidx.compose.ui.unit.Constraints.copy-Zbe2FdA(Constraints.kt:195)
	at androidx.compose.ui.unit.Constraints.copy-Zbe2FdA$default(Constraints.kt:179)
	at org.jetbrains.jewel.ui.component.InlineBannerKt.InlineBannerImpl$lambda$3$0$0(InlineBanner.kt:658)
	at androidx.compose.ui.layout.LayoutNodeSubcompositionsState$createMeasurePolicy$1.measure-3p2s80s(SubcomposeLayout.kt:955)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:130)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasureBlock$lambda$0(MeasurePassDelegate.kt:173)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:730)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:1073)
	at androidx.compose.ui.node.MeasurePassDelegate.measure-BRTryo0(MeasurePassDelegate.kt:470)
	at androidx.compose.foundation.layout.BoxMeasurePolicy.measure-3p2s80s(Box.kt:145)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:130)
	at androidx.compose.foundation.layout.PaddingValuesModifier.measure-3p2s80s(Padding.kt:513)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.ui.graphics.SimpleGraphicsLayerModifier.measure-3p2s80s(GraphicsLayerModifier.kt:962)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasureBlock$lambda$0(MeasurePassDelegate.kt:173)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:730)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:1073)
	at androidx.compose.ui.node.MeasurePassDelegate.measure-BRTryo0(MeasurePassDelegate.kt:470)
	at androidx.compose.foundation.layout.BoxMeasurePolicy.measure-3p2s80s(Box.kt:145)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:130)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasureBlock$lambda$0(MeasurePassDelegate.kt:173)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:730)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:1073)
	at androidx.compose.ui.node.MeasurePassDelegate.measure-BRTryo0(MeasurePassDelegate.kt:470)
	at androidx.compose.foundation.layout.BoxMeasurePolicy.measure-3p2s80s(Box.kt:145)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:130)
	at androidx.compose.foundation.layout.PaddingNode.measure-3p2s80s(Padding.kt:449)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasureBlock$lambda$0(MeasurePassDelegate.kt:173)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:730)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:1073)
	at androidx.compose.ui.node.MeasurePassDelegate.measure-BRTryo0(MeasurePassDelegate.kt:470)
	at androidx.compose.foundation.layout.BoxMeasurePolicy.measure-3p2s80s(Box.kt:145)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:130)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasureBlock$lambda$0(MeasurePassDelegate.kt:173)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:730)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:1073)
	at androidx.compose.ui.node.MeasurePassDelegate.measure-BRTryo0(MeasurePassDelegate.kt:470)
	at androidx.compose.ui.layout.OverlayLayout_skikoKt$OverlayLayout$1$1.measure-3p2s80s(OverlayLayout.skiko.kt:37)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:130)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasureBlock$lambda$0(MeasurePassDelegate.kt:173)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:730)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:1073)
	at androidx.compose.ui.node.MeasurePassDelegate.measure-BRTryo0(MeasurePassDelegate.kt:470)
	at androidx.compose.ui.layout.RootMeasurePolicy.measure-3p2s80s(RootMeasurePolicy.kt:37)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:130)
	at androidx.compose.ui.layout.RulerProviderModifierNode.measure-3p2s80s(WindowInsetsRulers.skiko.kt:149)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasureBlock$lambda$0(MeasurePassDelegate.kt:173)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:759)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:1073)
	at androidx.compose.ui.node.LayoutNode.remeasure-_Sx5XlM$ui(LayoutNode.kt:1288)
	at androidx.compose.ui.node.MeasureAndLayoutDelegate.doRemeasure-sdFAvZA(MeasureAndLayoutDelegate.kt:383)
	at androidx.compose.ui.node.MeasureAndLayoutDelegate.remeasureOnly(MeasureAndLayoutDelegate.kt:725)
	at androidx.compose.ui.node.MeasureAndLayoutDelegate.measureOnly(MeasureAndLayoutDelegate.kt:462)
	at androidx.compose.ui.node.RootNodeOwner.measuringRootWithConstraints-K40F9xA(RootNodeOwner.skiko.kt:237)
	at androidx.compose.ui.node.RootNodeOwner.measureContentWithConstraints-ToXhtMw(RootNodeOwner.skiko.kt:219)
	at androidx.compose.ui.scene.CanvasLayersComposeSceneImpl.measureContent-ToXhtMw(CanvasLayersComposeScene.skiko.kt:206)
	at androidx.compose.ui.scene.ComposeSceneMediator.measureContent-ToXhtMw(ComposeSceneMediator.desktop.kt:391)
	at androidx.compose.ui.scene.ComposeContainer.measureContent-ToXhtMw(ComposeContainer.desktop.kt:232)
	at androidx.compose.ui.scene.ComposeContainer.actualizeSize(ComposeContainer.desktop.kt:276)
	... 61 more
```

</p>
</details> 

Important part:

`Caused by: java.lang.IllegalArgumentException: Can't represent a width of 2147483499 and height of 0 in Constraints`

And oh boy, the reason for that is something so "sneaky" that ended up passing us by.

# Crash Reason

As you can infer from the number, this happens because we are trying to add a constraint using a really huge number. It's almost the maximum number that an `Int` can store (i.e., `Int.MAX_VALUE`).

Our `InlineBanner` is trying to use this value to calculate its width because its parent does not pass a limited space that it can use to render itself (a bound).

Compose's `Constraint` can't handle such a big number, so when we call `.copy` like this:

`constraints.copy(minWidth = 0, maxWidth = (contentAvailableWidth - actionIconsWidth).coerceAtLeast(0)`

It crashes.

For cases where a component is unbouded, we should let Compose handle the best way to render it. So, instead of just giving it a huge number, just pass `Constraints.Infinity` and Compose will do the rest. They have the same guard in their `offset` code, [you check it here](https://github.com/JetBrains/compose-multiplatform-core/blob/jb-main/compose/ui/ui-unit/src/commonMain/kotlin/androidx/compose/ui/unit/Constraints.kt#L551) (note: i also learned there's a `fastCoerceAtLeast` which I adopted now 😛).

This PR adopts the exact same fix.

## Bonus!

I also found that we should be setting the `minHeight` to 0 like we do for `minWidth` in three other sections of the code, otherwise the sublayouts in our `InlineBanner` will use a specified height to calculate their positions, leading to banners being rendered like this:

<img width="707" height="130" alt="image" src="https://github.com/user-attachments/assets/30f63fe0-e10d-4cca-9730-d3cf7c5f8130" />

# Changes

- Added guards to avoid doing calculations on unbounded widths (constraints received are `Int.MAX_VALUE`)
- Added `minHeight = 0` to every `constraints.copy()` call. This way each sublayout can properly calculate its own height instead of using the height passed in the banners modifier.
- Added regression tests for both fixes.

# Screenshots

## Width
| Before | After |
|--------|--------|
| <img width="1653" height="663" alt="image" src="https://github.com/user-attachments/assets/88ee4e39-dee7-44b4-9d59-6acaaf157bc9" /> | <img width="1654" height="663" alt="image" src="https://github.com/user-attachments/assets/7e42be00-2330-4f3b-bcf0-d836b0c7ed73" /> |

## Height
| Before | After |
|--------|--------|
| <img width="707" height="130" alt="image" src="https://github.com/user-attachments/assets/30f63fe0-e10d-4cca-9730-d3cf7c5f8130" /> | <img width="714" height="131" alt="image" src="https://github.com/user-attachments/assets/cbc740e9-3618-4713-a8b2-da5a86db950f" /> |

## Title bug
| Before | After |
|---|---|
| <img width="271" height="75" alt="image" src="https://github.com/user-attachments/assets/c73f2d26-9221-4629-b8a0-24bcbf71f615" /> | <img width="265" height="79" alt="image" src="https://github.com/user-attachments/assets/5c1e0ca3-0c32-4c8c-bebd-83df937fe6d2" /> |

## Release notes

### Bug fixes

* Fixed `InlineBanner` crashing when measured with an unbounded width, e.g. inside a horizontally scrollable parent, or when hosted in Swing via `JewelComposePanel`, where the host asks the panel for its preferred size.
* Fixed `InlineBanner` stretching its content to a parent-imposed minimum height, which pushed the link actions outside the banner and clipped them away.
* Fixed a visual bug in `InlineBanner` where the title of the banner would touch the first icon in the `actionIcons` composable.

