### PR TITLE
IDEA-393519 coverage: support JarFileSystem output roots in collectOutputRoots

### DIFF
--- a/plugins/coverage/src/com/intellij/coverage/analysis/analyse.kt
+++ b/plugins/coverage/src/com/intellij/coverage/analysis/analyse.kt
@@ -9,7 +9,9 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.OrderEnumerator
 import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.JarFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.toNioPathOrNull
 import org.jetbrains.annotations.ApiStatus
 import java.nio.file.Files
 import java.nio.file.Path
@@ -48,7 +50,7 @@ internal fun collectOutputRoots(
   return modules.flatMap { module ->
     CoverageOutputRoots.getRoots(coverageDataManager, module, includeTests)
       .asSequence()
-      .map(VirtualFile::toNioPath)
+      .mapNotNull(::toLocalPathOrNull)
       .filter(::isValidOutputRoot)
       .distinct()
       .map { root -> ModuleRequest(module, root, packageEntries) }
@@ -90,3 +92,14 @@ private fun String.isInPackage(packageName: String): Boolean {
 private fun isValidOutputRoot(root: Path): Boolean {
   return Files.isDirectory(root) || Files.isRegularFile(root) && root.fileName.toString().endsWith(".jar", ignoreCase = true)
 }
+
+private fun toLocalPathOrNull(root: VirtualFile): Path? {
+  val localRoot = if (root.fileSystem is JarFileSystem) {
+    JarFileSystem.getInstance().getVirtualFileForJar(root)
+  }
+  else {
+    root
+  }
+  return localRoot?.toNioPathOrNull()
+}
+

--- a/plugins/coverage/testSrc/com/intellij/coverage/CoverageIntegrationTest.kt
+++ b/plugins/coverage/testSrc/com/intellij/coverage/CoverageIntegrationTest.kt
@@ -181,7 +181,13 @@ class CoverageIntegrationTest : CoverageIntegrationBaseTest() {
   fun `test ij coverage reads classes from jar output roots`() = assertHitsWithJarOutputRoots { loadIJSuite() }
 
   @Test
+  fun `test ij coverage reads classes from jar filesystem roots`() = assertHitsWithJarFileSystemRoots { loadIJSuite() }
+
+  @Test
   fun `test jacoco reads classes from jar output roots`() = assertHitsWithJarOutputRoots { loadJaCoCoSuite() }
+
+  @Test
+  fun `test jacoco reads classes from jar filesystem roots`() = assertHitsWithJarFileSystemRoots { loadJaCoCoSuite() }
 
   @Test
   fun testJaCoCoWithoutUnloaded() = runBlocking {
@@ -436,6 +442,24 @@ class CoverageIntegrationTest : CoverageIntegrationBaseTest() {
       Files.deleteIfExists(jarOutput)
     }
   }
+
+  private fun assertHitsWithJarFileSystemRoots(loadSuite: () -> CoverageSuitesBundle) {
+    val module = ModuleManager.getInstance(myProject).findModuleByName("simple") ?: error("Module 'simple' is not found")
+    val originalOutputUrl = CompilerModuleExtension.getInstance(module)?.compilerOutputUrl ?: error("Module output URL is not configured")
+    val originalOutputPath = Path.of(VfsUtilCore.urlToPath(originalOutputUrl))
+    val jarOutput = Files.createTempFile("coverage-output", ".jar")
+    try {
+      createJarFromDirectory(originalOutputPath, jarOutput)
+      val jarRootUrl = "jar://" + jarOutput.toString().replace('\\', '/') + "!/"
+      PsiTestUtil.setCompilerOutputPath(module, jarRootUrl, false)
+      assertHits(loadSuite())
+    }
+    finally {
+      PsiTestUtil.setCompilerOutputPath(module, originalOutputUrl, false)
+      Files.deleteIfExists(jarOutput)
+    }
+  }
+
 
   private fun createJarFromDirectory(sourceDir: Path, targetJar: Path) {
     JarOutputStream(Files.newOutputStream(targetJar)).use { output ->


### PR DESCRIPTION
In `collectOutputRoots`, module output roots are mapped to `java.nio.Path`. For standard Java modules, classes roots are directories on the local file system. However, in projects such as Android Gradle modules, compiled JARs (e.g. `R.jar`) can be registered as module classes roots using the `jar://` file system (`JarFileSystem`).

Calling `VirtualFile.toNioPath()` directly on a `JarFileSystem` root fails with `UnsupportedOperationException` because NIO Path conversion is only supported for local file system VirtualFiles.

Resolve `JarFileSystem` roots to their underlying local JAR file using `JarFileSystem.getInstance().getVirtualFileForJar(root)` before converting to a Path.

This contribution is made on behalf of Google LLC.

Fixes [IDEA-393519](https://youtrack.jetbrains.com/issue/IDEA-393519).