### PR TITLE
[JEWEL-1436] Avoid JNA wrapper in standalone runtime

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -20677,6 +20677,16 @@ jvm_import(
     visibility = ["//visibility:public"],
 )
 
+java_library(
+    name = "platform-jewel-int_ui-standalone-jna",
+    visibility = ["//visibility:public"],
+    exports = [
+        # do not sort,
+        ":net_java_dev_jna-jna-platform-5_19_1_http_import",
+        ":net_java_dev_jna-jna-5_19_1_http_import",
+    ],
+)
+
 copy_file(
     name = "org.commonmark/commonmark-0.24.0.jar_copy",
     src = "@org_commonmark-commonmark-0_24_0_http//file",

--- a/platform/jewel/int-ui/int-ui-standalone/BUILD.bazel
+++ b/platform/jewel/int-ui/int-ui-standalone/BUILD.bazel
@@ -33,6 +33,7 @@ jvm_library(
         ["src/main/resources/**/*"],
     ),
     visibility = ["//visibility:public"],
+    exports = ["@lib//:platform-jewel-int_ui-standalone-jna"],
     deps = [
         # do not sort,
         "@lib//:kotlin-stdlib",
@@ -44,7 +45,7 @@ jvm_library(
         "//libraries/compose-runtime-desktop",
         "//platform/jewel/foundation",
         "//libraries/jbr",
-        "//libraries/jna",
+        "@lib//:platform-jewel-int_ui-standalone-jna",
         "//platform/icons-api",
         "//platform/icons-impl",
     ],
@@ -60,6 +61,7 @@ jvm_library(
     kotlinc_opts = ":custom_jewel-intUi-standalone",
     module_name = "intellij.platform.jewel.intUi.standalone",
     visibility = ["//visibility:public"],
+    exports = ["@lib//:platform-jewel-int_ui-standalone-jna"],
     runtime_deps = [
         # do not sort,
         ":jewel-intUi-standalone",
@@ -71,7 +73,6 @@ jvm_library(
         "//libraries/compose-runtime-desktop:compose-runtime-desktop_test_lib",
         "//platform/jewel/foundation:foundation_test_lib",
         "//libraries/jbr:jbr_test_lib",
-        "//libraries/jna:jna_test_lib",
         "//platform/icons-api:icons-api_test_lib",
         "//platform/icons-impl:icons-impl_test_lib",
     ],

--- a/platform/jewel/int-ui/int-ui-standalone/intellij.platform.jewel.intUi.standalone.iml
+++ b/platform/jewel/int-ui/int-ui-standalone/intellij.platform.jewel.intUi.standalone.iml
@@ -43,7 +43,35 @@
     <orderEntry type="module" module-name="intellij.libraries.compose.runtime.desktop" />
     <orderEntry type="module" module-name="intellij.platform.jewel.foundation" />
     <orderEntry type="module" module-name="intellij.libraries.jbr" />
-    <orderEntry type="module" module-name="intellij.libraries.jna" />
+    <orderEntry type="module-library" exported="">
+      <library name="jna" type="repository">
+        <properties maven-id="net.java.dev.jna:jna-platform:5.19.1">
+          <verification>
+            <artifact url="file://$MAVEN_REPOSITORY$/net/java/dev/jna/jna-platform/5.19.1/jna-platform-5.19.1.jar">
+              <sha256sum>3b3864f5b449e9c3c24b16861524b622b086563f44e0cd8384c8efc5a6052f82</sha256sum>
+            </artifact>
+            <artifact url="file://$MAVEN_REPOSITORY$/net/java/dev/jna/jna/5.19.1/jna-5.19.1.jar">
+              <sha256sum>4fb141dd8ef6b0585ffceea4bc49602fbc6312fa977e2c488794ea3e6aafecae</sha256sum>
+            </artifact>
+          </verification>
+        </properties>
+        <ANNOTATIONS>
+          <root url="file://$MODULE_DIR$/../../../../lib/annotations/jna" />
+        </ANNOTATIONS>
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/net/java/dev/jna/jna-platform/5.19.1/jna-platform-5.19.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/net/java/dev/jna/jna/5.19.1/jna-5.19.1.jar!/" />
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://$MAVEN_REPOSITORY$/net/java/dev/jna/jna-platform/5.19.1/jna-platform-5.19.1-javadoc.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/net/java/dev/jna/jna/5.19.1/jna-5.19.1-javadoc.jar!/" />
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://$MAVEN_REPOSITORY$/net/java/dev/jna/jna-platform/5.19.1/jna-platform-5.19.1-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/net/java/dev/jna/jna/5.19.1/jna-5.19.1-sources.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
     <orderEntry type="module" module-name="intellij.platform.icons.api" />
     <orderEntry type="module" module-name="intellij.platform.icons.impl" />
   </component>

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/resources/intellij.platform.jewel.intUi.standalone.xml
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/resources/intellij.platform.jewel.intUi.standalone.xml
@@ -2,7 +2,6 @@
   <!-- region Generated dependencies - run `Generate Product Layouts` to regenerate -->
   <dependencies>
     <module name="intellij.libraries.jetbrains.annotations"/>
-    <module name="intellij.libraries.jna"/>
     <module name="intellij.libraries.kotlinx.coroutines.core"/>
     <module name="intellij.platform.jewel.foundation"/>
     <module name="intellij.platform.jewel.ui"/>


### PR DESCRIPTION
The standalone runtime depended on `intellij.libraries.jna`, which contributes `com.intellij.jna.JnaLoader`. The Linux standalone smoke test rejects that IntelliJ Platform class.

## Changes

* Use the upstream JNA library directly in the standalone module.
* Regenerate the Bazel and product descriptor dependencies.

## Validation

* Linux Spectre target
* Product DSL tests (505 tests)
* Bazel formatting check

## Release notes

### Bug fixes

* Prevent IntelliJ Platform JNA classes from leaking into the standalone runtime.
