### PR TITLE
IJPL-254836 GitHub: back off on GraphQL rate limit and cap request concurrency

### DIFF
--- a/plugins/github/github-core/resources/graphql/fragment/rates.graphql
+++ b/plugins/github/github-core/resources/graphql/fragment/rates.graphql
@@ -1,3 +1,5 @@
 fragment rates on RateLimit {
   cost
+  remaining
+  resetAt
 }

--- a/plugins/github/github-core/resources/messages/GithubBundle.properties
+++ b/plugins/github/github-core/resources/messages/GithubBundle.properties
@@ -378,6 +378,7 @@ pull.request.details.adjusting.assignees=Adjusting assignees\u2026
 pull.request.details.adjusting.labels=Adjusting labels\u2026
 
 request.response.0=Request response: {0}.
+request.rate.limit.exceeded.resets.at=GitHub API rate limit exceeded, resets at {0}
 group.Github.PullRequest.Diff.Thread.View.Options.text=Show Review Threads
 
 github.actions.file.promo.label = GitHub Actions

--- a/plugins/github/github-core/src/org/jetbrains/plugins/github/api/GithubApiRequestExecutor.kt
+++ b/plugins/github/github-core/src/org/jetbrains/plugins/github/api/GithubApiRequestExecutor.kt
@@ -39,6 +39,14 @@ import java.io.InputStreamReader
 import java.io.Reader
 import java.net.HttpURLConnection
 import java.net.URL
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPInputStream
 
 /**
@@ -101,46 +109,76 @@ sealed class GithubApiRequestExecutor {
     }
   }
 
-  abstract class Base(private val githubSettings: GithubSettings) : GithubApiRequestExecutor() {
-    protected fun <T> RequestBuilder.execute(request: GithubApiRequest<T>, indicator: ProgressIndicator): T {
+  abstract class Base(
+    private val githubSettings: GithubSettings,
+    clock: Clock = Clock.systemUTC(),
+  ) : GithubApiRequestExecutor() {
+
+    @VisibleForTesting
+    internal val rateLimitState = RateLimitState(clock)
+
+    private val graphQLGate = Semaphore(MAX_CONCURRENT_GRAPHQL_REQUESTS)
+
+    protected fun <T> RequestBuilder.execute(request: GithubApiRequest<T>, indicator: ProgressIndicator): T =
+      executeRequest(request, indicator) { processor -> connect(processor) }
+
+    @VisibleForTesting
+    internal fun <T> executeRequest(
+      request: GithubApiRequest<T>,
+      indicator: ProgressIndicator,
+      connect: (HttpRequests.RequestProcessor<T>) -> T,
+    ): T {
       indicator.checkCanceled()
+      val resource = RateLimitState.resourceOf(request)
+      // no point in sending a request before the reset instant, the budget is per user
+      rateLimitState.checkNotExhausted(resource)
+
       try {
         LOG.debug("Request: ${request.url} ${request.operationName} : Connecting")
         val activity = GHPRStatisticsCollector.logApiRequestStart(request.operation)
-        return connect {
-          val connection = it.connection as HttpURLConnection
-          if (request is GithubApiRequest.WithBody) {
-            LOG.debug("Request: ${connection.requestMethod} ${connection.url} with body:\n${request.body} : Connected")
-            request.body?.let { body -> it.write(body) }
+        return withGraphQLGate(request, indicator) {
+          connect {
+            val connection = it.connection as HttpURLConnection
+            if (request is GithubApiRequest.WithBody) {
+              LOG.debug("Request: ${connection.requestMethod} ${connection.url} with body:\n${request.body} : Connected")
+              request.body?.let { body -> it.write(body) }
+            }
+            else {
+              LOG.debug("Request: ${connection.requestMethod} ${connection.url} : Connected")
+            }
+
+            GHPRStatisticsCollector.logApiResponseReceived(
+              activity = activity,
+              remaining = connection.getHeaderFieldInt(HEADER_RATE_LIMIT_REMAINING, -1),
+              resourceName = connection.getHeaderField(HEADER_RATE_LIMIT_RESOURCE) ?: "unknown",
+              statusCode = connection.responseCode,
+            )
+
+            updateRateLimitState(connection, resource)
+            checkResponseCode(connection, resource)
+            checkServerVersion(connection)
+
+            indicator.checkCanceled()
+
+            val (result, rates) = if (request is GithubApiRequest.Post.GQLQuery) {
+              request.extractResultWithCost(createResponse(it, indicator))
+            }
+            else {
+              request.extractResult(createResponse(it, indicator)) to null
+            }
+            val cost = rates?.cost
+
+            GHPRStatisticsCollector.logApiResponseRates(request.operation, cost ?: 1, isGuessed = cost == null)
+
+            // REST /rate_limit does not reflect the GraphQL budget, only this block does
+            val remaining = rates?.remaining
+            if (remaining != null) {
+              rateLimitState.update(RateLimitState.RESOURCE_GRAPHQL, remaining, rates.resetAt?.toInstant())
+            }
+
+            LOG.debug("Request: ${connection.requestMethod} ${connection.url} : Result extracted")
+            result
           }
-          else {
-            LOG.debug("Request: ${connection.requestMethod} ${connection.url} : Connected")
-          }
-
-          GHPRStatisticsCollector.logApiResponseReceived(
-            activity = activity,
-            remaining = connection.getHeaderFieldInt("x-ratelimit-remaining", -1),
-            resourceName = connection.getHeaderField("x-ratelimit-resource") ?: "unknown",
-            statusCode = connection.responseCode,
-          )
-
-          checkResponseCode(connection)
-          checkServerVersion(connection)
-
-          indicator.checkCanceled()
-
-          val (result, rates) = if (request is GithubApiRequest.Post.GQLQuery) {
-            request.extractResultWithCost(createResponse(it, indicator))
-          }
-          else {
-            request.extractResult(createResponse(it, indicator)) to null
-          }
-          val cost = rates?.cost
-
-          GHPRStatisticsCollector.logApiResponseRates(request.operation, cost ?: 1, isGuessed = cost == null)
-
-          LOG.debug("Request: ${connection.requestMethod} ${connection.url} : Result extracted")
-          result
         }
       }
       catch (e: GithubStatusCodeException) {
@@ -155,6 +193,34 @@ sealed class GithubApiRequestExecutor {
         }
         throw e
       }
+    }
+
+    private fun <T> withGraphQLGate(request: GithubApiRequest<*>, indicator: ProgressIndicator, body: () -> T): T {
+      if (request !is GithubApiRequest.Post.GQLQuery) return body()
+      while (!graphQLGate.tryAcquire(GATE_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS)) {
+        indicator.checkCanceled()
+      }
+      try {
+        return body()
+      }
+      finally {
+        graphQLGate.release()
+      }
+    }
+
+    private fun updateRateLimitState(connection: HttpURLConnection, requestResource: String) {
+      val remaining = connection.getHeaderFieldInt(HEADER_RATE_LIMIT_REMAINING, -1)
+      if (remaining < 0) return
+      val resource = connection.getHeaderField(HEADER_RATE_LIMIT_RESOURCE) ?: requestResource
+      rateLimitState.update(resource, remaining, getResetInstant(connection))
+    }
+
+    private fun getResetInstant(connection: HttpURLConnection): Instant? {
+      val resetEpochSeconds = connection.getHeaderFieldLong(HEADER_RATE_LIMIT_RESET, -1)
+      if (resetEpochSeconds > 0) return Instant.ofEpochSecond(resetEpochSeconds)
+      val retryAfterSeconds = connection.getHeaderFieldLong(HEADER_RETRY_AFTER, -1)
+      if (retryAfterSeconds > 0) return rateLimitState.now().plusSeconds(retryAfterSeconds)
+      return null
     }
 
     protected fun createRequestBuilder(request: GithubApiRequest<*>): RequestBuilder {
@@ -178,7 +244,7 @@ sealed class GithubApiRequestExecutor {
     }
 
     @Throws(IOException::class)
-    private fun checkResponseCode(connection: HttpURLConnection) {
+    private fun checkResponseCode(connection: HttpURLConnection, requestResource: String) {
       if (connection.responseCode < 400) return
       val statusLine = "${connection.responseCode} ${connection.responseMessage}"
       val errorText = getErrorText(connection)
@@ -193,7 +259,9 @@ sealed class GithubApiRequestExecutor {
         HttpURLConnection.HTTP_FORBIDDEN,
           -> {
           if (jsonError?.containsReasonMessage("API rate limit exceeded") == true) {
-            GithubRateLimitExceededException(jsonError.presentableError)
+            val resource = connection.getHeaderField(HEADER_RATE_LIMIT_RESOURCE) ?: requestResource
+            val resetAt = rateLimitState.markExhausted(resource, getResetInstant(connection))
+            GithubRateLimitExceededException(jsonError.presentableError, resetAt)
           }
           else GithubAuthenticationException(
             GithubBundle.message("request.response.0", jsonError?.presentableError ?: errorText ?: statusLine))
@@ -247,6 +315,71 @@ sealed class GithubApiRequestExecutor {
           converter.convert(it)
         }
       }
+    }
+
+    companion object {
+      @VisibleForTesting
+      internal const val MAX_CONCURRENT_GRAPHQL_REQUESTS = 8
+      private const val GATE_POLL_INTERVAL_MS = 100L
+
+      private const val HEADER_RATE_LIMIT_REMAINING = "x-ratelimit-remaining"
+      private const val HEADER_RATE_LIMIT_RESOURCE = "x-ratelimit-resource"
+      private const val HEADER_RATE_LIMIT_RESET = "x-ratelimit-reset"
+      private const val HEADER_RETRY_AFTER = "Retry-After"
+    }
+  }
+
+  @VisibleForTesting
+  internal class RateLimitState(private val clock: Clock) {
+    private val exhaustedUntil = ConcurrentHashMap<String, Instant>()
+
+    fun now(): Instant = clock.instant()
+
+    fun exhaustedUntil(resource: String): Instant? {
+      val until = exhaustedUntil[resource] ?: return null
+      if (!until.isAfter(now())) {
+        exhaustedUntil.remove(resource, until)
+        return null
+      }
+      return until
+    }
+
+    @Throws(GithubRateLimitExceededException::class)
+    fun checkNotExhausted(resource: String) {
+      val until = exhaustedUntil(resource) ?: return
+      val message = GithubBundle.message("request.rate.limit.exceeded.resets.at", RESET_TIME_FORMAT.format(until))
+      throw GithubRateLimitExceededException(message, until)
+    }
+
+    fun update(resource: String, remaining: Int, resetAt: Instant?) {
+      if (remaining > 0) {
+        exhaustedUntil.remove(resource)
+      }
+      else {
+        markExhausted(resource, resetAt)
+      }
+    }
+
+    fun markExhausted(resource: String, resetAt: Instant?): Instant {
+      val now = now()
+      val until = resetAt?.takeIf { it.isAfter(now) }
+                  ?: exhaustedUntil[resource]?.takeIf { it.isAfter(now) }
+                  ?: now.plus(DEFAULT_COOLDOWN)
+      exhaustedUntil[resource] = until
+      return until
+    }
+
+    companion object {
+      const val RESOURCE_GRAPHQL = "graphql"
+      const val RESOURCE_CORE = "core"
+
+      @VisibleForTesting
+      internal val DEFAULT_COOLDOWN: Duration = Duration.ofMinutes(1)
+
+      private val RESET_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
+
+      fun resourceOf(request: GithubApiRequest<*>): String =
+        if (request is GithubApiRequest.Post.GQLQuery) RESOURCE_GRAPHQL else RESOURCE_CORE
     }
   }
 

--- a/plugins/github/github-core/src/org/jetbrains/plugins/github/api/data/graphql/GHGQLRateLimit.kt
+++ b/plugins/github/github-core/src/org/jetbrains/plugins/github/api/data/graphql/GHGQLRateLimit.kt
@@ -2,6 +2,11 @@
 package org.jetbrains.plugins.github.api.data.graphql
 
 import com.intellij.collaboration.api.dto.GraphQLFragment
+import java.util.Date
 
 @GraphQLFragment("/graphql/fragment/rates.graphql")
-data class GHGQLRateLimit(val cost: Int)
+data class GHGQLRateLimit(
+  val cost: Int,
+  val remaining: Int? = null,
+  val resetAt: Date? = null,
+)

--- a/plugins/github/github-core/src/org/jetbrains/plugins/github/exceptions/GithubRateLimitExceededException.java
+++ b/plugins/github/github-core/src/org/jetbrains/plugins/github/exceptions/GithubRateLimitExceededException.java
@@ -15,13 +15,27 @@
  */
 package org.jetbrains.plugins.github.exceptions;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.IOException;
+import java.time.Instant;
 
 /**
  * @author Aleksey Pivovarov
  */
 public class GithubRateLimitExceededException extends IOException {
+  private final @Nullable Instant myResetAt;
+
   public GithubRateLimitExceededException(String message) {
+    this(message, null);
+  }
+
+  public GithubRateLimitExceededException(String message, @Nullable Instant resetAt) {
     super(message);
+    myResetAt = resetAt;
+  }
+
+  public @Nullable Instant getResetAt() {
+    return myResetAt;
   }
 }

--- a/plugins/github/github-core/test/org/jetbrains/plugins/github/api/GithubApiRequestExecutorRateLimitTest.kt
+++ b/plugins/github/github-core/test/org/jetbrains/plugins/github/api/GithubApiRequestExecutorRateLimitTest.kt
@@ -1,0 +1,298 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.plugins.github.api
+
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.util.io.HttpRequests
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.plugins.github.api.GithubApiRequest.Post.GQLQuery
+import org.jetbrains.plugins.github.exceptions.GithubRateLimitExceededException
+import org.jetbrains.plugins.github.util.GithubSettings
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLConnection
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * IJPL-254836: the executor must back off locally once the GitHub API rate limit is exhausted and must cap
+ * the number of concurrent GraphQL requests, so that a burst (e.g. the pull request view fan-out) can neither
+ * overshoot the budget nor be re-fired on every retry.
+ *
+ * No network is involved: the executor is wired to a fake connection and the number of "network" calls is counted.
+ */
+@TestApplication
+internal class GithubApiRequestExecutorRateLimitTest {
+
+  private val clock = MutableClock(Instant.parse("2026-09-10T10:00:00Z"))
+  private val server = GithubServerPath.DEFAULT_SERVER
+
+  private val resetAt: Instant = clock.instant().plus(Duration.ofHours(1))
+
+  private fun gqlRequest(): GithubApiRequest<Any> =
+    GQLQuery.Parsed(server.toGraphQLUrl(), GHGQLQueries.findPullRequestId,
+                    mapOf("repoOwner" to "owner", "repoName" to "repo", "number" to 1), Any::class.java)
+
+  private fun restRequest(): GithubApiRequest<String> =
+    object : GithubApiRequest.Get<String>(server.toApiUrl() + "/user") {
+      override fun extractResult(response: GithubApiResponse): String = response.readBody { it.readText() }
+    }
+
+  private fun rateLimitedResponse(resource: String, headers: Map<String, String> = rateLimitHeaders(resource, remaining = 0)) =
+    FakeResponse(HttpURLConnection.HTTP_FORBIDDEN, headers, RATE_LIMIT_ERROR_BODY)
+
+  private fun rateLimitHeaders(resource: String, remaining: Int): Map<String, String> =
+    mapOf("x-ratelimit-remaining" to remaining.toString(),
+          "x-ratelimit-reset" to resetAt.epochSecond.toString(),
+          "x-ratelimit-resource" to resource)
+
+  private fun gqlResponse(remaining: Int, headers: Map<String, String> = emptyMap()) =
+    FakeResponse(HttpURLConnection.HTTP_OK, headers, """
+      {"data": {"repository": {"pullRequest": {"id": "PR_1", "number": 1}},
+                "rateLimit": {"cost": 1, "remaining": $remaining, "resetAt": "$resetAt"}}}
+      """.trimIndent())
+
+  @Test
+  fun `rate limited response stops all further requests until reset without touching the network`() {
+    val executor = FakeExecutor(clock) { rateLimitedResponse("graphql") }
+
+    assertThatThrownBy { executor.execute(gqlRequest()) }
+      .isInstanceOf(GithubRateLimitExceededException::class.java)
+      .extracting { (it as GithubRateLimitExceededException).resetAt }.isEqualTo(resetAt)
+
+    repeat(20) {
+      assertThatThrownBy { executor.execute(gqlRequest()) }
+        .isInstanceOf(GithubRateLimitExceededException::class.java)
+        .hasMessageContaining("rate limit")
+        .extracting { (it as GithubRateLimitExceededException).resetAt }.isEqualTo(resetAt)
+    }
+
+    assertThat(executor.networkCalls.get()).describedAs("network calls").isEqualTo(1)
+  }
+
+  @Test
+  fun `requests resume after the reset instant`() {
+    var rateLimited = true
+    val executor = FakeExecutor(clock) { if (rateLimited) rateLimitedResponse("graphql") else gqlResponse(remaining = 4999) }
+
+    assertThatThrownBy { executor.execute(gqlRequest()) }.isInstanceOf(GithubRateLimitExceededException::class.java)
+    assertThatThrownBy { executor.execute(gqlRequest()) }.isInstanceOf(GithubRateLimitExceededException::class.java)
+    assertThat(executor.networkCalls.get()).isEqualTo(1)
+
+    rateLimited = false
+    clock.advance(Duration.ofHours(1).plusSeconds(1))
+
+    executor.execute(gqlRequest())
+    assertThat(executor.networkCalls.get()).isEqualTo(2)
+  }
+
+  @Test
+  fun `successful GraphQL response reporting an exhausted budget puts the executor into back-off`() {
+    val executor = FakeExecutor(clock) { gqlResponse(remaining = 0) }
+
+    executor.execute(gqlRequest())
+
+    assertThatThrownBy { executor.execute(gqlRequest()) }
+      .isInstanceOf(GithubRateLimitExceededException::class.java)
+      .extracting { (it as GithubRateLimitExceededException).resetAt }.isEqualTo(resetAt)
+    assertThat(executor.networkCalls.get()).isEqualTo(1)
+  }
+
+  @Test
+  fun `REST headers reporting an exhausted budget put the executor into back-off for that resource only`() {
+    val executor = FakeExecutor(clock) { request ->
+      if (request is GQLQuery) gqlResponse(remaining = 4999)
+      else FakeResponse(HttpURLConnection.HTTP_OK, rateLimitHeaders("core", remaining = 0), """{"login": "user"}""")
+    }
+
+    executor.execute(restRequest())
+    assertThatThrownBy { executor.execute(restRequest()) }.isInstanceOf(GithubRateLimitExceededException::class.java)
+    assertThat(executor.networkCalls.get()).isEqualTo(1)
+
+    // the GraphQL budget is separate and still available
+    executor.execute(gqlRequest())
+    assertThat(executor.networkCalls.get()).isEqualTo(2)
+  }
+
+  @Test
+  fun `rate limited response without reset headers backs off for the default cooldown`() {
+    val executor = FakeExecutor(clock) { rateLimitedResponse("core", headers = emptyMap()) }
+    val expectedResetAt = clock.instant().plus(GithubApiRequestExecutor.RateLimitState.DEFAULT_COOLDOWN)
+
+    assertThatThrownBy { executor.execute(restRequest()) }
+      .isInstanceOf(GithubRateLimitExceededException::class.java)
+      .extracting { (it as GithubRateLimitExceededException).resetAt }.isEqualTo(expectedResetAt)
+    assertThatThrownBy { executor.execute(restRequest()) }.isInstanceOf(GithubRateLimitExceededException::class.java)
+    assertThat(executor.networkCalls.get()).isEqualTo(1)
+
+    clock.advance(GithubApiRequestExecutor.RateLimitState.DEFAULT_COOLDOWN.plusSeconds(1))
+    assertThatThrownBy { executor.execute(restRequest()) }.isInstanceOf(GithubRateLimitExceededException::class.java)
+    assertThat(executor.networkCalls.get()).describedAs("request is re-sent after the cooldown").isEqualTo(2)
+  }
+
+  @Test
+  fun `Retry-After header is used when the reset header is absent`() {
+    val retryAfterSeconds = 120L
+    val executor = FakeExecutor(clock) {
+      rateLimitedResponse("core", headers = mapOf("Retry-After" to retryAfterSeconds.toString()))
+    }
+    val expectedResetAt = clock.instant().plusSeconds(retryAfterSeconds)
+
+    assertThatThrownBy { executor.execute(restRequest()) }
+      .isInstanceOf(GithubRateLimitExceededException::class.java)
+      .extracting { (it as GithubRateLimitExceededException).resetAt }.isEqualTo(expectedResetAt)
+    assertThatThrownBy { executor.execute(restRequest()) }.isInstanceOf(GithubRateLimitExceededException::class.java)
+    assertThat(executor.networkCalls.get()).isEqualTo(1)
+
+    clock.advance(Duration.ofSeconds(retryAfterSeconds + 1))
+    assertThatThrownBy { executor.execute(restRequest()) }.isInstanceOf(GithubRateLimitExceededException::class.java)
+    assertThat(executor.networkCalls.get()).isEqualTo(2)
+  }
+
+  @Test
+  fun `known reset instant is kept when no reset headers are available`() {
+    val executor = FakeExecutor(clock) { rateLimitedResponse("core") }
+
+    assertThatThrownBy { executor.execute(restRequest()) }
+      .extracting { (it as GithubRateLimitExceededException).resetAt }.isEqualTo(resetAt)
+
+    clock.advance(Duration.ofMinutes(30))
+    val state = executor.rateLimitState
+    assertThat(state.markExhausted(GithubApiRequestExecutor.RateLimitState.RESOURCE_CORE, null)).isEqualTo(resetAt)
+    assertThatThrownBy { executor.execute(restRequest()) }
+      .extracting { (it as GithubRateLimitExceededException).resetAt }.isEqualTo(resetAt)
+    assertThat(executor.networkCalls.get()).isEqualTo(1)
+  }
+
+  @Test
+  fun `missing rate limit information never blocks requests`() {
+    val executor = FakeExecutor(clock) { FakeResponse(HttpURLConnection.HTTP_OK, emptyMap(), """{"login": "user"}""") }
+
+    repeat(5) { executor.execute(restRequest()) }
+
+    assertThat(executor.networkCalls.get()).isEqualTo(5)
+  }
+
+  @Test
+  @Timeout(30)
+  fun `concurrent GraphQL requests are capped`() {
+    val requests = 50
+    val inFlight = AtomicInteger()
+    val maxInFlight = AtomicInteger()
+    val executor = FakeExecutor(clock) {
+      val current = inFlight.incrementAndGet()
+      maxInFlight.accumulateAndGet(current, Math::max)
+      Thread.sleep(50)
+      inFlight.decrementAndGet()
+      gqlResponse(remaining = 4999)
+    }
+
+    val pool = Executors.newFixedThreadPool(requests)
+    try {
+      val start = CountDownLatch(1)
+      val futures = (1..requests).map {
+        pool.submit(Callable {
+          start.await()
+          executor.execute(gqlRequest())
+        })
+      }
+      start.countDown()
+      futures.forEach { it.get(20, TimeUnit.SECONDS) }
+    }
+    finally {
+      pool.shutdownNow()
+    }
+
+    assertThat(executor.networkCalls.get()).isEqualTo(requests)
+    assertThat(maxInFlight.get())
+      .describedAs("max in-flight GraphQL requests")
+      .isGreaterThan(1)
+      .isLessThanOrEqualTo(GithubApiRequestExecutor.Base.MAX_CONCURRENT_GRAPHQL_REQUESTS)
+  }
+
+  private class FakeResponse(val code: Int, val headers: Map<String, String>, val body: String)
+
+  /**
+   * An executor whose network layer is replaced by [responder]; every call to it is counted in [networkCalls].
+   */
+  private class FakeExecutor(
+    clock: Clock,
+    private val responder: (GithubApiRequest<*>) -> FakeResponse,
+  ) : GithubApiRequestExecutor.Base(GithubSettings(), clock) {
+    val networkCalls = AtomicInteger()
+
+    override fun <T> execute(indicator: ProgressIndicator, request: GithubApiRequest<T>): T =
+      executeRequest(request, indicator) { processor ->
+        networkCalls.incrementAndGet()
+        processor.process(FakeRequest(request, responder(request)))
+      }
+  }
+
+  private class FakeRequest(request: GithubApiRequest<*>, response: FakeResponse) : HttpRequests.Request {
+    private val url = URL(request.url)
+    private val connection = FakeConnection(url, if (request is GithubApiRequest.WithBody) "POST" else "GET", response)
+
+    override fun getURL(): String = url.toString()
+    override fun getConnection(): URLConnection = connection
+    override fun getInputStream(): InputStream = connection.inputStream
+    override fun getReader(): BufferedReader = BufferedReader(InputStreamReader(inputStream, Charsets.UTF_8))
+    override fun getReader(indicator: ProgressIndicator?): BufferedReader = reader
+    override fun saveToFile(file: Path, indicator: ProgressIndicator?): Path = throw UnsupportedOperationException()
+    override fun saveToFile(file: Path, indicator: ProgressIndicator?, progressDescription: Boolean): Path =
+      throw UnsupportedOperationException()
+    override fun readBytes(indicator: ProgressIndicator?): ByteArray = inputStream.readAllBytes()
+    override fun readString(indicator: ProgressIndicator?): String = readBytes(indicator).toString(Charsets.UTF_8)
+    override fun readChars(indicator: ProgressIndicator?): CharSequence = readString(indicator)
+    override fun readError(): String? = connection.errorStream?.readAllBytes()?.toString(Charsets.UTF_8)
+    override fun write(data: ByteArray) = Unit
+  }
+
+  private class FakeConnection(url: URL, private val requestMethod: String, private val response: FakeResponse) : HttpURLConnection(url) {
+    private val headers = response.headers.mapKeys { it.key.lowercase() } + ("content-type" to GithubApiContentHelper.JSON_MIME_TYPE)
+
+    override fun connect() = Unit
+    override fun disconnect() = Unit
+    override fun usingProxy(): Boolean = false
+    override fun getRequestMethod(): String = requestMethod
+    override fun getResponseCode(): Int = response.code
+    override fun getResponseMessage(): String = if (response.code >= 400) "Error" else "OK"
+    override fun getHeaderField(name: String?): String? = name?.let { headers[it.lowercase()] }
+    override fun getInputStream(): InputStream =
+      if (response.code < 400) ByteArrayInputStream(response.body.toByteArray()) else throw IOException("HTTP ${response.code}")
+    override fun getErrorStream(): InputStream? =
+      if (response.code >= 400) ByteArrayInputStream(response.body.toByteArray()) else null
+  }
+
+  private class MutableClock(@Volatile private var now: Instant) : Clock() {
+    fun advance(duration: Duration) {
+      now = now.plus(duration)
+    }
+
+    override fun instant(): Instant = now
+    override fun getZone(): ZoneId = ZoneOffset.UTC
+    override fun withZone(zone: ZoneId?): Clock = this
+  }
+
+  companion object {
+    private const val RATE_LIMIT_ERROR_BODY =
+      """{"message": "API rate limit exceeded for user ID 1. If you reach out to GitHub Support for help, please include the request ID.",
+          "documentation_url": "https://docs.github.com/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api"}"""
+  }
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IJPL-254836

## Problem

`GithubApiRequestExecutor` read the `x-ratelimit-*` headers and the GraphQL `rateLimit` cost only for statistics. Once the primary GraphQL budget (5000 points per hour, per user) was exhausted, the plugin did not back off: every Retry and every reopened pull request view re-sent the whole GraphQL fan-out, each request failed with 403, and the UI offered "Log in again", which cannot help because a new token shares the same per-user bucket.

## Evidence from the ticket

- One large pull request (150+ commits, 80+ files) open in the tool window consumed about 65 points per minute, so the budget lasted about 75 minutes. Several open projects multiply this.
- GitHub reported `used 5042/5000, remaining 0`: the concurrent fan-out is admitted before the counter catches up, so the burst overshoots the budget.
- At the same moment the REST `/rate_limit` endpoint reported the GraphQL budget as untouched. Only the GraphQL `rateLimit` block is a reliable source for that budget.
- Raising the plugin connection timeout does nothing; GitHub rejects immediately.

## Approach (executor only)

- **Rate-limit state** per executor and per resource (`core`, `search`, `graphql`), fed from three sources: the REST headers, the GraphQL `rateLimit` block (the `rates` fragment now also requests `remaining` and `resetAt`), and a 403 rate-limit response (`x-ratelimit-reset` or `Retry-After`; a one-minute cooldown if neither is present).
- **Back-off**: before opening a connection, a request to an exhausted resource fails locally with `GithubRateLimitExceededException` carrying the reset instant. The message reads "GitHub API rate limit exceeded, resets at HH:mm" and surfaces in the existing UI. This is what stops Retry from re-firing the fan-out.
- **Concurrency gate**: a semaphore of 8 around GraphQL request execution so that a burst cannot overshoot the budget.
- Absent headers (some GitHub Enterprise versions) leave the state unknown and never block. Statistics calls are unchanged.

## Tests

`GithubApiRequestExecutorRateLimitTest` wires the executor to a fake connection and counts calls. No test touches the network.

- A 403 rate-limit response followed by 20 more requests results in exactly one network call; every later request throws the typed exception with the reset instant.
- Requests resume after the fake clock passes the reset instant.
- A successful GraphQL response whose `rateLimit` block reports `remaining: 0` puts the executor into back-off without any 403.
- REST headers reporting exhaustion back off that resource only; the GraphQL budget stays usable.
- A rate-limit response without reset headers backs off for the default cooldown.
- Missing rate-limit headers never block.
- 50 concurrent GraphQL requests never exceed the cap in flight.

Disabling the back-off and the gate makes the relevant tests fail. The whole `vcs-github-tests` target passes (1350 tests), including the GraphQL fragment and DTO schema checks.

## Follow-ups (out of scope)

- Reduce the baseline consumption of the pull request view (about 65 points per minute for a large PR): polling and caching redesign.
- The "Log in again" suggestion on a 403 rate-limit error is misleading and could be hidden when the error is a rate limit.
