### PR TITLE
IJPL-255020 GitLab: Preserve viewed state when reopening a diff

### DIFF
--- a/plugins/gitlab/gitlab-core/src/org/jetbrains/plugins/gitlab/mergerequest/diff/GitLabMergeRequestDiffViewModel.kt
+++ b/plugins/gitlab/gitlab-core/src/org/jetbrains/plugins/gitlab/mergerequest/diff/GitLabMergeRequestDiffViewModel.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.platform.util.coroutines.childScope
+import git4idea.changes.GitBranchComparisonResult
 import git4idea.changes.GitTextFilePatchWithHistory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -212,17 +213,18 @@ internal class GitLabMergeRequestDiffProcessorViewModelImpl(
             LOG.warn("Empty patch for change $change")
             return@mapScoped null
           }
-          createChangeVm(change, patchWithHistory)
+          createChangeVm(change, patchWithHistory, changes)
         }.stateIn(cs, SharingStarted.WhileSubscribed(5.minutes, ZERO), null)
     }
 
   private fun CoroutineScope.createChangeVm(
     change: RefComparisonChange,
     diffData: GitTextFilePatchWithHistory,
+    parsedChanges: GitBranchComparisonResult,
   ) =
     GitLabMergeRequestDiffReviewViewModelImpl(
       project, this,
-      mergeRequest, diffData, change,
+      mergeRequest, diffData, change, parsedChanges,
       this@GitLabMergeRequestDiffProcessorViewModelImpl,
       discussionsContainer, discussionsViewOption, avatarIconsProvider,
       imageLoader

--- a/plugins/gitlab/gitlab-core/src/org/jetbrains/plugins/gitlab/mergerequest/ui/diff/GitLabMergeRequestDiffReviewViewModel.kt
+++ b/plugins/gitlab/gitlab-core/src/org/jetbrains/plugins/gitlab/mergerequest/ui/diff/GitLabMergeRequestDiffReviewViewModel.kt
@@ -15,6 +15,7 @@ import com.intellij.diff.util.Side
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.platform.util.coroutines.childScope
+import git4idea.changes.GitBranchComparisonResult
 import git4idea.changes.GitTextFilePatchWithHistory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -25,6 +26,7 @@ import org.jetbrains.plugins.gitlab.data.GitLabImageLoader
 import org.jetbrains.plugins.gitlab.mergerequest.data.GitLabMergeRequest
 import org.jetbrains.plugins.gitlab.mergerequest.data.GitLabMergeRequestNewDiscussionPosition
 import org.jetbrains.plugins.gitlab.mergerequest.data.GitLabNoteLocation
+import org.jetbrains.plugins.gitlab.mergerequest.data.findLatestCommitWithChangesTo
 import org.jetbrains.plugins.gitlab.mergerequest.data.mapToLocation
 import org.jetbrains.plugins.gitlab.mergerequest.diff.GitLabMergeRequestDiffViewModel
 import org.jetbrains.plugins.gitlab.mergerequest.ui.details.model.GitLabPersistentMergeRequestChangesViewedState
@@ -67,6 +69,7 @@ internal class GitLabMergeRequestDiffReviewViewModelImpl(
   private val mergeRequest: GitLabMergeRequest,
   private val diffData: GitTextFilePatchWithHistory,
   private val change: RefComparisonChange,
+  private val parsedChanges: GitBranchComparisonResult,
   private val diffVm: GitLabMergeRequestDiffViewModel,
   private val discussionsContainer: GitLabMergeRequestDiscussionsViewModels,
   discussionsViewOption: StateFlow<DiscussionsViewOption>,
@@ -115,7 +118,8 @@ internal class GitLabMergeRequestDiffReviewViewModelImpl(
   }
 
   override fun markViewed() {
-    val sha = mergeRequest.details.value.diffRefs?.headSha ?: return
+    if (!isCumulativeChange) return
+    val sha = parsedChanges.findLatestCommitWithChangesTo(mergeRequest.gitRemote.repository, change.filePath) ?: return
     persistentChangesViewedState.markViewed(
       mergeRequest.serverPath, mergeRequest.projectId, mergeRequest.iid,
       mergeRequest.gitRemote.repository,

--- a/plugins/gitlab/gitlab-core/test/org/jetbrains/plugins/gitlab/mergerequest/ui/diff/GitLabMergeRequestViewedRevisionTest.kt
+++ b/plugins/gitlab/gitlab-core/test/org/jetbrains/plugins/gitlab/mergerequest/ui/diff/GitLabMergeRequestViewedRevisionTest.kt
@@ -1,0 +1,122 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.gitlab.mergerequest.ui.diff
+
+import com.intellij.collaboration.ui.codereview.diff.DiscussionsViewOption
+import com.intellij.collaboration.util.ComputedResult
+import com.intellij.collaboration.util.RefComparisonChange
+import com.intellij.openapi.diff.impl.patch.TextFilePatch
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.FilePath
+import git4idea.changes.GitBranchComparisonResult
+import git4idea.changes.GitCommitShaWithPatches
+import git4idea.changes.GitTextFilePatchWithHistory
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.plugins.gitlab.mergerequest.data.GitLabMergeRequest
+import org.jetbrains.plugins.gitlab.mergerequest.diff.GitLabMergeRequestDiffViewModel
+import org.jetbrains.plugins.gitlab.mergerequest.ui.details.model.GitLabPersistentMergeRequestChangesViewedState
+import org.jetbrains.plugins.gitlab.mergerequest.ui.review.GitLabMergeRequestDiscussionsViewModels
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+internal class GitLabMergeRequestViewedRevisionTest {
+  @Test
+  fun `opening an older changed file preserves its manually viewed revision`() = runTest {
+    val saved = mutableMapOf("/repo/x.txt" to "commit-a")
+    val vm = createViewModel(backgroundScope, saved)
+
+    vm.markViewed()
+    vm.markViewed()
+
+    assertEquals(mapOf("/repo/x.txt" to "commit-a"), saved)
+  }
+
+  @Test
+  fun `automatically marks an unviewed file with its last change revision`() = runTest {
+    val saved = mutableMapOf<String, String>()
+
+    createViewModel(backgroundScope, saved).markViewed()
+
+    assertEquals(mapOf("/repo/x.txt" to "commit-a"), saved)
+  }
+
+  @Test
+  fun `a later change to the file records the newer revision`() = runTest {
+    val saved = mutableMapOf("/repo/x.txt" to "commit-a")
+
+    createViewModel(backgroundScope, saved, lastCommitPath = "x.txt").markViewed()
+
+    assertEquals(mapOf("/repo/x.txt" to "commit-b"), saved)
+  }
+
+  @Test
+  fun `a single commit diff does not mark the cumulative file viewed`() = runTest {
+    val saved = mutableMapOf<String, String>()
+
+    createViewModel(backgroundScope, saved, cumulative = false).markViewed()
+
+    assertTrue(saved.isEmpty())
+  }
+
+  @Test
+  fun `missing file history does not overwrite an existing viewed revision`() = runTest {
+    val saved = mutableMapOf("/repo/x.txt" to "commit-a")
+
+    createViewModel(backgroundScope, saved, firstCommitPath = "other.txt").markViewed()
+
+    assertEquals(mapOf("/repo/x.txt" to "commit-a"), saved)
+  }
+
+  private fun createViewModel(
+    cs: CoroutineScope,
+    saved: MutableMap<String, String>,
+    cumulative: Boolean = true,
+    firstCommitPath: String = "x.txt",
+    lastCommitPath: String = "y.txt",
+  ): GitLabMergeRequestDiffReviewViewModelImpl {
+    val viewedState = mockk<GitLabPersistentMergeRequestChangesViewedState>()
+    every { viewedState.markViewed(any(), any(), any(), any(), any(), true) } answers {
+      arg<Iterable<Pair<FilePath, String>>>(4).forEach { (path, sha) -> saved[path.path] = sha }
+    }
+    val project = mockk<Project>()
+    every { project.getService(GitLabPersistentMergeRequestChangesViewedState::class.java) } returns viewedState
+    val mergeRequest = mockk<GitLabMergeRequest>(relaxed = true)
+    every { mergeRequest.gitRemote.repository.root.path } returns "/repo"
+    every { mergeRequest.gitRemote.repository.root.url } returns "file:///repo"
+    every { mergeRequest.details.value.diffRefs?.headSha } returns "commit-b"
+    every { mergeRequest.discussions } returns emptyFlow()
+    every { mergeRequest.draftNotes } returns emptyFlow()
+    val path = mockk<FilePath>()
+    every { path.path } returns "/repo/x.txt"
+    every { path.ioFile } returns File("/repo/x.txt")
+    val change = RefComparisonChange(mockk(), path, mockk(), path)
+    val parsedChanges = mockk<GitBranchComparisonResult>()
+    every { parsedChanges.commits } returns listOf(
+      commit("commit-a", firstCommitPath),
+      commit("commit-b", lastCommitPath),
+    )
+    val diffVm = mockk<GitLabMergeRequestDiffViewModel>()
+    every { diffVm.discussions } returns MutableStateFlow(ComputedResult.loading())
+    every { diffVm.draftDiscussions } returns MutableStateFlow(ComputedResult.loading())
+    every { diffVm.newDiscussions } returns MutableStateFlow(emptyList())
+    val discussions = mockk<GitLabMergeRequestDiscussionsViewModels>()
+    every { discussions.newDiscussions } returns MutableStateFlow(emptyList())
+    return GitLabMergeRequestDiffReviewViewModelImpl(
+      project, cs, mergeRequest, GitTextFilePatchWithHistory(TextFilePatch(StandardCharsets.UTF_8), cumulative, mockk()),
+      change, parsedChanges, diffVm, discussions, MutableStateFlow(DiscussionsViewOption.ALL), mockk(), mockk(),
+    )
+  }
+
+  private fun commit(sha: String, path: String): GitCommitShaWithPatches =
+    GitCommitShaWithPatches(sha, emptyList(), listOf(TextFilePatch(StandardCharsets.UTF_8).apply {
+      beforeName = path
+      afterName = path
+    }))
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IJPL-255020

With automatic marking enabled, opening a file can reset its viewed state when a later MR commit changes another file.

Automatic marking stores the MR head SHA. Manual marking and the state reader use the last commit that changed the file. These values differ for files unchanged in the latest commit.

Pass the parsed comparison to the diff review model and use the existing per-file commit lookup. This uses the snapshot for the displayed diff and adds no fetch. Leave the state unchanged when history is missing. Skip marking for a non-cumulative diff, which does not represent the full file changes.

The regression tests cover manual state preservation, automatic marking, later file changes, missing history, and non-cumulative diffs.

Validation:
- Five focused JUnit tests pass with the current source compiled against the installed CLion SDK. One unchanged upstream dependency was also compiled.
- Restoring the old method body in the release-based patch causes four failures; the unaffected test passes.
- The release-based plugin loads in CLion 2026.2.1. The reporter confirmed that automatic marking works during MR navigation.
- `git diff --check` passes.
- The repository test runner was attempted but stopped because the sparse checkout lacks global project dependencies. A complete repository build remains unverified.

Repository test command:
```text
./tests.cmd --module intellij.vcs.gitlab.tests --test org.jetbrains.plugins.gitlab.mergerequest.ui.diff.GitLabMergeRequestViewedRevisionTest
```