### PR TITLE
[JEWEL-919] Retune Classic Darcula checkbox validation outlines

### DIFF
--- a/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeCheckbox.kt
+++ b/platform/jewel/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridgeCheckbox.kt
@@ -74,15 +74,15 @@ private interface BridgeCheckboxMetrics {
 }
 
 private object ClassicUiCheckboxMetrics : BridgeCheckboxMetrics {
-    override val outlineSize = DpSize(14.dp, 14.dp)
-    override val outlineFocusedSize = DpSize(15.dp, 15.dp)
+    override val outlineSize = DpSize(15.dp, 15.dp)
+    override val outlineFocusedSize = outlineSize
     override val outlineSelectedSize = outlineSize
-    override val outlineSelectedFocusedSize = outlineFocusedSize
+    override val outlineSelectedFocusedSize = outlineSize
 
-    override val outlineCornerSize = 2.dp
-    override val outlineFocusedCornerSize = 3.dp
+    override val outlineCornerSize = 3.dp
+    override val outlineFocusedCornerSize = outlineCornerSize
     override val outlineSelectedCornerSize = outlineCornerSize
-    override val outlineSelectedFocusedCornerSize = outlineFocusedCornerSize
+    override val outlineSelectedFocusedCornerSize = outlineCornerSize
 
     override val checkboxSize = DpSize(20.dp, 19.dp)
     override val iconContentGap = 4.dp
@@ -91,13 +91,13 @@ private object ClassicUiCheckboxMetrics : BridgeCheckboxMetrics {
 private object NewUiCheckboxMetrics : BridgeCheckboxMetrics {
     override val outlineSize = DpSize(16.dp, 16.dp)
     override val outlineFocusedSize = outlineSize
-    override val outlineSelectedSize = DpSize(20.dp, 20.dp)
-    override val outlineSelectedFocusedSize = outlineSelectedSize
+    override val outlineSelectedSize = outlineSize
+    override val outlineSelectedFocusedSize = outlineSize
 
     override val outlineCornerSize = 3.dp
     override val outlineFocusedCornerSize = outlineCornerSize
-    override val outlineSelectedCornerSize = 4.5.dp
-    override val outlineSelectedFocusedCornerSize = outlineSelectedCornerSize
+    override val outlineSelectedCornerSize = outlineCornerSize
+    override val outlineSelectedFocusedCornerSize = outlineCornerSize
 
     override val checkboxSize = DpSize(24.dp, 24.dp)
     override val iconContentGap = 5.dp

--- a/platform/jewel/int-ui/int-ui-standalone-tests/src/spectreTest/kotlin/org/jetbrains/jewel/intui/standalone/ValidationOutlineSpectreTest.kt
+++ b/platform/jewel/int-ui/int-ui-standalone-tests/src/spectreTest/kotlin/org/jetbrains/jewel/intui/standalone/ValidationOutlineSpectreTest.kt
@@ -1,0 +1,214 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+@file:OptIn(ExperimentalJewelApi::class)
+
+package org.jetbrains.jewel.intui.standalone
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.testing.runSpectreTest
+import java.awt.image.BufferedImage
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+import javax.imageio.ImageIO
+import kotlin.concurrent.thread
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.intui.standalone.window.Window as JewelWindow
+import org.jetbrains.jewel.ui.Outline
+import org.jetbrains.jewel.ui.component.Checkbox
+import org.jetbrains.jewel.ui.component.RadioButton
+import org.jetbrains.jewel.ui.component.Text
+import org.junit.jupiter.api.Test
+
+// Headful, standalone-only. Spectre cannot see the IJP bridge or the Darcula LaF (JEWEL-1397).
+//   bazel test //platform/jewel/int-ui/int-ui-standalone-tests:jewel-intUi-standalone-spectre-tests
+//
+// Assertions are on framebuffer pixels in each control's bounds. Compose state alone would not
+// catch a missing Error/Warning outline.
+class ValidationOutlineSpectreTest {
+    @Test fun `light Int UI paints checkbox and radio validation outlines`(): Unit = assertOutlines(isDark = false)
+
+    @Test fun `dark Int UI paints checkbox and radio validation outlines`(): Unit = assertOutlines(isDark = true)
+}
+
+private fun assertOutlines(isDark: Boolean): Unit = runSpectreTest {
+    val app = ValidationOutlineApplication(isDark)
+    app.start()
+    try {
+        val window = app.awaitWindow()
+        window.isAlwaysOnTop = true
+        window.toFront()
+        val automator = ComposeAutomator.inProcess(RobotDriver.synthetic(window))
+        waitForTaggedNode(automator, READY_TAG)
+        automator.waitForIdle()
+
+        val screenshotDir = System.getenv("JEWEL_SPECTRE_SCREENSHOT_DIR")
+        if (!screenshotDir.isNullOrBlank()) {
+            val file = File(screenshotDir, if (isDark) "validation-dark.png" else "validation-light.png")
+            file.parentFile.mkdirs()
+            ImageIO.write(automator.screenshot(window.bounds), "png", file)
+        }
+
+        val shots = SPECS.associate { spec -> spec.tag to screenshotControl(automator, spec.tag) }
+        for (spec in SPECS) {
+            if (spec.outline == Outline.None) continue
+            val baseline =
+                SPECS.single {
+                    it.kind == spec.kind &&
+                        it.checked == spec.checked &&
+                        it.enabled == spec.enabled &&
+                        it.outline == Outline.None
+                }
+            val diff = shots.getValue(spec.tag).pixelDiffCount(shots.getValue(baseline.tag))
+            assertTrue(
+                diff >= MIN_OUTLINE_PIXELS,
+                "${spec.tag} should differ from ${baseline.tag} when ${spec.outline} is painted (diff=$diff)",
+            )
+        }
+    } finally {
+        app.stop()
+    }
+}
+
+@Composable
+private fun ValidationOutlineScreen() {
+    Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("ready", modifier = Modifier.testTag(READY_TAG))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            for (spec in SPECS.filter { it.kind == Kind.Checkbox }) {
+                Box(Modifier.testTag(spec.tag)) {
+                    Checkbox(
+                        checked = spec.checked,
+                        onCheckedChange = {},
+                        enabled = spec.enabled,
+                        outline = spec.outline,
+                    )
+                }
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            for (spec in SPECS.filter { it.kind == Kind.Radio }) {
+                Box(Modifier.testTag(spec.tag)) {
+                    RadioButton(selected = spec.checked, onClick = {}, enabled = spec.enabled, outline = spec.outline)
+                }
+            }
+        }
+    }
+}
+
+private class ValidationOutlineApplication(private val isDark: Boolean) {
+    private val exitApplication = AtomicReference<(() -> Unit)?>(null)
+    private val window = AtomicReference<ComposeWindow?>(null)
+
+    fun start() {
+        thread(name = "spectre-validation-outline-window", isDaemon = true) {
+            application(exitProcessOnExit = false) {
+                exitApplication.set(::exitApplication)
+                JewelWindow(
+                    onCloseRequest = ::exitApplication,
+                    state = rememberWindowState(size = DpSize(520.dp, 220.dp)),
+                    title = "Jewel Spectre validation outline ${if (isDark) "dark" else "light"}",
+                    alwaysOnTop = true,
+                ) {
+                    this@ValidationOutlineApplication.window.compareAndSet(null, window)
+                    IntUiTheme(isDark = isDark) {
+                        Box(Modifier.fillMaxSize().background(JewelTheme.globalColors.panelBackground)) {
+                            ValidationOutlineScreen()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        exitApplication.get()?.invoke()
+    }
+
+    suspend fun awaitWindow(): ComposeWindow {
+        repeat(100) {
+            window.get()?.let {
+                return it
+            }
+            delay(100.milliseconds)
+        }
+        error("The Compose test window was not created")
+    }
+}
+
+private suspend fun waitForTaggedNode(automator: ComposeAutomator, tag: String) =
+    try {
+        automator.waitForNode(tag = tag, timeout = 20.seconds)
+    } catch (e: TimeoutCancellationException) {
+        throw AssertionError("Missing testTag=$tag. Tree:\n${automator.printTree()}", e)
+    }
+
+private suspend fun screenshotControl(automator: ComposeAutomator, tag: String): BufferedImage {
+    val node = waitForTaggedNode(automator, tag)
+    return automator.screenshot(node.boundsOnScreen)
+}
+
+private fun BufferedImage.pixelDiffCount(other: BufferedImage): Int {
+    val width = minOf(width, other.width)
+    val height = minOf(height, other.height)
+    var count = 0
+    for (y in 0 until height) {
+        for (x in 0 until width) {
+            if (getRGB(x, y) != other.getRGB(x, y)) count++
+        }
+    }
+    return count
+}
+
+private enum class Kind {
+    Checkbox,
+    Radio,
+}
+
+private class Spec(val tag: String, val kind: Kind, val outline: Outline, val checked: Boolean, val enabled: Boolean)
+
+private val SPECS =
+    listOf(
+        Spec("checkbox.none.off", Kind.Checkbox, Outline.None, checked = false, enabled = true),
+        Spec("checkbox.none.on", Kind.Checkbox, Outline.None, checked = true, enabled = true),
+        Spec("checkbox.none.disabled", Kind.Checkbox, Outline.None, checked = false, enabled = false),
+        Spec("checkbox.error.off", Kind.Checkbox, Outline.Error, checked = false, enabled = true),
+        Spec("checkbox.error.on", Kind.Checkbox, Outline.Error, checked = true, enabled = true),
+        Spec("checkbox.error.disabled", Kind.Checkbox, Outline.Error, checked = false, enabled = false),
+        Spec("checkbox.warning.off", Kind.Checkbox, Outline.Warning, checked = false, enabled = true),
+        Spec("checkbox.warning.on", Kind.Checkbox, Outline.Warning, checked = true, enabled = true),
+        Spec("checkbox.warning.disabled", Kind.Checkbox, Outline.Warning, checked = false, enabled = false),
+        Spec("radio.none.off", Kind.Radio, Outline.None, checked = false, enabled = true),
+        Spec("radio.none.on", Kind.Radio, Outline.None, checked = true, enabled = true),
+        Spec("radio.none.disabled", Kind.Radio, Outline.None, checked = false, enabled = false),
+        Spec("radio.error.off", Kind.Radio, Outline.Error, checked = false, enabled = true),
+        Spec("radio.error.on", Kind.Radio, Outline.Error, checked = true, enabled = true),
+        Spec("radio.error.disabled", Kind.Radio, Outline.Error, checked = false, enabled = false),
+        Spec("radio.warning.off", Kind.Radio, Outline.Warning, checked = false, enabled = true),
+        Spec("radio.warning.on", Kind.Radio, Outline.Warning, checked = true, enabled = true),
+        Spec("radio.warning.disabled", Kind.Radio, Outline.Warning, checked = false, enabled = false),
+    )
+
+private const val READY_TAG = "spectre.validation.ready"
+private const val MIN_OUTLINE_PIXELS = 8

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Checkbox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Checkbox.kt
@@ -622,6 +622,7 @@ private fun CheckboxImpl(
                 alignment = Stroke.Alignment.Center,
             )
 
+    val iconState = if (outline != Outline.None) checkboxState.copy(focused = false) else checkboxState
     val painterProvider = rememberResourcePainterProvider(icons.checkbox)
     val checkboxPainter by
         painterProvider.getPainter(
@@ -630,8 +631,8 @@ private fun CheckboxImpl(
             } else {
                 PainterHint.None
             },
-            Selected(checkboxState.toggleableState != ToggleableState.Off),
-            Stateful(checkboxState),
+            Selected(iconState.toggleableState != ToggleableState.Off),
+            Stateful(iconState),
         )
 
     val checkboxBoxModifier = Modifier.size(metrics.checkboxSize)

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/RadioButton.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/RadioButton.kt
@@ -343,9 +343,9 @@ private fun RadioButtonImpl(
                 alignment = Stroke.Alignment.Center,
             )
 
+    val iconState = if (outline != Outline.None) radioButtonState.copy(focused = false) else radioButtonState
     val radioButtonPainterProvider = rememberResourcePainterProvider(style.icons.radioButton)
-    val radioButtonPainter by
-        radioButtonPainterProvider.getPainter(Selected(radioButtonState), Stateful(radioButtonState))
+    val radioButtonPainter by radioButtonPainterProvider.getPainter(Selected(iconState), Stateful(iconState))
 
     val radioButtonBoxModifier = Modifier.size(metrics.radioButtonSize)
 


### PR DESCRIPTION
After IJPL-198305, Classic Darcula Swing paints checkbox validation as an even-odd ring: outer 17×17 at (1,0) arc 8, inner 12×12 at (4,3) arc 3. New UI Swing is unchanged: 16×16 centered in 24×24 with a 2px center stroke → 18×18 at (3,3). Jewel still used the old Classic metrics from JEWEL-918, grew the New UI outline to 20.dp when selected, and painted the focused checkbox/radio SVG together with Error/Warning. Swing never does that (`hasFocus = op == null && b.hasFocus()`).

Jewel has no outline-offset API, so Classic matching is closest size/corner, not a pixel clone. Radio still has no Swing validation outline; this does not invent one.

## Changes

* Classic bridge checkbox metrics use 15×15 outlines and 3.dp corners in every focus/selection state.
* New UI selected outlines use 16×16 / 3.dp like the off state, matching Swing.
* When `Outline` is Error or Warning, Checkbox and RadioButton no longer use the focused icon. Focus still changes outline color.
* Standalone Spectre tests assert that Error/Warning controls differ on screen from `Outline.None` (light and dark Int UI). They cannot see the IJP bridge (JEWEL-1397).

Spectre: `./bazel.cmd test //platform/jewel/int-ui/int-ui-standalone-tests:jewel-intUi-standalone-spectre-tests`

## Screenshots

Swing (left) vs Jewel (right) after the change. Darcula + New UI Swing rings are still wrong on Classic icons; that is Swing, not this PR.

| Theme | After |
| --- | --- |
| Darcula | ![Darcula](https://static.sebastiano.dev/private/dc87c27e-f3ca-4eb0-85ae-3f66ee15de4d.png) |
| Dark | ![Dark](https://static.sebastiano.dev/private/a763a101-64fc-4322-9e43-2e4eceabe867.png) |
| High Contrast | ![High Contrast](https://static.sebastiano.dev/private/6540f1e9-6e22-4994-80e7-03ced5f272e5.png) |
| Islands Darcula | ![Islands Darcula](https://static.sebastiano.dev/private/6ff3eeff-fc6e-40c6-b0a1-da64635773e9.png) |
| Islands Dark | ![Islands Dark](https://static.sebastiano.dev/private/b585bdf2-e02f-47ca-9884-a7acb4cb1144.png) |

## Release notes

### Bug fixes

* Checkbox and radio Error/Warning outlines follow Swing more closely, including selected and focused states.
