### PR TITLE
[JEWEL-1025] Add JewelTheme.isIslands

### DIFF
--- a/platform/jewel/foundation/api-dump.txt
+++ b/platform/jewel/foundation/api-dump.txt
@@ -753,6 +753,7 @@ f:org.jetbrains.jewel.foundation.theme.JewelTheme$Companion
 - f:getInstanceUuid(androidx.compose.runtime.Composer,I):java.util.UUID
 - f:getName(androidx.compose.runtime.Composer,I):java.lang.String
 - f:isDark(androidx.compose.runtime.Composer,I):Z
+- f:isIslands(androidx.compose.runtime.Composer,I):Z
 - f:isSwingCompatMode(androidx.compose.runtime.Composer,I):Z
 f:org.jetbrains.jewel.foundation.theme.JewelThemeKt
 - sf:JewelTheme(org.jetbrains.jewel.foundation.theme.ThemeDefinition,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,I):V
@@ -817,6 +818,7 @@ f:org.jetbrains.jewel.foundation.theme.ThemeDefinition
 - f:getName():java.lang.String
 - hashCode():I
 - f:isDark():Z
+- f:isIslands():Z
 org.jetbrains.jewel.foundation.theme.ThemeDescriptor
 - a:getColors():org.jetbrains.jewel.foundation.theme.ThemeColorPalette
 - a:getIconData():org.jetbrains.jewel.foundation.theme.ThemeIconData

--- a/platform/jewel/foundation/metalava/foundation-api-0.42.0.txt
+++ b/platform/jewel/foundation/metalava/foundation-api-0.42.0.txt
@@ -935,6 +935,7 @@ package org.jetbrains.jewel.foundation.theme {
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public java.util.UUID getInstanceUuid();
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public String getName();
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isDark();
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isIslands();
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isSwingCompatMode();
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property public androidx.compose.ui.graphics.Color contentColor;
@@ -944,6 +945,7 @@ package org.jetbrains.jewel.foundation.theme {
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public java.util.UUID instanceUuid;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isDark;
+    property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isIslands;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isSwingCompatMode;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public String name;
   }
@@ -1018,7 +1020,7 @@ package org.jetbrains.jewel.foundation.theme {
   }
 
   @androidx.compose.runtime.Immutable @org.jetbrains.jewel.foundation.GenerateDataFunctions public final class ThemeDefinition {
-    ctor @KotlinOnly public ThemeDefinition(String name, boolean isDark, org.jetbrains.jewel.foundation.GlobalColors globalColors, org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics, androidx.compose.ui.text.TextStyle defaultTextStyle, androidx.compose.ui.text.TextStyle editorTextStyle, androidx.compose.ui.text.TextStyle consoleTextStyle, androidx.compose.ui.graphics.Color contentColor, org.jetbrains.jewel.foundation.theme.ThemeColorPalette colorPalette, org.jetbrains.jewel.foundation.theme.ThemeIconData iconData, org.jetbrains.jewel.foundation.DisabledAppearanceValues disabledAppearanceValues);
+    ctor @KotlinOnly public ThemeDefinition(String name, boolean isDark, org.jetbrains.jewel.foundation.GlobalColors globalColors, org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics, androidx.compose.ui.text.TextStyle defaultTextStyle, androidx.compose.ui.text.TextStyle editorTextStyle, androidx.compose.ui.text.TextStyle consoleTextStyle, androidx.compose.ui.graphics.Color contentColor, org.jetbrains.jewel.foundation.theme.ThemeColorPalette colorPalette, org.jetbrains.jewel.foundation.theme.ThemeIconData iconData, org.jetbrains.jewel.foundation.DisabledAppearanceValues disabledAppearanceValues, boolean isIslands);
     method public org.jetbrains.jewel.foundation.theme.ThemeColorPalette getColorPalette();
     method public androidx.compose.ui.text.TextStyle getConsoleTextStyle();
     method public androidx.compose.ui.text.TextStyle getDefaultTextStyle();
@@ -1029,6 +1031,7 @@ package org.jetbrains.jewel.foundation.theme {
     method public org.jetbrains.jewel.foundation.theme.ThemeIconData getIconData();
     method public String getName();
     method public boolean isDark();
+    method public boolean isIslands();
     property public org.jetbrains.jewel.foundation.theme.ThemeColorPalette colorPalette;
     property public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property public androidx.compose.ui.graphics.Color contentColor;
@@ -1039,6 +1042,7 @@ package org.jetbrains.jewel.foundation.theme {
     property public org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics;
     property public org.jetbrains.jewel.foundation.theme.ThemeIconData iconData;
     property public boolean isDark;
+    property public boolean isIslands;
     property public String name;
   }
 

--- a/platform/jewel/foundation/metalava/foundation-api-stable-0.42.0.txt
+++ b/platform/jewel/foundation/metalava/foundation-api-stable-0.42.0.txt
@@ -903,6 +903,7 @@ package org.jetbrains.jewel.foundation.theme {
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public java.util.UUID getInstanceUuid();
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public String getName();
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isDark();
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isIslands();
     method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isSwingCompatMode();
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property public androidx.compose.ui.graphics.Color contentColor;
@@ -912,6 +913,7 @@ package org.jetbrains.jewel.foundation.theme {
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public java.util.UUID instanceUuid;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isDark;
+    property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isIslands;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public boolean isSwingCompatMode;
     property @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public String name;
   }
@@ -986,7 +988,7 @@ package org.jetbrains.jewel.foundation.theme {
   }
 
   @androidx.compose.runtime.Immutable @org.jetbrains.jewel.foundation.GenerateDataFunctions public final class ThemeDefinition {
-    ctor @KotlinOnly public ThemeDefinition(String name, boolean isDark, org.jetbrains.jewel.foundation.GlobalColors globalColors, org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics, androidx.compose.ui.text.TextStyle defaultTextStyle, androidx.compose.ui.text.TextStyle editorTextStyle, androidx.compose.ui.text.TextStyle consoleTextStyle, androidx.compose.ui.graphics.Color contentColor, org.jetbrains.jewel.foundation.theme.ThemeColorPalette colorPalette, org.jetbrains.jewel.foundation.theme.ThemeIconData iconData, org.jetbrains.jewel.foundation.DisabledAppearanceValues disabledAppearanceValues);
+    ctor @KotlinOnly public ThemeDefinition(String name, boolean isDark, org.jetbrains.jewel.foundation.GlobalColors globalColors, org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics, androidx.compose.ui.text.TextStyle defaultTextStyle, androidx.compose.ui.text.TextStyle editorTextStyle, androidx.compose.ui.text.TextStyle consoleTextStyle, androidx.compose.ui.graphics.Color contentColor, org.jetbrains.jewel.foundation.theme.ThemeColorPalette colorPalette, org.jetbrains.jewel.foundation.theme.ThemeIconData iconData, org.jetbrains.jewel.foundation.DisabledAppearanceValues disabledAppearanceValues, boolean isIslands);
     method public org.jetbrains.jewel.foundation.theme.ThemeColorPalette getColorPalette();
     method public androidx.compose.ui.text.TextStyle getConsoleTextStyle();
     method public androidx.compose.ui.text.TextStyle getDefaultTextStyle();
@@ -997,6 +999,7 @@ package org.jetbrains.jewel.foundation.theme {
     method public org.jetbrains.jewel.foundation.theme.ThemeIconData getIconData();
     method public String getName();
     method public boolean isDark();
+    method public boolean isIslands();
     property public org.jetbrains.jewel.foundation.theme.ThemeColorPalette colorPalette;
     property public androidx.compose.ui.text.TextStyle consoleTextStyle;
     property public androidx.compose.ui.graphics.Color contentColor;
@@ -1007,6 +1010,7 @@ package org.jetbrains.jewel.foundation.theme {
     property public org.jetbrains.jewel.foundation.GlobalMetrics globalMetrics;
     property public org.jetbrains.jewel.foundation.theme.ThemeIconData iconData;
     property public boolean isDark;
+    property public boolean isIslands;
     property public String name;
   }
 

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/JewelTheme.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/JewelTheme.kt
@@ -58,6 +58,10 @@ public interface JewelTheme {
         /** Whether Swing compatibility mode is enabled, which disables hover and press state changes. */
         public val isSwingCompatMode: Boolean
             @Composable @ReadOnlyComposable get() = LocalSwingCompatMode.current
+
+        /** Whether the Islands rendering mode is enabled. Always `false` in standalone. */
+        public val isIslands: Boolean
+            @Composable @ReadOnlyComposable get() = LocalIsIslandsTheme.current
     }
 }
 
@@ -92,6 +96,7 @@ public fun JewelTheme(theme: ThemeDefinition, content: @Composable () -> Unit) {
         LocalGlobalColors provides theme.globalColors,
         LocalGlobalMetrics provides theme.globalMetrics,
         LocalDisabledAppearanceValues provides theme.disabledAppearanceValues,
+        LocalIsIslandsTheme provides theme.isIslands,
         content = content,
     )
 }
@@ -150,6 +155,9 @@ public val LocalEditorTextStyle: ProvidableCompositionLocal<TextStyle> = staticC
 public val LocalConsoleTextStyle: ProvidableCompositionLocal<TextStyle> = staticCompositionLocalOf {
     error("No ConsoleTextStyle provided. Have you forgotten the theme?")
 }
+
+/** Composition local providing whether the Islands rendering mode is enabled. */
+internal val LocalIsIslandsTheme: ProvidableCompositionLocal<Boolean> = staticCompositionLocalOf { false }
 
 /**
  * Overrides the [isDark] value for the [content]. It is used to inject a different dark mode style in a sub-tree.

--- a/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/ThemeDefinition.kt
+++ b/platform/jewel/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/ThemeDefinition.kt
@@ -37,7 +37,55 @@ public class ThemeDefinition(
     public val iconData: ThemeIconData,
     /** The values controlling the appearance of disabled components. */
     public val disabledAppearanceValues: DisabledAppearanceValues,
+    /** Whether the Islands rendering mode is enabled */
+    public val isIslands: Boolean,
 ) {
+    @Deprecated(
+        "Use the constructor that takes an `isIslands` property.",
+        ReplaceWith(
+            "ThemeDefinition(" +
+                "name, " +
+                "isDark, " +
+                "globalColors, " +
+                "globalMetrics, " +
+                "defaultTextStyle, " +
+                "editorTextStyle, " +
+                "consoleTextStyle, " +
+                "contentColor, " +
+                "colorPalette, " +
+                "iconData, " +
+                "disabledAppearanceValues, " +
+                "isIslands" +
+                ")"
+        ),
+    )
+    public constructor(
+        name: String,
+        isDark: Boolean,
+        globalColors: GlobalColors,
+        globalMetrics: GlobalMetrics,
+        defaultTextStyle: TextStyle,
+        editorTextStyle: TextStyle,
+        consoleTextStyle: TextStyle,
+        contentColor: Color,
+        colorPalette: ThemeColorPalette,
+        iconData: ThemeIconData,
+        disabledAppearanceValues: DisabledAppearanceValues,
+    ) : this(
+        name,
+        isDark,
+        globalColors,
+        globalMetrics,
+        defaultTextStyle,
+        editorTextStyle,
+        consoleTextStyle,
+        contentColor,
+        colorPalette,
+        iconData,
+        disabledAppearanceValues,
+        false,
+    )
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -45,6 +93,7 @@ public class ThemeDefinition(
         other as ThemeDefinition
 
         if (isDark != other.isDark) return false
+        if (isIslands != other.isIslands) return false
         if (name != other.name) return false
         if (globalColors != other.globalColors) return false
         if (globalMetrics != other.globalMetrics) return false
@@ -61,6 +110,7 @@ public class ThemeDefinition(
 
     override fun hashCode(): Int {
         var result = isDark.hashCode()
+        result = 31 * result + isIslands.hashCode()
         result = 31 * result + name.hashCode()
         result = 31 * result + globalColors.hashCode()
         result = 31 * result + globalMetrics.hashCode()
@@ -86,7 +136,8 @@ public class ThemeDefinition(
             "contentColor=$contentColor, " +
             "colorPalette=$colorPalette, " +
             "iconData=$iconData, " +
-            "grayFilterValues=$disabledAppearanceValues" +
+            "grayFilterValues=$disabledAppearanceValues, " +
+            "isIslands=$isIslands" +
             ")"
     }
 }

--- a/platform/jewel/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/theme/JewelThemeTest.kt
+++ b/platform/jewel/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/theme/JewelThemeTest.kt
@@ -1,0 +1,19 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.jetbrains.jewel.foundation.theme
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+public class JewelThemeTest {
+    @Test
+    public fun `isIslands defaults to false outside a theme`() {
+        runComposeUiTest {
+            var observed: Boolean? = null
+            setContent { observed = JewelTheme.isIslands }
+            assertEquals(false, observed)
+        }
+    }
+}

--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import com.intellij.ide.ui.laf.darcula.DarculaUIUtil
+import com.intellij.ui.IslandsState
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.DirProvider
 import javax.swing.UIManager
@@ -59,6 +60,7 @@ internal fun createBridgeThemeDefinition(
         colorPalette = ThemeColorPalette.readFromLaF(),
         iconData = ThemeIconData.readFromLaF(),
         disabledAppearanceValues = DisabledAppearanceValues.readFromLaF(),
+        isIslands = IslandsState.isEnabled(),
     )
 }
 

--- a/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
+++ b/platform/jewel/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
@@ -122,6 +122,7 @@ public fun JewelTheme.Companion.lightThemeDefinition(
         palette,
         iconData,
         disabledAppearanceValues,
+        isIslands = false,
     )
 
 /**
@@ -159,6 +160,7 @@ public fun JewelTheme.Companion.lightThemeDefinition(
         palette,
         iconData,
         DisabledAppearanceValues.light(),
+        isIslands = false,
     )
 
 /**
@@ -196,6 +198,7 @@ public fun JewelTheme.Companion.darkThemeDefinition(
         palette,
         iconData,
         DisabledAppearanceValues.dark(),
+        isIslands = false,
     )
 
 /**
@@ -234,6 +237,7 @@ public fun JewelTheme.Companion.darkThemeDefinition(
         palette,
         iconData,
         disabledAppearanceValues,
+        isIslands = false,
     )
 
 /**

--- a/platform/jewel/markdown/testing/src/main/kotlin/org/jetbrains/jewel/markdown/testing/MarkdownTestTheme.kt
+++ b/platform/jewel/markdown/testing/src/main/kotlin/org/jetbrains/jewel/markdown/testing/MarkdownTestTheme.kt
@@ -131,6 +131,7 @@ fun createMarkdownTestThemeDefinition(): ThemeDefinition =
         colorPalette = ThemeColorPalette.Empty,
         iconData = ThemeIconData.Empty,
         disabledAppearanceValues = DisabledAppearanceValues(brightness = 33, contrast = -35, alpha = 100),
+        isIslands = false,
     )
 
 /** Creates a minimal [MarkdownStyling] with stub span styles for use in Markdown rendering tests. */

--- a/platform/jewel/ui/metalava/ui-api-0.42.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-0.42.0.txt
@@ -3303,9 +3303,13 @@ package org.jetbrains.jewel.ui.icons {
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToBottomLeft;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToBottomRight;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToButton;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeft;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeftBottom;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeftSideBySide;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeftTop;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRight;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRightBottom;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRightSideBySide;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRightTop;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToTopLeft;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToTopRight;
@@ -3845,6 +3849,7 @@ package org.jetbrains.jewel.ui.icons {
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey ShowInfos;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey ShowWarning;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey Show_to_implement;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey SortBy;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey SuccessDialog;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey SuccessLogin;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey TbHidden;

--- a/platform/jewel/ui/metalava/ui-api-stable-0.42.0.txt
+++ b/platform/jewel/ui/metalava/ui-api-stable-0.42.0.txt
@@ -3169,9 +3169,13 @@ package org.jetbrains.jewel.ui.icons {
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToBottomLeft;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToBottomRight;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToButton;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeft;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeftBottom;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeftSideBySide;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToLeftTop;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRight;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRightBottom;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRightSideBySide;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToRightTop;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToTopLeft;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey MoveToTopRight;
@@ -3711,6 +3715,7 @@ package org.jetbrains.jewel.ui.icons {
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey ShowInfos;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey ShowWarning;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey Show_to_implement;
+    field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey SortBy;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey SuccessDialog;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey SuccessLogin;
     field @SuppressCompatibility public static final org.jetbrains.jewel.ui.icon.IntelliJIconKey TbHidden;


### PR DESCRIPTION
# Context

Pretty cool PR overall, now we expose whether or not the Islands rendering mode is enabled or not. Always false on standalone, on bridge is whatever the IDE returns.

# Changes

- Added `isIslands` and `LocalIsIslandsTheme` to `JewelTheme`
- Deprecated the old constructor (did not hid it since that'd be a source breaking change) and added the `isIslands` property to the main ctor of `ThemeDefinition`.
- Created a new `JewelThemeTest` file with a mindblowing test (really, do check it out!!!!!!)
- Updated bridge code to return `IslandsState.isEnabled()` for this new property
- On standalone I just hardcoded `false` everywhere :)

## Release notes

### New features
 * You can now see if the Islands rendering mode is active or not on bridge. On standalone the new `JewelTheme.isIslands` property is always false.
 
 ### Deprecated API
 * The `ThemeDefinition` constructor without `isIslands` is deprecated. Use the new constructor and pass `isIslands` explicitly (`false` outside the IDE).