### PR TITLE
[JEWEL-1265] Fix Speed Search Selection Being Overriden By Mouse Hover

### DIFF
--- a/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
+++ b/platform/jewel/samples/showcase/src/main/kotlin/org/jetbrains/jewel/samples/showcase/components/ComboBoxes.kt
@@ -143,13 +143,14 @@ private fun ListComboBoxes() {
 
         Column(Modifier.weight(1f).widthIn(min = 125.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text("Speed Search API")
+            val speedSearchItems = listOf("one", "two", "three")
             var selectedIndex by remember { mutableIntStateOf(2) }
-            val selectedItemText = if (selectedIndex >= 0) stringItems[selectedIndex] else "[none]"
+            val selectedItemText = if (selectedIndex >= 0) speedSearchItems[selectedIndex] else "[none]"
             InfoText(text = "Selected item: $selectedItemText")
 
             SpeedSearchArea(Modifier.widthIn(max = 200.dp)) {
                 SpeedSearchableComboBox(
-                    items = listOf("one", "two", "three"),
+                    items = speedSearchItems,
                     selectedIndex = selectedIndex,
                     onSelectedItemChange = { index -> selectedIndex = index },
                     modifier = Modifier.widthIn(max = 200.dp).fillMaxWidth(),

--- a/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBoxTest.kt
+++ b/platform/jewel/ui-tests/src/test/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBoxTest.kt
@@ -10,10 +10,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasTestTag
@@ -22,6 +24,7 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.unit.dp
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -52,6 +55,13 @@ class SpeedSearchableComboBoxTest {
 
     private fun ComposeContentTestRule.onComboBoxItem(text: String) =
         onNode(hasAnyAncestor(hasTestTag("Jewel.ComboBox.List")) and hasText(text))
+
+    private fun SemanticsNodeInteraction.hover() = performMouseInput {
+        // The first move only makes the pointer enter the item; onMove needs a second one to see it.
+        moveTo(center)
+        advanceEventTime()
+        moveBy(Offset(1f, 0f))
+    }
 
     @BeforeTest
     fun setUp() {
@@ -110,6 +120,31 @@ class SpeedSearchableComboBoxTest {
         comboBox.performKeyPress("Item 2", rule = this)
         onComboBoxItem("Item 2").assertIsDisplayed().assertIsSelected()
     }
+
+    @Test
+    fun `on type while an item is hovered, select the match instead of the hovered item`() = runComposeTest {
+        comboBox.performClick()
+
+        onComboBoxItem("Item 3").assertIsDisplayed().hover().assertIsSelected()
+
+        comboBox.performKeyPress("Item 5", rule = this)
+
+        onComboBoxItem("Item 5").assertIsDisplayed().assertIsSelected()
+        onComboBoxItem("Item 3").assertIsNotSelected()
+    }
+
+    @Test
+    fun `on type matching the selected item while another is hovered, keep the selection highlighted`() =
+        runComposeTest(entries = listOf("one", "two", "three"), initialSelectedIndex = 2) {
+            comboBox.performClick()
+
+            onComboBoxItem("two").assertIsDisplayed().hover().assertIsSelected()
+
+            comboBox.performKeyPress("three", rule = this)
+
+            onComboBoxItem("three").assertIsDisplayed().assertIsSelected()
+            onComboBoxItem("two").assertIsNotSelected()
+        }
 
     @Test
     fun `on type continue typing, continue selecting first occurrence`() = runComposeTest {
@@ -205,13 +240,14 @@ class SpeedSearchableComboBoxTest {
 
     private fun runComposeTest(
         entries: List<String> = List(500) { "Item ${it + 1}" },
+        initialSelectedIndex: Int = 0,
         block: ComposeContentTestRule.() -> Unit,
     ) {
         rule.setContent {
             val focusRequester = remember { FocusRequester() }
 
             IntUiTheme {
-                var selectedIndex by remember { mutableIntStateOf(0) }
+                var selectedIndex by remember { mutableIntStateOf(initialSelectedIndex) }
                 SpeedSearchArea(
                     modifier = Modifier.widthIn(max = 200.dp).focusRequester(focusRequester).testTag("SpeedSearchArea")
                 ) {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.takeOrElse
 import androidx.compose.ui.window.PopupPositionProvider
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.jetbrains.annotations.ApiStatus
@@ -615,6 +616,7 @@ internal fun <T : Any> ListComboBoxImpl(
             alignment = horizontalPopupAlignment,
             density = LocalDensity.current,
         ),
+    speedSearchState: SpeedSearchState? = null,
     itemContent: @Composable (index: Int, item: T, isSelected: Boolean, isActive: Boolean) -> Unit,
 ) {
     val density = LocalDensity.current
@@ -702,6 +704,14 @@ internal fun <T : Any> ListComboBoxImpl(
                 listState.selectedKeys = emptySet()
             }
         }
+    }
+
+    // The ultimate question this side effect answers is: is the live preview still trustworthy, or is it
+    // just where the pointer happened to be before the user started typing?
+    LaunchedEffect(listState, speedSearchState) {
+        snapshotFlow { listState.selectedKeys to speedSearchState?.searchText }
+            .drop(1) // ignoring current value from snapshotFlow
+            .collect { resetPreviewSelectedIndex() }
     }
 
     fun commitSelectionFromHoverOrMapped() {

--- a/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBox.kt
+++ b/platform/jewel/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/search/SpeedSearchableComboBox.kt
@@ -355,6 +355,7 @@ private fun <T : Any> SpeedSearchScope.SpeedSearchableComboBoxImpl(
             ),
         listState = listState,
         labelContent = labelContent,
+        speedSearchState = speedSearchState,
         itemContent = { index, item, isSelected, isActive ->
             ProvideSearchMatchState(speedSearchState, currentTexts[index], searchMatchStyle) {
                 itemContent(item, isSelected, isActive)


### PR DESCRIPTION
## Context

When speed search is active in a `SpeedSearchableComboBox`, the popup list highlighted whatever row the mouse was resting on rather than the row the search matched. The header named the right item and the matched characters got their highlight, but the selection background stayed put under the pointer.

`ListComboBoxImpl` tracks a `hoveredItemIndex`, a preview selection that takes precedence over the real one so that hovering highlights exactly one row but nowhere in the code we were "telling" this variable that it was stale. Speed search moves the selection without the pointer moving, so a leftover hover position kept vetoing the correct highlight until the user nudged the mouse.

## Changes

* `ListComboBoxImpl` now clears the hover preview when the list selection changes or the speed search query changes, using one `snapshotFlow` that reads both.
* Two signals are needed, not one. If the query matches the item that is already selected, `SpeedSearchableLazyColumnScrollEffect` leaves that selection alone and nothing in `listState` changes, so watching the selection would miss it entirely. That was the harder half of this bug: typing the name of the selected item left the highlight stranded on the hovered row.
* `ListComboBoxImpl` takes a new `speedSearchState` parameter that `SpeedSearchableComboBox` fills in. Both the function and the parameter are internal, so the public API is untouched and the Metalava dumps pick up nothing from this change.
* Fixed the showcase "Speed Search API" sample. Its "Selected item:" label indexed `stringItems` while the combo box rendered a different list, so the label showed an unrelated string.
* Added regression tests for both paths: a query that moves the selection, and one that matches the item already selected.

## Screen recordings

| Before | After |
|---|---|
| https://github.com/user-attachments/assets/fd1150ef-ebf9-4ed8-9a88-49b85fcae466  |   https://github.com/user-attachments/assets/edf94ca6-4f54-4fd2-b033-638f4dac4905 |

## Release notes

### Bug fixes

* Speed search in `SpeedSearchableComboBox` now highlights the matched item even when the mouse is resting over another row in the popup.
