### PR TITLE
[JEWEL-1416] Match GroupHeader dividers with Swing

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeGroupHeader.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeGroupHeader.kt
@@ -1,17 +1,27 @@
 package org.jetbrains.jewel.bridge.theme
 
 import androidx.compose.ui.unit.dp
-import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
+import com.intellij.ui.Gray
+import com.intellij.ui.JBColor
+import org.jetbrains.jewel.bridge.retrieveColorOrNull
+import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.ui.component.styling.GroupHeaderColors
 import org.jetbrains.jewel.ui.component.styling.GroupHeaderMetrics
 import org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle
 
-internal fun readGroupHeaderStyle() =
-    GroupHeaderStyle(
-        colors = GroupHeaderColors(divider = retrieveColorOrUnspecified("Separator.separatorColor")),
+internal fun readGroupHeaderStyle(): GroupHeaderStyle {
+    val divider = retrieveColorOrNull("Group.separatorColor") ?: JBColor(Gray.xCD, Gray.x51).toComposeColor()
+
+    return GroupHeaderStyle(
+        colors =
+            GroupHeaderColors(
+                divider = divider,
+                dividerDisabled = retrieveColorOrNull("Group.disabledSeparatorColor") ?: divider,
+            ),
         metrics =
             GroupHeaderMetrics(
                 dividerThickness = 1.dp, // see DarculaSeparatorUI
                 indent = 1.dp, // see DarculaSeparatorUI
             ),
     )
+}

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
@@ -22,12 +22,14 @@ public fun GroupHeaderStyle.Companion.dark(
 ): GroupHeaderStyle = GroupHeaderStyle(colors, metrics)
 
 /** Creates an Int UI light [GroupHeaderColors] with the provided parameters. */
-public fun GroupHeaderColors.Companion.light(divider: Color = IntUiLightTheme.colors.gray(12)): GroupHeaderColors =
-    GroupHeaderColors(divider)
+public fun GroupHeaderColors.Companion.light(
+    divider: Color = IntUiLightTheme.colors.grayOrNull(12) ?: Color(0xFFCDCDCD)
+): GroupHeaderColors = GroupHeaderColors(divider)
 
 /** Creates an Int UI dark [GroupHeaderColors] with the provided parameters. */
-public fun GroupHeaderColors.Companion.dark(divider: Color = IntUiDarkTheme.colors.gray(3)): GroupHeaderColors =
-    GroupHeaderColors(divider)
+public fun GroupHeaderColors.Companion.dark(
+    divider: Color = IntUiDarkTheme.colors.grayOrNull(3) ?: Color(0xFF515151)
+): GroupHeaderColors = GroupHeaderColors(divider)
 
 /** Creates an Int UI default [GroupHeaderMetrics] with the provided parameters. */
 public fun GroupHeaderMetrics.Companion.defaults(dividerThickness: Dp = 1.dp, indent: Dp = 8.dp): GroupHeaderMetrics =

--- a/platform/jewel/ui/api-dump.txt
+++ b/platform/jewel/ui/api-dump.txt
@@ -372,7 +372,8 @@ f:org.jetbrains.jewel.ui.component.EditableComboBoxKt
 - bsf:EditableComboBox(androidx.compose.foundation.text.input.TextFieldState,androidx.compose.ui.Modifier,androidx.compose.ui.Modifier,Z,org.jetbrains.jewel.ui.Outline,androidx.compose.foundation.interaction.MutableInteractionSource,org.jetbrains.jewel.ui.component.styling.ComboBoxStyle,androidx.compose.ui.text.TextStyle,kotlin.jvm.functions.Function0,kotlin.jvm.functions.Function0,kotlin.jvm.functions.Function0,org.jetbrains.jewel.ui.component.PopupManager,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I,I):V
 - sf:EditableComboBox-zcv-z8k(androidx.compose.foundation.text.input.TextFieldState,androidx.compose.ui.Modifier,androidx.compose.ui.Modifier,F,F,Z,org.jetbrains.jewel.ui.Outline,androidx.compose.foundation.interaction.MutableInteractionSource,org.jetbrains.jewel.ui.component.styling.ComboBoxStyle,androidx.compose.ui.text.TextStyle,kotlin.jvm.functions.Function0,kotlin.jvm.functions.Function0,kotlin.jvm.functions.Function0,org.jetbrains.jewel.ui.component.PopupManager,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I,I):V
 f:org.jetbrains.jewel.ui.component.GroupHeaderKt
-- sf:GroupHeader(java.lang.String,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function2,kotlin.jvm.functions.Function2,org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle,androidx.compose.ui.text.TextStyle,androidx.compose.runtime.Composer,I,I):V
+- bsf:GroupHeader(java.lang.String,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function2,kotlin.jvm.functions.Function2,org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle,androidx.compose.ui.text.TextStyle,androidx.compose.runtime.Composer,I,I):V
+- sf:GroupHeader(java.lang.String,androidx.compose.ui.Modifier,kotlin.jvm.functions.Function2,kotlin.jvm.functions.Function2,org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle,androidx.compose.ui.text.TextStyle,Z,androidx.compose.runtime.Composer,I,I):V
 f:org.jetbrains.jewel.ui.component.IconActionButtonKt
 - sf:IconActionButton(androidx.compose.ui.graphics.painter.Painter,java.lang.String,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.Modifier,Z,Z,org.jetbrains.jewel.ui.component.styling.IconButtonStyle,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.runtime.Composer,I,I):V
 - sf:IconActionButton(androidx.compose.ui.graphics.painter.Painter,java.lang.String,kotlin.jvm.functions.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.Modifier,Z,Z,org.jetbrains.jewel.ui.component.styling.IconButtonStyle,org.jetbrains.jewel.ui.component.styling.TooltipStyle,androidx.compose.ui.Modifier,androidx.compose.foundation.TooltipPlacement,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I,I,I):V
@@ -1483,8 +1484,10 @@ f:org.jetbrains.jewel.ui.component.styling.DropdownStylingKt
 f:org.jetbrains.jewel.ui.component.styling.GroupHeaderColors
 - sf:$stable:I
 - sf:Companion:org.jetbrains.jewel.ui.component.styling.GroupHeaderColors$Companion
+- b:<init>(J,J,I,kotlin.jvm.internal.DefaultConstructorMarker):V
 - equals(java.lang.Object):Z
 - f:getDivider-0d7_KjU():J
+- f:getDividerDisabled-0d7_KjU():J
 - hashCode():I
 f:org.jetbrains.jewel.ui.component.styling.GroupHeaderColors$Companion
 f:org.jetbrains.jewel.ui.component.styling.GroupHeaderMetrics

--- a/platform/jewel/ui/metalava/ui-api-0.42.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-0.42.0.txt
@@ -412,7 +412,8 @@ package org.jetbrains.jewel.ui.component {
   }
 
   public final class GroupHeaderKt {
-    method @androidx.compose.runtime.Composable public static void GroupHeader(@org.jetbrains.annotations.Nls String text, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? startComponent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? endComponent, optional org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle style, optional androidx.compose.ui.text.TextStyle textStyle);
+    method @Deprecated @androidx.compose.runtime.Composable public static void GroupHeader(@org.jetbrains.annotations.Nls String text, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? startComponent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? endComponent, optional org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle style, optional androidx.compose.ui.text.TextStyle textStyle);
+    method @androidx.compose.runtime.Composable public static void GroupHeader(@org.jetbrains.annotations.Nls String text, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? startComponent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? endComponent, optional org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle style, optional androidx.compose.ui.text.TextStyle textStyle, optional boolean enabled);
   }
 
   public final class IconActionButtonKt {
@@ -1750,8 +1751,9 @@ package org.jetbrains.jewel.ui.component.styling {
   }
 
   @androidx.compose.runtime.Immutable @org.jetbrains.jewel.foundation.GenerateDataFunctions public final class GroupHeaderColors {
-    ctor @KotlinOnly public GroupHeaderColors(androidx.compose.ui.graphics.Color divider);
+    ctor @KotlinOnly public GroupHeaderColors(androidx.compose.ui.graphics.Color divider, optional androidx.compose.ui.graphics.Color dividerDisabled);
     property public androidx.compose.ui.graphics.Color divider;
+    property public androidx.compose.ui.graphics.Color dividerDisabled;
     field public static final org.jetbrains.jewel.ui.component.styling.GroupHeaderColors.Companion Companion;
   }
 

--- a/platform/jewel/ui/metalava/ui-api-stable-0.42.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-stable-0.42.0.txt
@@ -384,7 +384,8 @@ package org.jetbrains.jewel.ui.component {
   }
 
   public final class GroupHeaderKt {
-    method @androidx.compose.runtime.Composable public static void GroupHeader(@org.jetbrains.annotations.Nls String text, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? startComponent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? endComponent, optional org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle style, optional androidx.compose.ui.text.TextStyle textStyle);
+    method @Deprecated @androidx.compose.runtime.Composable public static void GroupHeader(@org.jetbrains.annotations.Nls String text, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? startComponent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? endComponent, optional org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle style, optional androidx.compose.ui.text.TextStyle textStyle);
+    method @androidx.compose.runtime.Composable public static void GroupHeader(@org.jetbrains.annotations.Nls String text, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? startComponent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? endComponent, optional org.jetbrains.jewel.ui.component.styling.GroupHeaderStyle style, optional androidx.compose.ui.text.TextStyle textStyle, optional boolean enabled);
   }
 
   public final class IconActionButtonKt {
@@ -1634,8 +1635,9 @@ package org.jetbrains.jewel.ui.component.styling {
   }
 
   @androidx.compose.runtime.Immutable @org.jetbrains.jewel.foundation.GenerateDataFunctions public final class GroupHeaderColors {
-    ctor @KotlinOnly public GroupHeaderColors(androidx.compose.ui.graphics.Color divider);
+    ctor @KotlinOnly public GroupHeaderColors(androidx.compose.ui.graphics.Color divider, optional androidx.compose.ui.graphics.Color dividerDisabled);
     property public androidx.compose.ui.graphics.Color divider;
+    property public androidx.compose.ui.graphics.Color dividerDisabled;
     field public static final org.jetbrains.jewel.ui.component.styling.GroupHeaderColors.Companion Companion;
   }
 

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/GroupHeader.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/GroupHeader.kt
@@ -33,6 +33,7 @@ import org.jetbrains.jewel.ui.component.styling.LocalGroupHeaderStyle
  * @param endComponent The component to display on the right side of the header.
  * @param style The style to apply to the header.
  * @param textStyle The text style to apply to the header text. Defaults to [JewelTheme.defaultTextStyle].
+ * @param enabled Whether the divider is enabled.
  * @see com.intellij.ui.TitledSeparator
  */
 @Composable
@@ -43,11 +44,12 @@ public fun GroupHeader(
     endComponent: (@Composable () -> Unit)? = null,
     style: GroupHeaderStyle = LocalGroupHeaderStyle.current,
     textStyle: TextStyle = JewelTheme.defaultTextStyle,
+    enabled: Boolean = true,
 ) {
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(style.metrics.indent),
     ) {
         if (startComponent != null) {
             Box(Modifier.size(16.dp)) { startComponent() }
@@ -57,12 +59,44 @@ public fun GroupHeader(
         Divider(
             orientation = Orientation.Horizontal,
             modifier = Modifier.weight(1f),
-            color = style.colors.divider,
+            color = if (enabled) style.colors.divider else style.colors.dividerDisabled,
             thickness = style.metrics.dividerThickness,
-            startIndent = style.metrics.indent,
+            startIndent = 0.dp,
         )
         if (endComponent != null) {
             Row(Modifier.height(16.dp)) { endComponent() }
         }
     }
+}
+
+/**
+ * A component that displays a header for a group of items, with a title and optional slots on both sides.
+ *
+ * **Guidelines:** [on IJP SDK webhelp](https://plugins.jetbrains.com/docs/intellij/group-header.html)
+ *
+ * **Usage example:**
+ * [`Borders.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/Borders.kt)
+ *
+ * **Swing equivalent:**
+ * [`TitledSeparator`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ui/TitledSeparator.java)
+ *
+ * @param text The text to display in the header.
+ * @param modifier The modifier to apply to the header.
+ * @param startComponent The component to display on the left side of the header.
+ * @param endComponent The component to display on the right side of the header.
+ * @param style The style to apply to the header.
+ * @param textStyle The text style to apply to the header text. Defaults to [JewelTheme.defaultTextStyle].
+ * @see com.intellij.ui.TitledSeparator
+ */
+@Deprecated("Use GroupHeader with the enabled parameter.", level = DeprecationLevel.HIDDEN)
+@Composable
+public fun GroupHeader(
+    @Nls text: String,
+    modifier: Modifier = Modifier,
+    startComponent: (@Composable () -> Unit)? = null,
+    endComponent: (@Composable () -> Unit)? = null,
+    style: GroupHeaderStyle = LocalGroupHeaderStyle.current,
+    textStyle: TextStyle = JewelTheme.defaultTextStyle,
+) {
+    GroupHeader(text, modifier, startComponent, endComponent, style, textStyle, enabled = true)
 }

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/GroupHeaderStyling.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/GroupHeaderStyling.kt
@@ -44,21 +44,36 @@ public class GroupHeaderStyle(
 @Immutable
 @GenerateDataFunctions
 public class GroupHeaderColors(
-    /** The color of the divider line. */
-    public val divider: Color
+    /** The color of the enabled divider line. */
+    public val divider: Color,
+    /** The color of the disabled divider line. */
+    public val dividerDisabled: Color = divider,
 ) {
+    @Deprecated("Use GroupHeaderColors with the dividerDisabled parameter.", level = DeprecationLevel.HIDDEN)
+    public constructor(
+        /** The color of the enabled divider line. */
+        divider: Color
+    ) : this(divider, divider)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as GroupHeaderColors
 
-        return divider == other.divider
+        if (divider != other.divider) return false
+        if (dividerDisabled != other.dividerDisabled) return false
+
+        return true
     }
 
-    override fun hashCode(): Int = divider.hashCode()
+    override fun hashCode(): Int {
+        var result = divider.hashCode()
+        result = 31 * result + dividerDisabled.hashCode()
+        return result
+    }
 
-    override fun toString(): String = "GroupHeaderColors(divider=$divider)"
+    override fun toString(): String = "GroupHeaderColors(divider=$divider, dividerDisabled=$dividerDisabled)"
 
     /** Companion object for [GroupHeaderColors]. */
     public companion object


### PR DESCRIPTION
Align `GroupHeader` dividers with Swing `TitledSeparator`.

## Changes

* Read the group separator colors from the correct Look and Feel key, with the same fallback as Swing.
* Add enabled and disabled divider styling while retaining the previous binary API.
* Align the standalone light and dark divider defaults with Swing.
* Fix excessive spacing between the label and divider compared to Swing.
* Update the IntelliJ API dump and Jewel Metalava signatures.

Note: Jewel implements the New UI theme, not the Islands themes (for now), and Islands has a different colour for dividers.

## Screenshots

 Before | After
 --- | ---
 <img width="730" height="190" alt="image" src="https://github.com/user-attachments/assets/7393ca76-a08f-42ca-b5c1-bb62a847884f" /> | <img width="735" height="186" alt="image" src="https://github.com/user-attachments/assets/093117a7-c09b-4fb0-bc86-8b7f77126608" />

### Swing vs Jewel

| Light | Dark |
| --- | --- |
| <img width="535" height="57" alt="image" src="https://github.com/user-attachments/assets/9ac8ef33-7859-49b1-a077-fc8d3854b4d9" /> | <img width="539" height="64" alt="image" src="https://github.com/user-attachments/assets/24bfb500-a597-4d1c-af4d-5184abc515f1" /> |

## Release notes

### New features

* Add enabled and disabled states to `GroupHeader` dividers.

### Bug fixes

* Align `GroupHeader` divider appearance with IntelliJ Swing group headers.
