### PR TITLE
IJPL-252865 Right-align Copy/Path Reference popup values

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/actions/CopyReferencePopup.java
+++ b/platform/lang-impl/src/com/intellij/ide/actions/CopyReferencePopup.java
@@ -31,6 +31,7 @@ import javax.swing.JPanel;
 import javax.swing.ListCellRenderer;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 
 import static com.intellij.util.ui.UIUtil.DEFAULT_HGAP;
@@ -84,7 +85,7 @@ public class CopyReferencePopup extends NonTrivialActionGroup {
             panel.add(myIconLabel, gbc.next());
             panel.add(myTextLabel, gbc.next());
             panel.add(myShortcutLabel, gbc.next());
-            panel.add(myInfoLabel, gbc.next().weightx(1));
+            panel.add(myInfoLabel, gbc.next().anchor(GridBagConstraints.EAST).weightx(1));
 
             return layoutComponent(panel);
           }


### PR DESCRIPTION
Super simple fix to align the value in the _Copy Path/Reference_ popup with its right edge.

Also keeps the action label and shortcut in their existing columns.

Original issue https://youtrack.jetbrains.com/issue/IJPL-252865/When-copying-paths-things-are-not-aligned

**Before**
<img width="511" height="175" alt="image" src="https://github.com/user-attachments/assets/352cb011-2e2e-4b9e-be68-50102f91d13f" />

**After**
<img width="514" height="189" alt="image" src="https://github.com/user-attachments/assets/d1a985e9-ef45-4f17-9961-35283ea7f961" />
