### PR TITLE
IJPL-158683 TOML: distinguish nested tables in repeated arrays

### DIFF
--- a/plugins/toml/json/src/main/kotlin/org/toml/ide/json/TomlJsonPsiWalker.kt
+++ b/plugins/toml/json/src/main/kotlin/org/toml/ide/json/TomlJsonPsiWalker.kt
@@ -24,6 +24,7 @@ import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlKeySegment
 import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlTable
+import org.toml.lang.psi.TomlTableHeader
 import org.toml.lang.psi.TomlValue
 
 object TomlJsonPsiWalker : JsonLikePsiWalker {
@@ -50,11 +51,14 @@ object TomlJsonPsiWalker : JsonLikePsiWalker {
                 current is TomlKeySegment && parent is TomlKey -> {
                     // forceLastTransition as true is used in inspections, whether as false is used in completion
                     // to skip the last segment as it may not have been typed completely yet
-                    if (current != element || forceLastTransition) {
-                        position.addPrecedingStep(current.name)
-                    }
-                    for (segment in parent.segments.takeWhile { it != current }.asReversed()) {
-                        position.addPrecedingStep(segment.name)
+                    val segments = parent.segments.takeWhile { it != current } +
+                        if (current != element || forceLastTransition) listOf(current) else emptyList()
+                    if (parent.parent is TomlTableHeader) {
+                        segments.mapTo(tableHeaderSegments) { it.name }
+                    } else {
+                        for (segment in segments.asReversed()) {
+                            position.addPrecedingStep(segment.name)
+                        }
                     }
                 }
                 current is TomlKeyValue && parent is TomlHeaderOwner -> {

--- a/plugins/toml/tests/src/test/kotlin/org/toml/ide/json/TomlJsonFindPositionTest.kt
+++ b/plugins/toml/tests/src/test/kotlin/org/toml/ide/json/TomlJsonFindPositionTest.kt
@@ -77,6 +77,18 @@ class TomlJsonFindPositionTest : TomlTestBase() {
         [[foo]]
     """, "/foo/1/bar")
 
+    fun `test nested table header in repeated array table`() = assertPosition("""
+        [[a]]
+        unit = "first"
+        [a.b]
+        unit = "first"
+
+        [[a]]
+        unit = "second"
+        [a.b<caret>]
+        unit = "second"
+    """, "/a/1/b")
+
     fun `test inline array`() = assertPosition("""
         [[foo]]
         


### PR DESCRIPTION
Include array table indexes when the TOML walker calculates a table header path. This prevents equal child headers from using the same path.